### PR TITLE
Check if article.path in resave articles

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -350,8 +350,8 @@ class User < ApplicationRecord
   def resave_articles
     cache_buster = CacheBuster.new
     articles.each do |article|
-      cache_buster.bust(article.path)
-      cache_buster.bust(article.path + "?i=i")
+      cache_buster.bust(article.path) if article.path
+      cache_buster.bust(article.path + "?i=i") if article.path
       article.save
     end
   end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
It seems like it's possible for `path` to be nil here, possibly a legacy issue. Making sure path exists for all articles before trying to `+` against it.

fixes #1205 