### PR TITLE
Fix LinkedIn accepted urls

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -68,7 +68,8 @@ class User < ApplicationRecord
               format: /\A(http|https):\/\/(www.behance.net|behance.net).*\z/m
   validates :linkedin_url,
               allow_blank: true,
-              format: /\A(http|https):\/\/(www.linkedin.com|linkedin.com).*\z/m
+              format:
+                /\A(http|https):\/\/(www.linkedin.com|linkedin.com|[A-Za-z]{2}.linkedin.com).*\z/m
   validates :dribbble_url,
               allow_blank: true,
               format: /\A(http|https):\/\/(www.dribbble.com|dribbble.com).*\z/m
@@ -92,7 +93,8 @@ class User < ApplicationRecord
   validates :website_url, :employer_name, :employer_url,
             :employment_title, :education, :location,
             length: { maximum: 100 }
-  validates :mostly_work_with, :currently_learning, :currently_hacking_on, :available_for, :mentee_description, :mentor_description,
+  validates :mostly_work_with, :currently_learning, :currently_hacking_on,
+            :available_for, :mentee_description, :mentor_description,
             length: { maximum: 500 }
   validate  :conditionally_validate_summary
   validate  :validate_feed_url
@@ -196,7 +198,10 @@ class User < ApplicationRecord
   end
 
   def cached_following_users_ids
-    Rails.cache.fetch("user-#{id}-#{updated_at}-#{following_users_count}/following_users_ids", expires_in: 120.hours) do
+    Rails.cache.fetch(
+      "user-#{id}-#{updated_at}-#{following_users_count}/following_users_ids",
+      expires_in: 120.hours,
+    ) do
       # More efficient query. May not cover future edge cases.
       # Should probably only return users who have published lately
       # But this should be okay for most for now.
@@ -459,7 +464,9 @@ class User < ApplicationRecord
   end
 
   def comments_blob
-    ActionView::Base.full_sanitizer.sanitize(comments.last(2).pluck(:body_markdown).join(" "))[0..2500]
+    ActionView::Base.full_sanitizer.sanitize(
+      comments.last(2).pluck(:body_markdown).join(" "),
+    )[0..2500]
   end
 
   def body_text
@@ -478,7 +485,8 @@ class User < ApplicationRecord
   end
 
   def search_score
-    score = (((articles_count + comments_count + reactions_count) * 10) + tag_keywords_for_search.size) * reputation_modifier * followers_count
+    article_score = (articles_count + comments_count + reactions_count) * 10
+    score = (article_score + tag_keywords_for_search.size) * reputation_modifier * followers_count
     score.to_i
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -115,8 +115,18 @@ RSpec.describe User, type: :model do
       expect(user).to be_valid
     end
 
+    it "accepts valid country specific http linkedin url" do
+      user.linkedin_url = "http://mx.linkedin.com/in/jessleenyc"
+      expect(user).to be_valid
+    end
+
     it "accepts valid https linkedin url" do
       user.linkedin_url = "https://linkedin.com/in/jessleenyc"
+      expect(user).to be_valid
+    end
+
+    it "accepts valid country specific https linkedin url" do
+      user.linkedin_url = "https://mx.linkedin.com/in/jessleenyc"
       expect(user).to be_valid
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -130,6 +130,16 @@ RSpec.describe User, type: :model do
       expect(user).to be_valid
     end
 
+    it "does not accept three letters country codes in http linkedin url" do
+      user.linkedin_url = "http://mex.linkedin.com/in/jessleenyc"
+      expect(user).not_to be_valid
+    end
+
+    it "does not accept three letters country codes in https linkedin url" do
+      user.linkedin_url = "https://mex.linkedin.com/in/jessleenyc"
+      expect(user).not_to be_valid
+    end
+
     it "does not accept invalid linkedin url" do
       user.linkedin_url = "ben.com"
       expect(user).not_to be_valid


### PR DESCRIPTION
Closes #343

## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

I've expanded the Linkedin regexp to allow country specific urls. Linkedin apparently supports urls like:

https://mx.linkedin.com/in/jessleenyc
https://it.linkedin.com/in/jessleenyc
https://us.linkedin.com/in/jessleenyc

I've also tried three letters ISO codes and they don't work, like https://mex.linkedin.com/in/jessleenyc

Note: the other changes in user.rb are due to rubocop's barring me to push until the issues with Metrics/LineLength were fixed.

## Related Tickets & Documents
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
## Added to documentation?
  - [ ] docs.dev.to
  - [ ] readme
  - [x] no documentation needed
