### PR TITLE
Refactor badge rewarder, add contributor badge functionality, create rake tasks

### DIFF
--- a/app/labor/badge_rewarder.rb
+++ b/app/labor/badge_rewarder.rb
@@ -25,12 +25,20 @@ module BadgeRewarder
     end
   end
 
-  def self.reward_top_seven_badges(usernames)
+  def self.award_top_seven_badges(usernames, message_markdown = "Congrats!!!")
+    award_badges(usernames, "top-7", message_markdown)
+  end
+
+  def self.award_contributor_badges(usernames, message_markdown = "Thank you so much for your contributions!")
+    award_badges(usernames, "dev-contributor", message_markdown)
+  end
+
+  def self.award_badges(usernames, slug, message_markdown)
     User.where(username: usernames).each do |user|
       BadgeAchievement.create(
         user_id: user.id,
-        badge_id: Badge.find_by_slug("top-7").id,
-        rewarding_context_message_markdown: "Congrats!!!",
+        badge_id: Badge.find_by_slug(slug).id,
+        rewarding_context_message_markdown: message_markdown,
       )
       user.save
     end

--- a/lib/tasks/fetch.rake
+++ b/lib/tasks/fetch.rake
@@ -75,3 +75,20 @@ task award_badges: :environment do
   BadgeRewarder.award_yearly_club_badges
   BadgeRewarder.award_beloved_comment_badges
 end
+
+# rake award_top_seven_badges["ben jess peter mac liana andy"]
+task :award_top_seven_badges, [:arg1] => :environment do |t, args|
+  usernames = args[:arg1].split(" ")
+  puts "Awarding top-7 badges to #{usernames}"
+  BadgeRewarder.award_top_seven_badges(usernames)
+  puts "Done!"
+end
+
+# rake award_contributor_badges["ben jess peter mac liana andy"]
+task :award_contributor_badges, [:arg1] => :environment do |t, args|
+  usernames = args[:arg1].split(" ")
+  puts "Awarding dev-contributor badges to #{usernames}"
+  BadgeRewarder.award_contributor_badges(usernames)
+  puts "Done!"
+end
+

--- a/spec/labor/badge_rewarder_spec.rb
+++ b/spec/labor/badge_rewarder_spec.rb
@@ -34,7 +34,15 @@ RSpec.describe BadgeRewarder do
     badge = create(:badge, title: "Top 7")
     user = create(:user)
     user_other = create(:user)
-    described_class.reward_top_seven_badges([user.username, user_other.username])
+    described_class.award_top_seven_badges([user.username, user_other.username])
+    expect(BadgeAchievement.where(badge_id: badge.id).size).to eq(2)
+  end
+
+  it "rewards contributor badges" do
+    badge = create(:badge, title: "Dev Contributor")
+    user = create(:user)
+    user_other = create(:user)
+    described_class.award_contributor_badges([user.username, user_other.username])
     expect(BadgeAchievement.where(badge_id: badge.id).size).to eq(2)
   end
 end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
I created an `award_badges` method which the more specific methods can call. We barely need the specific ones, but in Ruby fashion, I think it's cool to have these specific methods.

I also added a rake task for each so they can be invoked from the command line.

`rake award_contributor_badges["ben jess peter mac liana andy"]` <- in that exact way, note the spaces and general guidelines.

In our case, it would be `heroku run award_contributor_badges["ben jess peter mac liana andy"]` to do this from command-line. Ultimately for niceties, we may eventually want our own custom admin cli (or general purpose DEV cli. But this should at least make our weekly routine more simple.

Both these things could be automated one step further which we can do, but doing it manually for a bit couldn't hurt in case we notice gotchas.

## [optional] What gif best describes this PR or how it makes you feel?
![alt-text](https://media.giphy.com/media/OFdCORvugWEb6/giphy.gif)
