### PR TITLE
Fixed /feedback_messages not having a title

### DIFF
--- a/app/views/feedback_messages/index.html.erb
+++ b/app/views/feedback_messages/index.html.erb
@@ -1,3 +1,4 @@
+<% title "Feedback" %>
 <div class="dialog">
   <div>
     <h2>Thank you for your report.</a></h2>


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

There was no title for the page, so in Firefox the tab looked like "dev.to/feedback_messages". I guess this should fix it.

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

