### PR TITLE
404 comments for unpublished posts

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -27,6 +27,7 @@ class CommentsController < ApplicationController
         @user.articles.find_by_slug(params[:slug]) ||
         not_found
       @article = @commentable
+      not_found unless @commentable.published
     end
     @commentable_type = @commentable.class.name
     if params[:id_code].present?

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -35,6 +35,18 @@ RSpec.describe "Comments", type: :request do
         expect(response).to have_http_status(200)
       end
     end
+
+    context "when the article is unpublished" do
+      before do
+        new_markdown = article.body_markdown.gsub("published: true", "published: false")
+        comment
+        article.update(body_markdown: new_markdown)
+      end
+
+      it "raises a Not Found error" do
+        expect { get comment.path }.to raise_error("Not Found")
+      end
+    end
   end
 
   describe "GET /:username/:slug/comments/:id_code/edit" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This prevents comments from being viewable if a post is unpublished.

## Added to documentation?
- [x] no documentation needed