### PR TITLE
Shrink bookmark icon on the reading list page for smaller devices

### DIFF
--- a/app/assets/stylesheets/user-profile-header.scss
+++ b/app/assets/stylesheets/user-profile-header.scss
@@ -30,6 +30,10 @@
         font-size:calc(0.9vw + 28px);
         font-weight:500;
       }
+      img {
+        max-height:calc(3vw + 33px);
+        max-width:calc(3vw + 33px);
+      }
     }
   }
   &.readinglist-header{
@@ -100,6 +104,9 @@
     overflow-y: auto;
     h1 {
       position:relative;
+      display:flex;
+      justify-content:space-evenly;
+      align-items:center;
     }
     a{
       color:rgb(97, 97, 97);


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
Make the bookmark icon just slightly larger than the font size, currently on the mobile reading list page around half the page is taken up by the header.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![image](https://user-images.githubusercontent.com/3534427/49328408-48b49c00-f568-11e8-893e-2baa03e57454.png)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
