### PR TITLE
Handle flash messages that are not arrays

### DIFF
--- a/app/views/devise/shared/_authorization_error.html.erb
+++ b/app/views/devise/shared/_authorization_error.html.erb
@@ -13,6 +13,7 @@
 <% unless flash[:alert].blank? %>
   <div class="error-notice">
   Something went wrong:
+    <% if flash[:alert].is_a?(Array) %>
     <ul>
       <% flash[:alert].each do |error| %>
         <li>
@@ -20,6 +21,10 @@
         </li>
       <% end %>
     </ul>
+    <% else %>
+      <%= flash[:alert] %>
+      <br>
+    <% end %>
     Please try again below, or contact <a href="mailto:yo@dev.to">yo@dev.to</a> if this persists.
   </div>
 <% end %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Fixes an error where views were failing to load because the flash message could not be `.each`ed, because it was a string and not an array.

This might happen if the OAuth process fails. When that happens, it seems to skip our custom logic and be rescued by either Devise or the Omniauth gem(s), and sets the flash message to a string with the error message. I don't think the OAuth failure is a big deal, since it's usually something like "Session expired" or "Invalid credentials". Trying to sign in again should work.

## Added to documentation?
- [x] no documentation needed