### PR TITLE
Add slack message for warned user activity

### DIFF
--- a/app/observers/application_observer.rb
+++ b/app/observers/application_observer.rb
@@ -1,0 +1,10 @@
+class ApplicationObserver < ActiveRecord::Observer
+  def warned_user_ping(activity)
+    if activity.user.warned == true
+      SlackBot.ping "@#{activity.user.username} just posted.\nThey've been warned since #{activity.user.roles.where(name: 'warned')[0].updated_at.strftime('%d %B %Y')}\nhttps://dev.to#{activity.path}",
+              channel: "warned-user-activity",
+              username: "sloan_watch_bot",
+              icon_emoji: ":sloan:"
+    end
+  end
+end

--- a/app/observers/article_observer.rb
+++ b/app/observers/article_observer.rb
@@ -8,6 +8,12 @@ class ArticleObserver < ActiveRecord::Observer
                     icon_emoji: ":writing_hand:"
 
     end
+    if article.user.warned == true
+      SlackBot.ping "@#{article.user.username} just posted an article.\nThey've been warned since #{article.user.roles.where(name: 'warned')[0].updated_at.strftime('%d %B %Y')}\nhttps://dev.to#{article.path}",
+              channel: "warned-user-activity",
+              username: "sloan_watch_bot",
+              icon_emoji: ":sloan:"
+    end
   rescue StandardError
     puts "error"
   end

--- a/app/observers/article_observer.rb
+++ b/app/observers/article_observer.rb
@@ -9,7 +9,7 @@ class ArticleObserver < ActiveRecord::Observer
 
     end
     if article.user.warned == true
-      SlackBot.ping "@#{article.user.username} just posted an article.\nThey've been warned since #{article.user.roles.where(name: 'warned')[0].updated_at.strftime('%d %B %Y')}\nhttps://dev.to#{article.path}",
+      SlackBot.delay.ping "@#{article.user.username} just posted an article.\nThey've been warned since #{article.user.roles.where(name: 'warned')[0].updated_at.strftime('%d %B %Y')}\nhttps://dev.to#{article.path}",
               channel: "warned-user-activity",
               username: "sloan_watch_bot",
               icon_emoji: ":sloan:"

--- a/app/observers/article_observer.rb
+++ b/app/observers/article_observer.rb
@@ -1,4 +1,4 @@
-class ArticleObserver < ActiveRecord::Observer
+class ArticleObserver < ApplicationObserver
   def after_save(article)
     return if Rails.env.development?
     if article.published && article.published_at > 30.seconds.ago
@@ -8,12 +8,7 @@ class ArticleObserver < ActiveRecord::Observer
                     icon_emoji: ":writing_hand:"
 
     end
-    if article.user.warned == true
-      SlackBot.delay.ping "@#{article.user.username} just posted an article.\nThey've been warned since #{article.user.roles.where(name: 'warned')[0].updated_at.strftime('%d %B %Y')}\nhttps://dev.to#{article.path}",
-              channel: "warned-user-activity",
-              username: "sloan_watch_bot",
-              icon_emoji: ":sloan:"
-    end
+    warned_user_ping(article)
   rescue StandardError
     puts "error"
   end

--- a/app/observers/comment_observer.rb
+++ b/app/observers/comment_observer.rb
@@ -2,7 +2,7 @@ class CommentObserver < ActiveRecord::Observer
   def after_save(comment)
     return if Rails.env.development?
     if comment.user.warned == true
-      SlackBot.ping "@#{comment.user.username} just posted a comment.\nThey've been warned since #{comment.user.roles.where(name: 'warned')[0].updated_at.strftime('%d %B %Y')}\nhttps://dev.to#{comment.path}",
+      SlackBot.delay.ping "@#{comment.user.username} just posted a comment.\nThey've been warned since #{comment.user.roles.where(name: 'warned')[0].updated_at.strftime('%d %B %Y')}\nhttps://dev.to#{comment.path}",
               channel: "warned-user-activity",
               username: "sloan_watch_bot",
               icon_emoji: ":sloan:"

--- a/app/observers/comment_observer.rb
+++ b/app/observers/comment_observer.rb
@@ -1,0 +1,13 @@
+class CommentObserver < ActiveRecord::Observer
+  def after_save(comment)
+    return if Rails.env.development?
+    if comment.user.warned == true
+      SlackBot.ping "@#{comment.user.username} just posted a comment.\nThey've been warned since #{comment.user.roles.where(name: 'warned')[0].updated_at.strftime('%d %B %Y')}\nhttps://dev.to#{comment.path}",
+              channel: "warned-user-activity",
+              username: "sloan_watch_bot",
+              icon_emoji: ":sloan:"
+    end
+  rescue StandardError
+    puts "error"
+  end
+end

--- a/app/observers/comment_observer.rb
+++ b/app/observers/comment_observer.rb
@@ -1,12 +1,7 @@
-class CommentObserver < ActiveRecord::Observer
+class CommentObserver < ApplicationObserver
   def after_save(comment)
     return if Rails.env.development?
