### PR TITLE
setting user-select to none on the top-bar profile image.

### DIFF
--- a/app/assets/stylesheets/top-bar.scss
+++ b/app/assets/stylesheets/top-bar.scss
@@ -155,6 +155,10 @@
         border-radius: 100%;
         margin-top: -1px;
         margin-left: -1px;
+        -ms-user-select:none;
+        -moz-user-select:none;
+        -webkit-user-select:none;
+        user-select:none;
       }
     }
     .bars {


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [ x ] Bug Fix
- [ ] Documentation Update

## Description

When clicking on the profile picture in the top bar, it get's selected automatically. Since the menu is on hover and clicking the icon doesn't do anything, it seemed right to remove any action when clicking the image. 



## Related Tickets & Documents
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
### Before Changes
![before changes](https://user-images.githubusercontent.com/20668329/46305703-6fa62000-c56f-11e8-81dd-f9676884f7a8.gif)

### After Changes
![after changes](https://user-images.githubusercontent.com/20668329/46305728-7fbdff80-c56f-11e8-9438-b1331f4f4bef.gif)


## Added to documentation?
  - [ ] docs.dev.to
  - [ ] readme
  - [ x ] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?
![alt-text](https://media2.giphy.com/media/12CEqcfGczE8Tu/200.gif)
