### PR TITLE
Fix errant scroll behavior on /new when using keyboard scrolling

### DIFF
--- a/app/assets/javascripts/initializers/initEditorResize.js
+++ b/app/assets/javascripts/initializers/initEditorResize.js
@@ -3,8 +3,12 @@
  * It is a slightly modified version of the solution found here.
  * stackoverflow.com/questions/18262729/ how-to-stop-window-jumping-when-typing-in-autoresizing-textarea
  */
+// eslint-disable-next-line no-unused-vars
 function initEditorResize() {
-  var observe, scrollLeft, scrollTop;
+  var observe;
+  var scrollLeft;
+  var scrollTop;
+  var lastText;
   var textarea = document.getElementById('article_body_markdown');
   var oldEditor = document.getElementById('markdown-editor-main');
 
@@ -39,15 +43,26 @@ function initEditorResize() {
   }
 
   function resize() {
+    var len;
+    var newText = textarea.value;
+    // Don't resize or scroll if not modifying the text
+    if (newText === lastText) {
+      return;
+    }
+    lastText = newText;
     textarea.style.height = 'auto';
     textarea.style.height = textarea.scrollHeight - 29 + 'px';
     window.scrollTo(scrollLeft, scrollTop);
     if (oldEditor) {
       return;
     }
-    var len = textarea.value.length;
+    len = textarea.value.length;
     // If character entered is at the end of the textarea (therefore cursor)
-    if((textarea.selectionEnd > (len - 15)) && len > 400 && document.activeElement === textarea ) {
+    if (
+      textarea.selectionEnd > len - 15 &&
+      len > 400 &&
+      document.activeElement === textarea
+    ) {
       window.scrollTo(scrollLeft, 10000);
     } else {
       window.scrollTo(scrollLeft, scrollTop);


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
Disable textarea resize and window scroll method when doing anything that does not actually modify the textarea contents (e.g. arrow keys, pgup/pgdn).

Note: needed to make formatting changes since it looks like linting-related precommit hooks were added after this file was created. Particularly, needed to disable a `no-unused-vars` lint rule since the function is exposed and consumed globally.

## Related Tickets & Documents
Fixes #1109

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![scroll is working](https://user-images.githubusercontent.com/1325549/49064595-3802cf80-f1d0-11e8-92b8-2cdbdb5a5fa6.gif)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed