### PR TITLE
Silence cache logs and fix a small bug

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -46,7 +46,7 @@ class Article < ApplicationRecord
   before_save       :set_all_dates
   before_save       :calculate_base_scores
   before_save       :set_caches
-  after_save        :async_score_calc
+  after_save        :async_score_calc, if: :published
   after_save        :bust_cache
   after_save        :update_main_image_background_hex
   after_save        :detect_human_language
@@ -364,7 +364,7 @@ class Article < ApplicationRecord
   def async_score_calc
     update_column(:hotness_score, BlackBox.article_hotness_score(self))
     update_column(:spaminess_rating, BlackBox.calculate_spaminess(self))
-    index! if published && tag_list.exclude?("hiring")
+    index! if tag_list.exclude?("hiring")
   end
   handle_asynchronously :async_score_calc
 

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -418,6 +418,40 @@ RSpec.describe Article, type: :model do
     expect(article.update_main_image_background_hex_without_delay).to eq(true)
   end
 
+  describe "#async_score_calc" do
+    before { Delayed::Worker.delay_jobs = false }
+
+    context "when published" do
+      let(:article) { create(:article) }
+
+      it "updates the hotness score" do
+        article.save
+        expect(article.hotness_score > 0).to eq(true)
+      end
+
+      it "updates the spaminess score" do
+        article.update_column(:spaminess_rating, -1)
+        article.save
+        expect(article.spaminess_rating).to eq(0)
+      end
+    end
+
+    context "when unpublished" do
+      let(:article) { create(:article, published: false) }
+
+      it "does not update the hotness score" do
+        article.save
+        expect(article.hotness_score).to eq(0)
+      end
+
+      it "does not update the spaminess score" do
+        article.update_column(:spaminess_rating, -1)
+        article.save
+        expect(article.spaminess_rating).to eq(-1)
+      end
+    end
+  end
+
   it "detects detect_human_language" do
     article.save
     article.detect_human_language

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -421,6 +421,8 @@ RSpec.describe Article, type: :model do
   describe "#async_score_calc" do
     before { Delayed::Worker.delay_jobs = false }
 
+    after  { Delayed::Worker.delay_jobs = true }
+
     context "when published" do
       let(:article) { create(:article) }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This silences our log output again, and also fixes a bug that I happen to find in our logs. It happens somewhat silently since it fails as a job. 

Error message:
```
Article#async_score_calc_without_delay FAILED with 
NoMethodError: undefined method `>' for nil:NilClass
```