### PR TITLE
Bug/notification typo

### DIFF
--- a/app/views/moderations/mod.html.erb
+++ b/app/views/moderations/mod.html.erb
@@ -84,7 +84,7 @@
   <% if @moderatable.class.name == "Article" && (current_user.has_role?(:super_admin) || is_mod) %>
     <div class="tag-mod-form" >
       <%= form_for(TagAdjustment.new) do |f| %>
-        <h2> Remove Innapropriate Tags</h2>
+        <h2> Remove Inappropriate Tags</h2>
         <% unless current_user.has_role?(:super_admin) %>
           <ul>
             <li>You can only remove tags that you moderate.</li>

--- a/app/views/notifications/_comment.html.erb
+++ b/app/views/notifications/_comment.html.erb
@@ -3,7 +3,7 @@
 <% else %>
   <% json_data = notification.json_data %>
   <% cache "activity-profile-pic-#{json_data["user"]["id"]}-#{json_data["user"]["profile_image_90"]}" do %>
-    <a href="<%= json_data["comment"]["path"] %>" class="small-pic-link-wrapper">
+    <a href="<%= json_data["user"]["path"] %>" class="small-pic-link-wrapper">
       <div class="small-pic">
         <img src="<%= json_data["user"]["profile_image_90"] %>" alt="link to <%= json_data["user"]["username"] %>'s profile">
       </div>

--- a/spec/features/podcasts/user_visits_podcast_episode_spec.rb
+++ b/spec/features/podcasts/user_visits_podcast_episode_spec.rb
@@ -4,7 +4,7 @@ describe "User visits podcast show page", type: :feature do
   let(:podcast) { create(:podcast) }
   let(:podcast_episode) { create(:podcast_episode, podcast_id: podcast.id) }
 
-  it "they see the content of the hero" do
+  it "they see the content of the hero", retry: 3 do
     visit podcast_episode.path.to_s
     expect(page).to have_text(podcast_episode.title)
     expect(page).to have_css ".record"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Fixes a few minor things:
- a typo for tag moderators in `/mod`
- adds `retry: 3` to a test that often fails for unknown Capybara/database cleaning reasons
- **uses the correct path for comment profile pics** oops :(