### PR TITLE
Change default <from> in notifymailer mentor emails

### DIFF
--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -85,13 +85,13 @@ class NotifyMailer < ApplicationMailer
     @mentee = mentee
     @mentor = mentor
     subject = "You have been matched with a DEV mentor!"
-    mail(to: @mentee.email, subject: subject)
+    mail(to: @mentee.email, subject: subject, from: "Liana (from DEV) <liana@dev.to>")
   end
 
   def mentor_email(mentor, mentee)
     @mentor = mentor
     @mentee = mentee
     subject = "You have been matched with a new DEV mentee!"
-    mail(to: @mentor.email, subject: subject)
+    mail(to: @mentor.email, subject: subject, from: "Liana (from DEV) <liana@dev.to>")
   end
 end

--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -85,13 +85,13 @@ class NotifyMailer < ApplicationMailer
     @mentee = mentee
     @mentor = mentor
     subject = "You have been matched with a DEV mentor!"
-    mail(to: @mentee.email, subject: subject, from: "Liana (from DEV) <liana@dev.to>")
+    mail(to: @mentee.email, subject: subject, from: "Liana (from dev.to) <liana@dev.to>")
   end
 
   def mentor_email(mentor, mentee)
     @mentor = mentor
     @mentee = mentee
     subject = "You have been matched with a new DEV mentee!"
-    mail(to: @mentor.email, subject: subject, from: "Liana (from DEV) <liana@dev.to>")
+    mail(to: @mentor.email, subject: subject, from: "Liana (from dev.to) <liana@dev.to>")
   end
 end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Change from default `yo@dev.to` in mentorship emails