### PR TITLE
change height for mobile specific css

### DIFF
--- a/app/assets/stylesheets/chat.scss
+++ b/app/assets/stylesheets/chat.scss
@@ -10,7 +10,7 @@
 .live-chat{
   height: calc(100vh - 80px);
   &.live-chat--iossafari{
-    height: calc(100vh - 190px);
+    height: 100vh;
   }
   overflow-y: hidden;
   @media screen and ( min-width: 400px ){
@@ -23,7 +23,7 @@
   display: flex;
   height: calc(100vh - 91px);
   &.chat--iossafari{
-    height: calc(100vh - 201px);
+    height: calc(100vh - 100px);
   }
   padding-right: 3px;
   @media screen and ( min-width: 400px ){


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
While I couldn't replicate #1018 on Chrome, the dev.to app, and Safari on my iPhone XS, I was able to replicate it on Firefox and found that the reduced height was because of the determined height on the `chat--iossafari` tag, so I adjust the height to allow for more use of screen space. I checked other mobile/tablet screen sizes and other browsers after the change and all of them make good use of  space. 

## Related Tickets & Documents
aims to address #1018

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
### Before:
<img width="576" alt="screen shot 2018-12-11 at 12 16 25" src="https://user-images.githubusercontent.com/13403332/49818019-bb2f3400-fd3f-11e8-83e9-a621309dced8.png">

### After:
<img width="575" alt="screen shot 2018-12-11 at 12 16 58" src="https://user-images.githubusercontent.com/13403332/49818036-c1bdab80-fd3f-11e8-8979-2aead5555d1c.png">

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## What gif best describes this PR or how it makes you feel?
![tall](https://media.giphy.com/media/Ay2yAQgxhFD7a/giphy.gif)
