### PR TITLE
Show employment title without an employer

### DIFF
--- a/app/views/articles/_user_metadata.html.erb
+++ b/app/views/articles/_user_metadata.html.erb
@@ -60,19 +60,20 @@
           </div>
         </div>
       <% end %>
-      <% if @user.employer_name.present? %>
+      <% if @user.employment_title.present? %>
         <div class="row">
           <div class="key">
             work
           </div>
           <div class="value">
-            <% if @user.employment_title.present? %>
-              <span><%= @user.employment_title %> at </span>
-            <% end %>
-            <% if @user.employer_url.present? %>
-              <a href="<%= @user.employer_url %>" target="_blank" rel="noopener"><%= @user.employer_name %></a>
-            <% else %>
-              <%= @user.employer_name %>
+            <span><%= @user.employment_title %></span>
+            <% if @user.employer_name.present? %>
+              <span> at <span>
+              <% if @user.employer_url.present? %>
+                <a href="<%= @user.employer_url %>" target="_blank" rel="noopener"><%= @user.employer_name %></a>
+              <% else %>
+                <%= @user.employer_name %>
+              <% end %>
             <% end %>
           </div>
         </div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix

## Description

As someone who values privacy, I'd rather not link my dev.to profile with my employer. However, due to the current layout of the profile page, I cannot show my title without stating the location that gave me the title. This seems like a silly requirement, so I'm pitching a change to the UI to allow title without an employer. This takes the place of allowing an employer without a title (current behavior) since it seemed more practical to have what you do rather than where you do it. 

## Related Tickets & Documents

None.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Original:
![screen shot 2018-08-08 at 8 12 53 pm](https://user-images.githubusercontent.com/11020425/43870872-c691fe86-9b47-11e8-9f4f-18290e765213.png)

With this change:
![screen shot 2018-08-08 at 8 13 04 pm](https://user-images.githubusercontent.com/11020425/43870885-d34b7f8a-9b47-11e8-8f3d-db7ac392d074.png)

With an employer:
![screen shot 2018-08-08 at 8 13 34 pm](https://user-images.githubusercontent.com/11020425/43870895-dfadbcc0-9b47-11e8-8a5b-9cd1380f17da.png)

(with an employer link works too -- that was just impossible to screenshot)

## Added to documentation?
  - [ ] docs.dev.to
  - [ ] readme
  - [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?
![I tried](https://media.giphy.com/media/3otPora2GgtfqRX7Xy/giphy.gif)