### PR TITLE
Add grammar fixes and space separated to tags section

### DIFF
--- a/app/views/pages/_editor_guide_text.html.erb
+++ b/app/views/pages/_editor_guide_text.html.erb
@@ -13,13 +13,13 @@
     </ul>
 
     <h2><u><strong>Front Matter</strong></u></h2>
-    <p>Custom variables set for each post, located between the triple-dashed lines in your editor. Here are a list of possibilities:</p>
+    <p>Custom variables set for each post, located between the triple-dashed lines in your editor. Here is a list of possibilities:</p>
     <ul>
-      <li><strong>title:</strong> title of your article</li>
+      <li><strong>title:</strong> the title of your article</li>
       <li><strong>published:</strong> boolean that determines whether or not your article is published</li>
       <li><strong>description:</strong> description area in Twitter cards and open graph cards</li>
-      <li><strong>tags:</strong> max of four tags, needs to be comma-separated</li>
-      <li><strong>canonical_url:</strong> link for canonical version of content</li>
+      <li><strong>tags:</strong> max of four tags, needs to be comma-separated or space-separated</li>
+      <li><strong>canonical_url:</strong> link for the canonical version of the content</li>
       <li><strong>cover_image: </strong> cover image for post, accepts a URL. <br>The best size is 1000 x 420.</li>
     </ul>
     <h2><u><strong>Markdown Basics</strong></u></h2>

--- a/app/views/pages/_editor_guide_text.html.erb
+++ b/app/views/pages/_editor_guide_text.html.erb
@@ -18,7 +18,7 @@
       <li><strong>title:</strong> the title of your article</li>
       <li><strong>published:</strong> boolean that determines whether or not your article is published</li>
       <li><strong>description:</strong> description area in Twitter cards and open graph cards</li>
-      <li><strong>tags:</strong> max of four tags, needs to be comma-separated or space-separated</li>
+      <li><strong>tags:</strong> max of four tags, needs to be comma-separated</li>
       <li><strong>canonical_url:</strong> link for the canonical version of the content</li>
       <li><strong>cover_image: </strong> cover image for post, accepts a URL. <br>The best size is 1000 x 420.</li>
     </ul>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [x] Documentation Update

## Description
The tags section in editor guide was saying that only comma-separated is possible when in fact space-separated is allowed as well. While I was there I cleaned up some grammar as well.

See below for space separated working...
![devto-space-separated](https://user-images.githubusercontent.com/1869717/46425665-22ea5280-c6f1-11e8-8501-bf597c9e0ecc.gif)

## Related Tickets & Documents
None.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
n/a

## Added to documentation?
  - [ ] docs.dev.to
  - [ ] readme
  - [x] no documentation needed
