### PR TITLE
Fix notification cache typo

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -57,7 +57,7 @@ module StreamRails
           includes(:user, :commentable)
       when "Reaction"
         model.classify.constantize.where(id: ids.keys).
-          includes(reactable: :user)
+          includes(:reactable, :user)
       when "Article"
         model.classify.constantize.where(id: ids.keys).
           select(:id, :title, :path, :user_id, :updated_at, :cached_tag_list)


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
We can't cache `Reaction` query with `includes(reactable: :user)` because `User` is not a valid reactable.
## Added to documentation?
  - [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?
![alt-text](https://media.giphy.com/media/26ufdipQqU2lhNA4g/giphy-downsized.gif)
