### PR TITLE
Correctly handle trying to edit not existing settings tab

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -173,6 +173,8 @@ class UsersController < ApplicationController
         %0A
         YOUR-DEV-USERNAME-HERE
       HEREDOC
+    else
+      not_found unless @tab_list.map { |t| t.downcase.gsub(" ", "-") }.include? @tab
     end
   end
 end

--- a/spec/requests/user_settings_spec.rb
+++ b/spec/requests/user_settings_spec.rb
@@ -21,6 +21,11 @@ RSpec.describe "UserSettings", type: :request do
         end
       end
 
+      it "handles unknown settings tab properly" do
+        expect { get "/settings/does-not-exist" }.
+          to raise_error(ActionController::RoutingError)
+      end
+
       it "doesn't let user access membership if user has no monthly_dues" do
         get "/settings/membership"
         expect(response.body).not_to include("Settings for")


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Documentation Update

## Description
Properly handle a non existing settings tab edit request by responding with a 404 instead of a 500

## Related Tickets & Documents
fixes #999 

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed
