### PR TITLE
[Docker] Install latest version of bundler before installing packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ ENV RAILS_ENV development
 
 ENV YARN_INTEGRITY_ENABLED "false"
 
+RUN gem install bundler
+
 RUN bundle install --jobs 20 --retry 5
 
 ENTRYPOINT ["bundle", "exec"]


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

I just tried going through the Docker installation guide and I got the following warning:

> Warning: the running version of Bundler (1.16.3) is older than the version that created the lockfile (1.16.6). We suggest you upgrade to the latest version of Bundler by running `gem install bundler`.

This way the build should always use the latest version of Bundler

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
