### PR TITLE
Update analytics controller to prevent viewing other people's analytics

### DIFF
--- a/app/controllers/analytics_controller.rb
+++ b/app/controllers/analytics_controller.rb
@@ -6,8 +6,8 @@ class AnalyticsController < ApplicationController
 
   def index
     article_ids = analytics_params.split(",")
-    article_to_check = Article.find_by(id: article_ids.first)
-    authorize article_to_check, :analytics_index?
+    articles_to_check = Article.where(id: article_ids)
+    authorize articles_to_check, :analytics_index?
     cache_name = "pageviews-#{article_ids}/dashboard-index"
     pageviews = Rails.cache.fetch(cache_name, expires_in: 15.minutes) do
       GoogleAnalytics.new(article_ids).get_pageviews

--- a/app/policies/article_policy.rb
+++ b/app/policies/article_policy.rb
@@ -36,7 +36,11 @@ class ArticlePolicy < ApplicationPolicy
   private
 
   def user_is_author?
-    record.user_id == user.id
+    if record.instance_of?(Article)
+      record.user_id == user.id
+    else
+      record.pluck(:user_id).uniq == [user.id]
+    end
   end
 
   def user_org_admin?

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -53,6 +53,14 @@ FactoryBot.define do
       after(:build) { |user| user.add_role(:analytics_beta_tester) }
     end
 
+    trait :org_admin do
+      after(:build) do |user|
+        org = create(:organization)
+        user.organization_id = org.id
+        user.org_admin = true
+      end
+    end
+
     after(:create) do |user|
       create(:identity, user_id: user.id)
     end

--- a/spec/policies/article_policy_spec.rb
+++ b/spec/policies/article_policy_spec.rb
@@ -20,13 +20,13 @@ RSpec.describe ArticlePolicy do
     let(:user) { build(:user) }
 
     it { is_expected.to permit_actions(%i[new create preview]) }
-    it { is_expected.to forbid_actions(%i[update delete_confirm destroy]) }
+    it { is_expected.to forbid_actions(%i[update delete_confirm destroy analytics_index]) }
 
     context "with banned status" do
       before { user.add_role :banned }
 
       it { is_expected.to permit_actions(%i[new preview]) }
-      it { is_expected.to forbid_actions(%i[create update delete_confirm destroy]) }
+      it { is_expected.to forbid_actions(%i[create update delete_confirm destroy analytics_index]) }
     end
   end
 
@@ -47,5 +47,47 @@ RSpec.describe ArticlePolicy do
     let(:user) { build(:user, :super_admin) }
 
     it { is_expected.to permit_actions(%i[update new create delete_confirm destroy preview]) }
+  end
+
+  context "when user does not have any analytics permission" do
+    let(:user) { build(:user) }
+
+    it { is_expected.to forbid_action(:analytics_index) }
+  end
+
+  context "when trying to view analytics with proper permissions" do
+    let(:org_admin)         { build(:user, :org_admin) }
+    let(:super_admin)       { build(:user, :super_admin) }
+    let(:analytics_user)    { build(:user, :analytics, organization_id: org_admin.organization_id) }
+    let(:article) do
+      build(:article, user_id: analytics_user.id, organization_id: org_admin.organization_id)
+    end
+
+    it "allows all users to view analytics" do
+      described_classes = [org_admin, super_admin, analytics_user].map do |user|
+        described_class.new(user, article)
+      end
+      expect(described_classes).to all(permit_action(:analytics_index))
+    end
+  end
+
+  context "when a user with analytics tries to view someone else's article" do
+    let(:user)          { create(:user, :analytics) }
+    let(:other_user)    { create(:user, :analytics) }
+    let(:article)       { create(:article, user_id: user.id) }
+    let(:article2)      { create(:article, user_id: other_user.id) }
+
+    it "forbids the first user from viewing the other user's analytics via their article" do
+      expect(described_class.new(user, article2)).to forbid_action(:analytics_index)
+    end
+
+    it "forbids the other user from viewing the first user's analytics" do
+      expect(described_class.new(other_user, article)).to forbid_action(:analytics_index)
+    end
+
+    it "forbids them from viewing another person's analytics even if their article is first" do
+      articles = Article.all
+      expect(described_class.new(user, articles)).to forbid_action(:analytics_index)
+    end
   end
 end

--- a/spec/requests/analytics_spec.rb
+++ b/spec/requests/analytics_spec.rb
@@ -1,16 +1,16 @@
 require "rails_helper"
 
 vcr_option = {
-  cassette_name: "google_api_request_spec",
+  cassette_name: "google_api_request_spec"
 }
 
 RSpec.describe "Analytics", type: :request, vcr: vcr_option do
   describe "GET /analytics" do
     context "when signed in as an authorized user" do
-      let(:user) { create(:user, :analytics) }
-      let(:article1) { create(:article, user_id: user.id) }
-      let(:article2) { create(:article, user_id: user.id) }
-      let(:ga_double) { instance_double(GoogleAnalytics) }
+      let(:user)                { create(:user, :analytics) }
+      let(:article1)            { create(:article, user_id: user.id) }
+      let(:article2)            { create(:article, user_id: user.id) }
+      let(:ga_double)           { instance_double(GoogleAnalytics) }
 
       before do
         allow(GoogleAnalytics).to receive(:new).and_return(ga_double)


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This fixes #578 and prevents a user from viewing other people's analytics.

## Added to documentation?
  - [x] no documentation needed
