### PR TITLE
Add nofollow to /moderate links

### DIFF
--- a/app/assets/javascripts/initializers/initializeBaseUserData.js
+++ b/app/assets/javascripts/initializers/initializeBaseUserData.js
@@ -43,9 +43,9 @@ function addRelevantButtonsToArticle(user) {
   var articleContainer = document.getElementById('article-show-container');
   if (articleContainer) {
     if (parseInt(articleContainer.dataset.authorId) == user.id) {
-      document.getElementById('action-space').innerHTML = '<a href="' + articleContainer.dataset.path + '/edit">EDIT <span class="post-word">POST</span></a>';
+      document.getElementById('action-space').innerHTML = '<a href="' + articleContainer.dataset.path + '/edit" rel="nofollow">EDIT <span class="post-word">POST</span></a>';
     } else if (user.trusted) {
-      document.getElementById('action-space').innerHTML = '<a href="' + articleContainer.dataset.path + '/mod">MODERATE <span class="post-word">POST</span></a>';
+      document.getElementById('action-space').innerHTML = '<a href="' + articleContainer.dataset.path + '/mod" rel="nofollow">MODERATE <span class="post-word">POST</span></a>';
     }
   }
   var commentsContainer = document.getElementById('comments-container');

--- a/app/views/moderations/mod.html.erb
+++ b/app/views/moderations/mod.html.erb
@@ -23,7 +23,7 @@
 </style>
 
 <div class="container" style="text-align: center">
-  <h2>MODERATE: <a href="<%= @moderatable.path %>"><%= @moderatable.title %></a></h2>
+  <h2>MODERATE: <a href="<%= @moderatable.path %>" rel="nofollow"><%= @moderatable.title %>></a></h2>
 
   <button class="reaction-button <%= Reaction.cached_any_reactions_for?(@moderatable, current_user, "thumbsdown") ? "reacted" : "" %>" data-reactable-id="<%= @moderatable.id %>" data-category="thumbsdown" data-reactable-type="<%= @moderatable.class.name %>">
     <%= image_tag "emoji/emoji-one-thumbs-down-gray.png" %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
I added `rel="nofollow"` to /mod and /edit links for comments, as well as the moderate page. Latter is probably unnecessary.

Closes #510.

## Added to documentation?
  - [x] no documentation needed