### PR TITLE
Add spring to rspec

### DIFF
--- a/bin/rspec
+++ b/bin/rspec
@@ -1,4 +1,9 @@
 #!/usr/bin/env ruby
+begin
+  load File.expand_path('../spring', __FILE__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
+end
 # frozen_string_literal: true
 
 #

--- a/bin/spring
+++ b/bin/spring
@@ -4,14 +4,14 @@
 # It gets overwritten when you run the `spring binstub` command.
 
 unless defined?(Spring)
-  require "rubygems"
-  require "bundler"
+  require 'rubygems'
+  require 'bundler'
 
   lockfile = Bundler::LockfileParser.new(Bundler.default_lockfile.read)
   spring = lockfile.specs.detect { |spec| spec.name == "spring" }
   if spring
     Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
-    gem "spring", spring.version
-    require "spring/binstub"
+    gem 'spring', spring.version
+    require 'spring/binstub'
   end
 end


### PR DESCRIPTION
Running dev.to tests is always slow on my machine. I googled "make rspec faster" and found this quick fix, ie. adding spring to rspec.

Kudos to @schwad's article https://schwad.github.io/ruby/rails/testing/2017/08/14/50-times-faster-rspec-loading.html

I think it can be made much faster (CI runs the whole suite in 3 minutes) but this is a non destructive quick win :-)

## What type of PR is this? (check all applicable)
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

Before:

```shell
$ time ./bin/rspec spec/labor
Finished in 1 minute 3.46 seconds (files took 34.35 seconds to load)
61.36s user 14.82s system 100.69s real 426400kB mem -- ./bin/rspec spec/labor
```

After:

```shell
$ time ./bin/rspec spec/labor
Running via Spring preloader in process 79151
Finished in 44.97 seconds (files took 1.76 seconds to load)
0.32s user 0.08s system 48.66s real 18740kB mem -- ./bin/rspec spec/labor
```

The occupied memory also went down from 426 MB (?) to 18 MB

## Related Tickets & Documents
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
## Added to documentation?
  - [ ] docs.dev.to
  - [ ] readme
  - [x] no documentation needed
