### PR TITLE
#118 Allow users to embed Medium posts with Liquid Tags

### DIFF
--- a/app/labor/markdown_parser.rb
+++ b/app/labor/markdown_parser.rb
@@ -98,7 +98,7 @@ class MarkdownParser
 
   def allowed_image_host?(src)
     # GitHub camo image won't parse but should be safe to host direct
-    src.start_with?("https://camo.githubusercontent.com/")
+    src.start_with?("https://camo.githubusercontent.com/", "https://cdn-images-1.medium.com")
   end
 
   def giphy_img?(source)

--- a/app/liquid_tags/medium_tag.rb
+++ b/app/liquid_tags/medium_tag.rb
@@ -1,6 +1,7 @@
 class MediumTag < LiquidTagBase
   include ApplicationHelper
   include ActionView::Helpers::TagHelper
+  include InlineSvg::ActionView::Helpers
   attr_reader :response
 
   def initialize(_tag_name, url, _tokens)
@@ -13,13 +14,15 @@ class MediumTag < LiquidTagBase
         <a href='#{response[:url]}' class='ltag__link__link'>
           <div class='ltag__link__pic'>
             <img src='#{response[:author_image]}' alt='#{response[:author]}'/>
-          </div></a>
-          <a href='#{response[:url]}' class='ltag__link__link'>
-            <div class='ltag__link__content'>
-              <h2>#{response[:title]}</h2>
-              <h3>#{response[:author]}</h3>
-              <div class='ltag__link__taglist'>#{response[:reading_time]}</div>
-            </div>
+          </div>
+        </a>
+        <a href='#{response[:url]}' class='ltag__link__link'>
+          <div class='ltag__link__content'>
+            <h2>#{response[:title]}</h2>
+            <h3>#{response[:author]}</h3>
+            #{inline_svg('medium_icon.svg', size: '27px*27px')} Medium
+            <div class='ltag__link__taglist'>#{response[:reading_time]}</div>
+          </div>
         </a>
       </div>
     HTML
@@ -39,5 +42,3 @@ class MediumTag < LiquidTagBase
     raise StandardError, "Invalid link URL or link URL does not exist"
   end
 end
-
-Liquid::Template.register_tag("medium", MediumTag)

--- a/app/liquid_tags/medium_tag.rb
+++ b/app/liquid_tags/medium_tag.rb
@@ -1,0 +1,43 @@
+class MediumTag < LiquidTagBase
+  include ApplicationHelper
+  include ActionView::Helpers::TagHelper
+  attr_reader :response
+
+  def initialize(_tag_name, url, _tokens)
+    @response = parse_url_for_medium_article(url)
+  end
+
+  def render(_context)
+    <<-HTML
+      <div class='ltag__link'>
+        <a href='#{response[:url]}' class='ltag__link__link'>
+          <div class='ltag__link__pic'>
+            <img src='#{response[:author_image]}' alt='#{response[:author]}'/>
+          </div></a>
+          <a href='#{response[:url]}' class='ltag__link__link'>
+            <div class='ltag__link__content'>
+              <h2>#{response[:title]}</h2>
+              <h3>#{response[:author]}</h3>
+              <div class='ltag__link__taglist'>#{response[:reading_time]}</div>
+            </div>
+        </a>
+      </div>
+    HTML
+  end
+
+  private
+
+  def parse_url_for_medium_article(url)
+    sanitized_article_url = ActionController::Base.helpers.strip_tags(url).strip
+
+    MediumArticleRetrievalService.new(sanitized_article_url).call
+  rescue StandardError
+    raise_error
+  end
+
+  def raise_error
+    raise StandardError, "Invalid link URL or link URL does not exist"
+  end
+end
+
+Liquid::Template.register_tag("medium", MediumTag)

--- a/app/services/medium_article_retrieval_service.rb
+++ b/app/services/medium_article_retrieval_service.rb
@@ -1,0 +1,25 @@
+class MediumArticleRetrievalService
+  attr_reader :url
+
+  def initialize(url)
+    @url = url
+  end
+
+  def call
+    html = HTTParty.get(url)
+    page = Nokogiri::HTML(html)
+
+    title = page.css("h1").first.content
+    author_image = page.css("img.avatar-image").first.attributes["src"].value
+    reading_time = page.css("span.readingTime").first.values.last
+    author = page.css("a[data-user-id]")[1].content
+
+    {
+      title: title,
+      author: author,
+      author_image: author_image,
+      reading_time: reading_time,
+      url: url
+    }
+  end
+end

--- a/spec/liquid_tags/medium_tag_spec.rb
+++ b/spec/liquid_tags/medium_tag_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+RSpec.describe MediumTag, type: :liquid_template do
+  setup { Liquid::Template.register_tag("medium", MediumTag) }
+
+  subject { Liquid::Template.parse("{% medium #{link} %}") }
+
+  let(:stubbed_scraper) { instance_double("MediumArticleRetrievalService") }
+  let(:medium_link) { "https://medium.com/@edisonywh/my-ruby-journey-hooking-things-up-91d757e1c59c" }
+  let(:response) do
+    {
+      title: "Title",
+      author: "Edison",
+      author_image: "https://cdn-images-1.medium.com/fit/c/120/120/1*qFzi921ix0_kkrFMKYgELw.jpeg",
+      reading_time: "4 min read",
+      url: "https://medium.com/@edisonywh"
+    }
+  end
+
+  def generate_medium_tag(link)
+    Liquid::Template.parse("{% medium #{link} %}")
+  end
+
+  context "when given valid medium url" do
+    before do
+      allow(MediumArticleRetrievalService).to receive(:new).with(medium_link).and_return(stubbed_scraper)
+      allow(stubbed_scraper).to receive(:call).and_return(response)
+    end
+
+    it "renders the proper author name" do
+      liquid = generate_medium_tag(medium_link)
+      expect(liquid.render).to include(response[:author])
+    end
+
+    it "renders user image html" do
+      liquid = generate_medium_tag(medium_link)
+      expect(liquid.render).to include("<img")
+    end
+
+    it "renders article reading time" do
+      liquid = generate_medium_tag(medium_link)
+      expect(liquid.render).to include(response[:reading_time])
+    end
+
+    it "renders link to Medium profile" do
+      liquid = generate_medium_tag(medium_link)
+      expect(liquid.render).to include("<a href='#{response[:url]}'")
+    end
+  end
+
+  it "raises an error when invalid" do
+    expect { generate_medium_tag("invalid link") }. to raise_error("Invalid link URL or link URL does not exist")
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
- Added new liquid tag - "{% medium https://medium.com}"
- Added a scraper - `MediumArticleRetrievalService` which crawls the
given Medium URL for informations needed for the liquid tag

Right now my implementation takes a full link, but we can choose to use handle + article ID. Open to suggestion here.

## Related Tickets & Documents
#118 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
<img width="640" alt="11-20-923pm" src="https://user-images.githubusercontent.com/20277437/48778152-6e8fa480-ed0f-11e8-8c27-76a567fddc6e.png">
<img width="640" alt="11-20-923pm-1" src="https://user-images.githubusercontent.com/20277437/48778162-70f1fe80-ed0f-11e8-9760-e9857e0f4dac.png">

<img width="1552" alt="03-15-1229AM" src="https://user-images.githubusercontent.com/20277437/54374311-d5b7d700-46b9-11e9-8536-d55defebf101.png">

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [ ] no documentation needed

