### PR TITLE
Fix FOLLOWING button

### DIFF
--- a/app/assets/stylesheets/sticky-nav.scss
+++ b/app/assets/stylesheets/sticky-nav.scss
@@ -39,7 +39,7 @@
     .primary-sticky-nav-author-follow{
       padding-top:8px;
       button{
-        width:135px;
+        width:136px;
         font-size:1.1em;
         border:0px;
         border-radius:3px;


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

I use Chrome 69.
 `✓ FOLLOWING` button is broken the line as below.

```
✓
FOLLOWING
````

This fixs this problem.

## Related Tickets & Documents
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
## Added to documentation?
  - [ ] docs.dev.to
  - [ ] readme
  - [ ] no documentation needed


