### PR TITLE
docs: add upstream sync and setup shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ Inside your dev.to directory, add a remote to the official dev.to repo:
 $ git remote add upstream https://github.com/thepracticaldev/dev.to.git
 ```
 
+Optionally, you can run two commands to setup and sync your fork:
+  * `npm run upstream:setup` Will perform the above command
+  * `npm run upstream:sync` Will checkout the master branch and pull the master branch from Dev.to into your local master branch.
+
 #### Rebasing from Upstream
 Do this prior to every time you create a branch for a PR:
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "test:watch": "jest app/javascript/ --watch",
     "storybook": "start-storybook -p 6006 -c app/javascript/.storybook -s app/javascript/.storybook/assets",
     "build-storybook": "build-storybook -c app/javascript/.storybook -s app/javascript/.storybook/assets",
-    "precommit": "lint-staged"
+    "precommit": "lint-staged",
+    "upstream:sync": "git checkout master; git pull upstream master;",
+    "upstream:connect": "git remote add upstream https://github.com/thepracticaldev/dev.to.git"
   },
   "lint-staged": {
     "*.{js,jsx}": [

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build-storybook": "build-storybook -c app/javascript/.storybook -s app/javascript/.storybook/assets",
     "precommit": "lint-staged",
     "upstream:sync": "git checkout master; git pull upstream master;",
-    "upstream:connect": "git remote add upstream https://github.com/thepracticaldev/dev.to.git"
+    "upstream:setup": "git remote add upstream https://github.com/thepracticaldev/dev.to.git"
   },
   "lint-staged": {
     "*.{js,jsx}": [


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Documentation Update

## Description

This adds two commands:
* `npm run upstream:connect` Adds Dev.to remote to a local repo.  In most cases, this will be a fork.
* `npm run upstream:sync` Does a checkout on master, then does a pull from latest commit on dev.to master and merges with local branch

## Related Tickets & Documents
Related to #740 and #742

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
## Added to documentation?
  - [ ] docs.dev.to
  - [x] readme
  - [ ] no documentation needed