### PR TITLE
Fixed the overflowing user name in the top bar under profile thumbnail

### DIFF
--- a/app/assets/stylesheets/top-bar.scss
+++ b/app/assets/stylesheets/top-bar.scss
@@ -246,7 +246,8 @@
           margin-bottom: 5px;
           font-size: 1.22em;
           font-weight: 500;
-          overflow-wrap: break-word;
+          overflow: hidden;
+          text-overflow: ellipsis;
         }
         &:hover {
           background: darken($tan, 2%);

--- a/app/assets/stylesheets/top-bar.scss
+++ b/app/assets/stylesheets/top-bar.scss
@@ -246,6 +246,7 @@
           margin-bottom: 5px;
           font-size: 1.22em;
           font-weight: 500;
+          overflow-wrap: break-word;
         }
         &:hover {
           background: darken($tan, 2%);


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
<img width="1379" alt="screen shot 2018-09-04 at 9 27 01 pm" src="https://user-images.githubusercontent.com/5854475/45042852-4df96c00-b089-11e8-89bf-f477a10488d0.png">

- [ ] Documentation Update

## Description
If the user name is too long it flows out of the div tag. I've just added the break-word to fix this.
## Related Tickets & Documents
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
## Added to documentation?
  - [ ] docs.dev.to
  - [ ] readme
  - [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?
![alt-text](gif-link)
