### PR TITLE
Update bundle-audit step due to updated rubyzip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ script:
 - "./cc-test-reporter format-coverage -t lcov -o coverage/codeclimate.lcov.json"
 - "./cc-test-reporter sum-coverage coverage/codeclimate.*.json"
 - "./cc-test-reporter upload-coverage"
-- "bundle exec bundle-audit check --update --ignore CVE-2018-1000544"
+- "bundle exec bundle-audit check --update"
 deploy:
   provider: heroku
   api_key: "$HEROKU_AUTH_TOKEN"


### PR DESCRIPTION
rubyzip 1.2.1, responsible for https://nvd.nist.gov/vuln/detail/CVE-2018-1000544, has been superseded by rubyzip 1.2.2 which fixes the security vulnerability.

rubyzip 1.2.2 has been merged in this PR https://github.com/thepracticaldev/dev.to/pull/567

Hence, the code doesn't need to ignore it anymore

## What type of PR is this? (check all applicable)
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
## Related Tickets & Documents
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
## Added to documentation?
  - [ ] docs.dev.to
  - [ ] readme
  - [x ] no documentation needed
