### PR TITLE
Fixes #1298: Overflowing User Bio in article sidebar.

### DIFF
--- a/app/assets/stylesheets/sticky-nav.scss
+++ b/app/assets/stylesheets/sticky-nav.scss
@@ -35,6 +35,9 @@
       padding: 10px 0px 5px;
       font-style: italic;
       font-size:0.88em;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      overflow-wrap: break-word;
     }
     .primary-sticky-nav-author-follow{
       padding-top:8px;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
For long non-breaking text (like links), the author summary was not being wrapped. Fixed this by adding an `overflow-wrap: break-word` to the `.primary-sticky-nav-author-summary` CSS rule and additionally adding `overflow: hidden` and `text-overflow: ellipsis` to make the CSS more robust. 

## Related Tickets & Documents
Issue #1298

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
Before:
<img width="330" alt="screen shot 2018-12-10 at 2 16 46 pm" src="https://user-images.githubusercontent.com/509059/49765105-451ac680-fc86-11e8-9a38-afe5d19535e3.png">

After:
<img width="317" alt="screen shot 2018-12-10 at 1 43 56 pm" src="https://user-images.githubusercontent.com/509059/49765075-2f0d0600-fc86-11e8-89ce-552ec495bec3.png">


## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?
