### PR TITLE
Change article header image css to center it

### DIFF
--- a/app/assets/stylesheets/article-show.scss
+++ b/app/assets/stylesheets/article-show.scss
@@ -52,7 +52,7 @@ header{
     width:100%;
     margin:auto;
     max-width:1024px;
-    background: transparent no-repeat top center;
+    background: transparent no-repeat center center;
     background-size: cover;
     z-index:2;
     padding-top: 42%;


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)
- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description 
Changes article header image positioning to `center center`
## Related Tickets & Documents
Closes #772 
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
before:
<img width="697" alt="screenshot 2018-09-30 13 03 33" src="https://user-images.githubusercontent.com/1466420/46256284-42933800-c4b1-11e8-934a-882976ab0555.png">
after:
<img width="697" alt="screenshot 2018-09-30 13 03 22" src="https://user-images.githubusercontent.com/1466420/46256286-46bf5580-c4b1-11e8-87bb-12f786c5613c.png">

## Added to documentation?
  - [ ] docs.dev.to
  - [ ] readme
  - [x] no documentation needed
