### PR TITLE
Stop using the Fake Notifications Dark Pattern

### DIFF
--- a/app/assets/javascripts/initializers/initNotifications.js
+++ b/app/assets/javascripts/initializers/initNotifications.js
@@ -57,10 +57,6 @@ function fetchNotificationsCount() {
     xmlhttp.open('Get', '/notifications/counts', true);
     xmlhttp.send();
   }
-  else if (document.getElementById("notifications-container") == null) {
-    document.getElementById("notifications-number").innerHTML = "1";
-    document.getElementById("notifications-number").classList.add("showing");
-  }
 }
 
 function initReactions() {


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix

## Description

A fake notification is displayed for non-logged-in users

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Before:
![firefox_2018-08-09_07-19-18](https://user-images.githubusercontent.com/226692/43865292-85afe924-9ba5-11e8-8e21-56af1d3303ce.png)

After:
![2018-08-09_07-19-52](https://user-images.githubusercontent.com/226692/43865295-8881ab7e-9ba5-11e8-81c2-c6218d52f4b6.png)

## Added to documentation?
  - [ ] docs.dev.to
  - [ ] readme
  - [x] no documentation needed

## What gif best describes this PR or how it makes you feel?

![alt-text](https://media.giphy.com/media/SGT03NX8u32ZG/giphy.gif)