### PR TITLE
Add allow-top-navigation-by-user-activation to glitch embed iframe

### DIFF
--- a/app/liquid_tags/glitch_tag.rb
+++ b/app/liquid_tags/glitch_tag.rb
@@ -12,7 +12,7 @@ class GlitchTag < LiquidTagBase
     html = <<-HTML
       <div class="glitch-embed-wrap" style="height: 450px; width: 100%;margin: 1em auto 1.3em">
         <iframe
-          sandbox="allow-same-origin allow-scripts allow-forms"
+          sandbox="allow-same-origin allow-scripts allow-forms allow-top-navigation-by-user-activation"
           src="#{@uri}"
           alt="#{@id} on glitch"
           style="height: 100%; width: 100%; border: 0;margin:0;padding:0"></iframe>


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
Adds the `allow-top-navigation-by-user-activation` flag to iframe sandbox. May solve the problem on Chrome. Firefox hasn't implemented yet. For broader, but less secure support, consider `allow-top-navigation` flag.

## Related Tickets & Documents
Potential fix (should be tested) for #253 

