### PR TITLE
Fixed typo in mac installation docs

### DIFF
--- a/docs/installation/mac-os.md
+++ b/docs/installation/mac-os.md
@@ -3,7 +3,7 @@
 ### Ruby
 
 1.  If you don't already a Ruby version manager, we highly recommend [rbenv](https://github.com/rbenv/rbenv). Please follow their [installation guide](https://github.com/rbenv/rbenv#installation).
-2.  With the Ruby version manager, install Ruby verion listed on our badge. (ie with rbenv: `rbenv install 2.5.1`)
+2.  With the Ruby version manager, install Ruby version listed on our badge. (ie with rbenv: `rbenv install 2.5.1`)
 
 ### Yarn
 
@@ -25,9 +25,9 @@ For additional configuration, [click here](/additional-postgres-setup)
 6.  Install our frontend dependencies with `bin/yarn`
 7.  Set up your environment variables/secrets
 
-* Take a look at `Envfile`. This file lists all the `ENV` variables we use and provides a fake default for any missing keys. You'll need to get your own free [Algolia credentials](http://docs.dev.to/get-api-keys-dev-env/#algolia) to get your development environment running.
-* This [guide](http://docs.dev.to/get-api-keys-dev-env/) will show you how to get free API keys for additional servies that may be required to run certain parts of the app.
-* For any key that you wish to enter/replace:
+- Take a look at `Envfile`. This file lists all the `ENV` variables we use and provides a fake default for any missing keys. You'll need to get your own free [Algolia credentials](http://docs.dev.to/get-api-keys-dev-env/#algolia) to get your development environment running.
+- This [guide](http://docs.dev.to/get-api-keys-dev-env/) will show you how to get free API keys for additional servies that may be required to run certain parts of the app.
+- For any key that you wish to enter/replace:
 
 8.  Create `config/application.yml` by copying from the provided template (ie. with bash: `cp config/sample_application.yml config/application.yml`). This is a personal file that is ignored in git.
 9.  Obtain the development variable and apply the key you wish to enter/replace. ie:
@@ -37,8 +37,8 @@ For additional configuration, [click here](/additional-postgres-setup)
     GITHUB_SECRET: "ANOTHER_REAL_SECURE_KEY_HERE"
     ```
 
-* If you are missing `ENV` variables on bootup, `envied` gem will alert you with messages similar to `'error_on_missing_variables!': The following environment variables should be set: A_MISSING_KEY.`.
-* You do not need "real" keys for basic development. Some features require certain keys, so you may be able to add them as you go.
+- If you are missing `ENV` variables on bootup, `envied` gem will alert you with messages similar to `'error_on_missing_variables!': The following environment variables should be set: A_MISSING_KEY.`.
+- You do not need "real" keys for basic development. Some features require certain keys, so you may be able to add them as you go.
 
 10. Run `bin/setup`
 


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [X] Documentation Update

## Description
I fixed a typo in the installation docs for mac (https://docs.dev.to/installation/mac-os/). Specifically, in the section about installing Ruby, there was a typo on the word "version". 

Also, I'm not sure why there are changes in the markdown for the bullet lists (* vs -). I only edited the file to change the typo and left the rest of the file alone.

## Related Tickets & Documents
I couldn't find any.

## Added to documentation?

- [X] docs.dev.to
- [ ] readme
- [ ] no documentation needed
