### PR TITLE
Prefer pluck over map for Tag#tag_moderator_ids for better performance

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -28,7 +28,7 @@ class Tag < ActsAsTaggableOn::Tag
   end
 
   def tag_moderator_ids
-    User.with_role(:tag_moderator, self).map(&:id).sort
+    User.with_role(:tag_moderator, self).order("id ASC").pluck(:id)
   end
 
   private


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [X] Refactor
- [ ] Feature
- [ ] Bug Fix

## Description

I think it would be more performant if you used `pluck` instead of map within `Tag#tag_moderator_ids`

I'm not sure you need the order clause if you use `pluck` but I added it just in case. (?)

## Related Tickets & Documents

Sorry, I didn't create an issue because it is such a small change that I don't know if it deserves one.

## Added to documentation?
  - [ ] docs.dev.to
  - [ ] readme
  - [X] no documentation needed

Please let me know if it is a good idea.

Thanks!