### PR TITLE
Url encode article's title for Twitter sharing

### DIFF
--- a/app/views/articles/_actions.html.erb
+++ b/app/views/articles/_actions.html.erb
@@ -16,7 +16,7 @@
   </button>
   <a class="article-actions-tweet-button"
       target='_blank'
-      href='https://twitter.com/intent/tweet?text="<%= @article.title %>" by <%= @article.user.twitter_username ? "@" + @article.user.twitter_username : @article.user.name %> %23DEVcommunity https://dev.to<%= @article.path %>'>
+      href='https://twitter.com/intent/tweet?text="<%=u @article.title.strip %>" by <%= @article.user.twitter_username ? "@" + @article.user.twitter_username : @article.user.name %> %23DEVcommunity https://dev.to<%= @article.path %>'>
     <img src="<%= asset_path("twitter.svg") %>" />
   </a>
   <a class="article-actions-comments-count" href="#comments" id="jump-to-comments">


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

If the article's title contains the `#` character the Twitter share won't work correctly.
The article's title to work needs to be URL encoded.

## Related Tickets & Documents

Closes https://github.com/thepracticaldev/dev.to/issues/1091

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![before](https://user-images.githubusercontent.com/146201/48317214-165df180-e5ef-11e8-9149-210952faf637.gif)


## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
