### PR TITLE
remove punctuations in header anchor links

### DIFF
--- a/app/lib/redcarpet/render/html_rouge.rb
+++ b/app/lib/redcarpet/render/html_rouge.rb
@@ -31,7 +31,7 @@ module Redcarpet
 
       def slugify(string)
         stripped_string = ActionView::Base.full_sanitizer.sanitize string
-        stripped_string.downcase.gsub(EmojiRegex::Regex, "").strip.gsub(/\s/, "-").gsub(/[[:punct:]]/u, "")
+        stripped_string.downcase.gsub(EmojiRegex::Regex, "").strip.gsub(/[[:punct:]]/u, "").gsub(/\s+/, "-")
       end
     end
   end

--- a/app/lib/redcarpet/render/html_rouge.rb
+++ b/app/lib/redcarpet/render/html_rouge.rb
@@ -17,7 +17,7 @@ module Redcarpet
       end
 
       def header(title, header_number)
-        anchor_link = remove_emoji_and_hyphenate(title)
+        anchor_link = slugify(title)
         <<~HEREDOC
           <h#{header_number}>
             <a name="#{anchor_link}" href="##{anchor_link}" class="anchor">
@@ -29,9 +29,9 @@ module Redcarpet
 
       private
 
-      def remove_emoji_and_hyphenate(string)
+      def slugify(string)
         stripped_string = ActionView::Base.full_sanitizer.sanitize string
-        stripped_string.downcase.gsub(EmojiRegex::Regex, "").strip.gsub(/\s/, "-")
+        stripped_string.downcase.gsub(EmojiRegex::Regex, "").strip.gsub(/\s/, "-").gsub(/[[:punct:]]/u, "")
       end
     end
   end

--- a/spec/support/fixtures/approvals/user_preview_article_body.approved.html
+++ b/spec/support/fixtures/approvals/user_preview_article_body.approved.html
@@ -43,6 +43,12 @@
 </h1>
 
 <h1>
+  <a name="" href="#multiword-heading-with-weird-punctuation" class="anchor" id="multiword-heading-with-weird-punctuation">
+  </a>
+  multiword heading with ( weird ? punctu&^ation
+</h1>
+
+<h1>
   <a name="%F0%9F%98%8E-emoji-heading" href="#%F0%9F%98%8E-emoji-heading" class="anchor" id="%F0%9F%98%8E-emoji-heading">
   </a>
   😎 emoji heading

--- a/spec/support/fixtures/sample_article_template_spec.txt
+++ b/spec/support/fixtures/sample_article_template_spec.txt
@@ -12,6 +12,7 @@ tags:
 ##### h5
 ###### h6
 # multiword heading
+# multiword heading with ( weird ? punctu&^ation
 # &#128526; emoji heading
 
 *italic* _italic_


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
The current method for slugifying the header anchor links keeps punctuations. This PR removes the punctuations before replacing spaces with `-`.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed