### PR TITLE
Fix wrong cursor pointer of search query filter buttons on hover

### DIFF
--- a/app/assets/stylesheets/articles.scss
+++ b/app/assets/stylesheets/articles.scss
@@ -1185,9 +1185,9 @@
         text-align:left;
         border-radius: 0px;
         color: $black;
+        cursor: pointer;
         &:hover{
           background: lighten($bold-blue, 38%);
-          cursor: pointer;
         }
         &.selected{
           background: lighten($bold-blue, 10%);

--- a/app/assets/stylesheets/articles.scss
+++ b/app/assets/stylesheets/articles.scss
@@ -1187,6 +1187,7 @@
         color: $black;
         &:hover{
           background: lighten($bold-blue, 38%);
+          cursor: pointer;
         }
         &.selected{
           background: lighten($bold-blue, 10%);


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
Currently, when users search something in the site, they're brought to the search results page. In that page, the widget that contains the query filter buttons on the left sidebar (Posts, Podcasts, People, Only My Posts) does not change the cursor to a pointer when it hovers over the buttons. This pull request hopefully fixes that issue.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
### Before
![Screenshot before the commit](https://user-images.githubusercontent.com/39114273/50373841-7ba9f700-061f-11e9-8ab8-df4ef6d358b1.png)

### After
![Screenshot after the commit](https://user-images.githubusercontent.com/39114273/50373846-82d10500-061f-11e9-94a7-27d57f967c37.png)

## Added to documentation?
- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?
![GIF that conveys relief](https://media.giphy.com/media/z23hGvopHu7w4/giphy.gif)
