### PR TITLE
update ruby badge version in main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <br/>
 <p align="center">
   <a href="https://www.ruby-lang.org/en/">
-    <img src="https://img.shields.io/badge/Ruby-v2.5.1-green.svg" alt="ruby version"/>
+    <img src="https://img.shields.io/badge/Ruby-v2.5.3-green.svg" alt="ruby version"/>
   </a>
   <a href="http://rubyonrails.org/">
     <img src="https://img.shields.io/badge/Rails-v5.1.6-brightgreen.svg" alt="rails version"/>


### PR DESCRIPTION
## What type of PR is this? 

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Documentation Update

## Description
Just changing the shield.io ruby badge version from 2.5.1 -> 2.5.3 for clarity if first contact with repo is the main readme. All other ruby versions in the docs are already updated to 2.5.3.

## Related Tickets & Documents
N/A

## Added to documentation?
- [ ] docs.dev.to
- [x] readme
- [ ] no documentation needed
