### PR TITLE
Support RunKit preamble

### DIFF
--- a/app/liquid_tags/runkit_tag.rb
+++ b/app/liquid_tags/runkit_tag.rb
@@ -8,8 +8,9 @@ class RunkitTag < Liquid::Block
     content = Nokogiri::HTML.parse(super)
     parsed_content = content.xpath("//html/body").text
     html = <<~HTML
-      <div class="runkit-element" data-preamble="#{@preamble}">
-        #{parsed_content}
+      <div class="runkit-element">
+        <code style="display: none">#{@preamble}</code>
+        <code>#{parsed_content}</code>
       </div>
     HTML
     html
@@ -19,8 +20,8 @@ class RunkitTag < Liquid::Block
     <<~JAVASCRIPT
       var targets = document.getElementsByClassName("runkit-element");
       for (var i = 0; i < targets.length; i++) {
-        var content = targets[i].textContent;
-        var preamble = targets[i].dataset.preamble;
+        var preamble = targets[i].children[0].textContent;
+        var content = targets[i].children[1].textContent;
         targets[i].innerHTML = "";
         var notebook = RunKit.createNotebook({
           element: targets[i],
@@ -37,8 +38,8 @@ class RunkitTag < Liquid::Block
         if(typeof(RunKit) !== 'undefined') {
           var targets = document.getElementsByClassName("runkit-element");
           for (var i = 0; i < targets.length; i++) {
-            var content = targets[i].textContent;
-            var preamble = targets[i].dataset.preamble;
+            var preamble = targets[i].children[0].textContent;
+            var content = targets[i].children[1].textContent;
             if(/^(\<iframe src)/.test(content) === false) {
               targets[i].innerHTML = "";
               var notebook = RunKit.createNotebook({

--- a/app/liquid_tags/runkit_tag.rb
+++ b/app/liquid_tags/runkit_tag.rb
@@ -18,17 +18,15 @@ class RunkitTag < Liquid::Block
   def self.special_script
     <<~JAVASCRIPT
       var targets = document.getElementsByClassName("runkit-element");
-      if (targets.length > 0) {
-        for (var i = 0; i < targets.length; i++) {
-          var content = targets[i].textContent;
-          var preamble = targets[i].dataset.preamble;
-          targets[i].innerHTML = "";
-          var notebook = RunKit.createNotebook({
-            element: targets[i],
-            source: content,
-            preamble: preamble
-          });
-        }
+      for (var i = 0; i < targets.length; i++) {
+        var content = targets[i].textContent;
+        var preamble = targets[i].dataset.preamble;
+        targets[i].innerHTML = "";
+        var notebook = RunKit.createNotebook({
+          element: targets[i],
+          source: content,
+          preamble: preamble
+        });
       }
     JAVASCRIPT
   end
@@ -38,18 +36,16 @@ class RunkitTag < Liquid::Block
       var checkRunkit = setInterval(function() {
         if(typeof(RunKit) !== 'undefined') {
           var targets = document.getElementsByClassName("runkit-element");
-          if (targets.length > 0) {
-            for (var i = 0; i < targets.length; i++) {
-              var content = targets[i].textContent;
-              var preamble = targets[i].dataset.preamble;
-              if(/^(\<iframe src)/.test(content) === false) {
-                targets[i].innerHTML = "";
-                var notebook = RunKit.createNotebook({
-                  element: targets[i],
-                  source: content,
-                  preamble: preamble
-                });
-              }
+          for (var i = 0; i < targets.length; i++) {
+            var content = targets[i].textContent;
+            var preamble = targets[i].dataset.preamble;
+            if(/^(\<iframe src)/.test(content) === false) {
+              targets[i].innerHTML = "";
+              var notebook = RunKit.createNotebook({
+                element: targets[i],
+                source: content,
+                preamble: preamble
+              });
             }
           }
           clearInterval(checkRunkit);

--- a/app/liquid_tags/runkit_tag.rb
+++ b/app/liquid_tags/runkit_tag.rb
@@ -1,7 +1,7 @@
 class RunkitTag < Liquid::Block
   def initialize(tag_name, markup, tokens)
     super
-    @preamble = sanitize(markup, tags: [])
+    @preamble = ActionView::Base.full_sanitizer.sanitize(markup, tags: [])
   end
 
   def render(context)

--- a/app/liquid_tags/runkit_tag.rb
+++ b/app/liquid_tags/runkit_tag.rb
@@ -1,14 +1,14 @@
 class RunkitTag < Liquid::Block
   def initialize(tag_name, markup, tokens)
     super
-    @markup = markup
+    @preamble = sanitize(markup, tags: [])
   end
 
   def render(context)
     content = Nokogiri::HTML.parse(super)
     parsed_content = content.xpath("//html/body").text
     html = <<~HTML
-      <div class="runkit-element">
+      <div class="runkit-element" data-preamble="#{@preamble}">
         #{parsed_content}
       </div>
     HTML
@@ -21,10 +21,12 @@ class RunkitTag < Liquid::Block
       if (targets.length > 0) {
         for (var i = 0; i < targets.length; i++) {
           var content = targets[i].textContent;
+          var preamble = targets[i].dataset.preamble;
           targets[i].innerHTML = "";
           var notebook = RunKit.createNotebook({
             element: targets[i],
             source: content,
+            preamble: preamble
           });
         }
       }
@@ -39,11 +41,13 @@ class RunkitTag < Liquid::Block
           if (targets.length > 0) {
             for (var i = 0; i < targets.length; i++) {
               var content = targets[i].textContent;
+              var preamble = targets[i].dataset.preamble;
               if(/^(\<iframe src)/.test(content) === false) {
                 targets[i].innerHTML = "";
                 var notebook = RunKit.createNotebook({
                   element: targets[i],
                   source: content,
+                  preamble: preamble
                 });
               }
             }

--- a/app/liquid_tags/runkit_tag.rb
+++ b/app/liquid_tags/runkit_tag.rb
@@ -38,9 +38,10 @@ class RunkitTag < Liquid::Block
         if(typeof(RunKit) !== 'undefined') {
           var targets = document.getElementsByClassName("runkit-element");
           for (var i = 0; i < targets.length; i++) {
-            var preamble = targets[i].children[0].textContent;
-            var content = targets[i].children[1].textContent;
-            if(/^(\<iframe src)/.test(content) === false) {
+            var wrapperContent = targets[i].textContent;
+            if(/^(\<iframe src)/.test(wrapperContent) === false) {
+              var preamble = targets[i].children[0].textContent;
+              var content = targets[i].children[1].textContent;
               targets[i].innerHTML = "";
               var notebook = RunKit.createNotebook({
                 element: targets[i],

--- a/app/views/pages/_editor_guide_text.html.erb
+++ b/app/views/pages/_editor_guide_text.html.erb
@@ -136,7 +136,7 @@
 
     <h3><strong>RunKit Embed</strong></h3>
     <p>Put executable code within a runkit liquid block, as follows:</p>
-    <pre>{% runkit %}<br>console.log("Place javascript here!"); <br>{% endrunkit %} <br></pre>
+    <pre>{% runkit<br>// hidden setup JavaScript code goes in this preamble area<br>const hiddenVar = 42<br>%}<br>// visible, reader-editable JavaScript code goes here<br>console.log(hiddenVar)<br>{% endrunkit %} <br></pre>
 
     <h3><strong>repl.it Embed</strong></h3>
     <p>All you need is the URL after the domain name:</p>

--- a/spec/liquid_tags/runkit_tag_spec.rb
+++ b/spec/liquid_tags/runkit_tag_spec.rb
@@ -2,6 +2,12 @@ require "rails_helper"
 
 RSpec.describe RunkitTag, type: :liquid_template do
   describe "#render" do
+    let(:preamble) do
+      <<~CODE
+        const myVar = 9001
+      CODE
+    end
+
     let(:content) do
       <<~CODE
         // GeoJSON!
@@ -11,22 +17,22 @@ RSpec.describe RunkitTag, type: :liquid_template do
       CODE
     end
 
-    def generate_new_liquid(block)
+    def generate_new_liquid(preamble_str, block)
       Liquid::Template.register_tag("runkit", described_class)
-      Liquid::Template.parse("{% runkit %}#{block}{% endrunkit %}")
+      Liquid::Template.parse("{% runkit #{preamble_str}%}#{block}{% endrunkit %}")
     end
 
-    def generate_script(block)
+    def generate_script(preamble_str, block)
       <<~HTML
-        <div class="runkit-element">
+        <div class="runkit-element" data-preamble="#{preamble_str}">
           #{block}
         </div>
       HTML
     end
 
     it "generates proper div with content" do
-      liquid = generate_new_liquid(content)
-      expect(liquid.render).to eq(generate_script(content))
+      liquid = generate_new_liquid(preamble, content)
+      expect(liquid.render).to eq(generate_script(preamble, content))
     end
   end
 end

--- a/spec/liquid_tags/runkit_tag_spec.rb
+++ b/spec/liquid_tags/runkit_tag_spec.rb
@@ -24,8 +24,9 @@ RSpec.describe RunkitTag, type: :liquid_template do
 
     def generate_script(preamble_str, block)
       <<~HTML
-        <div class="runkit-element" data-preamble="#{preamble_str}">
-          #{block}
+        <div class="runkit-element">
+          <code style="display: none">#{preamble_str}</code>
+          <code>#{block}</code>
         </div>
       HTML
     end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

RunKit is an embed for reader-editable JavaScript code snippets. Dev.to supports RunKit embeds but not the _preamble_, which is hidden setup code. This PR adds support for the preamble field, which can now be placed within the opening tag:

```
{% runkit
const secret = 'shhhh' // <- this part is new
%}
console.log(secret)
{% endrunkit %}
```

Readers do not see the preamble directly, but can interact with any global variables initialized in it. This is ideal for tutorials / challenges, or just cleaning up imports & setup which are necessary but noisy.

Some considerations:

- I do not know Ruby, so there may be better ways of accomplishing this PR. Please sanity-check the code.
- The existing JS had a superfluous if-check for `length` which was already implicit in the for loop. I removed it on principle.
- This is not the only way in theory that the preamble could be supported, syntactically, but was the simplest way I could see. As a downside, if more arguments are ever desired for the RunKit tag, this would require refactoring.
- Currently, the code leaves the preamble string in the DOM as a `data-preamble` attribute on the wrapping runkit `div`. It could be removed if desired, though it didn't seem necessary.

In addition, I changed the editor help guide to reflect this new feature. I will attach screenshots to demonstrate, though of course you can see the changes in the source as well.

## Related Tickets & Documents

Closes #662

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![screen shot 2018-09-18 at 00 14 26](https://user-images.githubusercontent.com/7230206/45664127-48b00e80-bad8-11e8-974c-5dd99046fb92.jpg)
![screen shot 2018-09-18 at 00 14 47](https://user-images.githubusercontent.com/7230206/45664128-48b00e80-bad8-11e8-8d08-fafa41439e02.jpg)
![screen shot 2018-09-18 at 00 12 42](https://user-images.githubusercontent.com/7230206/45664124-451c8780-bad8-11e8-9208-2710249b8eec.jpg)
![screen shot 2018-09-18 at 00 16 32](https://user-images.githubusercontent.com/7230206/45664129-48b00e80-bad8-11e8-8d57-1cec8f39a8a2.jpg)

## Added to documentation?
  - [ ] docs.dev.to
  - [ ] readme
  - [x] no documentation needed