### PR TITLE
Add readonly attribute to input on link select

### DIFF
--- a/app/views/articles/_actions.html.erb
+++ b/app/views/articles/_actions.html.erb
@@ -33,7 +33,7 @@
     <div class="dropdown-content">
       <div>
         <div class="dropdown-link-row">
-          <img src="<%= asset_path("link.svg") %>" /><input value="https://dev.to<%= @article.path %>" onClick="this.setSelectionRange(0, this.value.length)"/>
+          <img src="<%= asset_path("link.svg") %>" /><input value="https://dev.to<%= @article.path %>" onClick="this.setSelectionRange(0, this.value.length)" readonly/>
         </div>
         <div class="dropdown-link-row"><a target='_blank' href='https://twitter.com/intent/tweet?text="<%= @article.title %>" by <%= @article.user.twitter_username ? "@" + @article.user.twitter_username : @article.user.name %> %23DEVcommunity https://dev.to<%= @article.path %>'>Share to Twitter</a></div>
         <div class="dropdown-link-row"><a target='_blank' href='https://www.linkedin.com/shareArticle?mini=true&url=https://dev.to<%=@article.path%>&title=<%=@article.title%>&summary=<%=@article.description%>&source=dev.to'>Share to LinkedIn</a></div>


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Documentation Update

## Description
In mobile view, when selecting the link in the drop downs partial, the mobile keyboard displays. Added a readonly attribute to the input tag on the action partial so the keyboard doesn't display.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![turnt](https://www.google.com/url?sa=i&source=images&cd=&cad=rja&uact=8&ved=2ahUKEwiw-7yd5rneAhXudN8KHYt6DIIQjRx6BAgBEAU&url=https%3A%2F%2Fgiphy.com%2Fstickers%2Ffunny-fun-1BcxaG4Lh2WrrTkACc&psig=AOvVaw12bD5rrloslcpSNKw_NDUW&ust=1541388622365341)
