### PR TITLE
Add page_views_count to articles and track from analytics

### DIFF
--- a/app/controllers/analytics_controller.rb
+++ b/app/controllers/analytics_controller.rb
@@ -1,18 +1,44 @@
 class AnalyticsController < ApplicationController
   caches_action :index,
     cache_path: Proc.new { "#{request.params}___#{current_user.id}" },
-    expires_in: 15.minutes
+    expires_in: 12.minutes
   after_action :verify_authorized
 
   def index
-    article_ids = analytics_params.split(",")
-    articles_to_check = Article.where(id: article_ids)
+    @article_ids = analytics_params.split(",")
+    articles_to_check = Article.where(id: @article_ids)
     authorize articles_to_check, :analytics_index?
-    cache_name = "pageviews-#{article_ids}/dashboard-index"
-    pageviews = Rails.cache.fetch(cache_name, expires_in: 15.minutes) do
-      GoogleAnalytics.new(article_ids).get_pageviews
+
+    qualified_articles = get_articles_that_qualify(articles_to_check)
+    fetch_and_update_page_views_and_reaction_counts(qualified_articles)
+
+    render_finalized_json
+  end
+
+  def get_articles_that_qualify(articles_to_check)
+    qualified_articles = []
+    articles_to_check.each do |article|
+      if article.positive_reactions_count > article.previous_positive_reactions_count
+        qualified_articles << article
+      end
     end
-    render json: pageviews.to_json
+    qualified_articles
+  end
+
+  def fetch_and_update_page_views_and_reaction_counts(qualified_articles)
+    pageviews = GoogleAnalytics.new(qualified_articles.pluck(:id)).get_pageviews
+    page_views_obj = pageviews.to_h
+    qualified_articles.each do |article|
+      article.update_columns(page_views_count: page_views_obj[article.id],
+                             previous_positive_reactions_count: article.positive_reactions_count)
+    end
+  end
+
+  def render_finalized_json
+    finalized_object = {}
+    Article.where(id: @article_ids).
+      pluck(:id, :page_views_count).map { |a| finalized_object[a[0]] = a[1].to_s }
+    render json: finalized_object.to_json
   end
 
   private

--- a/db/migrate/20180928161837_add_page_views_count_to_articles.rb
+++ b/db/migrate/20180928161837_add_page_views_count_to_articles.rb
@@ -1,0 +1,6 @@
+class AddPageViewsCountToArticles < ActiveRecord::Migration[5.1]
+  def change
+    add_column :articles, :page_views_count, :integer, default: 0
+    add_column :articles, :previous_positive_reactions_count, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180924204406) do
+ActiveRecord::Schema.define(version: 20180928161837) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -77,10 +77,12 @@ ActiveRecord::Schema.define(version: 20180924204406) do
     t.string "main_tag_name_for_social"
     t.string "name_within_collection"
     t.integer "organization_id"
+    t.integer "page_views_count", default: 0
     t.boolean "paid", default: false
     t.string "password"
     t.string "path"
     t.integer "positive_reactions_count", default: 0, null: false
+    t.integer "previous_positive_reactions_count", default: 0
     t.text "processed_html"
     t.boolean "published", default: false
     t.datetime "published_at"

--- a/spec/requests/analytics_spec.rb
+++ b/spec/requests/analytics_spec.rb
@@ -36,6 +36,18 @@ RSpec.describe "Analytics", type: :request, vcr: vcr_option do
         get "/analytics?article_ids=#{article1.id},#{article2.id}"
         expect(JSON.parse(response.body)).to eq(article1.id.to_s => "0", article2.id.to_s => "0")
       end
+
+      it "updates article view counts" do
+        Reaction.create!(
+          user_id: user.id,
+          reactable_id: article1.id,
+          reactable_type: "Article",
+          category: "readinglist",
+        )
+        expect(article1.reload.previous_positive_reactions_count).not_to eq(article1.positive_reactions_count)
+        get "/analytics?article_ids=#{article1.id},#{article2.id}"
+        expect(article1.reload.previous_positive_reactions_count).to eq(article1.positive_reactions_count)
+      end
     end
   end
 end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Adds page views count as an attribute for articles. We fetch from Google Analytics and then can query against this from within the app.
