### PR TITLE
[Feature #446] - Seconds, minutes and hours ago for articles

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -340,7 +340,7 @@ class Article < ApplicationRecord
     end
   end
 
-  def time_from_publish
+  def time_since_publish
     relevant_date = crossposted_at.present? ? crossposted_at : published_at
     seconds = (Time.now - relevant_date.to_time) / 1.second
     if seconds < 60

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -340,6 +340,20 @@ class Article < ApplicationRecord
     end
   end
 
+  def time_from_publish
+    relevant_date = crossposted_at.present? ? crossposted_at : published_at
+    seconds = (Time.now - relevant_date.to_time) / 1.second
+    if seconds < 60
+      "・" + (seconds <= 1 ? "a second" : seconds.floor.to_s + " seconds") + " ago"
+    elsif seconds >= 60 && seconds < 3600
+      minutes = (seconds / 60).floor
+      "・" + (minutes == 1 ? "a minute" : minutes.to_s + " minutes") + " ago"
+    elsif seconds >= 3600 && seconds < 86400
+      hours = (seconds / (60 * 60)).floor
+      "・" + (hours == 1 ? "an hour" : hours.to_s + " hours") + " ago"
+    end
+  end
+
   def self.cached_find(id)
     Rails.cache.fetch("find-article-by-id-#{id}", expires_in: 5.hours) do
       find(id)

--- a/app/views/articles/_single_story.html.erb
+++ b/app/views/articles/_single_story.html.erb
@@ -22,7 +22,7 @@
       </div>
     </a>
     <h4>
-      <a href="<%=story.user.path%>"><%= story.user.name %>・<%= story.readable_publish_date %><%= story.time_from_publish %></a>
+      <a href="<%=story.user.path%>"><%= story.user.name %>・<%= story.readable_publish_date %><%= story.time_since_publish %></a>
       
     </h4>
     <div class="tags">

--- a/app/views/articles/_single_story.html.erb
+++ b/app/views/articles/_single_story.html.erb
@@ -22,7 +22,7 @@
       </div>
     </a>
     <h4>
-      <a href="<%=story.user.path%>"><%= story.user.name %>・<%= story.readable_publish_date %></a>
+      <a href="<%=story.user.path%>"><%= story.user.name %>・<%= story.readable_publish_date %><%= story.time_from_publish %></a>
       
     </h4>
     <div class="tags">

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -326,7 +326,7 @@
           <a href="<%= @featured_story.user.path %>" class="featured-profile-button">
             <img class="featured-profile-pic" src="<%= ProfileImage.new(@featured_story.user).get(90) %>" alt="<%= @featured_story.title %>" />
           </a>
-          <div class="featured-user-name"><a href="<%= @featured_story.user.path %>"><%= @featured_story.user.name %>・<%= @featured_story.readable_publish_date %></a></div>
+          <div class="featured-user-name"><a href="<%= @featured_story.user.path %>"><%= @featured_story.user.name %>・<%= @featured_story.readable_publish_date %><%= @featured_story.time_from_publish %></a></div>
           <div class="featured-tags tags">
             <% @featured_story.cached_tag_list_array.each do |tag| %>
               <a href="/t/<%= tag %>"><span class="tag">#<%= tag %></span></a>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -326,7 +326,7 @@
           <a href="<%= @featured_story.user.path %>" class="featured-profile-button">
             <img class="featured-profile-pic" src="<%= ProfileImage.new(@featured_story.user).get(90) %>" alt="<%= @featured_story.title %>" />
           </a>
-          <div class="featured-user-name"><a href="<%= @featured_story.user.path %>"><%= @featured_story.user.name %>・<%= @featured_story.readable_publish_date %><%= @featured_story.time_from_publish %></a></div>
+          <div class="featured-user-name"><a href="<%= @featured_story.user.path %>"><%= @featured_story.user.name %>・<%= @featured_story.readable_publish_date %><%= @featured_story.time_since_publish %></a></div>
           <div class="featured-tags tags">
             <% @featured_story.cached_tag_list_array.each do |tag| %>
               <a href="/t/<%= tag %>"><span class="tag">#<%= tag %></span></a>

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -478,37 +478,37 @@ RSpec.describe Article, type: :model do
 
   it "shows a second ago for 1 seconds from publish time" do
     article.published_at = Time.current
-    expect(article.time_from_publish).to eq("・a second ago")
+    expect(article.time_since_publish).to eq("・a second ago")
   end
 
   it "shows seconds ago for less than 60 seconds from publish time" do
     article.published_at = 5.second.ago
-    expect(article.time_from_publish).to eq("・5 seconds ago")
+    expect(article.time_since_publish).to eq("・5 seconds ago")
   end
 
   it "shows a minute ago for 1 minute from publish time" do
     article.published_at = 1.minute.ago
-    expect(article.time_from_publish).to eq("・a minute ago")
+    expect(article.time_since_publish).to eq("・a minute ago")
   end
 
   it "shows minutes ago for less than 60 minutes from publish time" do
     article.published_at = 50.minute.ago
-    expect(article.time_from_publish).to eq("・50 minutes ago")
+    expect(article.time_since_publish).to eq("・50 minutes ago")
   end
 
   it "shows an hour ago for 1 hour from publish time" do
     article.published_at = 1.hour.ago
-    expect(article.time_from_publish).to eq("・an hour ago")
+    expect(article.time_since_publish).to eq("・an hour ago")
   end
 
   it "shows hours ago for less than 24 hours from publish time" do
     article.published_at = 15.hour.ago
-    expect(article.time_from_publish).to eq("・15 hours ago")
+    expect(article.time_since_publish).to eq("・15 hours ago")
   end
 
   it "doesn't show ago time for more than 24 hours from publish time" do
     article.published_at = 24.hour.ago
-    expect(article.time_from_publish).to eq(nil)
+    expect(article.time_since_publish).to eq(nil)
   end
 end
 # rubocop:enable RSpec/ExampleLength, RSpec/MultipleExpectations

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -475,5 +475,40 @@ RSpec.describe Article, type: :model do
     last_year = 1.year.ago.year % 100
     expect(article.readable_publish_date.include?("'#{last_year}")).to eq(true)
   end
+
+  it "shows a second ago for 1 seconds from publish time" do
+    article.published_at = Time.current
+    expect(article.time_from_publish).to eq("・a second ago")
+  end
+
+  it "shows seconds ago for less than 60 seconds from publish time" do
+    article.published_at = 5.second.ago
+    expect(article.time_from_publish).to eq("・5 seconds ago")
+  end
+
+  it "shows a minute ago for 1 minute from publish time" do
+    article.published_at = 1.minute.ago
+    expect(article.time_from_publish).to eq("・a minute ago")
+  end
+
+  it "shows minutes ago for less than 60 minutes from publish time" do
+    article.published_at = 50.minute.ago
+    expect(article.time_from_publish).to eq("・50 minutes ago")
+  end
+
+  it "shows an hour ago for 1 hour from publish time" do
+    article.published_at = 1.hour.ago
+    expect(article.time_from_publish).to eq("・an hour ago")
+  end
+
+  it "shows hours ago for less than 24 hours from publish time" do
+    article.published_at = 15.hour.ago
+    expect(article.time_from_publish).to eq("・15 hours ago")
+  end
+
+  it "doesn't show ago time for more than 24 hours from publish time" do
+    article.published_at = 24.hour.ago
+    expect(article.time_from_publish).to eq(nil)
+  end
 end
 # rubocop:enable RSpec/ExampleLength, RSpec/MultipleExpectations


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Adding seconds, minutes and hours ago for posts in the feed for upto 24 hours.
## Related Tickets & Documents
#446 
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![screen shot 2018-08-26 at 9 15 24 pm](https://user-images.githubusercontent.com/8450195/44630077-f024a000-a975-11e8-8f6b-6a13c28c86a0.png)
![screen shot 2018-08-26 at 9 15 41 pm](https://user-images.githubusercontent.com/8450195/44630080-f3b82700-a975-11e8-8ef9-081e4b2f7954.png)

## Added to documentation?
  - [ ] docs.dev.to
  - [ ] readme
  - [x] no documentation needed
