### PR TITLE
Allow Giphy links to be used and not from Cloudinary

### DIFF
--- a/app/labor/markdown_parser.rb
+++ b/app/labor/markdown_parser.rb
@@ -59,12 +59,18 @@ class MarkdownParser
   end
 
   def prefix_all_images(html, width = 880)
+    # wrap with Cloudinary or allow if from giphy or githubusercontent.com
     doc = Nokogiri::HTML.fragment(html)
     doc.css("img").each do |img|
-      if img.attr("src") && check_image_rehost_whitelist(img.attr("src"))
-        src = img.attr("src")
-        img["src"] = img_of_size(src, width)
-      end
+      src = img.attr("src")
+      next unless src
+      # allow image to render as-is
+      next if whitelisted_image_host?(src)
+      img["src"] = if giphy_img?(src)
+                     src.gsub("https://media.", "https://i.")
+                   else
+                     img_of_size(src, width)
+                   end
     end
     doc.to_html
   end
@@ -99,9 +105,19 @@ class MarkdownParser
     end
   end
 
-  def check_image_rehost_whitelist(src)
+  def whitelisted_image_host?(src)
     # GitHub camo image won't parse but should be safe to host direct
-    !src.start_with?("https://camo.githubusercontent.com/")
+    src.start_with?("https://camo.githubusercontent.com/")
+  end
+
+  def giphy_img?(source)
+    uri = URI.parse(source)
+    return false if uri.scheme != "https"
+    return false if uri.userinfo || uri.fragment || uri.query
+    return false if uri.host != "media.giphy.com" && uri.host != "i.giphy.com"
+    return false if uri.port != 443 # I think it has to be this if its https?
+
+    uri.path.ends_with?(".gif")
   end
 
   def remove_nested_linebreak_in_list(html)

--- a/spec/labor/markdown_parser_spec.rb
+++ b/spec/labor/markdown_parser_spec.rb
@@ -77,10 +77,42 @@ RSpec.describe MarkdownParser do
     end
   end
 
+  context "when using gifs from Giphy as images" do
+    let(:giphy_markdown_texts) do
+      %w(
+        ![source](https://media.giphy.com/media/3ow0TN2M8TH2aAn67F/giphy.gif)
+        ![social](https://media.giphy.com/media/3ow0TN2M8TH2aAn67F/giphy.gif)
+        ![small](https://media.giphy.com/media/3ow0TN2M8TH2aAn67F/200w_d.gif)
+      )
+    end
+
+    it "does not wrap giphy images with Cloudinary" do
+      giphy_markdown_texts.each do |body_markdown|
+        html = Nokogiri::HTML(generate_and_parse_markdown(body_markdown))
+        img_src = html.search("img")[0]["src"]
+        expect(img_src).not_to include("https://res.cloudinary.com")
+      end
+    end
+
+    it "uses the raw gif from i.giphy.com" do
+      giphy_markdown_texts.each do |body_markdown|
+        html = Nokogiri::HTML(generate_and_parse_markdown(body_markdown))
+        img_src = html.search("img")[0]["src"]
+        expect(img_src).to start_with("https://i.giphy.com")
+      end
+    end
+  end
+
   context "when an image is used" do
+    let(:markdown_with_img) { "![](https://image.com/image.jpg)" }
+
     it "wraps image in link" do
-      inline_code = "![](https://image.com/image.jpg)"
-      expect(generate_and_parse_markdown(inline_code)).to include("<a")
+      expect(generate_and_parse_markdown(markdown_with_img)).to include("<a")
+    end
+
+    it "wraps the image with Cloudinary" do
+      expect(generate_and_parse_markdown(markdown_with_img)).
+        to include("https://res.cloudinary.com")
     end
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
Very occasionally, we'll have some gifs that break because we optimize them with Cloudinary. This allows people to upload gifs to Giphy to use directly on dev.to.

Some technical details:
- We change `media.giphy.com` to `i.giphy.com` since the `media` gif doesn't render properly in Firefox
- I refactored some of the if/else logic, but the `whitelisted_image_host?` method doesn't include `giphy.com` since we need to manipulate the `src` and `giphy_img?` would be called twice.

## Added to documentation?
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![Giphy logo glitching out](https://media.giphy.com/media/YJBNjrvG5Ctmo/giphy.gif)