### PR TITLE
Allow one tap copying when sharing link

### DIFF
--- a/app/assets/stylesheets/article-show.scss
+++ b/app/assets/stylesheets/article-show.scss
@@ -758,6 +758,31 @@ header{
             border-radius: 3px;
             margin: 10px auto 5px;
           }
+          #snackbar{
+            display: none;
+            min-width: 100px;
+            background-color: #333;
+            color: #fff;
+            text-align: center;
+            border-radius: 30px;
+            padding: 10px;
+            position: fixed;
+            z-index: 1;
+            left: 35%;
+            bottom: 30px;
+            &.showing {
+              display: block;
+              animation: fadein 0.5s, fadeout 0.5s 2.5s forwards;
+            }
+            @keyframes fadein {
+              from {bottom: 0; opacity: 0;}
+              to {bottom: 30px; opacity: 1;}
+            }
+            @keyframes fadeout {
+              from {bottom: 30px; opacity: 1;}
+              to {bottom: 0; opacity: 0;}
+            }
+          }
           a{
             font-weight: bold;
             color: $black;

--- a/app/views/articles/_actions.html.erb
+++ b/app/views/articles/_actions.html.erb
@@ -20,8 +20,19 @@
     </button>
     <div class="dropdown-content">
       <div>
+        <script async>
+          function copyLink() {
+            var copyButton = document.getElementById('copy-link')
+            copyButton.select()
+            document.execCommand('copy')
+            var snackbar = document.getElementById('snackbar')
+            snackbar.classList.add('showing')
+            setTimeout(() => { snackbar.classList.remove('showing') }, 3000 )
+          }
+        </script>
         <div class="dropdown-link-row">
-          <img src="<%= asset_path("link.svg") %>" /><input value="https://dev.to<%= @article.path %>" onClick="this.setSelectionRange(0, this.value.length)"/>
+          <img src="<%= asset_path("link.svg") %>" /><input id="copy-link" readonly value="https://dev.to<%= @article.path %>" onClick="copyLink()"/>
+          <div id='snackbar'>Copied!</div>
         </div>
         <div class="dropdown-link-row"><a href='https://twitter.com/intent/tweet?text="<%= @article.title %>" by <%= @article.user.twitter_username ? "@" + @article.user.twitter_username : @article.user.name %> https://dev.to<%= @article.path %>'>Share to Twitter</a></div>
         <div class="dropdown-link-row"><a href="/report-abuse">Report Abuse</a></div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Right now the behaviour for tapping on the link is just selecting the range. This PR is created to automatically copy the link to clipboard upon clicking.

## Related Tickets & Documents
#399 
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
<img src="https://user-images.githubusercontent.com/20277437/44630940-bfedf900-a997-11e8-91da-4e734e5b997f.gif" width="400">

## Added to documentation?
  - [ ] docs.dev.to
  - [ ] readme
  - [x] no documentation needed
