### PR TITLE
webpack dev server now does not fails on docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Our docker implementation is incomplete and may not work smoothly. Please kindly
 1. Set environment variables above as described in the "Basic Installation"
 1. run `docker-compose build`
 1. run `docker-compose run web rails db:setup`
+1. run `docker-compose run web yarn install`
 1. run `docker-compose up`
 1. That's it! Navigate to `localhost:3000`
 


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Documentation Update

## Description
Updated the docker installation readme, webpack dev server fails to load because manifest is missing. Just doing `yarn install` solves the issue!

## Related Tickets & Documents
Fixes #1001 

## Added to documentation?

- [ ] docs.dev.to
- [x] readme
- [ ] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![Gif](https://media.giphy.com/media/iBpyopnIX2t4oSrBnJ/giphy.gif)
