### PR TITLE
Add reaction confirm/invalidate workflow for admins

### DIFF
--- a/app/controllers/internal/feedback_messages_controller.rb
+++ b/app/controllers/internal/feedback_messages_controller.rb
@@ -10,6 +10,17 @@ class Internal::FeedbackMessagesController < Internal::ApplicationController
       order("feedback_messages.created_at DESC").
       page(params[:page] || 1).per(5)
     @email_messages = EmailMessage.find_for_reports(@feedback_messages.pluck(:id))
+    @vomits = get_vomits
+  end
+
+  def get_vomits
+    if params[:status] == "Open" || params[:status].blank?
+      Reaction.where(category: "vomit", status: "valid").includes(:user, :reactable).order("updated_at DESC")
+    elsif params[:status] == "Resolved"
+      Reaction.where(category: "vomit", status: "confirmed").includes(:user, :reactable).order("updated_at DESC").limit(10)
+    else
+      Reaction.where(category: "vomit", status: "invalid").includes(:user, :reactable).order("updated_at DESC").limit(10)
+    end
   end
 
   def save_status

--- a/app/controllers/internal/reactions_controller.rb
+++ b/app/controllers/internal/reactions_controller.rb
@@ -1,0 +1,8 @@
+class Internal::ReactionsController < Internal::ApplicationController
+  def update
+    # raise
+    @reaction = Reaction.find(params[:id])
+    @reaction.update(status: params[:reaction][:status])
+    redirect_to "/internal/reports"
+  end
+end

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -9,6 +9,7 @@ class Reaction < ApplicationRecord
 
   validates :category, inclusion: { in: %w(like thinking hands unicorn thumbsdown vomit readinglist) }
   validates :reactable_type, inclusion: { in: %w(Comment Article) }
+  validates :status, inclusion: { in: %w(valid invalid confirmed) }
   validates :user_id, uniqueness: { scope: %i[reactable_id reactable_type category] }
   validate  :permissions
 
@@ -127,6 +128,8 @@ class Reaction < ApplicationRecord
 
   def assign_points
     base_points = BASE_POINTS.fetch(category, 1.0)
+    base_points = 0 if status == "invalid"
+    base_points = base_points * 2 if status == "confirmed"
     self.points = user ? (base_points * user.reputation_modifier) : -5
   end
 

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -57,8 +57,8 @@
     <meta property="og:image" content="<%= cloud_social_image(@article) %>" />
     <meta name="twitter:image:src" content="<%= cloud_social_image(@article) %>">
   <% end %>
-  <% if !@article.published || (@article.positive_reactions_count < 8 && @article.user.comments_count < 1 && !@article.featured) ||
-    @article.featured_number.to_i < 1500000000 %>
+  <% if !@article.published || (@article.positive_reactions_count < 7 && @article.user.comments_count < 1 && !@article.featured) ||
+    @article.featured_number.to_i < 1500000000 || @article.score < -10 %>
     <meta name="googlebot" content="noindex">
     <meta name="googlebot" content="nofollow">
   <% end %>

--- a/app/views/internal/feedback_messages/index.html.erb
+++ b/app/views/internal/feedback_messages/index.html.erb
@@ -13,6 +13,33 @@
 
 <%= paginate @feedback_messages %>
 
+  <% if @feedback_type == "abuse-reports" %>
+    <% @vomits.each do |reaction| %>
+        <div class="row">
+          <div class="inner-row col-md-3">
+            <strong>🤢 <a href="<%= reaction.user.path %>">@<%= reaction.user.username %></a></strong>
+          </div>
+          <div class="inner-row col-md-<%= (params[:status] == "Open" || params[:status].blank?) ? "5" : "9" %>">
+            <strong><%= reaction.reactable_type %>:</strong> <a href="<%= reaction.reactable.path %>"><%= reaction.reactable.title %></a>
+          </div>
+          <% if params[:status] == "Open" || params[:status].blank? %>
+            <div class="inner-row col-md-2">
+              <%= form_for [:internal, reaction] do |f| %>
+                <%= f.hidden_field :status, value: "confirmed" %>
+                <%= f.submit "CONFIRMED", class: "btn btn-success btn-lg" %>
+              <% end %>
+            </div>
+            <div class="inner-row col-md-2">
+              <%= form_for [:internal, reaction] do |f| %>
+                <%= f.hidden_field :status, value: "invalid" %>
+                <%= f.submit "INVALID", class: "btn btn-danger btn-lg" %>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+    <% end %>
+  <% end %>
+
   <% @feedback_messages.each do |feedback_message| %>
     <%= form_for [:internal, feedback_message] do |f| %>
       <%= render "feedback_message", f: f, feedback_message: feedback_message %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
     resources :articles
     resources :tags
     resources :welcome, only: %i[index create]
