### PR TITLE
Fix #848.  Code inside Markdown inside Gist displays.

### DIFF
--- a/app/assets/stylesheets/ltags/GistTag.scss
+++ b/app/assets/stylesheets/ltags/GistTag.scss
@@ -8,4 +8,15 @@
     width: 0 !important;
   }
 
+  .gist .markdown-body pre {
+    margin-left: 0;
+    width: 100%;
+    box-sizing: border-box;
+    color: #29292e;
+  }
+
+  .gist .markdown-body pre code {
+    color: #29292e;
+  }
+
 }


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
Previously, if you had a code block inside a markdown document inside a gist inside an article, it would display weird:

![before](https://user-images.githubusercontent.com/14909201/46907160-3cdf1e80-cec3-11e8-835b-97c274c485d3.jpeg)

Honestly, when I write it all out, it's really a wonder that it displays at all with all of that nested rendering.  🥇 for the Cascade I guess!

Anyways, the two main issues were that there was a `margin-left: -11%` for some reason, which moved the text out of the parent box, hiding it.  Once I moved it in, the text color was essentially the same color as the background.  So I added `color: #29292e` to match the other surrounding black text.

Lastly, the margin shift into view that I did shifted the right side of the `<pre>` element over, causing the entire gist to become left-right scrollable for no reason, so I shrank the width to `100%` rather than the previous `110%`, and converted it to `box-sizing: border-box`.  So now, it fits nicely inside main pane, and manages its own scroll rather than forcing the parent to scroll.

![after](https://user-images.githubusercontent.com/14909201/46907215-06ee6a00-cec4-11e8-90a7-9034459182df.jpeg)

I know that the selectors I added are pretty specific, which is unfortunate, but I needed to be that specific to override the default styling of the gist itself.  Better than `!important` I think.

Hopefully this helps!

## Related Tickets & Documents

Fixes #848.

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![Kermit Dancing](https://i.makeagif.com/media/3-22-2016/1Nr1-a.gif)
