### PR TITLE
Add request specs (#275)

### DIFF
--- a/spec/requests/internal_events_spec.rb
+++ b/spec/requests/internal_events_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe "Internal Events", type: :request do
+  let(:event) { create(:event) }
+  let(:admin) { create(:user, :super_admin) }
+
+  describe "PUT internal/events" do
+    before do
+      login_as(admin)
+    end
+
+    it "marks an event as not live now" do
+      event.update(live_now: true)
+      patch "/internal/events/#{event.id}", params: { event: { live_now: "0" } }
+      expect(event.reload.live_now).to eq false
+    end
+
+    it "marks an event as live now" do
+      patch "/internal/events/#{event.id}", params: { event: { live_now: "1" } }
+      expect(event.reload.live_now).to eq true
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix

## Description

Fixes #275. The issue describes "The 'live now' functionality was messed up because past events marked as not live now were not actually getting marked that way," so the plan was to write a request spec to verify this behavior. However, after writing the request specs, they passed. It appears the issue has since been fixed.

I did a little digging into git history of related files, but couldn't find much. Just to be sure, I wrote an integration test as well (checking live now, saving, unchecking it, saving). That test seems to pass as well - but I didn't include it here as it seems a little overkill.

As it's my first time in the code base, I could be missing something. As far as I can tell though, #275 appears to be resolved. These request specs should help make sure it stays functional moving forward.

## Added to documentation?
  - [ ] docs.dev.to
  - [ ] readme
  - [x] no documentation needed