### PR TITLE
CSS height fix for Read Post button [Fixes #921]

### DIFF
--- a/app/assets/stylesheets/settings.scss
+++ b/app/assets/stylesheets/settings.scss
@@ -209,7 +209,7 @@
         }
       }
       button {
-        width: 100px;
+        width: 130px;
         padding: 3px 0px;
         font-size: 1.2em;
         font-weight: bold;

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2,18 +2,18 @@
 
 We use the following testing tools:
 
-* [**RSpec**](http://rspec.info/) for testing the backend
-* [**Capybara**](https://github.com/teamcapybara/capybara) with [**selenium-webdriver**](https://github.com/SeleniumHQ/selenium/tree/master/javascript/node/selenium-webdriver) for view testing
-* [**chromedriver-helper**](https://github.com/flavorjones/chromedriver-helper) for standard JS testing
-* [**guard-rspec**](https://github.com/guard/guard-rspec) for automated testing
-* [**Jest**](https://facebook.github.io/jest) for testing in the front-end
-* [**SimpleCov**](https://github.com/colszowka/simplecov) for tracking overall test coverage
+* **RSpec** for testing the backend
+* **Capybara** with **selenium-webdriver** for view testing
+* **chromedriver-helper** for standard JS testing
+* **guard-rspec** for automated testing
+* [Jest](https://facebook.github.io/jest) for testing in the front-end
+* [SimpleCov](link-to-simplecov-repo) for tracking overall test coverage
 
 Each pull request should come with tests related to the newly written feature or bug fix. Ideally, we should test both the front end and back end.
 
 If you'd like to help us improve our test coverage, we recommend checking out our total coverage and writing tests for selected files based on SimpleCov's (more below) test coverage results.
 
-If you're new to writing tests in general or with Rails, we recommend reading about testing with Rails, RSpec, and Capybara first.
+If you're new to writing tests in general or with Rails, we recommend reading about testing with Rails, RSpec, and Capybara first. For Webpack and
 
 ## How to Use SimpleCov
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2,18 +2,18 @@
 
 We use the following testing tools:
 
-* **RSpec** for testing the backend
-* **Capybara** with **selenium-webdriver** for view testing
-* **chromedriver-helper** for standard JS testing
-* **guard-rspec** for automated testing
-* [Jest](https://facebook.github.io/jest) for testing in the front-end
-* [SimpleCov](link-to-simplecov-repo) for tracking overall test coverage
+* [**RSpec**](http://rspec.info/) for testing the backend
+* [**Capybara**](https://github.com/teamcapybara/capybara) with [**selenium-webdriver**](https://github.com/SeleniumHQ/selenium/tree/master/javascript/node/selenium-webdriver) for view testing
+* [**chromedriver-helper**](https://github.com/flavorjones/chromedriver-helper) for standard JS testing
+* [**guard-rspec**](https://github.com/guard/guard-rspec) for automated testing
+* [**Jest**](https://facebook.github.io/jest) for testing in the front-end
+* [**SimpleCov**](https://github.com/colszowka/simplecov) for tracking overall test coverage
 
 Each pull request should come with tests related to the newly written feature or bug fix. Ideally, we should test both the front end and back end.
 
 If you'd like to help us improve our test coverage, we recommend checking out our total coverage and writing tests for selected files based on SimpleCov's (more below) test coverage results.
 
-If you're new to writing tests in general or with Rails, we recommend reading about testing with Rails, RSpec, and Capybara first. For Webpack and
+If you're new to writing tests in general or with Rails, we recommend reading about testing with Rails, RSpec, and Capybara first.
 
 ## How to Use SimpleCov
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Small CSS modification to fix the height of the READ POST button as stated on #921 .

## Related Tickets & Documents

Fixes https://github.com/thepracticaldev/dev.to/issues/921
That was modified on: https://github.com/thepracticaldev/dev.to/pull/836 , just added a little bit more width to also fix this other button which uses the same css class.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

**Before (too much height and overflowing text)**
![before](https://user-images.githubusercontent.com/38727945/46950405-3b1f8180-d0a2-11e8-8733-1b7bbfa850e8.png)

**After:**
![after](https://user-images.githubusercontent.com/11021461/46957300-91d38e00-d097-11e8-8068-94c1f6d3d737.png)
