### PR TITLE
Fixes #969. Better UX for screenreader users

### DIFF
--- a/app/views/articles/_main_stories_feed.html.erb
+++ b/app/views/articles/_main_stories_feed.html.erb
@@ -12,10 +12,10 @@
               <% end %>
             </h2>
             <div class="button-container">
-              <a href="/users/auth/twitter?callback_url=<%= ApplicationConfig["APP_PROTOCOL"] %><%= ApplicationConfig["APP_DOMAIN"] %>/users/auth/twitter/callback" class="cta cta-button" data-no-instant>
+              <a href="/users/auth/twitter?callback_url=<%= ApplicationConfig["APP_PROTOCOL"] %><%= ApplicationConfig["APP_DOMAIN"] %>/users/auth/twitter/callback" class="cta cta-button" aria-label="Sign in with Twitter." data-no-instant>
                 TWITTER
               </a>
-              <a href="/users/auth/github?state=in-feed-cta" class="cta cta-button" data-no-instant>
+              <a href="/users/auth/github?state=in-feed-cta" class="cta cta-button" aria-label="Sign in with GitHub." data-no-instant>
                 GITHUB
               </a>
             </div>


### PR DESCRIPTION


## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x ] Bug Fix (Accessibility)
- [ ] Documentation Update

## Description
In the main articles page CTA for signing in via Twitter or Github, previously, screen readers say "Twitter" and "GitHub."  I added an `aria-label` attribute so that screen readers will say "Sign in with Twitter" and "Sign in with GitHub."  Tested on Windows 7, in Chrome, using Chrome Vox extension, and works well!

## Related Tickets & Documents
Fixes #969 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
I've never screen-recorded with audio and am not sure how to quickly.  I'm happy to give it a go if it's important to you to ~~see~~ hear the changes.

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x ] no documentation needed