-    if comment.user.warned == true
-      SlackBot.delay.ping "@#{comment.user.username} just posted a comment.\nThey've been warned since #{comment.user.roles.where(name: 'warned')[0].updated_at.strftime('%d %B %Y')}\nhttps://dev.to#{comment.path}",
-              channel: "warned-user-activity",
-              username: "sloan_watch_bot",
-              icon_emoji: ":sloan:"
-    end
+    warned_user_ping(comment)
   rescue StandardError
     puts "error"
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,7 +31,7 @@ module PracticalDeveloper
     config.autoload_paths += Dir["#{config.root}/app/sanitizers"]
     config.autoload_paths += Dir["#{config.root}/lib/"]
 
-    config.active_record.observers = :article_observer, :reaction_observer
+    config.active_record.observers = :article_observer, :reaction_observer, :comment_observer
     config.active_job.queue_adapter = :delayed_job
 
     config.middleware.use Rack::Deflater

--- a/spec/observers/article_observer_spec.rb
+++ b/spec/observers/article_observer_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe ArticleObserver, type: :observer do
+  let(:user) { create(:user) }
+
+  before do
+    allow(SlackBot).to receive(:ping).and_return(true)
+  end
+
+  it "pings slack if user with warned role creates an article" do
+    user.add_role :warned
+    Article.observers.enable :article_observer do
+      create(:article, user_id: user.id)
+    end
+    expect(SlackBot).to have_received(:ping).twice
+  end
+end

--- a/spec/observers/comment_observer_spec.rb
+++ b/spec/observers/comment_observer_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe CommentObserver, type: :observer do
+  let(:user) { create(:user) }
+  let(:article) { create(:article) }
+
+  before do
+    allow(SlackBot).to receive(:ping).and_return(true)
+  end
+
+  it "pings slack if user with warned role creates a comment" do
+    user.add_role :warned
+    Comment.observers.enable :comment_observer do
+      create(:comment, user_id: user.id, commentable_id: article.id)
+    end
+    expect(SlackBot).to have_received(:ping).twice
+  end
+end

--- a/spec/requests/articles_create_spec.rb
+++ b/spec/requests/articles_create_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "ArticlesCreate", type: :request do
       expect(Article.last.user_id).to eq(user.id)
     end
 
-    it "pings slack if user is has warned role" do
+    it "pings slack if user has warned role" do
       user.add_role :warned
       expect(SlackBot).to have_received(:ping)
     end

--- a/spec/requests/articles_create_spec.rb
+++ b/spec/requests/articles_create_spec.rb
@@ -5,14 +5,27 @@ RSpec.describe "ArticlesCreate", type: :request do
 
   before do
     sign_in user
+    allow(SlackBot).to receive(:ping).and_return(true)
   end
 
-  it "creates ordinary article with proper params" do
-    new_title = "NEW TITLE #{rand(100)}"
-    post "/articles", params: {
-      article: { title: new_title, body_markdown: "Yo ho ho#{rand(100)}", tag_list: "yo" }
-    }
-    expect(Article.last.user_id).to eq(user.id)
+  context "when an ordinary article is created with proper params" do
+    before do
+      new_title = "NEW TITLE #{rand(100)}"
+      post "/articles", params: {
+        article: { title: new_title,
+                   body_markdown: "Yo ho ho#{rand(100)}",
+                   tag_list: "yo" }
+      }
+    end
+
+    it "creates ordinary article with proper params" do
+      expect(Article.last.user_id).to eq(user.id)
+    end
+
+    it "pings slack if user is has warned role" do
+      user.add_role :warned
+      expect(SlackBot).to have_received(:ping)
+    end
   end
 
   # rubocop:disable RSpec/ExampleLength
@@ -56,7 +69,7 @@ RSpec.describe "ArticlesCreate", type: :request do
     post "/articles", params: {
       article: {
         title: new_title,
-        body_markdown: "---\ntitle: hey hey hahuu\npublished: false\nseries: helloyo\n---\nYo ho ho#{rand(100)}",
+        body_markdown: "---\ntitle: hey hey hahuu\npublished: false\nseries: helloyo\n---\nYo ho ho#{rand(100)}"
       }
     }
     expect(Collection.last.slug).to eq("helloyo")

--- a/spec/requests/articles_create_spec.rb
+++ b/spec/requests/articles_create_spec.rb
@@ -5,11 +5,14 @@ RSpec.describe "ArticlesCreate", type: :request do
 
   before do
     sign_in user
-    allow(SlackBot).to receive(:ping).and_return(true)
   end
 
   context "when an ordinary article is created with proper params" do
     before do
