### PR TITLE
Add a descriptive title to the series links

### DIFF
--- a/app/views/articles/_collection.html.erb
+++ b/app/views/articles/_collection.html.erb
@@ -7,11 +7,12 @@
       <p>Part of a series</p>
     <% end %>
     <div class="article-collection">
-      <% @collection.articles.where(published: true).order("published_at ASC").each_with_index do |article,i| %>
+      <% @collection.articles.where(published: true).order("published_at ASC").each_with_index do |article, i| %>
           <a
             href="<%= article.path if article.published %>"
-            class="<%= collection_link_class(@article,article) %>"
+            class="<%= collection_link_class(@article, article) %>"
             data-preload-image="<%=cloud_cover_url(article.main_image) %>"
+            title="Part <%= i + 1 %>: <%= article.title %>"
           >
           </a>
       <% end %>


### PR DESCRIPTION
It's easy to navigate each part of a series when there only a few of them. It's hard to jump from a part to another if there are many. This change makes it also a little friendlier to accessibility tools.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

I was looking through the series "A month of Flutter" and noticed the various circular links do not have any description, which is fine if you have only a few parts of a series, but it's less usable when you have many. This way you can just hover on a link and know which article it points to.

![screenshot_2018-12-15 a month of flutter rendering network images](https://user-images.githubusercontent.com/146201/50042809-137c7380-0069-11e9-8b63-6d83c9dd5116.png)


## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

It will look like something like this:

![screenshot 2018-12-15 at 12 57 52 pm](https://user-images.githubusercontent.com/146201/50042815-1f683580-0069-11e9-8a08-0b4f7a4f144e.png)


## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
