### PR TITLE
[Article Actions] Using position sticky

### DIFF
--- a/app/assets/stylesheets/article-show.scss
+++ b/app/assets/stylesheets/article-show.scss
@@ -647,7 +647,7 @@ header{
   .article-actions{
     text-align:center;
     padding:9px 0px 16px;
-    position: fixed;
+    position: sticky;
     bottom:0;
     z-index:22;
     background: white;

--- a/app/assets/stylesheets/articles.scss
+++ b/app/assets/stylesheets/articles.scss
@@ -5,7 +5,6 @@
 
 .home{
   position:relative;
-  overflow:hidden;
   min-height:440px;
   margin:auto;
   max-width:1250px;
@@ -560,7 +559,7 @@
         }
         .bm-success{
           display:none;
-        }       
+        }
         &.selected{
           color: darken($purple, 33%);
           background: transparent;

--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -28,7 +28,6 @@ body {
 
 
 .universal-page-content-wrapper{
-  overflow:hidden;
   min-height:88vh;
   visibility: visible;
   &.stories-index,&.notifications-index,&.stories-search,&.podcast_episodes-index,&.reading_list_items-index,.tags-index{

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -165,7 +165,6 @@
         <%= @article.processed_html.html_safe %>
       </div>
       <%= render "articles/collection", position: "bottom" %>
-      <%= render 'articles/actions' %>
     </section>
     <% if @article.body_markdown && @article.body_markdown.size > 900 %>
       <% cache("article-about-author-#{@user.id}-#{@user.updated_at}", :expires_in => 100.hours) do %>
@@ -200,6 +199,7 @@
         </div>
       </div>
     <% end %>
+    <%= render 'articles/actions' %>
   </div>
   <% cache("article-bottom-content-#{@article.cached_tag_list_array.sort}", :expires_in => 6.hours) do %>
     <% @classic_article = Suggester::Articles::Classic.new(@article).get %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,7 +21,6 @@
     <style>
       .home {
           position: relative;
-          overflow: hidden;
           text-align: center;
           min-height: 440px;
           margin: auto;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Changed position of article actions bar (or reactions). 
Keep bar in the bottom of the article section using `position: sticky`.
This was [recently discussed here](https://dev.to/frontendmentor/why-its-time-to-embrace-position-sticky-20i2).
Main motivation on this is that it doesn't make sense (at least to me 🙈) to have reaction buttons for the article when you are below its container, cause you are actually seeing suggestions to read other articles. 

## Related Tickets & Documents
_none_

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
[Gif showing it in action](https://imgur.com/jVhPpqs)
![Reactions bar](https://i.imgur.com/r9eppma.png)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?
https://imgur.com/gallery/aX1c9FW
