### PR TITLE
Add mentorship automation

### DIFF
--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -80,4 +80,18 @@ class NotifyMailer < ApplicationMailer
     subject = "dev.to - Account Deletion Confirmation"
     mail(to: user.email, subject: subject)
   end
+
+  def mentee_email(mentee, mentor)
+    @mentee = mentee
+    @mentor = mentor
+    subject = "You have been matched with a DEV mentor!"
+    mail(to: @mentee.email, subject: subject)
+  end
+
+  def mentor_email(mentor, mentee)
+    @mentor = mentor
+    @mentee = mentee
+    subject = "You have been matched with a new DEV mentee!"
+    mail(to: @mentor.email, subject: subject)
+  end
 end

--- a/app/models/mentor_relationship.rb
+++ b/app/models/mentor_relationship.rb
@@ -6,9 +6,24 @@ class MentorRelationship < ApplicationRecord
   validate :check_for_same_user
   validates_uniqueness_of :mentor_id, scope: :mentee_id
 
+  after_create :mutual_follow
+  after_create :send_emails
+
   def check_for_same_user
     if mentor_id == mentee_id
       errors.add(:mentor_relationship, "Mentor and Mentee cannot be the same person")
     end
+  end
+
+  private
+
+  def mutual_follow
+    mentor.follow(mentee)
+    mentee.follow(mentor)
+  end
+
+  def send_emails
+    NotifyMailer.mentee_email(mentee, mentor).deliver
+    NotifyMailer.mentor_email(mentor, mentee).deliver
   end
 end

--- a/app/views/internal/users/show.html.erb
+++ b/app/views/internal/users/show.html.erb
@@ -98,6 +98,49 @@
     <br/>
     <%= f.submit %>
   <% end %>
-
 </div>
 
+<% if @user.seeking_mentorship %>
+  <h2> Possible Mentors </h2>
+  <% count = 0 %>
+  <% User.where(offering_mentorship: true).order("mentor_form_updated_at DESC").each do |possible_mentor| %>
+    <% break if count > 18 %>
+    <% count = count + 1 %>
+    <% tag_intersection = ( @user.cached_followed_tag_names & possible_mentor.cached_followed_tag_names ) %>
+    <% mentor_relationships_count = MentorRelationship.where(mentor_id: possible_mentor.id).size %>
+    <% if tag_intersection.any? && mentor_relationships_count < 2 %>
+      <div class="row">
+        <div class="col-md-2">
+          <h4>User</h4>
+          <a href="/<%= possible_mentor.username %>" target="_blank">@<%= possible_mentor.username %></a>
+        </div>
+        <div class="col-md-3">
+          <h4>Tag Intersection</h4>
+          <%= tag_intersection.join(", ") %>
+        </div>
+        <div class="col-md-3">
+          <h4>Mentor description</h4>
+          <%= possible_mentor.mentor_description %>
+        </div>
+        <div class="col-md-3">
+          <h4>Skills/Languages</h4>
+          <%= possible_mentor.mostly_work_with %>
+        </div>
+        <div class="col-md-1">
+          <h4>Action</h4>
+          <%= form_for ([:internal, @user]) do |f| %>
+            <%= f.hidden_field :add_mentor, value: possible_mentor.id %>
+            <%= f.submit "Match!" %>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+  <% end %>
+<% end %>
+
+<h2> Recent Emails </h2>
+<% @user.email_messages.order("sent_at DESC").limit(50).each do |email| %>
+  <div class="row">
+    <a href="/admin/email_messages/<%= email.id %>"><%= email.subject %></a> <%= email.sent_at&.strftime("%b %e '%y") %>
+  </div>
+<% end %>

--- a/app/views/mailers/notify_mailer/mentee_email.html.erb
+++ b/app/views/mailers/notify_mailer/mentee_email.html.erb
@@ -1,0 +1,15 @@
+<p>
+  Hey <b>@<%= @mentee.username %></b>!
+</p>
+<p>
+  You have been matched with a mentor: <b><a href="https://dev.to/<%= @mentor.username %>">@<%= @mentor.username %></a></b>
+</p>
+<p>
+  As part of the mentorship program, you two have been mutually followed so you may message one another via <b><a href="https://dev.to/connect">DEV Connect</a></b>
+</p>
+<p>
+  <b>@<%= @mentor.username %></b> has been notified as well, so feel free to reach out!
+</p>
+<p>
+  Have a nice day!
+</p>