+    resources :reactions, only: [:update]
     resources :broadcasts
     resources :users do
       member do

--- a/db/migrate/20181116223239_add_status_to_reactions.rb
+++ b/db/migrate/20181116223239_add_status_to_reactions.rb
@@ -1,0 +1,5 @@
+class AddStatusToReactions < ActiveRecord::Migration[5.1]
+  def change
+    add_column :reactions, :status, :string, default: "valid"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181111040732) do
+ActiveRecord::Schema.define(version: 20181116223239) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -560,6 +560,7 @@ ActiveRecord::Schema.define(version: 20181111040732) do
     t.float "points", default: 1.0
     t.integer "reactable_id"
     t.string "reactable_type"
+    t.string "status", default: "valid"
     t.datetime "updated_at", null: false
     t.integer "user_id"
     t.index ["category"], name: "index_reactions_on_category"

--- a/spec/models/reaction_spec.rb
+++ b/spec/models/reaction_spec.rb
@@ -58,6 +58,17 @@ RSpec.describe Reaction, type: :model do
       expect(reaction).not_to be_valid
     end
 
+    it "assigns 0 points if reaction is invalid" do
+      reaction.update(status: "invalid")
+      expect(reaction.points).to eq(0)
+    end
+
+    it "assigns 0 points if reaction is invalid" do
+      reaction_points = reaction.points
+      reaction.update(status: "confirmed")
+      expect(reaction.points).to eq(reaction_points*2)
+    end
+
     context "when user is trusted" do
       before { reaction.user.add_role(:trusted) }
 

--- a/spec/requests/internal_reactions_spec.rb
+++ b/spec/requests/internal_reactions_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe "/internal/reactions", type: :request do
+  let(:user)             { create(:user) }
+  let(:article)          { create(:article, user_id: user.id) }
+  let(:admin)            { create(:user, :super_admin) }
+
+  describe "PUT /internal/reactions as admin" do
+    before do
+      user.add_role(:trusted)
+      @reaction = create(:reaction, category: "vomit", user_id: user.id, reactable_id: article.id)
+      login_as admin
+    end
+    it "updates reaction to be confirmed" do
+      put "/internal/reactions/#{@reaction.id}", params: {
+        reaction: { status: "confirmed" }
+      }
+      expect(@reaction.reload.status).to eq("confirmed")
+    end
+    it "does not set invalid status" do
+      put "/internal/reactions/#{@reaction.id}", params: {
+        reaction: { status: "confirmedsssss" }
+      }
+      expect(@reaction.reload.status).not_to eq("confirmedsssss")
+    end
+  end
+  describe "PUT /internal/reactions as non-admin" do
+    before do
+      user.add_role(:trusted)
+      @reaction = create(:reaction, category: "vomit", user_id: user.id, reactable_id: article.id)
+      login_as user
+    end
+    it "updates reaction to be confirmed" do
+      expect { put "/internal/reactions/#{@reaction.id}", params: {
+        reaction: { status: "confirmed" }
+      } }.to raise_error(Pundit::NotAuthorizedError)
+    end
+  end
+end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Add ability for admins to quickly confirm/invalidate reactions from mod-privilege users.

This "status" column will also be useful for a possible future workflow of marking a post as "out of date" or similar via reactions. A user could "resolve" a reaction this way.

![](https://duaw26jehqd4r.cloudfront.net/items/2l0P362D0y02230l3U3x/Image%202018-11-16%20at%206.19.03%20PM.png)