### PR TITLE
Fixing the twitter link open issue and ci-skip tag [ci skip]

### DIFF
--- a/docs/get-api-keys-dev-env.md
+++ b/docs/get-api-keys-dev-env.md
@@ -76,7 +76,7 @@ That's it! You should try logging in with development, it should work. If it doe
 
 # Twitter App
 
-1.  [Click this link and sign in/sign up for a Twitter account.](<(https://apps.twitter.com)>) Note that your Twitter account will need a phone number linked to it in order to create an app.
+1.  [Click this link and sign in/sign up for a Twitter account.](https://apps.twitter.com) Note that your Twitter account will need a phone number linked to it in order to create an app.
 2.  Create a new app, and fill out the form, like the following example image: ![](https://user-images.githubusercontent.com/17884966/41612665-952d4cae-73c1-11e8-8047-cf0bd03bffb6.png)
 
 The only important field is the "Callback URL" `http://localhost:3000/users/auth/twitter/callback`, which redirects you properly to `localhost:3000` when signing in.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -30,7 +30,7 @@ Travis will upload Simplecov data to CodeClimate. We are still in the early stag
 
 #### Skipping CI build (Not recommended)
 
-If your changes are **minor** (i.e. updating README, fixing a typo), you can skip CI by adding `[skip ci]` to your commit message.
+If your changes are **minor** (i.e. updating README, fixing a typo), you can skip CI by adding `[ci skip]` to your commit message.
 
 ## Continuous Integration & Continuous Deployment
 


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix

## Description
- The twitter link was not opening from docs. When we click on the hyperlink it was redirecting to "http://docs.dev.to/get-api-keys-dev-env/(https://apps.twitter.com" instead of "https://apps.twitter.com".

- The tag that is used to skip running CI for minor changes is `[ci skip]` but in the docs it was `[skip ci]`
## Related Tickets & Documents
- http://docs.dev.to/get-api-keys-dev-env/#twitter-app
- http://docs.dev.to/testing/#codeclimate
## Added to documentation?
  - [x] docs.dev.to
  - [ ] readme
  - [ ] no documentation needed