### PR TITLE
Improve dashboard action buttons' styling

### DIFF
--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -23,25 +23,47 @@
     }
   }
   .actions{
-    text-align:center;
-    padding:10px 0px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    align-items: center;
+    padding: 2% 0; /* about .dashboard-container's left / right margin */
+    @media screen and ( min-width: 600px ){
+      flex-direction: row;
+    }
     .action{
-      width:calc(90% - 26px);
-      margin:7px 3px;
+      flex-basis: 0;
+      flex-grow: 1;
+      flex-shrink: 0;
+      width: 100%;
       color:$black;
       padding:10px 0px;
       border-radius:3px;
       min-width:115px;
-      display:inline-block;
-      transition: background-color 250ms ease;
+      transition: background-color 250ms ease, opacity 250ms ease;
       font-family: $helvetica-condensed;
       font-stretch:condensed;
-      font-size: 1.2em;
+      font-size: 1.1em;
+      text-align: center;
       &.active{
         background: $purple;
       }
-      @media screen and ( min-width: 600px ){
-        width:calc(25% - 16px);
+      &:not(.active):hover{
+        background: $light-medium-purple;
+      }
+      &:not(:last-child) {
+        /* gap between actions */
+        margin-bottom: 8px;
+        @media screen and ( min-width: 600px ){
+          margin-bottom: 0;
+          margin-right: 8px;
+        }
+      }
+      span {
+        display: inline-block;
+        @media screen and ( min-width: 600px ) and  ( max-width: 800px ){
+          display: block;
+        }
       }
     }
   }

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -5,6 +5,7 @@ $green: #66e2d5;
 $light-green: lighten($green,30%);
 $dark-purple: #4e57ef;
 $purple: #cfd7ff;
+$light-medium-purple: lighten($purple, 4%);
 $light-purple: lighten($purple, 7%);
 $blue: #1395b8;
 $sky-blue: #557de8;

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -2,9 +2,18 @@
 
 <div class="dashboard-container">
   <div class="actions">
-    <a class="action <%= 'active' if params[:which] == "organization" || params[:which].blank? %>" href="/dashboard">POSTS (<%= @user.articles_count %>)</a>
-    <a class="action <%= 'active' if params[:which] == "user_followers" %>" href="/dashboard/user_followers">FOLLOWERS (<%= @user.followers_count %>)</a>
-    <a class="action <%= 'active' if params[:which] == "following_users" %>" href="/dashboard/following_users">FOLLOWING (<%= @user.following_users_count %>)</a>
+    <a class="action <%= 'active' if params[:which] == "organization" || params[:which].blank? %>" href="/dashboard">
+      <span>POSTS</span>
+      <span>(<%= @user.articles_count %>)</span>
+    </a>
+    <a class="action <%= 'active' if params[:which] == "user_followers" %>" href="/dashboard/user_followers">
+      <span>FOLLOWERS</span>
+      <span>(<%= @user.followers_count %>)</span>
+    </a>
+    <a class="action <%= 'active' if params[:which] == "following_users" %>" href="/dashboard/following_users">
+      <span>FOLLOWING</span>
+      <span>(<%= @user.following_users_count %>)</span>
+    </a>
   </div>
 <% if @user.org_admin && @user.organization %>
   <h1>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

Improved CSS (and some markup) of dashboard action buttons:

* Use CSS flex boxes
* Span full content width (one line with content below)
* Fix gap between actions
* Add hover color and transition for opacity
* Decrease font size a little bit
* Force break "POSTS" and "(123)" into two lines when width is 600-800px

## Related Tickets & Documents

This PR fixes #505. 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![devto1](https://user-images.githubusercontent.com/7782229/46441451-d6d9f500-c766-11e8-8df6-0a61e4df46c4.png)
Actions now span the whole content width. The left edge of the left button is at the same vertical line like the left edge of the post card.

![devto2](https://user-images.githubusercontent.com/7782229/46441452-d6d9f500-c766-11e8-8334-f3440638919f.png)
On normal desktop, follower counts up to the hundred millions won't wrap.

![devto3](https://user-images.githubusercontent.com/7782229/46441454-d6d9f500-c766-11e8-9ece-2874e0aade5f.png)
On some tablets (600-800px screen width), it's nearly impossible to avoid the follower count break into another line. I decided to force wrap all actions on these screens – better than a single action being wrapped.

![devto4](https://user-images.githubusercontent.com/7782229/46441455-d7728b80-c766-11e8-90c2-fd27ec3af419.png)
Also on mobile, actions now span the whole content width.

## Added to documentation?
  - [ ] docs.dev.to
  - [ ] readme
  - [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?
![alt_text](https://media.giphy.com/media/3d2OJh9B0XY7m/source.gif)
