### PR TITLE
Add retry for a failing test where user was not signed in yet

### DIFF
--- a/spec/features/user_edits_an_article_spec.rb
+++ b/spec/features/user_edits_an_article_spec.rb
@@ -28,7 +28,7 @@ describe "Editing with an editor" do
     expect(page).to have_text(template[-200..-1])
   end
 
-  it "user update their post" do
+  it "user update their post", retry: 3 do
     visit "/#{user.username}/#{article.slug}/edit"
     fill_in "article_body_markdown", with: template.gsub("true", "false")
     click_button("article-submit")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This adds `retry: 3` for a test that was failing. The test failed because the user was not signed in yet, even though there is a `before { sign_in user }` block that _should_ have ran before each test.