### PR TITLE
Add random skin colors to page title developers

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -40,10 +40,12 @@ module ApplicationHelper
   end
 
   def title(page_title)
+    women = ["👩‍💻", "👩🏻‍💻", "👩🏼‍💻", "👩🏽‍💻", "👩🏾‍💻", "👩🏿‍💻"]
+    men = ["👨‍💻", "👨🏻‍💻", "👨🏼‍💻", "👨🏽‍💻", "👨🏾‍💻", "👨🏿‍💻"]
     derived_title = if page_title.include?("DEV")
                       page_title
                     else
-                      page_title + " - DEV Community 👩‍💻👨‍💻"
+                      page_title + " - DEV Community " + women.sample + men.sample
                     end
     content_for(:title) { derived_title }
     derived_title
@@ -154,7 +156,7 @@ module ApplicationHelper
   end
 
   def follow_button(followable, style = "full")
-    tag :button, #Yikes
+    tag :button, # Yikes
       class: "cta follow-action-button",
       data: {
         info: { id: followable.id, className: followable.class.name, style: style }.to_json,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Makes the developers emoji in pages' title bar appear with a random skin color. Thought it would be cute.

Pages with hardcoded titles (such as the index or official DEV pages) still have Simpsons skin.

## Related Tickets & Documents
N/A

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![screenshot of developer emoji with skin tones](https://user-images.githubusercontent.com/5362035/47651571-d43da600-db40-11e8-943f-2458f46f79bd.png)
![screenshot of developer emoji with skin tones](https://user-images.githubusercontent.com/5362035/47651578-d869c380-db40-11e8-8e34-e0aa36f03c4b.png)
![screenshot of developer emoji with skin tones](https://user-images.githubusercontent.com/5362035/47651580-da338700-db40-11e8-9c5f-6d62c6570b05.png)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![Black women yelling "yas" while typing](https://user-images.githubusercontent.com/5362035/47652029-10bdd180-db42-11e8-8e35-19b6f9d07b32.gif)


