### PR TITLE
Add haptic feedback where it was missing

### DIFF
--- a/app/assets/javascripts/initializers/initNotifications.js
+++ b/app/assets/javascripts/initializers/initNotifications.js
@@ -68,6 +68,7 @@ function initReactions() {
         var butt = butts[i];
         butt.onclick = function (event) {
           event.preventDefault();
+          sendHapticMessage('medium');
           var thisButt = this;
           thisButt.classList.add('reacted');
 

--- a/app/assets/javascripts/initializers/initializeCommentsPage.js.erb
+++ b/app/assets/javascripts/initializers/initializeCommentsPage.js.erb
@@ -60,6 +60,7 @@ function initializeCommentsPage() {
       butt.onclick = function (event) {
         event.preventDefault();
         var thisButt = this;
+        sendHapticMessage('medium');
         var userStatus = document.getElementsByTagName('body')[0].getAttribute('data-user-status');
         if (userStatus === 'logged-out') {
           showModal('react-to-comment');


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
Adds haptic feedback to a couple reaction `onclick`s where it should be but was missing. iPhone app will now vibrate when comment hearts and notification page hearts are touched.

PS, I still find it very cool that we can push code to the web app and have it trigger native functionality like this.