### PR TITLE
Night/Dark mode

### DIFF
--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -36,7 +36,10 @@ body {
   &.night-theme {
     background-color: black !important;
 
-    &, & [class="highlight"], & iframe {
+    &,
+    & [class="highlight"],
+    & iframe,
+    & video {
       -webkit-filter: invert(100%);
       filter: invert(100%);
     }

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -37,7 +37,7 @@ body {
     background-color: black !important;
 
     &,
-    & [class="highlight"],
+    & .highlight,
     & iframe,
     & video {
       -webkit-filter: invert(100%);

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -31,3 +31,31 @@ $shadow: 1px 2px 4px 0 rgba(0, 0, 0, 0.18);
 $light-shadow: 1px 2px 4px 0 rgba(0, 0, 0, 0.1);
 $dark-shadow: 1px 2px 4px 0 rgba(0, 0, 0, 0.25);
 $bold-shadow: 3px 3px 0px darken($light-medium-gray, 13%);
+
+body {
+  &.night-theme {
+    background-color: black !important;
+
+    &, & [class="highlight"], & iframe {
+      -webkit-filter: invert(100%);
+      filter: invert(100%);
+    }
+
+    & * {
+      background-blend-mode: difference;
+    }
+
+    img,
+    .image.image {
+      -webkit-transition: -webkit-filter 0.5s ease-in, filter 0.5s ease-in;
+      -webkit-filter: invert(100%) grayscale(100%);
+      transition: -webkit-filter 0.5s ease-in, filter 0.5s ease-in;
+      filter: invert(100%) grayscale(100%);
+
+      &:hover {
+        -webkit-filter: invert(100%) grayscale(0%);
+        filter: invert(100%) grayscale(0%);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
This is an initial attempt at a night/dark theme for dev.to. Though the use of css filters, modern browsers will see an inversion of the colors used in the site, along with grayscale images until mouse hover. Needs more testing and a means to enable `body.night-theme` in user settings.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![nov-26-2018 14-53-22](https://user-images.githubusercontent.com/1634457/49038482-13d0cf80-f18b-11e8-81ca-388f13102bed.gif)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [ ] no documentation needed
