### PR TITLE
Update profile links regex to allow trailing slash

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -56,7 +56,7 @@ class User < ApplicationRecord
   validates :website_url, url: { allow_blank: true, no_local: true, schemes: ["https", "http"] }
   # rubocop:disable Metrics/LineLength
   validates :facebook_url,
-              format: /\Ahttps:\/\/(www.facebook.com|facebook.com)\/([a-zA-Z0-9]{5,50})\/?\Z/,
+              format: /\Ahttps:\/\/(www.facebook.com|facebook.com)\/(?=([a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*)).{5,50}\/?\Z/,
               allow_blank: true
   validates :stackoverflow_url,
               allow_blank: true,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -56,22 +56,22 @@ class User < ApplicationRecord
   validates :website_url, url: { allow_blank: true, no_local: true, schemes: ["https", "http"] }
   # rubocop:disable Metrics/LineLength
   validates :facebook_url,
-              format: /\Ahttps:\/\/(www.facebook.com|facebook.com)\/([a-zA-Z0-9]{5,50})\Z/,
+              format: /\Ahttps:\/\/(www.facebook.com|facebook.com)\/([a-zA-Z0-9]{5,50})\/?\Z/,
               allow_blank: true
   validates :stackoverflow_url,
               allow_blank: true,
               format:
-              /\Ahttps:\/\/(www.stackoverflow.com|stackoverflow.com)\/users\/([0-9]{3,10})\/([a-zA-Z0-9\s\'\-]{3,30})\Z/
+              /\Ahttps:\/\/(www.stackoverflow.com|stackoverflow.com)\/users\/([0-9]{3,10})\/([a-zA-Z0-9\s\'\-]{3,30})\/?\Z/
   validates :behance_url,
               allow_blank: true,
-              format: /\Ahttps:\/\/(www.behance.net|behance.net)\/([a-zA-Z0-9\-\_]{3,20})\Z/
+              format: /\Ahttps:\/\/(www.behance.net|behance.net)\/([a-zA-Z0-9\-\_]{3,20})\/?\Z/
   validates :linkedin_url,
               allow_blank: true,
               format:
-                /\Ahttps:\/\/(www.linkedin.com|linkedin.com|[A-Za-z]{2}.linkedin.com)\/in\/([a-zA-Z0-9\-]{3,100})\Z/
+                /\Ahttps:\/\/(www.linkedin.com|linkedin.com|[A-Za-z]{2}.linkedin.com)\/in\/([a-zA-Z0-9\-]{3,100})\/?\Z/
   validates :dribbble_url,
               allow_blank: true,
-              format: /\Ahttps:\/\/(www.dribbble.com|dribbble.com)\/([a-zA-Z0-9\-\_]{2,20})\Z/
+              format: /\Ahttps:\/\/(www.dribbble.com|dribbble.com)\/([a-zA-Z0-9\-\_]{2,20})\/?\Z/
   # rubocop:enable Metrics/LineLength
   validates :employer_url, url: { allow_blank: true, no_local: true, schemes: ["https", "http"] }
   validates :shirt_gender,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -56,7 +56,7 @@ class User < ApplicationRecord
   validates :website_url, url: { allow_blank: true, no_local: true, schemes: ["https", "http"] }
   # rubocop:disable Metrics/LineLength
   validates :facebook_url,
-              format: /\Ahttps:\/\/(www.facebook.com|facebook.com)\/[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*\/?\Z/,
+              format: /\Ahttps:\/\/(www.facebook.com|facebook.com)\/[a-zA-Z0-9.]+\/?\Z/,
               allow_blank: true
   validates :stackoverflow_url,
               allow_blank: true,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -56,7 +56,7 @@ class User < ApplicationRecord
   validates :website_url, url: { allow_blank: true, no_local: true, schemes: ["https", "http"] }
   # rubocop:disable Metrics/LineLength
   validates :facebook_url,
-              format: /\Ahttps:\/\/(www.facebook.com|facebook.com)\/(?=([a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*)).{5,50}\/?\Z/,
+              format: /\Ahttps:\/\/(www.facebook.com|facebook.com)\/[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*\/?\Z/,
               allow_blank: true
   validates :stackoverflow_url,
               allow_blank: true,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -56,7 +56,7 @@ class User < ApplicationRecord
   validates :website_url, url: { allow_blank: true, no_local: true, schemes: ["https", "http"] }
   # rubocop:disable Metrics/LineLength
   validates :facebook_url,
-              format: /\Ahttps:\/\/(www.facebook.com|facebook.com)\/[a-zA-Z0-9.]+\/?\Z/,
+              format: /\Ahttps:\/\/(www.facebook.com|facebook.com)\/[a-zA-Z0-9.]{5,50}\/?\Z/,
               allow_blank: true
   validates :stackoverflow_url,
               allow_blank: true,

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -66,8 +66,10 @@ RSpec.describe User, type: :model do
     end
 
     it "accepts valid https facebook url" do
-      user.facebook_url = "https://facebook.com/thepracticaldev"
-      expect(user).to be_valid
+      %w(thepracticaldev thepracticaldev/).each do |username|
+        user.facebook_url = "https://facebook.com/#{username}"
+        expect(user).to be_valid
+      end
     end
 
     it "does not accept invalid facebook url" do
@@ -76,8 +78,10 @@ RSpec.describe User, type: :model do
     end
 
     it "accepts valid https behance url" do
-      user.behance_url = "https://behance.net/jess"
-      expect(user).to be_valid
+      %w(jess jess/ je-ss jes_ss).each do |username|
+        user.behance_url = "https://behance.net/#{username}"
+        expect(user).to be_valid
+      end
     end
 
     it "does not accept invalid behance url" do
@@ -86,8 +90,10 @@ RSpec.describe User, type: :model do
     end
 
     it "accepts valid https stackoverflow url" do
-      user.stackoverflow_url = "https://stackoverflow.com/users/7381391/pandyzhao"
-      expect(user).to be_valid
+      %w(pandyzhao pandyzhao/ pandy-zhao).each do |username|
+        user.stackoverflow_url = "https://stackoverflow.com/users/7381391/#{username}"
+        expect(user).to be_valid
+      end
     end
 
     it "does not accept invalid stackoverflow url" do
@@ -96,8 +102,10 @@ RSpec.describe User, type: :model do
     end
 
     it "accepts valid https linkedin url" do
-      user.linkedin_url = "https://linkedin.com/in/jessleenyc"
-      expect(user).to be_valid
+      %w(jessleenyc jessleenyc/ jess-lee-nyc).each do |username|
+        user.linkedin_url = "https://linkedin.com/in/#{username}"
+        expect(user).to be_valid
+      end
     end
 
     it "accepts valid country specific https linkedin url" do
@@ -121,8 +129,10 @@ RSpec.describe User, type: :model do
     end
 
     it "accepts valid https dribbble url" do
-      user.dribbble_url = "https://dribbble.com/jess"
-      expect(user).to be_valid
+      %w(jess jess/ je-ss je_ss).each do |username|
+        user.dribbble_url = "https://dribbble.com/#{username}"
+        expect(user).to be_valid
+      end
     end
 
     it "does not accept invalid dribbble url" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe User, type: :model do
     end
 
     it "accepts valid https facebook url" do
-      %w(thepracticaldev thepracticaldev/).each do |username|
+      %w(thepracticaldev thepracticaldev/ the.practical.dev).each do |username|
         user.facebook_url = "https://facebook.com/#{username}"
         expect(user).to be_valid
       end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Documentation Update

## Description
Previously, for all links in the profile section "Links", trailing slashes would cause a validation failure.

Summary of changes:
* Update all regexes for link validation to allow trailing slashes
* Update specs for link validation to include variations of valid usernames
* Update Facebook regex to allow dots (see discussion in #595)

## Related Tickets & Documents
Resolves #595 

## Added to documentation?
  - [ ] docs.dev.to
  - [ ] readme
  - [X] no documentation needed