### PR TITLE
bin/startup requires to have foreman installed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -109,6 +109,7 @@ group :development do
   gem "guard-rspec", "~> 4.7", require: false
   gem "rb-fsevent", "~> 0.10", require: false
   gem "web-console", "~> 3.5"
+  gem 'foreman', require: false
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -242,6 +242,7 @@ GEM
     docile (1.3.1)
     domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
+    dotenv (0.7.0)
     draper (3.0.1)
       actionpack (~> 5.0)
       activemodel (~> 5.0)
@@ -438,6 +439,9 @@ GEM
     fog-xml (0.1.3)
       fog-core
       nokogiri (>= 1.5.11, < 2.0.0)
+    foreman (0.64.0)
+      dotenv (~> 0.7.0)
+      thor (>= 0.13.6)
     formatador (0.2.5)
     front_matter_parser (0.1.1)
     get_process_mem (0.2.2)
@@ -956,6 +960,7 @@ DEPENDENCIES
   fix-db-schema-conflicts!
   flipflop (~> 2.3)
   fog (~> 1.41)
+  foreman
   front_matter_parser (~> 0.1)
   gibbon (~> 2.2)
   google-api-client (~> 0.19)


### PR DESCRIPTION
Hi

- [x] Bug Fix

On running `./bin/startup` it is using `foreman` but it's not installed for development env after running `bundle install`

  - [x] no documentation needed
