### PR TITLE
Increase #cache_tag_list limit

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -414,7 +414,7 @@ class Article < ApplicationRecord
     return errors.add(:tag_list, "exceed the maximum of 4 tags") if tag_list.length > 4
     tag_list.each do |tag|
       if tag.length > 20
-        errors.add(:tag, "\"#{tag}\" is too long (maximum is 16 characters)")
+        errors.add(:tag, "\"#{tag}\" is too long (maximum is 20 characters)")
       end
     end
   end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -31,7 +31,7 @@ class Article < ApplicationRecord
   validate :validate_tag
   validate :validate_video
   validates :video_state, inclusion: { in: %w(PROGRESSING COMPLETED) }, allow_nil: true
-  validates :cached_tag_list, length: { maximum: 64 }
+  validates :cached_tag_list, length: { maximum: 86 }
   validates :main_image, url: { allow_blank: true, schemes: ["https", "http"] }
   validates :main_image_background_hex_color, format: /\A#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})\z/
   validates :video, url: { allow_blank: true, schemes: ["https", "http"] }

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Article, type: :model do
   it { is_expected.to validate_uniqueness_of(:feed_source_url).allow_blank }
   it { is_expected.to validate_presence_of(:title) }
   it { is_expected.to validate_length_of(:title).is_at_most(128) }
-  it { is_expected.to validate_length_of(:cached_tag_list).is_at_most(64) }
+  it { is_expected.to validate_length_of(:cached_tag_list).is_at_most(86) }
   it { is_expected.to belong_to(:user) }
   it { is_expected.to belong_to(:organization) }
   it { is_expected.to belong_to(:collection) }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Fixes the single tag limit error message (message said 16 character limit, actual was 20). Also fixes the `cached_tag_list` limit, which is a joined string of `tag_list`, which is an array of words. For example:
```ruby
# article.tag_list = ['cool', 'beans', 'dude', 'four']
article.cached_tag_list
#=> "cool, beans, dude, four"
article.cached_tag_list.length
#=> 22
article.tag_list.sum(&:length)
#=> 16
22 - 16
#=> 6
```
4 tags at a maximum of 20 character limits = 80. Since it's a joined string of an array of words, we have to add 6 characters for the additional commas and spaces. 
80 + 6 = 86

## Additional Links
https://dev.to/vishwan/is-this-a-bug-or-am-i-missing-something-cached-tag-list-is-too-long-580m

## Added to documentation?
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?
![dude writing math formula on chalkboard](https://media.giphy.com/media/xUA7b6oaRIgzmAKpUY/giphy-downsized.gif)
