### PR TITLE
Fix flashing cursor when hovering over .wide-nav-links

### DIFF
--- a/app/assets/stylesheets/articles.scss
+++ b/app/assets/stylesheets/articles.scss
@@ -143,6 +143,7 @@
           }
           .wide-nav-links{
             display: block;
+            cursor: default;
           }
         }
         @media screen and ( min-width: 950px ){


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
When hovering over the `.wide-nav-links` (Feed, Week, Month, Year, Infinity, and Latest) from left to right (or right to left), the cursor abruptly flashes between three states sequentially—`default`, `pointer`, and then `text`. Once the cursor reaches the next link, the cycle repeats itself. If done to all the links from any direction horizontally, the effect becomes apparent (and quite annoying). This pull request ensures that the cursor will only cycle through its `default` and `pointer` state, which ultimately removes the flashing cursor effect.

Also, happy holidays! 🎉🎄

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
### Before
![Before the commit](https://user-images.githubusercontent.com/39114273/50413248-d7a39400-0848-11e9-8bb1-1c1d1829403a.png)

### After
![image](https://user-images.githubusercontent.com/39114273/50413262-f0ac4500-0848-11e9-93cc-f97f63ee26d7.png)

## Added to documentation?
- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?
![Celebration](https://media.giphy.com/media/Is1O1TWV0LEJi/giphy.gif)
