### PR TITLE
Fix reactions rendering on notifications

### DIFF
--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -41,7 +41,7 @@ class Reaction < ApplicationRecord
     def cached_any_reactions_for?(reactable, user, category)
       cache_name = "any_reactions_for-#{reactable.class.name}-#{reactable.id}-#{user.updated_at}-#{category}"
       Rails.cache.fetch(cache_name, expires_in: 24.hours) do
-        Reaction.where(reactable: reactable, user: user, category: category).any?
+        Reaction.where(reactable_id: reactable.id, reactable_type: reactable.class.name, user: user, category: category).any?
       end
     end
   end

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -173,6 +173,16 @@ RSpec.describe "NotificationsIndex", type: :request do
       xit "renders the comment's processed HTML" do
         expect(response.body).to include CGI.escapeHTML(comment.processed_html)
       end
+
+      it "renders the reaction as previously reacted if it was reacted on" do
+        Reaction.create(user: user, reactable: comment, category: "like")
+        get "/notifications"
+        expect(response.body).to include "reaction-button reacted"
+      end
+
+      it "does not render the reaction as reacted if it was not reacted on" do
+        expect(response.body).not_to include "reaction-button reacted"
+      end
     end
 
     context "when a user has a new moderation notification" do
@@ -294,6 +304,16 @@ RSpec.describe "NotificationsIndex", type: :request do
 
       xit "renders the author's name" do
         expect(response.body).to include CGI.escapeHTML(article.user.name)
+      end
+
+      it "renders the reaction as previously reacted if it was reacted on" do
+        Reaction.create(user: user, reactable: article, category: "like")
+        get "/notifications"
+        expect(response.body).to include "reaction-button reacted"
+      end
+
+      it "does not render the reaction as reacted if it was not reacted on" do
+        expect(response.body).not_to include "reaction-button reacted"
       end
     end
   end

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -4,13 +4,13 @@ RSpec.describe "NotificationsIndex", type: :request do
   let(:user) { create(:user) }
 
   describe "GET notifications" do
-    xit "renders page with the proper heading" do
+    it "renders page with the proper heading" do
       get "/notifications"
       expect(response.body).to include("Notifications")
     end
 
     context "when signed out" do
-      xit "renders the signup cue" do
+      it "renders the signup cue" do
         get "/notifications"
         expect(response.body).to include "<div class=\"signup-cue"
       end
@@ -19,7 +19,7 @@ RSpec.describe "NotificationsIndex", type: :request do
     context "when signed in" do
       before { sign_in user }
 
-      xit "does not render the signup cue" do
+      it "does not render the signup cue" do
         get "/notifications"
         expect(response.body).not_to include "Create your account"
       end

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -307,7 +307,7 @@ RSpec.describe "NotificationsIndex", type: :request do
       end
 
       it "renders the reaction as previously reacted if it was reacted on" do
-        Reaction.create(user: user, reactable: article, category: "like")
+        Reaction.create(user: user2, reactable: article, category: "like")
         get "/notifications"
         expect(response.body).to include "reaction-button reacted"
       end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Fixes reactions rendering properly on the notification page, and adds a few tests for them.

Resolves #1352 