### PR TITLE
Adjust modal to not interfere with pull-to-refresh

### DIFF
--- a/app/assets/javascripts/lib/pulltorefresh.js
+++ b/app/assets/javascripts/lib/pulltorefresh.js
@@ -31,8 +31,7 @@
     onRefresh: function () { return location.reload(); },
     resistanceFunction: function (t) { return Math.min(1, t / 2.5); },
     shouldPullToRefresh: function () {
-      return !window.scrollY && document.getElementById('articles-list')
-    
+      return !window.scrollY && document.getElementById('articles-list') && !document.body.classList.contains('modal-open')
     },
   };
 

--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -23,6 +23,7 @@ body {
   margin: 0;
   overflow: hidden;
   overflow-y: hidden;
+  height: 90vh;
 }
 
 

--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -1,7 +1,4 @@
 @import 'variables';
-html {
-  overflow-y:scroll;
-}
 
 body {
   background: $lightest-gray;
@@ -11,6 +8,7 @@ body {
   padding:0 !important;
   margin:0 !important;
   margin-top:-20px !important;
+  overflow-y:scroll;
   :focus {
   outline: 0;
   }

--- a/app/javascript/src/Onboarding.jsx
+++ b/app/javascript/src/Onboarding.jsx
@@ -40,7 +40,7 @@ class Onboarding extends Component {
   componentDidMount() {
     this.updateUserData();
     this.getUserTags();
-    document.getElementsByTagName('body')[0].classList.add('modal-open');
+    document.getElementsByTagName("body")[0].classList.add("modal-open");
   }
 
   getUserTags() {
@@ -89,27 +89,6 @@ class Onboarding extends Component {
       });
   }
 
-  getSuggestedArticles() {
-    const followedTags = [];
-    for (let i = 0; i < this.state.allTags.length; i += 1) {
-      if (this.state.allTags[i].following) {
-        followedTags.push(this.state.allTags[i].name);
-      }
-    }
-
-    fetch(`/api/articles/onboarding?tag_list=${followedTags.join(',')}`, {
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-      },
-      credentials: 'same-origin',
-    })
-      .then(response => response.json())
-      .then(json => {
-        this.setState({ articles: json, savedArticles: json });
-      });
-  }
-
   handleBulkFollowUsers(users) {
     if (this.state.checkedUsers.length > 0 && !this.state.followRequestSent) {
       const csrfToken = document.querySelector("meta[name='csrf-token']")
@@ -128,29 +107,6 @@ class Onboarding extends Component {
       }).then(response => {
         if (response.ok) {
           this.setState({ followRequestSent: true });
-        }
-      });
-    }
-  }
-
-  handleBulkSaveArticles(articles) {
-    if (this.state.savedArticles.length > 0 && !this.state.saveRequestSent) {
-      const csrfToken = document.querySelector("meta[name='csrf-token']")
-        .content;
-
-      const formData = new FormData();
-      formData.append('articles', JSON.stringify(articles));
-
-      fetch('/api/reactions/onboarding', {
-        method: 'POST',
-        headers: {
-          'X-CSRF-Token': csrfToken,
-        },
-        body: formData,
-        credentials: 'same-origin',
-      }).then(response => {
-        if (response.ok) {
-          this.setState({ saveRequestSent: true });
         }
       });
     }
@@ -278,7 +234,6 @@ class Onboarding extends Component {
   handleNextHover() {
     if (this.state.pageNumber === 2 && this.state.users.length === 0) {
       this.getUsersToFollow();
-      this.getSuggestedArticles();
     }
   }
 
@@ -289,7 +244,6 @@ class Onboarding extends Component {
       this.state.articles.length === 0
     ) {
       this.getUsersToFollow();
-      this.getSuggestedArticles();
     }
     if (this.state.pageNumber < 5) {
       this.setState({ pageNumber: this.state.pageNumber + 1 });


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
Pull to refresh causes scenarios where the onboarding modal can be accidentally refreshed in a mobile context, which could be frustrating. This should ensure that that does not happen.