### PR TITLE
#542 Add a link to Reading List for easier access

### DIFF
--- a/app/views/layouts/_nav_menu.html.erb
+++ b/app/views/layouts/_nav_menu.html.erb
@@ -15,6 +15,11 @@
         Write a Post
       </div>
     </a>
+    <a href="/readinglist">
+      <div class="option">
+        Reading List
+      </div>
+    </a>
     <a href="/settings">
       <div class="option">
         Settings


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Add a link to access `Reading List` from top nav bar's dropdown

- Currently, it takes three steps from an article in order to access Reading List, this change reduce that to 2 steps from any page.
- It doesn't really make sense to force a user to go back to the homepage in order to go read their Reading List

## Related Tickets & Documents
#542 
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
<img src="https://user-images.githubusercontent.com/20277437/44932674-fc0aca80-ad98-11e8-839b-2e85653a5593.png" width="400">

## Added to documentation?
  - [ ] docs.dev.to
  - [ ] readme
  - [x] no documentation needed
