### PR TITLE
Add two German Mastodon instances

### DIFF
--- a/app/lib/constants.rb
+++ b/app/lib/constants.rb
@@ -2,6 +2,7 @@ module Constants
   MASTODON_INSTANCE_WHITELIST = [
     "acg.mn",
     "bitcoinhackers.org",
+    "chaos.social",
     "cmx.im",
     "framapiaf.org",
     "friends.nico",
@@ -42,6 +43,7 @@ module Constants
     "pawoo.net",
     "qiitadon.com",
     "ro-mastodon.puyo.jp",
+    "ruhr.social",
     "social.targaryen.house",
     "social.tchncs.de",
     "switter.at",


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

Add two instances to the Mastodon whitelist:

- ruhr.social
- chaos.social

## Related Tickets & Documents

-https://dev.to/timkrueger/comment/7bjc

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
