### PR TITLE
Remove thumbsdown slack ping to remove abuse noise

### DIFF
--- a/app/observers/reaction_observer.rb
+++ b/app/observers/reaction_observer.rb
@@ -1,7 +1,7 @@
 class ReactionObserver < ActiveRecord::Observer
   def after_create(reaction)
-    if reaction.points.negative?
-      emoji = reaction.category == "thumbsdown" ? ":thumbsdown:" : ":cry:"
+    if reaction.category == "vomit"
+      emoji = ":cry:"
       SlackBot.delay.ping(
         "#{reaction.user.name} (https://dev.to#{reaction.user.path}) \nreacted with a #{reaction.category} on\nhttps://dev.to#{reaction.reactable.path}",
         channel: "abuse-reports",


### PR DESCRIPTION
We don't need to see every "thumbs down" reaction in our internal feed.

Resolves #420 🌲🔥