### PR TITLE
Add ability to create trending tags

### DIFF
--- a/Envfile
+++ b/Envfile
@@ -139,9 +139,13 @@ variable :TWILIO_ACCOUNT_SID, :String, default: "Optional"
 variable :TWILIO_VIDEO_API_KEY, :String, default: "Optional"
 variable :TWILIO_VIDEO_API_SECRET, :String, default: "Optional"
 
+#Trending tags on home page
+variable :TRENDING_TAGS, :String, default: "git,beginners"
+
 ##### Legacy test related env vars ######
 variable :FACEBOOK_PIXEL_ID, :String, default: "Optional"
 variable :SMARTY_STREETS_WEB_KEY, :String, default: "Optional"
+
 
 group :production do
   variable :SECRET_KEY_BASE, :String

--- a/app/controllers/admin/tags_controller.rb
+++ b/app/controllers/admin/tags_controller.rb
@@ -40,7 +40,7 @@ module Admin
 
     def handle_moderators
       user_ids = params[:tag][:tag_moderator_ids].split(",")
-      UserRoleService.new(nil).update_tag_moderators(user_ids.sort, @tag)
+      UserRoleService.new(nil, current_user.id).update_tag_moderators(user_ids.sort, @tag)
     end
   end
 end

--- a/app/views/articles/_sidebar_additional.html.erb
+++ b/app/views/articles/_sidebar_additional.html.erb
@@ -145,6 +145,22 @@
           </div>
         </div>
       <% end %>
+      <% ApplicationConfig["TRENDING_TAGS"].split(",").each do |tag| %>
+        <div class="widget">
+          <header>
+            <a href="/t/<%= tag %>">#<%= tag %></a>
+          </header>
+          <div class="widget-body">
+            <div class="widget-link-list">
+              <% Article.active_threads([tag], Timeframer.new(params[:timeframe]).datetime).
+                each do |plucked_article| %>
+                  <%= render "articles/widget_list_item", plucked_article: plucked_article, show_comment_count: true %>
+              <% end %>
+            </div>
+              <a class="cta cta-button" href="/new/<%= tag %>">MAKE A #<%= tag.upcase %> POST</a>
+          </div>
+        </div>
+      <% end %>
       <% if Article.active_help.any? %>
         <div class="widget">
           <header>


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Admins can now use environment vars to mark tags as trending. Example: We will want to mark #hacktoberfest as trending right now.
## [optional] What gif best describes this PR or how it makes you feel?
![alt-text](https://media.giphy.com/media/TSrAQ9DmCmFWw/giphy.gif)