+      allow(SlackBot).to receive(:ping).and_return(true)
+    end
+
+    def create_article
       new_title = "NEW TITLE #{rand(100)}"
       post "/articles", params: {
         article: { title: new_title,
@@ -18,12 +21,14 @@ RSpec.describe "ArticlesCreate", type: :request do
       }
     end
 
-    it "creates ordinary article with proper params" do
+    it "creates article" do
+      create_article
       expect(Article.last.user_id).to eq(user.id)
     end
 
     it "pings slack if user has warned role" do
       user.add_role :warned
+      create_article
       expect(SlackBot).to have_received(:ping)
     end
   end

--- a/spec/requests/articles_create_spec.rb
+++ b/spec/requests/articles_create_spec.rb
@@ -7,30 +7,12 @@ RSpec.describe "ArticlesCreate", type: :request do
     sign_in user
   end
 
-  context "when an ordinary article is created with proper params" do
-    before do
-      allow(SlackBot).to receive(:ping).and_return(true)
-    end
-
-    def create_article
-      new_title = "NEW TITLE #{rand(100)}"
-      post "/articles", params: {
-        article: { title: new_title,
-                   body_markdown: "Yo ho ho#{rand(100)}",
-                   tag_list: "yo" }
-      }
-    end
-
-    it "creates article" do
-      create_article
-      expect(Article.last.user_id).to eq(user.id)
-    end
-
-    it "pings slack if user has warned role" do
-      user.add_role :warned
-      create_article
-      expect(SlackBot).to have_received(:ping)
-    end
+  it "creates ordinary article with proper params" do
+    new_title = "NEW TITLE #{rand(100)}"
+    post "/articles", params: {
+      article: { title: new_title, body_markdown: "Yo ho ho#{rand(100)}", tag_list: "yo" }
+    }
+    expect(Article.last.user_id).to eq(user.id)
   end
 
   # rubocop:disable RSpec/ExampleLength

--- a/spec/requests/comments_create_spec.rb
+++ b/spec/requests/comments_create_spec.rb
@@ -8,27 +8,11 @@ RSpec.describe "CommentsCreate", type: :request do
     sign_in user
   end
 
-  context "when an ordinary comment is created with proper params" do
-    before do
-      allow(SlackBot).to receive(:ping).and_return(true)
-    end
-
-    def create_comment
-      new_body = "NEW BODY #{rand(100)}"
-      post "/comments", params: {
-        comment: { body_markdown: new_body, commentable_id: article.id, commentable_type: "Article" }
-      }
-    end
-
-    it "creates comment" do
-      create_comment
-      expect(Comment.last.user_id).to eq(user.id)
-    end
-
-    it "creates comment and pings slack if user has warned role" do
-      user.add_role :warned
-      create_comment
-      expect(SlackBot).to have_received(:ping)
-    end
+  it "creates ordinary article with proper params" do
+    new_body = "NEW BODY #{rand(100)}"
+    post "/comments", params: {
+      comment: { body_markdown: new_body, commentable_id: article.id, commentable_type: "Article" }
+    }
+    expect(Comment.last.user_id).to eq(user.id)
   end
 end

--- a/spec/requests/comments_create_spec.rb
+++ b/spec/requests/comments_create_spec.rb
@@ -11,6 +11,9 @@ RSpec.describe "CommentsCreate", type: :request do
   context "when an ordinary comment is created with proper params" do
     before do
       allow(SlackBot).to receive(:ping).and_return(true)
+    end
+
+    def create_comment
       new_body = "NEW BODY #{rand(100)}"
       post "/comments", params: {
         comment: { body_markdown: new_body, commentable_id: article.id, commentable_type: "Article" }
@@ -18,11 +21,13 @@ RSpec.describe "CommentsCreate", type: :request do
     end
 
     it "creates comment" do
+      create_comment
       expect(Comment.last.user_id).to eq(user.id)
     end
 
-    it "pings slack if user has warned role" do
+    it "creates comment and pings slack if user has warned role" do
       user.add_role :warned
+      create_comment
       expect(SlackBot).to have_received(:ping)
     end
   end

--- a/spec/requests/comments_create_spec.rb
+++ b/spec/requests/comments_create_spec.rb
@@ -8,11 +8,22 @@ RSpec.describe "CommentsCreate", type: :request do
     sign_in user
   end
 
-  it "creates ordinary article with proper params" do
-    new_body = "NEW BODY #{rand(100)}"
-    post "/comments", params: {
-      comment: { body_markdown: new_body, commentable_id: article.id, commentable_type: "Article" }
-    }
-    expect(Comment.last.user_id).to eq(user.id)
+  context "when an ordinary comment is created with proper params" do
+    before do
+      allow(SlackBot).to receive(:ping).and_return(true)
+      new_body = "NEW BODY #{rand(100)}"
+      post "/comments", params: {
+        comment: { body_markdown: new_body, commentable_id: article.id, commentable_type: "Article" }
+      }
+    end
+
+    it "creates comment" do
+      expect(Comment.last.user_id).to eq(user.id)
+    end
+
+    it "pings slack if user has warned role" do
+      user.add_role :warned
+      expect(SlackBot).to have_received(:ping)
+    end
   end
 end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Send slack message to core team (warned_user_activity)  if a 'warned' creates/updates an article or comment.

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![red button](https://media.giphy.com/media/xUA7bbaSmCUfNYjhks/giphy.gif)
