### PR TITLE
Remove open source announcement box

### DIFF
--- a/app/assets/stylesheets/sticky-nav.scss
+++ b/app/assets/stylesheets/sticky-nav.scss
@@ -47,32 +47,6 @@
       }
     }
   }
-  .primary-sticky-nav-countdown{
-    text-align: center;
-    padding-top: 15px !important;
-    padding-bottom: 20px !important;
-    img{
-      width:100%;
-      border-radius: 3px;
-    }
-    .primary-sticky-nav-countdown-timer-element{
-      padding: 14px 2px;
-      height: 30px;
-      font-size:1.5em;
-      background: $yellow;
-      border-radius: 3px;
-    }
-    .primary-sticky-nav-countdown-headline{
-      font-size:1.33em;
-      font-family: $helvetica-condensed;
-      padding: 16px 2px 3px;
-    }
-    a{
-      display: block;
-      padding: 10px 0px 0px;
-      color: $bold-blue;
-    }
-  }
   .primary-sticky-nav-profile-image{
     height: 23px;
     width: 23px;

--- a/app/views/articles/_sticky_nav.html.erb
+++ b/app/views/articles/_sticky_nav.html.erb
@@ -25,11 +25,6 @@
 </style>
 
 <div class="primary-sticky-nav">
-  <div class="primary-sticky-nav-element primary-sticky-nav-countdown">
-    <div class="primary-sticky-nav-countdown-headline" id="countdown-headline">dev.to is now open source!</div>
-    <a href="https://dev.to/ben/devto-is-now-open-source-5n1">View Announcement Post</a>
-    <a href="https://github.com/thepracticaldev/dev.to" target="_blank" rel="noopener" style="margin-bottom: 11px">View GitHub Repo</a>
-  </div>
   <div class="primary-sticky-nav-element primary-sticky-nav-author">
     <a href="<%= @actor.path %>"><img src="<%= ProfileImage.new(@actor).get(90) %>" class="primary-sticky-nav-author-top-profile-image" /></a>
     <span class="primary-sticky-nav-author-name">


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Removing the big box announcing open source. It's no longer timely, but I think we should add back in some other cues that you can contribute here.

The user's box is now back on top:

![](https://cl.ly/289e2d2d12f7/Image%202018-08-29%20at%2010.17.05%20AM.png)