### PR TITLE
Fix runkit HTML encoding issue

### DIFF
--- a/app/liquid_tags/runkit_tag.rb
+++ b/app/liquid_tags/runkit_tag.rb
@@ -20,7 +20,7 @@ class RunkitTag < Liquid::Block
       var targets = document.getElementsByClassName("runkit-element");
       if (targets.length > 0) {
         for (var i = 0; i < targets.length; i++) {
-          var content = targets[i].innerHTML;
+          var content = targets[i].textContent;
           targets[i].innerHTML = "";
           var notebook = RunKit.createNotebook({
             element: targets[i],
@@ -38,7 +38,7 @@ class RunkitTag < Liquid::Block
           var targets = document.getElementsByClassName("runkit-element");
           if (targets.length > 0) {
             for (var i = 0; i < targets.length; i++) {
-              var content = targets[i].innerHTML;
+              var content = targets[i].textContent;
               if(/^(\<iframe src)/.test(content) === false) {
                 targets[i].innerHTML = "";
                 var notebook = RunKit.createNotebook({


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Currently, we have an issue where the RunKit Liquid tag doesn't run properly with less than/greater than signs, and potentially other symbols. The current changes fix that; however, using backticks are not parsed properly in the Liquid tag.

The issue lies in the [`markdown_parser.rb#112`](https://github.com/thepracticaldev/dev.to/blob/master/app/labor/markdown_parser.rb#L112). We're currently turning all backticks to Liquid's raw tags in order to process other parts of Markdown properly. This however removes backticks from any code that someone might have within the RunKit tag. We'll need to properly adjust for this behavior.

I'm setting this aside for now since I got half of it working, but not the other half. Here's an example codeblock to use for a RunKit tag:
```javascript
let beansArray = ['kidney', 'chickpea', 'adzuki'];
for (let i = 0; i < beansArray.length; i++) {
  // the console.log backticks are removed
  console.log(`${beansArray[i]} is a yummy bean!`);
}
```

## Added to documentation?
  - [x] no documentation needed