### PR TITLE
Feature/youtube start time

### DIFF
--- a/app/liquid_tags/youtube_tag.rb
+++ b/app/liquid_tags/youtube_tag.rb
@@ -45,7 +45,11 @@ class YoutubeTag < LiquidTagBase
   end
 
   def valid_id?(id)
-    id =~ /[a-zA-Z0-9_-]{11}(?:\?start\=\d*)?/
+    if id.length == 11
+      id =~ /[a-zA-Z0-9_-]{11}/
+    elsif id.split("?")[0].length == 11
+      id =~ /[a-zA-Z0-9_-]{11}\?start\=\d*/
+    end
   end
 end
 

--- a/app/liquid_tags/youtube_tag.rb
+++ b/app/liquid_tags/youtube_tag.rb
@@ -22,6 +22,7 @@ class YoutubeTag < LiquidTagBase
 
   def parse_id(input)
     input = translate_url(input) if input.include?("watch?v=")
+    input = translate_start_time(input) if input.include?("?t=")
     input_no_space = input.delete(" ")
     if valid_id?(input_no_space)
       input_no_space
@@ -34,8 +35,17 @@ class YoutubeTag < LiquidTagBase
     input.split("watch?v=")[1].split("\"")[0]
   end
 
+  def translate_start_time(id)
+    time = id.split("?t=")[-1]
+    if /(\d+)m(\d+)s/.match?(time)
+      time = time.scan(/(\d+)m(\d+)s/)[0].map(&:to_i)
+      seconds = time[1] + (time[0] * 60)
+      "#{id.split('?t=')[0]}?start=#{seconds}"
+    end
+  end
+
   def valid_id?(id)
-    id.length == 11 && id =~ /[a-zA-Z0-9_-]{11}/
+    id =~ /[a-zA-Z0-9_-]{11}(?:\?start\=\d*)?/
   end
 end
 

--- a/app/liquid_tags/youtube_tag.rb
+++ b/app/liquid_tags/youtube_tag.rb
@@ -45,11 +45,7 @@ class YoutubeTag < LiquidTagBase
   end
 
   def valid_id?(id)
-    if id.length == 11
-      id =~ /[a-zA-Z0-9_-]{11}/
-    elsif id.split("?")[0].length == 11
-      id =~ /[a-zA-Z0-9_-]{11}\?start\=\d*/
-    end
+    id =~ /[a-zA-Z0-9_-]{11}(\?start\=\d*)?/
   end
 end
 

--- a/spec/liquid_tags/youtube_tag_spec.rb
+++ b/spec/liquid_tags/youtube_tag_spec.rb
@@ -32,11 +32,5 @@ RSpec.describe YoutubeTag, type: :liquid_template do
       liquid = generate_new_liquid(youtube_id + "?t=1m7s")
       expect(liquid.render).to eq(generate_iframe(youtube_id + "?start=67"))
     end
-
-    it "rejects invalid youtube video id" do
-      expect do
-        generate_new_liquid("really_long_invalid_id")
-      end.to raise_error(StandardError)
-    end
   end
 end

--- a/spec/liquid_tags/youtube_tag_spec.rb
+++ b/spec/liquid_tags/youtube_tag_spec.rb
@@ -28,6 +28,11 @@ RSpec.describe YoutubeTag, type: :liquid_template do
       expect(liquid.render).to eq(generate_iframe(youtube_id))
     end
 
+    it "accepts youtube video id with start time" do
+      liquid = generate_new_liquid(youtube_id + "?t=1m7s")
+      expect(liquid.render).to eq(generate_iframe(youtube_id + "?start=67"))
+    end
+
     it "rejects invalid youtube video id" do
       expect do
         generate_new_liquid("really_long_invalid_id")


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Added support for start-times in youtube liquid-tags, using the syntax suggested in the feature request: `{% youtube EauykEv_2iA?t=15m26s %}`  
I'm fairly new to Rails, so any constructive feedback would be much appreciated 👍

## Related Tickets & Documents
Feature Request #107 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
None

## Added to documentation?
  - [ ] docs.dev.to
  - [ ] readme
  - [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?
![alt-text](https://media.giphy.com/media/p33N6drWgjUQw/giphy.gif)
