### PR TITLE
Add tag moderation info page

### DIFF
--- a/app/views/pages/tag_moderation.html.erb
+++ b/app/views/pages/tag_moderation.html.erb
@@ -1,0 +1,72 @@
+<% title "Tag Moderation Guide for dev.to()" %>
+
+<%= content_for :page_meta do %>
+  <link rel="canonical" href="https://dev.to/tag-moderation"/>
+  <meta name="description" content="Tag Moderation Guide for dev.to()">
+  <meta name="keywords" content="software development,engineering,rails,javascript,ruby">
+
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://dev.to/tag-moderation" />
+  <meta property="og:title" content="Tag Moderation Guide for dev.to()" />
+  <meta property="og:image" content="https://thepracticaldev.s3.amazonaws.com/i/g355ol6qsrg0j2mhngz9.png" />
+  <meta property="og:description" content="Things to know!" />
+  <meta property="og:site_name" content="The Practical Dev" />
+
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:site" content="@ThePracticalDev">
+  <meta name="twitter:title" content="Tag Moderation Guide for dev.to()">
+  <meta name="twitter:description" content="Things to know!">
+  <meta name="twitter:image:src" content="https://thepracticaldev.s3.amazonaws.com/i/g355ol6qsrg0j2mhngz9.png">
+<% end %>
+<style>
+  img {
+    border: solid #444444;
+  }
+</style>
+
+<header>
+  <div class="blank-space"></div>
+</header>
+<div class="container article">
+  <div class="title">
+    <h1>
+      Tag Moderation Guide
+    </h1>
+  </div>
+  <div class="body">
+    <p>In order to ensure articles are published with the correct tags, we rely on awesome community tag moderators. The feature is currently in beta so privileges will evolve, but currently, tag moderators have the ability to:</p>
+    <ul>
+      <li>Remove tags you are moderating from certain posts</li>
+      <li>Update the tag sidebar (i.e. add a description, submission guideline, etc).</li>
+      <li>Update the tag’s ‘pretty name’ and colors.</li>
+    </ul>
+    <h3>How to remove tags from a post</h3>
+    <p>If you are the moderator of a tag, you have the ability to remove your tag from posts that should not contain the tag. This helps us keep content categorized appropriately so people can confidently follow tags and expect to see subjects they're interested in.</p>
+    <ol>
+      <li>Visit the article in question.</li>
+      <li>Append /mod to the end of the article URL (i.e. https://dev.to/ben/devto-is-now-open-source-5n1/mod)</li>
+      <li>You'll see the below form. Update the appropriate fields. Please include the reason for removing your tag from this post. </li>
+      <li>Note: once you remove the tag, the author will not be able to add it back. Only remove tags when you are confident they are not approprite, and please do not remove tags simply because you did not like the post.</li>
+      <li>Click remove!</li>
+    </ol>
+    <img alt="tag-removal-form" src="https://cl.ly/d1ed6068b0b8/download/Image%202018-12-18%20at%202.19.53%20PM.png">
+
+    <h3>How to Update the Tag Sidebar</h3>
+    <ol>
+      <li>Visit: https://dev.to/t/{tag name}/edit (i.e. https://dev.to/t/discuss/edit)</li>
+      <li>Update form. See below for a reference for each field.</li>
+      <li>Click Save!</li>
+    </ol>
+    <img alt="tag-edit-form" src="https://cl.ly/bcef43f32464/download/Image%202018-12-18%20at%201.04.52%20PM.png">
+    <br>
+    <img alt="example-tag-page" src="https://thepracticaldev.s3.amazonaws.com/i/cc8vz48djnhty6c31jog.png">
+    <h4>Examples of supported tags:</h4>
+      <ul>
+        <li><a href="https://dev.to/t/shecoded">#shecoded</a></li>
+        <li><a href="https://dev.to/t/weeklyui">#weeklyui</a></li>
+        <li><a href="https://dev.to/t/meta">#meta</a></li>
+      </ul>
+    <h3>How to become a moderator</h3>
+    <p>If you're interested in becoming a tag moderator, please email yo@dev.to!</p>
+  </div>
+</div>

--- a/app/views/tags/edit.html.erb
+++ b/app/views/tags/edit.html.erb
@@ -13,7 +13,7 @@
 </style>
 <br>
 <br>
-<br> 
+<br>
   <div class="user-profile-header tag-header" style="background-color:<%=@tag.bg_color_hex %>;color:<%=@tag.text_color_hex %>;">
     <div class="slanty-accent"></div>
     <div class="tag-or-query-header-container tag-edit-tag">
@@ -22,7 +22,7 @@
     </div>
   </div>
 
-  
+
   <%= form_tag("/tag/#{@tag.id}", method: :patch, class: "tag-edit-form") do %>
     <div class="tag-edit-container">
       <% if flash[:success] %>
@@ -37,7 +37,7 @@
           </ul>
       <% end %>
       <h4>
-        <a target="_blank" href="https://thepracticaldev.s3.amazonaws.com/i/47bnwguw2rv8npa85egm.png">
+        <a target="_blank" href="https://thepracticaldev.s3.amazonaws.com/i/myeca1z2tq0k0ty6aqxf.png">
           Click here to see an example of attributes.
         </a>
       </h4>
@@ -64,12 +64,12 @@
       <div class="tag-form-field">
         <%= label_tag :rules_markdown %>
         <br>
-        <%= text_area_tag "tag[rules_markdown]", @tag.rules_markdown, placeholder: "", class: "tag-form-text-field tag-area-text" %>
+        <%= text_area_tag "tag[rules_markdown]", @tag.rules_markdown, placeholder: "i.e. submission guidelines", class: "tag-form-text-field tag-area-text" %>
       </div>
       <div class="tag-form-field">
         <%= label_tag :wiki_body_markdown %>
         <br>
-        <%= text_area_tag "tag[wiki_body_markdown]", @tag.wiki_body_markdown, placeholder: "", class: "tag-form-text-field tag-area-text" %>
+        <%= text_area_tag "tag[wiki_body_markdown]", @tag.wiki_body_markdown, placeholder: "This is an 'about' section. Feel free to add an FAQ, additional resources, etc.", class: "tag-form-text-field tag-area-text" %>
       </div>
       <div class="tag-form-field">
         <%= submit_tag "Save Changes", class: "tag-edit-submit" %>

--- a/app/views/tags/edit.html.erb
+++ b/app/views/tags/edit.html.erb
@@ -37,7 +37,7 @@
           </ul>
       <% end %>
       <h4>
-        <a target="_blank" href="https://thepracticaldev.s3.amazonaws.com/i/myeca1z2tq0k0ty6aqxf.png">
+        <a target="_blank" href="https://thepracticaldev.s3.amazonaws.com/i/cc8vz48djnhty6c31jog.png">
           Click here to see an example of attributes.
         </a>
       </h4>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -223,6 +223,7 @@ Rails.application.routes.draw do
   get "/scholarships", to: redirect("/p/scholarships")
   get "/memberships", to: redirect("/membership")
   get "/shop", to: redirect("https://shop.dev.to/")
+  get "/tag-moderation" => "pages#tag_moderation"
 
   post "/fallback_activity_recorder" => "ga_events#create"
 


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Documentation Update

## Description
- Updates the tag edit page  "click here to see attributes" screenshot w/ current design.
- Adds a route + guide to tag moderation

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
new page: /tag-moderation 
![](https://cl.ly/60d5c68409da/download/Image%202018-12-18%20at%202.46.54%20PM.png)

new screenshot for tag edit page: 
![](https://cl.ly/8e2cd4d87fe9/download/Image%202018-12-18%20at%202.48.16%20PM.png)
updating screenshot: 



## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed