### PR TITLE
[Fixes #733] Modify UI/UX of settings notification

### DIFF
--- a/app/assets/stylesheets/settings.scss
+++ b/app/assets/stylesheets/settings.scss
@@ -37,14 +37,16 @@
       }
     }
     .field-notice {
-      background:$red;
+      background: white;
       max-width:95%;
       padding:25px 0px;
       text-align:center;
       margin:0px 0px 25px;
-      color:white;
+      color:$black;
       font-weight:bold;
       border-radius:2px;
+      border: 1px solid $light-medium-gray;
+      box-shadow: $shadow;
       .small {
         font-size:13px;
         font-weight:300;


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
The original issue pointed out that the email-verification notification displayed on the settings page after saving the profile made the email difficult to read and the appearance misleads users to believe that an error may have occurred.  
In response, I modified the styling to more closely resemble with the dashboard/sidebar elements to fit the overall styling of dev.to.  

There was also some discussion within #733  about the accessibilty of the link color, though seeing as the colors are universally used on dev.to, I assumed that it would probably be best to address that in a seperate issue rather than modify the link color of a single element.

## Related Tickets & Documents
Issue #733 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
### Mobile:
<p>
<img width="220" alt="before-mobile" src="https://user-images.githubusercontent.com/16360374/47404772-625dfa80-d703-11e8-8462-d30947f80a53.png">
<img width="220" alt="after-mobile" src="https://user-images.githubusercontent.com/16360374/47404758-507c5780-d703-11e8-96ef-a6bd40834504.png">
</p>

### Desktop:  
<img width="650" alt="before-desktop" src="https://user-images.githubusercontent.com/16360374/47403787-bb2b9400-d6ff-11e8-9677-48f25da1412e.png">
<img width="650" alt="after-desktop" src="https://user-images.githubusercontent.com/16360374/46566828-dcf0e280-c8da-11e8-904e-d5f6b136650f.png">

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

