### PR TITLE
Visit a page before visiting the delete confirm page

### DIFF
--- a/spec/features/user_delete_a_comment_spec.rb
+++ b/spec/features/user_delete_a_comment_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe "Deleting Comment", type: :feature, js: true do
   end
 
   it "works" do
+    visit "/"
     visit comment.path + "/delete_confirm"
     click_link("DELETE")
     expect(page).to have_current_path(article.path)


### PR DESCRIPTION
Fix a CI bug that fails pretty often by using a test hack. We should probably revisit it eventually.