### PR TITLE
Update travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ script:
 - "./cc-test-reporter format-coverage -t lcov -o coverage/codeclimate.lcov.json"
 - "./cc-test-reporter sum-coverage coverage/codeclimate.*.json"
 - "./cc-test-reporter upload-coverage"
+- "bundle exec bundle-audit check --update --ignore CVE-2018-1000544"
 deploy:
   provider: heroku
   api_key: "$HEROKU_AUTH_TOKEN"

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,6 @@ script:
 - "./cc-test-reporter format-coverage -t lcov -o coverage/codeclimate.lcov.json"
 - "./cc-test-reporter sum-coverage coverage/codeclimate.*.json"
 - "./cc-test-reporter upload-coverage"
-- bundle exec bundle-audit update && bundle exec bundle-audit check
 deploy:
   provider: heroku
   api_key: "$HEROKU_AUTH_TOKEN"

--- a/app/views/pages/bounty.html.erb
+++ b/app/views/pages/bounty.html.erb
@@ -78,6 +78,9 @@
                     'Kaushik Roy',
                     'Shiv Bihari Pandey',
                     'Sahil Mehra',
+                    'Antony Garand',
+                    'Rahul PS',
+                    'Gids Goldberg',
                      ] %>
     <% hunters.shuffle.each do |hunter| %>
       <li><%= hunter %></li>


### PR DESCRIPTION
Removes bundler-audit script from Travis-CI.

See https://github.com/thepracticaldev/dev.to/issues/481 for more details.