### PR TITLE
Don't fetch user_stickies if post belongs to current_user

### DIFF
--- a/app/views/articles/_sticky_nav.html.erb
+++ b/app/views/articles/_sticky_nav.html.erb
@@ -1,7 +1,7 @@
 <% if user_signed_in? %>
   <% @sticky_collection = StickyArticleCollection.new(@article, @organization || @user) %>
   <% @sticky_articles = @sticky_collection.suggested_stickies %>
-  <% @user_stickies = @sticky_collection.user_stickies %>
+  <% @user_stickies = @sticky_collection.user_stickies unless current_user.username == @user.username %>
 <% end %>
 
 <% @actor = @article.organization || @article.user %>


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

Does not show user stickies if article author is current_user

## Related Tickets & Documents

#1202 

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

