### PR TITLE
Add Support Chrome and other browsers for anchor jumps

### DIFF
--- a/app/assets/stylesheets/article-show.scss
+++ b/app/assets/stylesheets/article-show.scss
@@ -95,6 +95,7 @@ header{
     z-index:5;
   }
   .title{
+    z-index:6;
     position:relative;
     width:81%;
     font-family: $helvetica;

--- a/app/assets/stylesheets/article-show.scss
+++ b/app/assets/stylesheets/article-show.scss
@@ -407,7 +407,9 @@ header{
       line-height:1.4em;
       color:darken($medium-gray,8%);
       display:block;
-      margin-top:-0.8em;
+    }
+    p~figcaption{
+      margin-top: -0.8em;
     }
     @media screen and ( max-width:550px) {
       width:90%;

--- a/app/assets/stylesheets/article-show.scss
+++ b/app/assets/stylesheets/article-show.scss
@@ -315,6 +315,8 @@ header{
       &.anchor{
         padding-top: 50px;
         margin-top: -50px;
+        display: block;
+        visibility: hidden;
         -webkit-background-clip: content-box;
         background-clip: content-box;
       }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Fixes/adds support for Chrome and Safari (and probably other browsers).

Note: I feel okay with using `visibility: hidden` because the anchor link is **not** meant to be read by screen readers.

Also resolves #760 

### Safari on the left, Chrome on the right:
![header anchor jump example](https://user-images.githubusercontent.com/17884966/49184340-15d29400-f32d-11e8-8667-e8370e7ce556.gif)

## Added to documentation?
- [x] no documentation needed