### PR TITLE
Feature/add parler.io liquid tag for audio embed

### DIFF
--- a/app/liquid_tags/parler_tag.rb
+++ b/app/liquid_tags/parler_tag.rb
@@ -1,0 +1,33 @@
+class ParlerTag < LiquidTagBase
+  def initialize(tag_name, id, tokens)
+    super
+    @id = parse_id(id)
+    @width = 710
+    @height = 120
+  end
+
+  def render(_context)
+    html = <<-HTML
+    <iframe
+      width="#{@width}"
+      height="#{@height}"
+      src="https://api.parler.io/ss/player?url=#{@id}">
+    </iframe>
+    HTML
+    finalize_html(html)
+  end
+
+  private
+
+  def parse_id(input)
+    input_no_space = input.delete(" ")
+    raise StandardError, "Invalid Parler URL" unless valid_id?(input_no_space)
+    input_no_space
+  end
+
+  def valid_id?(id)
+    id =~ /\A(https:\/\/www.parler.io\/audio\/\d{1,11}\/[a-zA-Z0-9]{11,40}.[0-9a-zA-Z-]{11,36}.mp3)\Z/
+  end
+end
+
+Liquid::Template.register_tag("parler", ParlerTag)

--- a/app/liquid_tags/parler_tag.rb
+++ b/app/liquid_tags/parler_tag.rb
@@ -21,11 +21,13 @@ class ParlerTag < LiquidTagBase
 
   def parse_id(input)
     input_no_space = input.delete(" ")
+    input_no_space = input_no_space.scan(/\bhttps?:\/\/[a-z.\/0-9-]+\b/).first
     raise StandardError, "Invalid Parler URL" unless valid_id?(input_no_space)
     input_no_space
   end
 
   def valid_id?(id)
+    puts id
     id =~ /\A(https:\/\/www.parler.io\/audio\/\d{1,11}\/[a-zA-Z0-9]{11,40}.[0-9a-zA-Z-]{11,36}.mp3)\Z/
   end
 end

--- a/spec/liquid_tags/parler_tag_spec.rb
+++ b/spec/liquid_tags/parler_tag_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe ParlerTag, type: :liquid_template do
+  describe "#id" do
+    let(:valid_id) { "https://www.parler.io/audio/73240183203/d53cff009eac2ab1bc9dd8821a638823c39cbcea.7dd28611-b7fc-4cf8-9977-b6e3aaf644a1.mp3" }
+
+    let(:invalid_id) { "https://www.google.com" }
+
+    def generate_new_liquid(id)
+      Liquid::Template.register_tag("parler", ParlerTag)
+      Liquid::Template.parse("{% parler #{id} %}")
+    end
+
+    def generate_iframe(id)
+      "<iframe "\
+        "width=\"710\" "\
+        "height=\"120\" "\
+        "src=\"https://api.parler.io/ss/player?url=#{valid_id}\" "\
+      "</iframe>"
+    end
+
+    it "accepts a valid Parler URL" do
+      liquid = generate_new_liquid(valid_id)
+      expect(liquid.render).to eq(generate_iframe(valid_id))
+    end
+
+    it "raises an error for invalid IDs" do
+      expect { generate_new_liquid(invalid_id).render }.to raise_error("Invalid Parler URL")
+    end
+  end
+end

--- a/spec/liquid_tags/parler_tag_spec.rb
+++ b/spec/liquid_tags/parler_tag_spec.rb
@@ -11,16 +11,17 @@ RSpec.describe ParlerTag, type: :liquid_template do
       Liquid::Template.parse("{% parler #{id} %}")
     end
 
-    def generate_iframe(id)
+    def generate_iframe(_id)
       "<iframe "\
         "width=\"710\" "\
         "height=\"120\" "\
-        "src=\"https://api.parler.io/ss/player?url=#{valid_id}\" "\
+        "src=\"https://api.parler.io/ss/player?url=#{valid_id}\"> "\
       "</iframe>"
     end
 
     it "accepts a valid Parler URL" do
       liquid = generate_new_liquid(valid_id)
+      puts liquid
       expect(liquid.render).to eq(generate_iframe(valid_id))
     end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
This is a PR to add a new liquid tag that takes a [parler.io](https://parler.io) audio file and embed it into a post. Right now the parler endpoint has no notion of a user so I can't just use a generic id as the other liquid tags do.

Also, note that this was based on a quick conversation with Ben over [Twitter](https://twitter.com/bendhalpern/status/1047965662801485825). So we could certainly do more here in the future. I also didn't do a ton of refactoring while I was here as it took a lot longer than I expected to get up and going on a Linux subsystem.

## Related Tickets & Documents
There isn't one at this time, but happy to create one if necessary.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
## Added to documentation?
  - [ ] docs.dev.to
  - [ ] readme
  - [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?
![battle scars](https://media.giphy.com/media/l1J9y0rf8zncJDztm/giphy.gif)
