### PR TITLE
[WIP] #509 Fix chat channels being blocked by footer

### DIFF
--- a/app/assets/stylesheets/chat.scss
+++ b/app/assets/stylesheets/chat.scss
@@ -605,7 +605,7 @@
   padding: 3px 0 10px;
   flex-grow: 1;
   overflow: scroll;
-  padding-bottom: 25px;
+  padding-bottom: 9vw;
   overflow-x: hidden;
 }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
`.chatchannels__config` is being placed over it. This change is to increase the padding so it pushes the content up from the `config` footer.

## Related Tickets & Documents
#509 

<img width="1552" alt="08-28-607pm-1" src="https://user-images.githubusercontent.com/20277437/44716641-83341600-aaed-11e8-81a8-25ba55e6c8ba.png">

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

- Desktop
<img width="800" alt="08-28-607pm-1" src="https://user-images.githubusercontent.com/20277437/44716641-83341600-aaed-11e8-81a8-25ba55e6c8ba.png">
- Pixel 2XL
<img width="380" alt="08-28-606pm" src="https://user-images.githubusercontent.com/20277437/44716682-a232a800-aaed-11e8-851e-5318595ea6e6.png">
- iPhone X (Bug?)
<img width="353" alt="08-28-607pm" src="https://user-images.githubusercontent.com/20277437/44716709-aeb70080-aaed-11e8-9c63-64a73a3f206e.png">

## Added to documentation?
  - [ ] docs.dev.to
  - [ ] readme
  - [ ] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?
![alt-text](gif-link)
