### PR TITLE
Feature/vimeo tag

### DIFF
--- a/app/liquid_tags/vimeo_tag.rb
+++ b/app/liquid_tags/vimeo_tag.rb
@@ -1,0 +1,32 @@
+require "uri"
+
+class VimeoTag < LiquidTagBase
+  def initialize(tag_name, token, tokens)
+    super
+    @id     = id_for token
+    @width  = 710
+    @height = 399
+  end
+
+  def render(_context)
+    finalize_html <<~HTML
+      <iframe
+        src="https://player.vimeo.com/video/#{@id}"
+        width="#{@width}"
+        height="#{@height}"
+        frameborder="0"
+        webkitallowfullscreen
+        mozallowfullscreen
+        allowfullscreen>
+      </iframe>
+    HTML
+  end
+
+  private
+
+  def id_for(input)
+    File.basename URI(input.to_s.strip).path
+  end
+end
+
+Liquid::Template.register_tag("vimeo", VimeoTag)

--- a/app/liquid_tags/vimeo_tag.rb
+++ b/app/liquid_tags/vimeo_tag.rb
@@ -1,5 +1,3 @@
-require "uri"
-
 class VimeoTag < LiquidTagBase
   def initialize(tag_name, token, tokens)
     super
@@ -25,7 +23,12 @@ class VimeoTag < LiquidTagBase
   private
 
   def id_for(input)
-    File.basename URI(input.to_s.strip).path
+    # This was the original plan:
+    #   require "uri"
+    #   File.basename URI(input).path
+    # But the markdown turns the link into html. This is simple enough,
+    # works for all the use cases and isn't exploitable.
+    input.to_s.scan(/\d+/).max_by(&:length)
   end
 end
 

--- a/app/views/pages/markdown_basics.html.erb
+++ b/app/views/pages/markdown_basics.html.erb
@@ -55,9 +55,10 @@
     <p>All you need is the gist link</p>
     <code>{% gist https://gist.github.com/QuincyLarson/4bb1682ce590dc42402b2edddbca7aaa %}</code>
 
-    <h3><strong>YouTube Embed</strong></h3>
-    <p>All you need is the YouTube <code>id</code> from the URL.</p>
-    <code>{% youtube 9z-Pdfxxdyo %}</code>
+    <h3><strong>Video Embed</strong></h3>
+    <p>All you need is the <code>id</code> from the URL.</p>
+    <code>{% youtube 9z-Pdfxxdyo %}</code><br />
+    <code>{% vimeo 193110695 %}</code><br />
 
     <h3><strong>Instagram Embed</strong></h3>
     <p>All you need is the Instagram post <code>id</code> from the URL.</p>

--- a/spec/liquid_tags/vimeo_tag_spec.rb
+++ b/spec/liquid_tags/vimeo_tag_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe VimeoTag, type: :liquid_template do
     html   = Nokogiri.parse(liquid.render).root
     expect(html.name).to eq "iframe"
     expect(html[:src]).to eq "https://player.vimeo.com/video/#{vimeo_id}"
+    expect(html[:width]).to eq "710"
+    expect(html[:height]).to eq "399"
   end
 
   it "accepts vimeo video id" do
@@ -27,5 +29,16 @@ RSpec.describe VimeoTag, type: :liquid_template do
   it "accepts a vimeo player url" do
     assert_parses id, "https://player.vimeo.com/video/#{id}"
     assert_parses id, "ps://player.vimeo.com/video/#{id}"
+  end
+
+  # NOTE: This is kinda dumb. It seems like the right answer is that
+  # either it should run liquid before markdown, or markdown shouldn't
+  # mess with the liquid tags (there is a fn to escape them, but it doesn't
+  # seem to escape the url here)
+  # https://github.com/thepracticaldev/dev.to/blob/master/app/labor/markdown_parser.rb#L73-L92
+  # My test suite isn't entirely passing, and I've spent longer on this than I
+  # wanted to, io Instead of looking into those, I'm going to just make this work  ¯\_(ツ)_/¯
+  it "accepts urls that were over-eagerly turned into links by markdown" do
+    assert_parses id, "<a href=\"https://vimeo.com/#{id}\">https://vimeo.com/192819855</a> "
   end
 end

--- a/spec/liquid_tags/vimeo_tag_spec.rb
+++ b/spec/liquid_tags/vimeo_tag_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+require "nokogiri"
+
+RSpec.describe VimeoTag, type: :liquid_template do
+  let(:id) { "205930710" }
+
+  def assert_parses(vimeo_id, token)
+    liquid = Liquid::Template.parse("{% vimeo #{token} %}")
+    html   = Nokogiri.parse(liquid.render).root
+    expect(html.name).to eq "iframe"
+    expect(html[:src]).to eq "https://player.vimeo.com/video/#{vimeo_id}"
+  end
+
+  it "accepts vimeo video id" do
+    assert_parses id, id
+  end
+
+  it "accepts vimeo video id with wonky whitespace" do
+    assert_parses id, " #{id}  \t"
+  end
+
+  it "accepts a vimeo video url" do
+    assert_parses id, "https://vimeo.com/#{id}"
+    assert_parses id, "vimeo.com/#{id}"
+  end
+
+  it "accepts a vimeo player url" do
+    assert_parses id, "https://player.vimeo.com/video/#{id}"
+    assert_parses id, "ps://player.vimeo.com/video/#{id}"
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

There is a tag to render youtube videos ([link](https://dev.to/jess/comment/4739)). But I host on vimeo. This adds an equivalent Vimeo tag.

Note that dropping a vimeo url into it will work also, but there's a wonky thing where the markdown parser turns it into an anchor tag.

## Related Tickets & Documents

* Jess announces the Youtube Tag ([link](https://dev.to/jess/comment/4739))
* `YoutubeTag`'s source ([link](https://github.com/thepracticaldev/dev.to/blob/4b3951cfb211316a0ff05862318d2a9f532b15c4/app/liquid_tags/youtube_tag.rb))
* `YoutubeTag`'s spec ([link](https://github.com/thepracticaldev/dev.to/blob/4b3951cfb211316a0ff05862318d2a9f532b15c4/spec/liquid_tags/youtube_tag_spec.rb))

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Here I change a post's body to have a vimeo tag in it:

![screen shot 2018-08-19 at 1 02 15 pm](https://user-images.githubusercontent.com/77495/44311613-24192780-a3b0-11e8-8358-44f2ee5dc92c.png)

Here is what it looks like rendered:

![screen shot 2018-08-19 at 1 05 14 pm](https://user-images.githubusercontent.com/77495/44311645-9d187f00-a3b0-11e8-9a76-ba7446a75877.png)

I haven't looked at it on my phone, but it uses the same dimensions as the YouTube tag, so if that one looks fine, this one should as well.

## Added to documentation?
  - [ ] docs.dev.to
  - [ ] readme
  - [ ] no documentation needed
  - [x] Markdown Basics

![screen shot 2018-08-19 at 1 15 07 pm](https://user-images.githubusercontent.com/77495/44311718-182e6500-a3b2-11e8-9547-d4d6256aa59d.png)