--- a/app/views/mailers/notify_mailer/mentee_email.text.erb
+++ b/app/views/mailers/notify_mailer/mentee_email.text.erb
@@ -1,0 +1,11 @@
+Hey!
+
+You have been matched with a mentor:
+
+https://dev.to/<%= @mentor.username %>
+
+As part of the mentorship program, you two have been mutually followed so you may message one another at https://dev.to/connect
+
+@<%= @mentor.username %> has been notified as well, so feel free to reach out!
+
+Have a nice day!

--- a/app/views/mailers/notify_mailer/mentor_email.html.erb
+++ b/app/views/mailers/notify_mailer/mentor_email.html.erb
@@ -1,0 +1,16 @@
+<p>
+  Hey <b>@<%= @mentor.username %></b>!
+</p>
+<p>
+You have been matched with a new mentee: <b><a href="https://dev.to/<%= @mentee.username %>">@<%= @mentee.username %></a></b>
+</p>
+<p>
+As part of the mentorship program, you two have been mutually followed so you may message one another via <b><a href="https://dev.to/connect">DEV Connect</a></b>
+</p>
+<p>
+Have a nice day!
+</p>
+<p>
+If you need guidance on how to be a great mentor, check out these posts:
+</p>
+<h1><a href="https://dev.to/jess/mentorship-resources-19p0">Mentorship Resources</a></h1>

--- a/app/views/mailers/notify_mailer/mentor_email.text.erb
+++ b/app/views/mailers/notify_mailer/mentor_email.text.erb
@@ -1,0 +1,12 @@
+Hey!
+
+You have been matched with a new mentee:
+
+https://dev.to/<%= @mentee.username %>
+
+As part of the mentorship program, you two have been mutually followed so you may message one another at https://dev.to/connect
+
+Have a nice day!
+
+If you need guidance on how to be a great mentor, check out these posts:
+

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -111,5 +111,23 @@ RSpec.describe NotifyMailer, type: :mailer do
         expect(account_deleted_email.to).to eq [user.email]
       end
     end
+
+    describe "#mentee_email" do
+      let(:mentee) { create(:user) }
+      let(:mentor) { create(:user) }
+      it "renders proper subject" do
+        mentee_email = described_class.mentee_email(mentee, mentor)
+        expect(mentee_email.subject).to eq "You have been matched with a DEV mentor!"
+      end
+    end
+
+    describe "#mentor_email" do
+      let(:mentee) { create(:user) }
+      let(:mentor) { create(:user) }
+      it "renders proper subject" do
+        mentor_email = described_class.mentor_email(mentor, mentee)
+        expect(mentor_email.subject).to eq "You have been matched with a new DEV mentee!"
+      end
+    end
   end
 end

--- a/spec/mailers/previews/notify_mailer_preview.rb
+++ b/spec/mailers/previews/notify_mailer_preview.rb
@@ -28,6 +28,14 @@ class NotifyMailerPreview < ActionMailer::Preview
     NotifyMailer.new_report_email(FeedbackMessage.first)
   end
 
+  def mentee_email
+    NotifyMailer.mentee_email(User.first, User.second)
+  end
+
+  def mentor_email
+    NotifyMailer.mentor_email(User.first, User.second)
+  end
+
   def feedback_message_resolution_email
     # change email_body text when you need to see a different version
     @user = User.first

--- a/spec/models/mentor_relationship_spec.rb
+++ b/spec/models/mentor_relationship_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe MentorRelationship, type: :model do
   let(:mentor) { create(:user) }
   let(:mentee) { create(:user) }
-  let(:relationship) { MentorRelationship.new(mentor: mentor, mentee_id: mentee) }
+  let(:relationship) { MentorRelationship.new(mentor_id: mentor.id, mentee_id: mentee.id) }
 
   describe "validations" do
     subject { MentorRelationship.new(mentor: mentor, mentee: mentee) }
@@ -19,5 +19,16 @@ RSpec.describe MentorRelationship, type: :model do
 
   it "is not the same user" do
     expect(MentorRelationship.new(mentor_id: mentor.id, mentee_id: mentor.id)).to be_invalid
+  end
+
+  it "makes the users follow one another" do
+    relationship.save!
+    expect(mentor.reload.following?(mentee)).to eq(true)
+    expect(mentee.reload.following?(mentor)).to eq(true)
+  end
+
+  it "sends an email to both users" do
+    relationship.save!
+    expect(EmailMessage.all.size).to eq(2)
   end
 end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
This makes mentor matches and the related email more automatic. Needs some copy adjustment and needs to be tested a bit in prod.

Now we have an interface which attempts to offer possible mentorship matches and allow you to match right from there. Once match is made, all technical details should happen automatically.

This approach should work, but will have to test to see if it really works properly with prod data.