### PR TITLE
Initial basic paginionation-ish for notifications

### DIFF
--- a/app/assets/javascripts/initializers/initNotifications.js
+++ b/app/assets/javascripts/initializers/initNotifications.js
@@ -3,6 +3,7 @@ function initNotifications() {
   markNotificationsAsRead();
   initReactions();
   listenForNotificationsBellClick();
+  initPagination();
 }
 
 function markNotificationsAsRead() {
@@ -115,4 +116,20 @@ function listenForNotificationsBellClick() {
       document.getElementById('notifications-number').classList.remove('showing');
     };
   }, 180);
+}
+
+function initPagination() {
+  var el = document.getElementById("notifications-pagination")
+  if (el) {
+    window.fetch(el.dataset.paginationPath, {
+      method: 'GET',
+      credentials: 'same-origin'
+    }).then(function (response) {
+      if (response.status === 200) {
+        response.text().then(function(html){
+          el.innerHTML = html
+        });
+      }
+    });
+  }
 }

--- a/app/views/notifications/_aggregated_reactions.html.erb
+++ b/app/views/notifications/_aggregated_reactions.html.erb
@@ -1,9 +1,8 @@
 <%# TODO: change to map of IDs %>
 <% siblings = notification.json_data["reaction"]["aggregated_siblings"].select{|n| n["created_at"] > 24.hours.ago } %>
-<% cache "activity-aggregated-reactions-#{siblings}_#{siblings}" do %>
+<% cache "activity-aggregated-reactions-#{siblings}" do %>
   <% actors = siblings.map { |n| n["user"] }.uniq %>
   <% reactable_data = notification.json_data["reaction"]["reactable"] %>
-
   <% cache "activity-profile-pic-#{actors.first["id"]}-#{actors.first["profile_image_90"]}" do %>
     <a href="<%= actors.first["path"] %>" class="small-pic-link-wrapper">
       <div class="small-pic">

--- a/app/views/notifications/_notifications_list.html.erb
+++ b/app/views/notifications/_notifications_list.html.erb
@@ -1,0 +1,10 @@
+<% notification_count = 0 %>
+<% @notifications.each do |notification| %>
+  <% next if (notification.notified_at < 24.hours.ago && notification.aggregated?) %>
+  <% notification_count = notification_count + 1 %>
+  <div class="single-article single-article-small-pic <%= "unseen" unless notification.read? %>" data-notification-id="<%= notification.id %>" >
+    <%= render "#{notification.notifiable_type.downcase}", notification: notification %>
+  </div>
+<% rescue => e %>
+  <% logger.error("Notifification error - #{e.message} - #{notification.id}") %>
+<% end %>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -42,16 +42,9 @@
             <a class="query-filter-button <%= "selected" if params[:filter].to_s.downcase == "comments" %>" href="/notifications/comments">COMMENTS</a>
             <a class="query-filter-button <%= "selected" if params[:filter].to_s.downcase == "posts" %>" href="/notifications/posts">POSTS</a>
           </div>
-          <% notification_count = 0 %>
-          <% @notifications.each do |notification| %>
-            <% next if (notification.notified_at < 24.hours.ago && notification.aggregated?) %>
-            <% notification_count = notification_count + 1 %>
-            <% break if notification_count > 45 %>
-            <div class="single-article single-article-small-pic <%= "unseen" unless notification.read? %>">
-              <%= render "#{notification.notifiable_type.downcase}", notification: notification %>
-            </div>
-          <% rescue => e %>
-            <% logger.error("Notifification error - #{e.message} - #{notification.id}") %>
+          <%= render "notifications_list" %>
+          <% if @notifications.any? %>
+            <div id="notifications-pagination" data-pagination-path="/notifications/<%= params[:filter].to_s %>?page=<%= @notifications.last.id %>"></div>
           <% end %>
         <% else %>
           <div class="content notification-content comment-content">

--- a/app/views/notifications/shared/_comment_box.html.erb
+++ b/app/views/notifications/shared/_comment_box.html.erb
@@ -19,30 +19,31 @@
         <img class="reacted-emoji" src="<%= asset_path("emoji/emoji-one-nausea-face.png") %>"/>
       </button>
     <% end %>
-    <% reply = Comment.select(:id, :user_id, :ancestry).find_by(id: json_data["comment"]["id"]).children.find_by(user_id: current_user.id) %>
-    <% if reply %>
-      <a class="toggle-reply-form already-replied-link" href="<%= reply.path %>">
-        Replied
-      </a>
-    <% else %>
-      <a class="toggle-reply-form" data-reactable-id="<%= json_data["comment"]["id"] %>" href="#<%= json_data["comment"]["path"] %>">
-        Reply
-      </a>
-    <% end %>
-    </div>
-    <% @comment = Comment.new %>
-    <%= form_for(@comment, authenticity_token: false, html: {id: "comment-form-for-#{json_data["comment"]["id"]}", onsubmit: "handleCommentSubmit.bind(this)(event)"}) do |f| %>
-      <input type="hidden" name="authenticity_token" value="NOTHING" id="new_comment_authenticity_token">
-      <%= f.hidden_field :commentable_id, value: json_data["comment"]["commentable"]["id"] %>
-      <%= f.hidden_field :commentable_type, value: json_data["comment"]["commentable"]["class"]["name"] %>
+    <% cache "comment-box-comment-reply-#{@last_user_comment}-#{json_data["comment"]["updated_at"]}-#{json_data["comment"]["id"]}" do %>
+      <% reply = Comment.select(:id, :user_id, :ancestry).find_by(id: json_data["comment"]["id"]).children.find_by(user_id: current_user.id) %>
+      <% if reply %>
+        <a class="toggle-reply-form already-replied-link" href="<%= reply.path %>">
+          Replied
+        </a>
+      <% else %>
+        <a class="toggle-reply-form" data-reactable-id="<%= json_data["comment"]["id"] %>" href="#<%= json_data["comment"]["path"] %>">
+          Reply
+        </a>
+      <% end %>
+      </div>
+      <% @comment = Comment.new %>
+      <%= form_for(@comment, authenticity_token: false, html: {id: "comment-form-for-#{json_data["comment"]["id"]}", onsubmit: "handleCommentSubmit.bind(this)(event)"}) do |f| %>
+        <%= f.hidden_field :commentable_id, value: json_data["comment"]["commentable"]["id"] %>
+        <%= f.hidden_field :commentable_type, value: json_data["comment"]["commentable"]["class"]["name"] %>
 
-      <%= f.hidden_field :parent_id, value: json_data["comment"]["id"] %>
-      <div class="field" id="textarea-wrapper">
-        <%= f.text_area :body_markdown, id: "comment-textarea-for-#{json_data["comment"]["id"]}" %>
-      </div>
-      <div class="actions" id="submit-wrapper">
-        <%= f.submit "SUBMIT", id: "submit-button", onclick:"validateField(event)" %>
-      </div>
+        <%= f.hidden_field :parent_id, value: json_data["comment"]["id"] %>
+        <div class="field" id="textarea-wrapper">
+          <%= f.text_area :body_markdown, id: "comment-textarea-for-#{json_data["comment"]["id"]}" %>
+        </div>
+        <div class="actions" id="submit-wrapper">
+          <%= f.submit "SUBMIT", id: "submit-button", onclick:"validateField(event)" %>
+        </div>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Adds the beginnings of pagination to notifications. It loads the first 12 notifications and then the next 48 async. We can add more true pagination after, but this has the nice benefit of immediately speeding up first page load and we can use this sort of pattern to speed up more if we care to.