### PR TITLE
Adjust gist embed styles for readability on mobile browsers

### DIFF
--- a/app/assets/stylesheets/articles.scss
+++ b/app/assets/stylesheets/articles.scss
@@ -1433,11 +1433,6 @@
   }
 }
 
-.gist .blob-wrapper table {
-  text-size-adjust: none;
-  tab-size: 2;
-}
-
 .animated-background {
   animation-duration: 1.25s;
   animation-fill-mode: forwards;

--- a/app/assets/stylesheets/articles.scss
+++ b/app/assets/stylesheets/articles.scss
@@ -1433,6 +1433,11 @@
   }
 }
 
+.gist .blob-wrapper table {
+  text-size-adjust: none;
+  tab-size: 2;
+}
+
 .animated-background {
   animation-duration: 1.25s;
   animation-fill-mode: forwards;

--- a/app/assets/stylesheets/ltags/GistTag.scss
+++ b/app/assets/stylesheets/ltags/GistTag.scss
@@ -19,4 +19,9 @@
     color: #29292e;
   }
 
+  .gist .blob-wrapper table {
+    text-size-adjust: none;
+    tab-size: 2;
+  }
+
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
I found when [implementing github gists on my own site](https://tyhopp.com/blog/gatsby-gists) that while the github gist embed code looks fine on desktop browsers at mobile viewport sizes, on mobile browsers the code is much larger than the article text.

In order to improve readability of embedded gists on mobile browsers, it might be helpful to remove the `text-size-adjust` property shipped with the gist embed styles and set the tab-spacing to 2 (or any other number less than 8, which is the default).

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
Mobile (too big!):
<img width="375" alt="mbl-gist-embed" src="https://user-images.githubusercontent.com/13206278/49405923-e050f080-f708-11e8-884a-fba1d431afc6.jpeg">

Desktop (good!):
<img width="375" alt="desk-gist-embed" src="https://user-images.githubusercontent.com/13206278/49405937-f068d000-f708-11e8-8358-2b13cfaaa641.png">

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## Note
This is my first PR and I'm new to the dev.to codebase, please let me know if this is the wrong place for these styles ❤️

## [optional] What gif best describes this PR or how it makes you feel?

![contemplative batman](https://media.giphy.com/media/a5viI92PAF89q/giphy.gif)
