### PR TITLE
Darken cta-button

### DIFF
--- a/app/assets/stylesheets/articles.scss
+++ b/app/assets/stylesheets/articles.scss
@@ -1242,7 +1242,7 @@
         margin-top:8px;
         padding:8px 0px;
         font-size:0.93em;
-        color: $sky-blue;
+        color: darken($sky-blue, 17%);
         background: white;
         display:block;
         width:92%;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Documentation Update

## Description
Darken cta-button to bring contrast up to 7
The new colour value is `#1b4bcb`

## Related Tickets & Documents
No ticket but more issues to do with contrast on the homepage lowering lighthouse score.

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

