### PR TITLE
fix badge sizing on internal user show page

### DIFF
--- a/app/views/internal/users/show.html.erb
+++ b/app/views/internal/users/show.html.erb
@@ -20,10 +20,10 @@
   <% else %>
     <p>Admins cannot publish from RSS ❌<p>
   <% end %>
-  <h3>Badges</h3>
+  <h3><u>Badges</u></h3>
   <% if @user.badges.count > 0 %>
     <% @user.badges.each do |badge| %>
-      <img src="<%= badge.badge_image_url %>">
+      <img style="max-width: 230px;" src="<%= badge.badge_image_url %>">
     <% end %>
   <% end %>
   <h3><u>Mentorship Details</u></h3>
@@ -36,13 +36,13 @@
     <%= f.label :offering_mentorship %>
     <%= f.check_box :offering_mentorship %>
     <br>
-    <% if @user.mentor_description %>
+    <% if !@user.mentor_description.blank? %>
       <p>"<%= @user.mentor_description %>"</p>
     <% end %>
     <%= f.label :seeking_mentorship %>
     <%= f.check_box :seeking_mentorship %>
     <br>
-    <% if @user.mentee_description %>
+    <% if !@user.mentee_description.blank? %>
       <p>"<%= @user.mentee_description %>"</p>
     <% end %>
     <h3><u>Mentorship Matches</u> </h3>
@@ -60,6 +60,9 @@
         </li>
       <% end %>
       </ul>
+    <% else %>
+      <em>This member does not have any mentorship relationships right now.</em>
+      </br>
     <% end %>
     <br>
     <%= f.label :add_mentor %>


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)
- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
- add max-width to badge images on user dashboard so they are not gigantic
- hide blank description when users haven't filled out the mentorship forms

## Related Tickets & Documents
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![](https://cl.ly/4c6241c02f99/download/Image%202018-09-12%20at%201.23.23%20PM.png)
## Added to documentation?
  - [ ] docs.dev.to
  - [ ] readme
  - [x] no documentation needed
