### PR TITLE
connect channel details

### DIFF
--- a/app/assets/stylesheets/chat.scss
+++ b/app/assets/stylesheets/chat.scss
@@ -1,4 +1,5 @@
 @import 'variables';
+@import 'connect/_channel-details';
 
 // High level classes
 .chat-page-wrapper{
@@ -447,6 +448,7 @@
     }
   }
 }
+
 
 .activechatchannel__activecontentuserdetails{
   margin-top:20px;

--- a/app/assets/stylesheets/connect/_channel-details.scss
+++ b/app/assets/stylesheets/connect/_channel-details.scss
@@ -13,12 +13,13 @@
 
   // channel users
   .channeldetails__user {
-    .channeldetails__userprofileimage img {
+    padding: 2px 0;
+    .channeldetails__userprofileimage {
       height: 25px;
       width: 25px;
       margin-right: 6px;
       border-radius: 20px;
-      vertical-align: -3px;
+      vertical-align: -6px;
     }
     a {
       font-family: $helvetica;
@@ -41,35 +42,41 @@
       -webkit-appearance: none;
     }
 
-    .channeldetails__searchedusers {
-      // profile pic
-      img {
-        height: 25px;
-        width: 25px;
-        margin-right: 6px;
-        border-radius: 20px;
-        vertical-align: -3px;
-      }
+    .channeldetails__searchresults {
+      padding: 5px 0;
 
-      a {
-        font-size: 18px;
-        font-family: $helvetica;
-      }
+      .channeldetails__searchedusers {
+        padding: 1px 0;
 
-      // invite button
-      button {
-        width: 85px;
-        height: 24px;
-        background-color: $purple;
-        border-radius: 3px;
-        color: $white;
-      }
+        // profile pic
+        img {
+          height: 22px;
+          width: 22px;
+          margin-right: 6px;
+          border-radius: 20px;
+          vertical-align: -6px;
+        }
 
-      // in channel message
-      span {
-        color: $dark-gray;
-        font-size: 18px;
-        font-family: $helvetica;
+        a {
+          font-size: 14px;
+          font-family: $helvetica;
+        }
+
+        // invite button
+        button {
+          width: 45px;
+          height: 24px;
+          background-color: $purple;
+          border-radius: 3px;
+          color: $white;
+        }
+
+        // in channel message
+        span {
+          color: $dark-gray;
+          font-size: 14px;
+          font-family: $helvetica;
+        }
       }
     }
 

--- a/app/assets/stylesheets/connect/_channel-details.scss
+++ b/app/assets/stylesheets/connect/_channel-details.scss
@@ -1,0 +1,122 @@
+@import 'variables';
+
+.channeldetails {
+  .channeldetails__name {
+    font-family: $helvetica;
+    font-size: 48px;
+  }
+
+  .channeldetails__description {
+    font-family: $helvetica;
+    color: $dark-gray;
+  }
+
+  // channel users
+  .channeldetails__user {
+    .channeldetails__userprofileimage img {
+      height: 25px;
+      width: 25px;
+      margin-right: 6px;
+      border-radius: 20px;
+      vertical-align: -3px;
+    }
+    a {
+      font-family: $helvetica;
+    }
+  }
+
+  .channeldetails__inviteusers {
+    h2 {
+      font-family: $helvetica;
+    }
+
+    // find users
+    input {
+      border-radius: 3px;
+      border: 1px solid #dbdbdb;
+      box-sizing: border-box;
+      padding: 8px;
+      margin-left: 2px;
+      font-size: 18px;
+      -webkit-appearance: none;
+    }
+
+    .channeldetails__searchedusers {
+      // profile pic
+      img {
+        height: 25px;
+        width: 25px;
+        margin-right: 6px;
+        border-radius: 20px;
+        vertical-align: -3px;
+      }
+
+      a {
+        font-size: 18px;
+        font-family: $helvetica;
+      }
+
+      // invite button
+      button {
+        width: 85px;
+        height: 24px;
+        background-color: $purple;
+        border-radius: 3px;
+        color: $white;
+      }
+
+      // in channel message
+      span {
+        color: $dark-gray;
+        font-size: 18px;
+        font-family: $helvetica;
+      }
+    }
+
+    .channeldetails__pendingusers {
+      a {
+        font-size: 18px;
+        font-family: $helvetica;
+      }
+    }
+  }
+
+  .channeldetails__leavechannel {
+    // Danger Zone
+    h2 {
+      color: $red;
+      font-family: $helvetica-condensed;
+      font-size: 2.5em;
+    }
+    // leave channel
+    button {
+      width: 130px;
+      padding: 3px 0px;
+      border-radius: 3px;
+      background-color: $red;
+      color: $white;
+      font-size: 1.2em;
+      font-weight: bold;
+      cursor: pointer;
+    }
+
+  }
+
+  .channeldetails__leftchannel {
+    h2 {
+      font-family: $helvetica;
+      font-size: 32px;
+    }
+    h3 {
+      font-family: $helvetica;
+      font-size: 18px;
+    }
+    h4 {
+      font-family: $helvetica;
+      font-size: 18px;
+    }
+    p {
+      font-family: $helvetica;
+    }
+  }
+}

--- a/app/assets/stylesheets/connect/_channel-details.scss
+++ b/app/assets/stylesheets/connect/_channel-details.scss
@@ -97,7 +97,7 @@
     }
     // leave channel
     button {
-      width: 130px;
+      width: 180px;
       padding: 3px 0px;
       border-radius: 3px;
       background-color: $red;

--- a/app/javascript/chat/__tests__/__snapshots__/channelDetails.test.jsx.snap
+++ b/app/javascript/chat/__tests__/__snapshots__/channelDetails.test.jsx.snap
@@ -148,31 +148,7 @@ preact-render-spy (1 nodes)
         @channeluser1 - channel user 1
       </a>
        
-      <button
-        type="button"
-        onClick={[Function value]}
-        data-content="userid1"
-      >
-        Invite
-      </button>
-    </div>
-    <div class="channeldetails__searchedusers">
-      <a
-        href="/pending_path1"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        <img alt="profile_image" />
-        @pendinguser1 - pending user 1
-      </a>
-       
-      <button
-        type="button"
-        onClick={[Function value]}
-        data-content="pendinguserid1"
-      >
-        Invite
-      </button>
+      <span class="channel__member">is already in channel name</span>
     </div>
     <div class="channeldetails__searchedusers">
       <a

--- a/app/javascript/chat/__tests__/__snapshots__/channelDetails.test.jsx.snap
+++ b/app/javascript/chat/__tests__/__snapshots__/channelDetails.test.jsx.snap
@@ -70,7 +70,7 @@ exports[`<ChannelDetails /> as a moderator should render and test snapshot 1`] =
       class="channeldetails__pendingusers"
     >
       <a
-        data-content="users/pendingid1"
+        data-content="users/pendinguserid1"
         href="/pendinguser1"
         rel="noopener noreferrer"
         target="_blank"
@@ -82,7 +82,7 @@ exports[`<ChannelDetails /> as a moderator should render and test snapshot 1`] =
       class="channeldetails__pendingusers"
     >
       <a
-        data-content="users/pendingid2"
+        data-content="users/pendinguserid2"
         href="/pendinguser2"
         rel="noopener noreferrer"
         target="_blank"
@@ -140,51 +140,54 @@ preact-render-spy (1 nodes)
      />
     <div class="channeldetails__searchedusers">
       <a
-        href="/some_path1"
+        href="/user_path1"
         target="_blank"
         rel="noopener noreferrer"
       >
-        i am user1
+        <img />
+        @channeluser1 - channel user 1
       </a>
        
       <button
         type="button"
         onClick={[Function value]}
-        data-content="user_id1"
+        data-content="userid1"
       >
         Invite
       </button>
     </div>
     <div class="channeldetails__searchedusers">
       <a
-        href="/some_path2"
+        href="/pending_path1"
         target="_blank"
         rel="noopener noreferrer"
       >
-        i am user2
+        <img />
+        @pendinguser1 - pending user 1
       </a>
        
       <button
         type="button"
         onClick={[Function value]}
-        data-content="user_id2"
+        data-content="pendinguserid1"
       >
         Invite
       </button>
     </div>
     <div class="channeldetails__searchedusers">
       <a
-        href="/some_path3"
+        href="/search_path3"
         target="_blank"
         rel="noopener noreferrer"
       >
-        i am user3
+        <img />
+        @searcheduser3 - searched user 3
       </a>
        
       <button
         type="button"
         onClick={[Function value]}
-        data-content="user_id3"
+        data-content="searched_userid3"
       >
         Invite
       </button>
@@ -195,7 +198,7 @@ preact-render-spy (1 nodes)
         href="/pendinguser1"
         target="_blank"
         rel="noopener noreferrer"
-        data-content="users/pendingid1"
+        data-content="users/pendinguserid1"
       >
         @pendinguser1 - pending user 1
       </a>
@@ -205,7 +208,7 @@ preact-render-spy (1 nodes)
         href="/pendinguser2"
         target="_blank"
         rel="noopener noreferrer"
-        data-content="users/pendingid2"
+        data-content="users/pendinguserid2"
       >
         @pendinguser2 - pending user 2
       </a>

--- a/app/javascript/chat/__tests__/__snapshots__/channelDetails.test.jsx.snap
+++ b/app/javascript/chat/__tests__/__snapshots__/channelDetails.test.jsx.snap
@@ -144,7 +144,7 @@ preact-render-spy (1 nodes)
         target="_blank"
         rel="noopener noreferrer"
       >
-        <img />
+        <img alt="profile_image" />
         @channeluser1 - channel user 1
       </a>
        
@@ -162,7 +162,7 @@ preact-render-spy (1 nodes)
         target="_blank"
         rel="noopener noreferrer"
       >
-        <img />
+        <img alt="profile_image" />
         @pendinguser1 - pending user 1
       </a>
        
@@ -180,7 +180,7 @@ preact-render-spy (1 nodes)
         target="_blank"
         rel="noopener noreferrer"
       >
-        <img />
+        <img alt="profile_image" />
         @searcheduser3 - searched user 3
       </a>
        

--- a/app/javascript/chat/__tests__/__snapshots__/channelDetails.test.jsx.snap
+++ b/app/javascript/chat/__tests__/__snapshots__/channelDetails.test.jsx.snap
@@ -24,6 +24,12 @@ exports[`<ChannelDetails /> as a moderator should render and test snapshot 1`] =
   <div
     class="channeldetails__user"
   >
+    <img
+      alt="[object Object] profile"
+      class="channeldetails__userprofileimage"
+      data-content="users/userid1"
+      src="channeluser1pic.png"
+    />
     <a
       data-content="users/by_username?url=channeluser1"
       href="/channeluser1"
@@ -40,6 +46,12 @@ exports[`<ChannelDetails /> as a moderator should render and test snapshot 1`] =
   <div
     class="channeldetails__user"
   >
+    <img
+      alt="[object Object] profile"
+      class="channeldetails__userprofileimage"
+      data-content="users/userid2"
+      src="channeluser2pic.png"
+    />
     <a
       data-content="users/by_username?url=channeluser2"
       href="/channeluser2"
@@ -115,6 +127,12 @@ preact-render-spy (1 nodes)
     <em>something about this channel</em>
   </div>
   <div class="channeldetails__user">
+    <img
+      class="channeldetails__userprofileimage"
+      src="channeluser1pic.png"
+      alt="[object Object] profile"
+      data-content="users/userid1"
+     />
     <a
       href="/channeluser1"
       style="padding: 3px 0px;"
@@ -124,6 +142,12 @@ preact-render-spy (1 nodes)
     </a>
   </div>
   <div class="channeldetails__user">
+    <img
+      class="channeldetails__userprofileimage"
+      src="channeluser2pic.png"
+      alt="[object Object] profile"
+      data-content="users/userid2"
+     />
     <a
       href="/channeluser2"
       style="padding: 3px 0px;"
@@ -144,7 +168,10 @@ preact-render-spy (1 nodes)
         target="_blank"
         rel="noopener noreferrer"
       >
-        <img alt="profile_image" />
+        <img
+          alt="profile_image"
+          src="channeluser1pic.png"
+         />
         @channeluser1 - channel user 1
       </a>
        
@@ -156,7 +183,10 @@ preact-render-spy (1 nodes)
         target="_blank"
         rel="noopener noreferrer"
       >
-        <img alt="profile_image" />
+        <img
+          alt="profile_image"
+          src="searcheduser3pic.png"
+         />
         @searcheduser3 - searched user 3
       </a>
        
@@ -209,6 +239,12 @@ preact-render-spy (1 nodes)
     <em>something about this channel</em>
   </div>
   <div class="channeldetails__user">
+    <img
+      class="channeldetails__userprofileimage"
+      src="channeluser1pic.png"
+      alt="[object Object] profile"
+      data-content="users/userid1"
+     />
     <a
       href="/channeluser1"
       style="padding: 3px 0px;"
@@ -218,6 +254,12 @@ preact-render-spy (1 nodes)
     </a>
   </div>
   <div class="channeldetails__user">
+    <img
+      class="channeldetails__userprofileimage"
+      src="channeluser2pic.png"
+      alt="[object Object] profile"
+      data-content="users/userid2"
+     />
     <a
       href="/channeluser2"
       style="padding: 3px 0px;"
@@ -272,6 +314,12 @@ exports[`<ChannelDetails /> as a user should render and test snapshot 1`] = `
   <div
     class="channeldetails__user"
   >
+    <img
+      alt="[object Object] profile"
+      class="channeldetails__userprofileimage"
+      data-content="users/userid1"
+      src="channeluser1pic.png"
+    />
     <a
       data-content="users/by_username?url=channeluser1"
       href="/channeluser1"
@@ -288,6 +336,12 @@ exports[`<ChannelDetails /> as a user should render and test snapshot 1`] = `
   <div
     class="channeldetails__user"
   >
+    <img
+      alt="[object Object] profile"
+      class="channeldetails__userprofileimage"
+      data-content="users/userid2"
+      src="channeluser2pic.png"
+    />
     <a
       data-content="users/by_username?url=channeluser2"
       href="/channeluser2"
@@ -312,7 +366,7 @@ exports[`<ChannelDetails /> as a user should render and test snapshot 1`] = `
       data-content="12345"
       type="button"
     >
-      Leave Channel.
+      Leave Channel
     </button>
   </div>
 </div>

--- a/app/javascript/chat/__tests__/__snapshots__/channelDetails.test.jsx.snap
+++ b/app/javascript/chat/__tests__/__snapshots__/channelDetails.test.jsx.snap
@@ -25,10 +25,9 @@ exports[`<ChannelDetails /> as a moderator should render and test snapshot 1`] =
     class="channeldetails__user"
   >
     <img
-      alt="[object Object] profile"
+      alt="channeluser1 profile"
       class="channeldetails__userprofileimage"
       data-content="users/userid1"
-      src="channeluser1pic.png"
     />
     <a
       data-content="users/by_username?url=channeluser1"
@@ -47,10 +46,9 @@ exports[`<ChannelDetails /> as a moderator should render and test snapshot 1`] =
     class="channeldetails__user"
   >
     <img
-      alt="[object Object] profile"
+      alt="channeluser2 profile"
       class="channeldetails__userprofileimage"
       data-content="users/userid2"
-      src="channeluser2pic.png"
     />
     <a
       data-content="users/by_username?url=channeluser2"
@@ -74,6 +72,9 @@ exports[`<ChannelDetails /> as a moderator should render and test snapshot 1`] =
     <input
       onKeyUp={[Function]}
       placeholder="Find users"
+    />
+    <div
+      class="channeldetails__searchresults"
     />
     <h2>
       Pending Invites:
@@ -129,8 +130,7 @@ preact-render-spy (1 nodes)
   <div class="channeldetails__user">
     <img
       class="channeldetails__userprofileimage"
-      src="channeluser1pic.png"
-      alt="[object Object] profile"
+      alt="channeluser1 profile"
       data-content="users/userid1"
      />
     <a
@@ -144,8 +144,7 @@ preact-render-spy (1 nodes)
   <div class="channeldetails__user">
     <img
       class="channeldetails__userprofileimage"
-      src="channeluser2pic.png"
-      alt="[object Object] profile"
+      alt="channeluser2 profile"
       data-content="users/userid2"
      />
     <a
@@ -162,41 +161,46 @@ preact-render-spy (1 nodes)
       onKeyUp={[Function value]}
       placeholder="Find users"
      />
-    <div class="channeldetails__searchedusers">
-      <a
-        href="/user_path1"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        <img
-          alt="profile_image"
-          src="channeluser1pic.png"
-         />
-        @channeluser1 - channel user 1
-      </a>
-       
-      <span class="channel__member">is already in channel name</span>
-    </div>
-    <div class="channeldetails__searchedusers">
-      <a
-        href="/search_path3"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        <img
-          alt="profile_image"
-          src="searcheduser3pic.png"
-         />
-        @searcheduser3 - searched user 3
-      </a>
-       
-      <button
-        type="button"
-        onClick={[Function value]}
-        data-content="searched_userid3"
-      >
-        Invite
-      </button>
+    <div class="channeldetails__searchresults">
+      <div class="channeldetails__searchedusers">
+        <a
+          href="/user_path1"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="channeluser1pic.png"
+            alt="profile_image"
+           />
+          @channeluser1 - i am channel user 1
+        </a>
+         
+        <span class="channel__member">
+          is already in 
+          <em>channel name</em>
+        </span>
+      </div>
+      <div class="channeldetails__searchedusers">
+        <a
+          href="/search_path3"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="searcheduser3pic.png"
+            alt="profile_image"
+           />
+          @searcheduser3 - i am searched user 3
+        </a>
+         
+        <button
+          type="button"
+          onClick={[Function value]}
+          data-content="searched_userid3"
+        >
+          Invite
+        </button>
+      </div>
     </div>
     <h2>Pending Invites:</h2>
     <div class="channeldetails__pendingusers">
@@ -241,8 +245,7 @@ preact-render-spy (1 nodes)
   <div class="channeldetails__user">
     <img
       class="channeldetails__userprofileimage"
-      src="channeluser1pic.png"
-      alt="[object Object] profile"
+      alt="channeluser1 profile"
       data-content="users/userid1"
      />
     <a
@@ -256,8 +259,7 @@ preact-render-spy (1 nodes)
   <div class="channeldetails__user">
     <img
       class="channeldetails__userprofileimage"
-      src="channeluser2pic.png"
-      alt="[object Object] profile"
+      alt="channeluser2 profile"
       data-content="users/userid2"
      />
     <a
@@ -315,10 +317,9 @@ exports[`<ChannelDetails /> as a user should render and test snapshot 1`] = `
     class="channeldetails__user"
   >
     <img
-      alt="[object Object] profile"
+      alt="channeluser1 profile"
       class="channeldetails__userprofileimage"
       data-content="users/userid1"
-      src="channeluser1pic.png"
     />
     <a
       data-content="users/by_username?url=channeluser1"
@@ -337,10 +338,9 @@ exports[`<ChannelDetails /> as a user should render and test snapshot 1`] = `
     class="channeldetails__user"
   >
     <img
-      alt="[object Object] profile"
+      alt="channeluser2 profile"
       class="channeldetails__userprofileimage"
       data-content="users/userid2"
-      src="channeluser2pic.png"
     />
     <a
       data-content="users/by_username?url=channeluser2"

--- a/app/javascript/chat/__tests__/channelDetails.test.jsx
+++ b/app/javascript/chat/__tests__/channelDetails.test.jsx
@@ -158,26 +158,32 @@ describe('<ChannelDetails />', () => {
           {
             path: '/user_path1',
             title: 'i am channel user 1',
-            name: 'channel user 1',
-            username: 'channeluser1',
+            user: {
+              name: 'channel user 1',
+              username: 'channeluser1',
+              profile_image_90: 'channeluser1pic.png',
+            },
             id: 'userid1',
-            profile_image_url: 'channeluser1pic.png',
           },
           {
             path: '/pending_path1',
             title: 'i am pending user 1',
-            name: 'pending user 1',
-            username: 'pendinguser1',
+            user: {
+              name: 'pending user 1',
+              username: 'pendinguser1',
+              profile_image_90: 'pendinguser1pic.png',
+            },
             id: 'pendinguserid1',
-            profile_image_url: 'pendinguser1pic.png',
           },
           {
             path: '/search_path3',
             title: 'i am searched user 3',
-            name: 'searched user 3',
-            username: 'searcheduser3',
+            user: {
+              name: 'searched user 3',
+              username: 'searcheduser3',
+              profile_image_90: 'searcheduser3pic.png',
+            },
             id: 'searched_userid3',
-            profile_image_url: 'searcheduser3pic.png',
           },
         ],
       };
@@ -192,63 +198,57 @@ describe('<ChannelDetails />', () => {
       let inviteAttr;
       let inviteAttrAns;
       const included = (list, el) => {
-        for (let i = 0; i < list.length; i += 1) {
-          if (list[i].id === el.id) {
+        const keys = Object.keys(list);
+        for (var key of keys) {
+          if (list[key].id === el.id) {
             return true;
           }
         }
       };
       for (let i = 0; i < searchedusersdivs.length; i += 1) {
-        if (
-          included(
+        if (!included(
             moddetails.pending_users_select_fields,
-            searchedusers.searchedUsers[i],
-          )
-        ) {
-          continue;
-        }
-        expect(
-          searchedusersdivs
-            .at(i)
-            .childAt(0)
-            .attr('href'),
-        ).toEqual(searchedusers.searchedUsers[i].path);
-        expect(
-          searchedusersdivs
-            .at(i)
-            .childAt(0)
-            .text(),
-        ).toEqual(
-          `@${searchedusers.searchedUsers[i].username} - ${
-            searchedusers.searchedUsers[i].name
-          }`,
-        );
+            searchedusers.searchedUsers[i])) {
+          expect(
+            searchedusersdivs
+              .at(i)
+              .childAt(0)
+              .attr('href'),
+          ).toEqual(searchedusers.searchedUsers[i].path);
+          expect(
+            searchedusersdivs
+              .at(i)
+              .childAt(0)
+              .text(),
+          ).toEqual(
+            `@${searchedusers.searchedUsers[i].user.username} - ${
+              searchedusers.searchedUsers[i].title
+            }`,
+          );
 
-        if (
-          included(moddetails.channel_users, searchedusers.searchedUsers[i])
-        ) {
-          inviteMessage = `is already in ${moddetails.channel_name}`;
-          inviteAttr = 'className';
-          inviteAttrAns = 'channel__member';
-        } else {
-          inviteMessage = 'Invite';
-          inviteAttr = 'data-content';
-          inviteAttrAns = searchedusers.searchedUsers[i].id;
+          if (included(moddetails.channel_users, searchedusers.searchedUsers[i])) {
+            inviteMessage = `is already in ${moddetails.channel_name}`;
+            inviteAttr = 'className';
+            inviteAttrAns = 'channel__member';
+          } else {
+            inviteMessage = 'Invite';
+            inviteAttr = 'data-content';
+            inviteAttrAns = searchedusers.searchedUsers[i].id;
+          }
+          expect(
+            searchedusersdivs
+              .at(i)
+              .childAt(2)
+              .text(),
+          ).toEqual(inviteMessage);
+          expect(
+            searchedusersdivs
+              .at(i)
+              .childAt(2)
+              .attr(inviteAttr),
+          ).toEqual(inviteAttrAns);
+          }
         }
-        expect(
-          searchedusersdivs
-            .at(i)
-            .childAt(2)
-            .text(),
-        ).toEqual(inviteMessage);
-        expect(
-          searchedusersdivs
-            .at(i)
-            .childAt(2)
-            .attr(inviteAttr),
-        ).toEqual(inviteAttrAns);
-      }
-
       const tree = render(context);
       expect(tree).toMatchSnapshot();
     });

--- a/app/javascript/chat/__tests__/channelDetails.test.jsx
+++ b/app/javascript/chat/__tests__/channelDetails.test.jsx
@@ -179,10 +179,27 @@ describe('<ChannelDetails />', () => {
       context.rerender();
       const searchedusersdivs = context.find('.channeldetails__searchedusers');
       expect(searchedusersdivs.exists()).toEqual(true);
-      expect(searchedusersdivs.length).toEqual(3);
+      expect(searchedusersdivs.length).toEqual(2);
 
-      let invitemessage;
+      let inviteMessage;
+      let inviteAttr;
+      let inviteAttrAns;
+      const included = (list, el) => {
+        for (let i = 0; i < list.length; i += 1) {
+          if (list[i].id === el.id) {
+            return true;
+          }
+        }
+      };
       for (let i = 0; i < searchedusersdivs.length; i += 1) {
+        if (
+          included(
+            moddetails.pending_users_select_fields,
+            searchedusers.searchedUsers[i],
+          )
+        ) {
+          continue;
+        }
         expect(
           searchedusersdivs
             .at(i)
@@ -199,32 +216,30 @@ describe('<ChannelDetails />', () => {
             searchedusers.searchedUsers[i].name
           }`,
         );
-        expect(
-          searchedusersdivs
-            .at(i)
-            .childAt(2)
-            .attr('data-content'),
-        ).toEqual(searchedusers.searchedUsers[i].id);
 
-        if (moddetails.channel_users.includes(searchedusers.searchedUsers[i])) {
-          invitemessage = `is already in ${channelDetails.channel_name}`;
-        } else if (
-          moddetails.pending_users_select_fields.includes(
-            searchedusers.searchedUsers[i],
-          )
+        if (
+          included(moddetails.channel_users, searchedusers.searchedUsers[i])
         ) {
-          invitemessage = `has already been invited to ${
-            channelDetails.channel_name
-          }`;
+          inviteMessage = `is already in ${moddetails.channel_name}`;
+          inviteAttr = 'className';
+          inviteAttrAns = 'channel__member';
         } else {
-          invitemessage = 'Invite';
+          inviteMessage = 'Invite';
+          inviteAttr = 'data-content';
+          inviteAttrAns = searchedusers.searchedUsers[i].id;
         }
         expect(
           searchedusersdivs
             .at(i)
             .childAt(2)
             .text(),
-        ).toEqual(invitemessage);
+        ).toEqual(inviteMessage);
+        expect(
+          searchedusersdivs
+            .at(i)
+            .childAt(2)
+            .attr(inviteAttr),
+        ).toEqual(inviteAttrAns);
       }
 
       const tree = render(context);

--- a/app/javascript/chat/__tests__/channelDetails.test.jsx
+++ b/app/javascript/chat/__tests__/channelDetails.test.jsx
@@ -26,25 +26,35 @@ const channelDetails = mod => {
     id: '12345',
     channel_users: [
       {
+        path: '/user_path1',
+        title: 'i am channel user 1',
         name: 'channel user 1',
         username: 'channeluser1',
+        id: 'userid1',
       },
       {
+        path: '/user_path2',
+        title: 'i am channel user 2',
         name: 'channel user 2',
         username: 'channeluser2',
+        id: 'userid2',
       },
     ],
     type_of: 'channel-details',
     pending_users_select_fields: [
       {
-        username: 'pendinguser1',
-        id: 'pendingid1',
+        path: '/pending_path1',
+        title: 'i am pending user 1',
         name: 'pending user 1',
+        username: 'pendinguser1',
+        id: 'pendinguserid1',
       },
       {
-        username: 'pendinguser2',
-        id: 'pendingid2',
+        path: '/pending_path2',
+        title: 'i am pending user 2',
         name: 'pending user 2',
+        username: 'pendinguser2',
+        id: 'pendinguserid2',
       },
     ],
     channel_mod_ids: id,
@@ -142,19 +152,25 @@ describe('<ChannelDetails />', () => {
       const searchedusers = {
         searchedUsers: [
           {
-            path: '/some_path1',
-            title: 'i am user1',
-            id: 'user_id1',
+            path: '/user_path1',
+            title: 'i am channel user 1',
+            name: 'channel user 1',
+            username: 'channeluser1',
+            id: 'userid1',
           },
           {
-            path: '/some_path2',
-            title: 'i am user2',
-            id: 'user_id2',
+            path: '/pending_path1',
+            title: 'i am pending user 1',
+            name: 'pending user 1',
+            username: 'pendinguser1',
+            id: 'pendinguserid1',
           },
           {
-            path: '/some_path3',
-            title: 'i am user3',
-            id: 'user_id3',
+            path: '/search_path3',
+            title: 'i am searched user 3',
+            name: 'searched user 3',
+            username: 'searcheduser3',
+            id: 'searched_userid3',
           },
         ],
       };
@@ -165,6 +181,7 @@ describe('<ChannelDetails />', () => {
       expect(searchedusersdivs.exists()).toEqual(true);
       expect(searchedusersdivs.length).toEqual(3);
 
+      let invitemessage;
       for (let i = 0; i < searchedusersdivs.length; i += 1) {
         expect(
           searchedusersdivs
@@ -177,19 +194,37 @@ describe('<ChannelDetails />', () => {
             .at(i)
             .childAt(0)
             .text(),
-        ).toEqual(searchedusers.searchedUsers[i].title);
+        ).toEqual(
+          `@${searchedusers.searchedUsers[i].username} - ${
+            searchedusers.searchedUsers[i].name
+          }`,
+        );
         expect(
           searchedusersdivs
             .at(i)
             .childAt(2)
             .attr('data-content'),
         ).toEqual(searchedusers.searchedUsers[i].id);
+
+        if (moddetails.channel_users.includes(searchedusers.searchedUsers[i])) {
+          invitemessage = `is already in ${channelDetails.channel_name}`;
+        } else if (
+          moddetails.pending_users_select_fields.includes(
+            searchedusers.searchedUsers[i],
+          )
+        ) {
+          invitemessage = `has already been invited to ${
+            channelDetails.channel_name
+          }`;
+        } else {
+          invitemessage = 'Invite';
+        }
         expect(
           searchedusersdivs
             .at(i)
             .childAt(2)
             .text(),
-        ).toEqual('Invite');
+        ).toEqual(invitemessage);
       }
 
       const tree = render(context);

--- a/app/javascript/chat/__tests__/channelDetails.test.jsx
+++ b/app/javascript/chat/__tests__/channelDetails.test.jsx
@@ -31,6 +31,7 @@ const channelDetails = mod => {
         name: 'channel user 1',
         username: 'channeluser1',
         id: 'userid1',
+        profile_image_url: 'channeluser1pic.png',
       },
       {
         path: '/user_path2',
@@ -38,6 +39,7 @@ const channelDetails = mod => {
         name: 'channel user 2',
         username: 'channeluser2',
         id: 'userid2',
+        profile_image_url: 'channeluser2pic.png',
       },
     ],
     type_of: 'channel-details',
@@ -48,6 +50,7 @@ const channelDetails = mod => {
         name: 'pending user 1',
         username: 'pendinguser1',
         id: 'pendinguserid1',
+        profile_image_url: 'pendinguser1pic.png',
       },
       {
         path: '/pending_path2',
@@ -55,6 +58,7 @@ const channelDetails = mod => {
         name: 'pending user 2',
         username: 'pendinguser2',
         id: 'pendinguserid2',
+        profile_image_url: 'pendinguser2pic.png',
       },
     ],
     channel_mod_ids: id,
@@ -94,13 +98,13 @@ describe('<ChannelDetails />', () => {
         expect(
           channelmembers
             .at(i)
-            .childAt(0)
+            .childAt(1)
             .attr('href'),
         ).toEqual(`/${moddetails.channel_users[i].username}`);
         expect(
           channelmembers
             .at(i)
-            .childAt(0)
+            .childAt(1)
             .attr('data-content'),
         ).toEqual(
           `users/by_username?url=${moddetails.channel_users[i].username}`,
@@ -157,6 +161,7 @@ describe('<ChannelDetails />', () => {
             name: 'channel user 1',
             username: 'channeluser1',
             id: 'userid1',
+            profile_image_url: 'channeluser1pic.png',
           },
           {
             path: '/pending_path1',
@@ -164,6 +169,7 @@ describe('<ChannelDetails />', () => {
             name: 'pending user 1',
             username: 'pendinguser1',
             id: 'pendinguserid1',
+            profile_image_url: 'pendinguser1pic.png',
           },
           {
             path: '/search_path3',
@@ -171,6 +177,7 @@ describe('<ChannelDetails />', () => {
             name: 'searched user 3',
             username: 'searcheduser3',
             id: 'searched_userid3',
+            profile_image_url: 'searcheduser3pic.png',
           },
         ],
       };
@@ -274,13 +281,13 @@ describe('<ChannelDetails />', () => {
         expect(
           channelmembers
             .at(i)
-            .childAt(0)
+            .childAt(1)
             .attr('href'),
         ).toEqual(`/${userdetails.channel_users[i].username}`);
         expect(
           channelmembers
             .at(i)
-            .childAt(0)
+            .childAt(1)
             .attr('data-content'),
         ).toEqual(
           `users/by_username?url=${userdetails.channel_users[i].username}`,

--- a/app/javascript/chat/channelDetails.jsx
+++ b/app/javascript/chat/channelDetails.jsx
@@ -114,12 +114,8 @@ class ChannelDetails extends Component {
     let pendingInvites = [];
     if (channel.channel_mod_ids.includes(window.currentUser.id)) {
       // eslint-disable-next-line
-      searchedUsers = this.state.searchedUsers.map(user => (
-        <div className="channeldetails__searchedusers">
-          <a href={user.path} target="_blank" rel="noopener noreferrer">
-            {user.title}
-          </a>
-          {' '}
+      searchedUsers = this.state.searchedUsers.map(user => {
+        let invite = (
           <button
             type="button"
             onClick={this.triggerInvite}
@@ -127,8 +123,39 @@ class ChannelDetails extends Component {
           >
             Invite
           </button>
-        </div>
-      ));
+        );
+        if (channel.channel_users.includes(user)) {
+          invite = (
+            <span>
+              {' '}
+              is already in
+              {channel.name}
+            </span>
+          );
+        } else if (channel.pending_users_select_fields.includes(user)) {
+          invite = (
+            <span>
+              {' '}
+              has already been invited to
+              {channel.name}
+            </span>
+          );
+        }
+        return (
+          <div className="channeldetails__searchedusers">
+            <a href={user.path} target="_blank" rel="noopener noreferrer">
+              <img alt="profile_image" src={user.profile_image} />
+@
+              {user.username}
+              {' '}
+-
+              {user.name}
+            </a>
+            {' '}
+            {invite}
+          </div>
+        );
+      });
       pendingInvites = channel.pending_users_select_fields.map(user => (
         <div className="channeldetails__pendingusers">
           <a

--- a/app/javascript/chat/channelDetails.jsx
+++ b/app/javascript/chat/channelDetails.jsx
@@ -152,7 +152,7 @@ class ChannelDetails extends Component {
           return (
             <div className="channeldetails__searchedusers">
               <a href={user.path} target="_blank" rel="noopener noreferrer">
-                <img alt="profile_image" src={user.profile_image} />
+                <img alt="profile_image" src={user.profile_image_url} />
                 @
                 {user.username}
                 {' '}

--- a/app/javascript/chat/channelDetails.jsx
+++ b/app/javascript/chat/channelDetails.jsx
@@ -147,6 +147,7 @@ class ChannelDetails extends Component {
               {user.username}
               {' '}
 -
+              {' '}
               {user.name}
             </a>
             {' '}
@@ -165,7 +166,7 @@ class ChannelDetails extends Component {
             @
             {user.username}
             {' '}
-- 
+-
             {' '}
             {user.name}
           </a>
@@ -197,7 +198,7 @@ class ChannelDetails extends Component {
           </h3>
           <h4>It may not be immediately in the sidebar</h4>
           <p>
-            Contact the admins at 
+            Contact the admins at
             {' '}
             <a href="mailto:yo@dev.to">yo@dev.to</a>
             {' '}

--- a/app/javascript/chat/channelDetails.jsx
+++ b/app/javascript/chat/channelDetails.jsx
@@ -105,6 +105,12 @@ class ChannelDetails extends Component {
     const channel = this.props.channel; // eslint-disable-line
     const users = Object.values(channel.channel_users).map(user => (
       <div className="channeldetails__user">
+        <img
+          className="channeldetails__userprofileimage"
+          src={user.profile_image_url}
+          alt={`${user} profile`}
+          data-content={`users/${user.id}`}
+        />
         <a
           href={`/${user.username}`}
           style={{ color: user.darker_color, padding: '3px 0px' }}
@@ -137,7 +143,7 @@ class ChannelDetails extends Component {
           if (this.userInList(channel.channel_users, user)) {
             invite = (
               <span className="channel__member">
-                is already in
+                is already in 
                 {' '}
                 {channel.channel_name}
               </span>
@@ -151,7 +157,6 @@ class ChannelDetails extends Component {
                 {user.username}
                 {' '}
 -
-                {' '}
                 {user.name}
               </a>
               {' '}
@@ -171,7 +176,7 @@ class ChannelDetails extends Component {
             @
             {user.username}
             {' '}
--
+- 
             {' '}
             {user.name}
           </a>
@@ -203,7 +208,7 @@ class ChannelDetails extends Component {
           </h3>
           <h4>It may not be immediately in the sidebar</h4>
           <p>
-            Contact the admins at
+            Contact the admins at 
             {' '}
             <a href="mailto:yo@dev.to">yo@dev.to</a>
             {' '}
@@ -221,7 +226,7 @@ if
             Click={this.triggerLeaveChannel}
             data-content={channel.id}
           >
-            Leave Channel.
+            Leave Channel
           </button>
         </div>
       );
@@ -229,13 +234,13 @@ if
     return (
       <div className="channeldetails">
         <h1 className="channeldetails__name">{channel.channel_name}</h1>
-        {subHeader}
         <div
           className="channeldetails__description"
           style={{ marginBottom: '20px' }}
         >
           <em>{channel.description || ''}</em>
         </div>
+        {subHeader}
         {users}
         {modSection}
       </div>

--- a/app/javascript/chat/channelDetails.jsx
+++ b/app/javascript/chat/channelDetails.jsx
@@ -127,7 +127,6 @@ class ChannelDetails extends Component {
         if (channel.channel_users.includes(user)) {
           invite = (
             <span>
-              {' '}
               is already in
               {channel.name}
             </span>
@@ -135,7 +134,6 @@ class ChannelDetails extends Component {
         } else if (channel.pending_users_select_fields.includes(user)) {
           invite = (
             <span>
-              {' '}
               has already been invited to
               {channel.name}
             </span>

--- a/app/javascript/chat/channelDetails.jsx
+++ b/app/javascript/chat/channelDetails.jsx
@@ -137,7 +137,7 @@ class ChannelDetails extends Component {
           if (this.userInList(channel.channel_users, user)) {
             invite = (
               <span className="channel__member">
-                is already in 
+                is already in
                 {' '}
                 {channel.channel_name}
               </span>
@@ -151,6 +151,7 @@ class ChannelDetails extends Component {
                 {user.username}
                 {' '}
 -
+                {' '}
                 {user.name}
               </a>
               {' '}
@@ -170,7 +171,7 @@ class ChannelDetails extends Component {
             @
             {user.username}
             {' '}
-- 
+-
             {' '}
             {user.name}
           </a>
@@ -202,7 +203,7 @@ class ChannelDetails extends Component {
           </h3>
           <h4>It may not be immediately in the sidebar</h4>
           <p>
-            Contact the admins at 
+            Contact the admins at
             {' '}
             <a href="mailto:yo@dev.to">yo@dev.to</a>
             {' '}

--- a/app/javascript/chat/channelDetails.jsx
+++ b/app/javascript/chat/channelDetails.jsx
@@ -104,7 +104,7 @@ class ChannelDetails extends Component {
 
   render() {
     const channel = this.props.channel; // eslint-disable-line
-    const users = Object.values(channel.channel_users).slice(0, 12).map(user => (
+    const users = Object.values(channel.channel_users).slice(0, 11).map(user => (
       <div className="channeldetails__user">
         <img
           className="channeldetails__userprofileimage"
@@ -122,7 +122,7 @@ class ChannelDetails extends Component {
       </div>
     ));
     let subHeader = '';
-    if (users.length === 12) {
+    if (users.length === 11) {
       subHeader = <h3>Recently Active Members</h3>;
     }
     let modSection = '';

--- a/app/javascript/chat/channelDetails.jsx
+++ b/app/javascript/chat/channelDetails.jsx
@@ -121,7 +121,7 @@ class ChannelDetails extends Component {
         </a>
       </div>
     ));
-    let subHeader = '';
+    let subHeader = <h3>Members</h3>;
     if (users.length === 11) {
       subHeader = <h3>Recently Active Members</h3>;
     }

--- a/app/javascript/chat/channelDetails.jsx
+++ b/app/javascript/chat/channelDetails.jsx
@@ -29,7 +29,7 @@ class ChannelDetails extends Component {
     const query = e.target.value;
     const filters = {
       hitsPerPage: 20,
-      attributesToRetrieve: ['id', 'title', 'path'],
+      attributesToRetrieve: ['id', 'title', 'path', 'user'],
       attributesToHighlight: [],
       filters: 'class_name:User',
     };
@@ -93,8 +93,9 @@ class ChannelDetails extends Component {
   };
 
   userInList = (list, user) => {
-    for (let i = 0; i < list.length; i += 1) {
-      if (user.id === list[i].id) {
+    const keys = Object.keys(list)
+    for (const key of keys) {
+      if (user.id === list[key].id) {
         return true;
       }
     }
@@ -107,8 +108,8 @@ class ChannelDetails extends Component {
       <div className="channeldetails__user">
         <img
           className="channeldetails__userprofileimage"
-          src={user.profile_image_url}
-          alt={`${user} profile`}
+          src={user.profile_image}
+          alt={`${user.username} profile`}
           data-content={`users/${user.id}`}
         />
         <a
@@ -145,20 +146,20 @@ class ChannelDetails extends Component {
               <span className="channel__member">
                 is already in
                 {' '}
-                {channel.channel_name}
+                <em>{channel.channel_name}</em>
               </span>
             );
           }
           return (
             <div className="channeldetails__searchedusers">
               <a href={user.path} target="_blank" rel="noopener noreferrer">
-                <img alt="profile_image" src={user.profile_image_url} />
+                <img src={user.user.profile_image_90} alt="profile_image"/>
                 @
-                {user.username}
+                {user.user.username}
                 {' '}
 -
                 {' '}
-                {user.name}
+                {user.title}
               </a>
               {' '}
               {invite}
@@ -187,7 +188,9 @@ class ChannelDetails extends Component {
         <div className="channeldetails__inviteusers">
           <h2>Invite Members</h2>
           <input onKeyUp={this.triggerUserSearch} placeholder="Find users" />
-          {searchedUsers}
+          <div className="channeldetails__searchresults">
+            {searchedUsers}
+          </div>
           <h2>Pending Invites:</h2>
           {pendingInvites}
           <div style={{ marginTop: '10px' }}>

--- a/app/javascript/chat/channelDetails.jsx
+++ b/app/javascript/chat/channelDetails.jsx
@@ -104,7 +104,7 @@ class ChannelDetails extends Component {
 
   render() {
     const channel = this.props.channel; // eslint-disable-line
-    const users = Object.values(channel.channel_users).map(user => (
+    const users = Object.values(channel.channel_users).slice(0, 12).map(user => (
       <div className="channeldetails__user">
         <img
           className="channeldetails__userprofileimage"
@@ -122,7 +122,7 @@ class ChannelDetails extends Component {
       </div>
     ));
     let subHeader = '';
-    if (users.length === 80) {
+    if (users.length === 12) {
       subHeader = <h3>Recently Active Members</h3>;
     }
     let modSection = '';

--- a/app/javascript/chat/channelDetails.jsx
+++ b/app/javascript/chat/channelDetails.jsx
@@ -143,7 +143,7 @@ class ChannelDetails extends Component {
           if (this.userInList(channel.channel_users, user)) {
             invite = (
               <span className="channel__member">
-                is already in 
+                is already in
                 {' '}
                 {channel.channel_name}
               </span>
@@ -153,10 +153,11 @@ class ChannelDetails extends Component {
             <div className="channeldetails__searchedusers">
               <a href={user.path} target="_blank" rel="noopener noreferrer">
                 <img alt="profile_image" src={user.profile_image} />
-@
+                @
                 {user.username}
                 {' '}
 -
+                {' '}
                 {user.name}
               </a>
               {' '}
@@ -176,7 +177,7 @@ class ChannelDetails extends Component {
             @
             {user.username}
             {' '}
-- 
+-
             {' '}
             {user.name}
           </a>
@@ -208,7 +209,7 @@ class ChannelDetails extends Component {
           </h3>
           <h4>It may not be immediately in the sidebar</h4>
           <p>
-            Contact the admins at 
+            Contact the admins at
             {' '}
             <a href="mailto:yo@dev.to">yo@dev.to</a>
             {' '}

--- a/app/javascript/chat/channelDetails.jsx
+++ b/app/javascript/chat/channelDetails.jsx
@@ -121,7 +121,7 @@ class ChannelDetails extends Component {
         </a>
       </div>
     ));
-    let subHeader = <h3>Members</h3>;
+    let subHeader = '';
     if (users.length === 11) {
       subHeader = <h3>Recently Active Members</h3>;
     }

--- a/app/javascript/chat/channelDetails.jsx
+++ b/app/javascript/chat/channelDetails.jsx
@@ -92,6 +92,15 @@ class ChannelDetails extends Component {
     console.log(response); // eslint-disable-line no-console
   };
 
+  userInList = (list, user) => {
+    for (let i = 0; i < list.length; i += 1) {
+      if (user.id === list[i].id) {
+        return true;
+      }
+    }
+    return false;
+  };
+
   render() {
     const channel = this.props.channel; // eslint-disable-line
     const users = Object.values(channel.channel_users).map(user => (
@@ -115,45 +124,40 @@ class ChannelDetails extends Component {
     if (channel.channel_mod_ids.includes(window.currentUser.id)) {
       // eslint-disable-next-line
       searchedUsers = this.state.searchedUsers.map(user => {
-        let invite = (
-          <button
-            type="button"
-            onClick={this.triggerInvite}
-            data-content={user.id}
-          >
-            Invite
-          </button>
-        );
-        if (channel.channel_users.includes(user)) {
-          invite = (
-            <span>
-              is already in
-              {channel.name}
-            </span>
+        if (!this.userInList(channel.pending_users_select_fields, user)) {
+          let invite = (
+            <button
+              type="button"
+              onClick={this.triggerInvite}
+              data-content={user.id}
+            >
+              Invite
+            </button>
           );
-        } else if (channel.pending_users_select_fields.includes(user)) {
-          invite = (
-            <span>
-              has already been invited to
-              {channel.name}
-            </span>
+          if (this.userInList(channel.channel_users, user)) {
+            invite = (
+              <span className="channel__member">
+                is already in 
+                {' '}
+                {channel.channel_name}
+              </span>
+            );
+          }
+          return (
+            <div className="channeldetails__searchedusers">
+              <a href={user.path} target="_blank" rel="noopener noreferrer">
+                <img alt="profile_image" src={user.profile_image} />
+@
+                {user.username}
+                {' '}
+-
+                {user.name}
+              </a>
+              {' '}
+              {invite}
+            </div>
           );
         }
-        return (
-          <div className="channeldetails__searchedusers">
-            <a href={user.path} target="_blank" rel="noopener noreferrer">
-              <img alt="profile_image" src={user.profile_image} />
-@
-              {user.username}
-              {' '}
--
-              {' '}
-              {user.name}
-            </a>
-            {' '}
-            {invite}
-          </div>
-        );
       });
       pendingInvites = channel.pending_users_select_fields.map(user => (
         <div className="channeldetails__pendingusers">
@@ -166,7 +170,7 @@ class ChannelDetails extends Component {
             @
             {user.username}
             {' '}
--
+- 
             {' '}
             {user.name}
           </a>
@@ -198,7 +202,7 @@ class ChannelDetails extends Component {
           </h3>
           <h4>It may not be immediately in the sidebar</h4>
           <p>
-            Contact the admins at
+            Contact the admins at 
             {' '}
             <a href="mailto:yo@dev.to">yo@dev.to</a>
             {' '}

--- a/app/javascript/chat/chat.jsx
+++ b/app/javascript/chat/chat.jsx
@@ -81,7 +81,7 @@ export default class Chat extends Component {
       document.getElementById('chatchannels__channelslist').addEventListener('scroll', this.handleChannelScroll);
     }
     getChannelInvites(this.handleChannelInvites,null);
-    
+
   }
 
   componentDidUpdate() {
@@ -214,7 +214,7 @@ export default class Chat extends Component {
     }
     this.subscribePusher(`presence-channel-${channelId}`)
   };
-  
+
 
   observerCallback = entries => {
     entries.forEach(entry => {
@@ -314,7 +314,7 @@ export default class Chat extends Component {
     const target = e.target;
     if((target.scrollTop + target.offsetHeight + 1800) > target.scrollHeight) {
       this.setState({fetchingPaginatedChannels: true})
-      
+
       const filters = this.state.channelTypeFilter === 'all' ? {} : {filters: 'channel_type:'+this.state.channelTypeFilter};
       getChannels(
         this.state.filterQuery,
@@ -455,8 +455,8 @@ export default class Chat extends Component {
     const target = e.target
     if (
       //Trying to open in new tab
-            e.ctrlKey || 
-            e.shiftKey || 
+            e.ctrlKey ||
+            e.shiftKey ||
             e.metaKey || // apple
             (e.button && e.button == 1) // middle click, >IE9 + everyone else
         ) {
@@ -551,12 +551,20 @@ export default class Chat extends Component {
       return
     }
     if (messages[activeChannelId].length === 0 && activeChannel ) {
-      const channelUsername = activeChannel.slug.replace(`${window.currentUser.username}/`, '').replace(`/${window.currentUser.username}`, '')
-      return <div className="chatmessage" style={{color: "grey"}}>
-        <div className="chatmessage__body">
-          You and <a href={"/"+channelUsername} style={{color:activeChannel.channel_users[channelUsername].darker_color}} >@{channelUsername}</a> are connected because you both follow each other. All interactions <em><b>must</b></em> abide by the <a href="/code-of-conduct">code of conduct</a>.
+      if (activeChannel.channel_type === "direct") {
+        const channelUsername = activeChannel.slug.replace(`${window.currentUser.username}/`, '').replace(`/${window.currentUser.username}`, '')
+        return <div className="chatmessage" style={{color: "grey"}}>
+          <div className="chatmessage__body">
+            You and <a href={"/"+channelUsername} style={{color:activeChannel.channel_users[channelUsername].darker_color}} >@{channelUsername}</a> are connected because you both follow each other. All interactions <em><b>must</b></em> abide by the <a href="/code-of-conduct">code of conduct</a>.
+          </div>
         </div>
-      </div>
+      } else if (activeChannel.channel_type === "open") {
+        return <div className="chatmessage" style={{color: "grey"}}>
+          <div className="chatmessage__body">
+            You have joined {activeChannel.channel_name}!. All interactions <em><b>must</b></em> abide by the <a href="/code-of-conduct">code of conduct</a>.
+          </div>
+        </div>
+      }
     }
     return messages[activeChannelId].map(message => (
       <Message
@@ -684,7 +692,7 @@ export default class Chat extends Component {
     </div>
   );
 
-  
+
 
   render() {
     const detectIOSSafariClass = (navigator.userAgent.match(/iPhone/i) && !navigator.userAgent.match('CriOS')) ? " chat--iossafari" : "";

--- a/app/javascript/chat/chat.jsx
+++ b/app/javascript/chat/chat.jsx
@@ -561,7 +561,7 @@ export default class Chat extends Component {
       } else if (activeChannel.channel_type === "open") {
         return <div className="chatmessage" style={{color: "grey"}}>
           <div className="chatmessage__body">
-            You have joined {activeChannel.channel_name}!. All interactions <em><b>must</b></em> abide by the <a href="/code-of-conduct">code of conduct</a>.
+            You have joined {activeChannel.channel_name}! All interactions <em><b>must</b></em> abide by the <a href="/code-of-conduct">code of conduct</a>.
           </div>
         </div>
       }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
Now that profile pics have been added to the channel details from #1201 , after 10 profiles the image sources stop being fed into the image elements. 

Temporary fix is to limit active users to last 10 users. 

## Related Tickets & Documents
#1201 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
### Previous Behavior:
<img width="362" alt="screen shot 2018-12-03 at 13 51 42" src="https://user-images.githubusercontent.com/13403332/49395761-65d2a180-f705-11e8-964e-d7dbff493f0f.png">

### Updated Behavior: 
<img width="849" alt="screen shot 2018-12-03 at 16 39 09" src="https://user-images.githubusercontent.com/13403332/49403270-4eea7a00-f71a-11e8-80e6-2bbcfd8ce2e0.png">

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## What gif best describes this PR or how it makes you feel?

![jim](https://media.giphy.com/media/13jghlUIB6FHZm/giphy.gif)
