### PR TITLE
/connect rerender chat

### DIFF
--- a/app/javascript/chat/chat.jsx
+++ b/app/javascript/chat/chat.jsx
@@ -109,9 +109,11 @@ export default class Chat extends Component {
   }
 
   componentDidUpdate() {
-    if (!this.state.scrolled) {
-      scrollToBottom();
-    }
+    // if (document.getElementById('messagelist')) {
+      if (!this.state.scrolled) {
+        scrollToBottom();
+      }
+    // }
   }
 
   liveCoding = e => {
@@ -143,7 +145,7 @@ export default class Chat extends Component {
 
   subscribePusher = channelName => {
     if (this.state.subscribedPusherChannels.includes(channelName)) {
-      
+
     } else {
       setupPusher(this.props.pusherKey, {
         channelId: channelName,
@@ -194,7 +196,7 @@ export default class Chat extends Component {
       const channel = channels[0];
       const channelSlug =
         channel.channel_type === 'direct'
-          ? `@${ 
+          ? `@${
             channel.slug
               .replace(`${window.currentUser.username}/`, '')
               .replace(`/${window.currentUser.username}`, '')}`
@@ -271,6 +273,8 @@ export default class Chat extends Component {
 
   receiveNewMessage = message => {
     const receivedChatChannelId = message.chat_channel_id;
+    console.log(receivedChatChannelId, "receivedChatChannelId")
+    console.log(this.state.activeChannelId, "activeChannelId")
     if (!this.state.messages[receivedChatChannelId]) {
       return;
     }
@@ -648,7 +652,7 @@ export default class Chat extends Component {
                 <b>must</b>
               </em>
               {' '}
-              abide by the 
+              abide by the
               {' '}
               <a href="/code-of-conduct">code of conduct</a>
 .
@@ -659,7 +663,7 @@ export default class Chat extends Component {
         return (
           <div className="chatmessage" style={{ color: 'grey' }}>
             <div className="chatmessage__body">
-              You have joined 
+              You have joined
               {' '}
               {activeChannel.channel_name}
 ! All interactions
@@ -668,7 +672,7 @@ export default class Chat extends Component {
                 <b>must</b>
               </em>
               {' '}
-              abide by the 
+              abide by the
               {' '}
               <a href="/code-of-conduct">code of conduct</a>
 .
@@ -812,7 +816,7 @@ export default class Chat extends Component {
             {notificationsState}
           </div>
         );
-      } 
+      }
         return (
           <div className="chat__channels">
             {notificationsButton}
@@ -835,7 +839,7 @@ export default class Chat extends Component {
             {notificationsState}
           </div>
         );
-      
+
     }
     return '';
   };
@@ -948,8 +952,8 @@ export default class Chat extends Component {
     return (
       <div
         className={
-          `chat chat--${ 
-          this.state.expanded ? 'expanded' : 'contracted' 
+          `chat chat--${
+          this.state.expanded ? 'expanded' : 'contracted'
           }${detectIOSSafariClass}`
         }
         data-no-instant

--- a/app/javascript/chat/chat.jsx
+++ b/app/javascript/chat/chat.jsx
@@ -111,7 +111,7 @@ export default class Chat extends Component {
   componentDidUpdate() {
     if (document.getElementById('messagelist')) {
       if (!this.state.scrolled) {
-        scrollToBottom();
+        `scrollToBottom`();
       }
     }
   }
@@ -273,8 +273,6 @@ export default class Chat extends Component {
 
   receiveNewMessage = message => {
     const receivedChatChannelId = message.chat_channel_id;
-    console.log(receivedChatChannelId, "receivedChatChannelId")
-    console.log(this.state.activeChannelId, "activeChannelId")
     if (!this.state.messages[receivedChatChannelId]) {
       return;
     }

--- a/app/javascript/chat/chat.jsx
+++ b/app/javascript/chat/chat.jsx
@@ -111,7 +111,7 @@ export default class Chat extends Component {
   componentDidUpdate() {
     if (document.getElementById('messagelist')) {
       if (!this.state.scrolled) {
-        `scrollToBottom`();
+        scrollToBottom();
       }
     }
   }

--- a/app/javascript/chat/chat.jsx
+++ b/app/javascript/chat/chat.jsx
@@ -109,11 +109,11 @@ export default class Chat extends Component {
   }
 
   componentDidUpdate() {
-    // if (document.getElementById('messagelist')) {
+    if (document.getElementById('messagelist')) {
       if (!this.state.scrolled) {
         scrollToBottom();
       }
-    // }
+    }
   }
 
   liveCoding = e => {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description
When in 'dev.to/connect', clicking the paper airplane rerenders chat and triggers the `componentDidUpdate()` function in `chat.jsx`, which calls `scrollToBottom()` from `utils.js`. 

The error occurs because when `scrollToBottom()` is called, the element it needs `document.getElementById('messagelist')` has not been rendered yet thus not being able to find the `scrollHeight` attribute. To avoid this, I added an `if` statement in `componentDidUpdate()` that checks that `document.getElementById('messagelist')` is found before letting `scrollToBottom()` be called.

## Related Tickets & Documents
addresses #1357 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
See screenshots in #1357

## Added to documentation?

- [x] no documentation needed

