### PR TITLE
fix grammar and add space-separated option

### DIFF
--- a/app/views/pages/_editor_guide_text.html.erb
+++ b/app/views/pages/_editor_guide_text.html.erb
@@ -13,13 +13,13 @@
     </ul>
 
     <h2><u><strong>Front Matter</strong></u></h2>
-    <p>Custom variables set for each post, located between the triple-dashed lines in your editor. Here are a list of possibilities:</p>
+    <p>Custom variables set for each post, located between the triple-dashed lines in your editor. Here is a list of possibilities:</p>
     <ul>
-      <li><strong>title:</strong> title of your article</li>
+      <li><strong>title:</strong> the title of your article</li>
       <li><strong>published:</strong> boolean that determines whether or not your article is published</li>
       <li><strong>description:</strong> description area in Twitter cards and open graph cards</li>
-      <li><strong>tags:</strong> max of four tags, needs to be comma-separated</li>
-      <li><strong>canonical_url:</strong> link for canonical version of content</li>
+      <li><strong>tags:</strong> max of four tags, needs to be comma-separated or space-separated</li>
+      <li><strong>canonical_url:</strong> link for the canonical version of the content</li>
       <li><strong>cover_image: </strong> cover image for post, accepts a URL. <br>The best size is 1000 x 420.</li>
     </ul>
     <h2><u><strong>Markdown Basics</strong></u></h2>


### PR DESCRIPTION
- Fixed some grammar mistakes in the editor guide.
- Updated tags section in editor guide to reference the fact that space separated is allowed for tags as well.

## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Documentation Update

## Added to documentation?
  - [ ] docs.dev.to
  - [ ] readme
  - [x] no documentation needed

