### PR TITLE
redirect survey page to call for analysis

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -185,7 +185,7 @@ Rails.application.routes.draw do
   get "/welcome" => "pages#welcome"
   get "/💸", to: redirect("t/hiring")
   get "/security", to: "pages#bounty"
-  get "/survey", to: "pages#survey"
+  get "/survey", to: redirect("https://dev.to/devteam/state-of-the-web-data---call-for-analysis-2o75")
   get "/now" => "pages#now"
   get "/membership" => "pages#membership"
   get "/events" => "events#index"


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)
- [x] Other

## Description
There are external links (like the youtube video) pointing to dev.to/survey. Updating the route w/ the current call for analysis will be a better experience for people than landing on an expired survey. When the report is in, we should update again.

