### PR TITLE
Added mix-height to the DEV logo on the offline page to fix ff bug

### DIFF
--- a/public/offline.html
+++ b/public/offline.html
@@ -87,6 +87,7 @@
     .rainbow-logo {
       border-radius: 10%;
       max-width: 50%;
+      max-height: 400px;
     }
 
     .signature {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
Added a max-height to the logo on the offline page to prevent a problem in Firefox scaling it massively on 16:9 resolutions
(Tested in 1080p on Windows and 4k on Arch Linux)

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![GIF Demo](https://cdn.tcole.me/dev-offline-ff-bug.gif)

## Added to documentation?
  - [ ] docs.dev.to
  - [ ] readme
  - [x] no documentation needed
