### PR TITLE
Adjust org size labels in settings form

### DIFF
--- a/app/views/users/_org_admin.html.erb
+++ b/app/views/users/_org_admin.html.erb
@@ -101,8 +101,8 @@
     <%= f.text_field :email, maxlength: 64, placeholder: "Limit of 64 characters" %>
   </div> 
   <div class="field">
-    <%= f.label :company_size, "Company Size" %>
-    <%= f.text_field :company_size, maxlength: 64, placeholder: "Limit of 64 characters" %>
+    <%= f.label :company_size, "Organization Size" %>
+    <%= f.text_field :company_size, maxlength: 10, placeholder: "Enter a number" %>
   </div>   
   <div class="field">
     <%= f.label :story, "Our Story" %>


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
Adjust copy to make it more clear that organization size is a number. Also changed copy to read "Organization" instead of company.
## Related Tickets & Documents
#910 
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
https://cl.ly/4538ec7a8f5e/Image%202018-10-16%20at%201.30.01%20PM.png

