### PR TITLE
Add guard clause to hotfix some 500s

### DIFF
--- a/lib/instrumentation.rb
+++ b/lib/instrumentation.rb
@@ -12,6 +12,7 @@ module Instrumentation
   end
 
   def append_to_honeycomb(request, controller_name)
+    return if honeycomb_metadata.nil?
     honeycomb_metadata["trace.trace_id"] = request.request_id
     honeycomb_metadata["trace.span_id"] = request.request_id
     honeycomb_metadata[:service_name] = "rails"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This fixes some stray 500s that happens. We'll still need to investigate why `honeycomb_metadata` is returning `nil` though.