### PR TITLE
Replace dev.to with APP_DOMAIN config in a few places

### DIFF
--- a/app/controllers/buffered_articles_controller.rb
+++ b/app/controllers/buffered_articles_controller.rb
@@ -11,9 +11,9 @@ class BufferedArticlesController < ApplicationController
     if Rails.env.production?
       Article.
         where("last_buffered > ? OR published_at > ?", 24.hours.ago, 20.minutes.ago).
-        map { |a| "https://dev.to#{a.path}" }
+        map { |a| "https://#{ApplicationConfig["APP_DOMAIN"]}#{a.path}" }
     else
-      Article.all.map { |a| "https://dev.to#{a.path}" }
+      Article.all.map { |a| "https://#{ApplicationConfig["APP_DOMAIN"]}#{a.path}" }
     end
   end
 end

--- a/app/controllers/internal/feedback_messages_controller.rb
+++ b/app/controllers/internal/feedback_messages_controller.rb
@@ -83,7 +83,7 @@ class Internal::FeedbackMessagesController < Internal::ApplicationController
     <<~HEREDOC
       *New note from #{params['author_name']}:*
       *Report status: #{params['feedback_message_status']}*
-      Report page: https://dev.to/internal/reports/#{params['noteable_id']}
+      Report page: https://#{ApplicationConfig["APP_DOMAIN"]}/internal/reports/#{params['noteable_id']}
       --------
       Message: #{params['content']}
     HEREDOC

--- a/app/decorators/article_decorator.rb
+++ b/app/decorators/article_decorator.rb
@@ -22,7 +22,7 @@ class ArticleDecorator < ApplicationDecorator
   end
 
   def url
-    "https://dev.to#{path}"
+    "https://#{ApplicationConfig["APP_DOMAIN"]}#{path}"
   end
 
   def liquid_tags_used

--- a/app/views/articles/search/_meta.html.erb
+++ b/app/views/articles/search/_meta.html.erb
@@ -1,5 +1,5 @@
 <% title "Search Results" %>
-<link rel="canonical" href="https://dev.to/search"/>
+<link rel="canonical" href="https://<%= ApplicationConfig["APP_DOMAIN"] %>/search"/>
 <meta name="description" content="Where programmers share ideas and help each other grow.">
 <meta name="keywords" content="software development,engineering,rails,javascript,ruby">
 

--- a/app/views/podcast_episodes/_meta.html.erb
+++ b/app/views/podcast_episodes/_meta.html.erb
@@ -2,12 +2,12 @@
   <% title @podcast.title + " — The Practical Dev" %>
 
   <%= content_for :page_meta do %>
-    <link rel="canonical" href="https://dev.to/<%=@podcast.slug %>"/>
+    <link rel="canonical" href="https://<%= ApplicationConfig["APP_DOMAIN"] %>/<%=@podcast.slug %>"/>
     <meta name="description" content="<%= @podcast.description %>">
     <meta name="keywords" content="software development,engineering,rails,javascript,ruby">
 
     <meta property="og:type" content="article" />
-    <meta property="og:url" content="https://dev.to/<%=@podcast.slug %>" />
+    <meta property="og:url" content="https://<%= ApplicationConfig["APP_DOMAIN"] %>/<%=@podcast.slug %>" />
     <meta property="og:title" content="<%= @podcast.title %>" />
     <meta property="og:image" content="https://res.cloudinary.com/practicaldev/image/fetch/c_scale,h_300,w_300,r_max/u_listennow_kjml1x,y_45/<%= cloudinary(@podcast.image_url,300) %>">
 
@@ -24,12 +24,12 @@
 <% else %>
   <% title "Podcasts on The Practical Dev" %>
   <%= content_for :page_meta do %>
-    <link rel="canonical" href="https://dev.to/pod"/>
+    <link rel="canonical" href="https://<%= ApplicationConfig["APP_DOMAIN"] %>/pod"/>
     <meta name="description" content="Discover technical podcasts for developers">
     <meta name="keywords" content="software development,engineering,rails,javascript,ruby">
 
     <meta property="og:type" content="article" />
-    <meta property="og:url" content="https://dev.to/pod" />
+    <meta property="og:url" content="https://<%= ApplicationConfig["APP_DOMAIN"] %>/pod" />
     <meta property="og:title" content="Podcasts on The Practical Dev" />
     <meta property="og:image" content="http://i.imgur.com/e5tJ9L9.png">
 

--- a/app/views/users/_org_admin.html.erb
+++ b/app/views/users/_org_admin.html.erb
@@ -43,8 +43,8 @@
   <h3>Grow the team</h3>
   <h5>Invite teammates by sending them the secret and the following instructions:</h5>
   <ol style="margin-bottom: 30px">
-    <li>Sign up at <a href="https://dev.to">https://dev.to</a>
-    <li>Navigate to <a href="https://dev.to/settings/organization">https://dev.to/settings/organization</a>
+    <li>Sign up at <a href="https://<%= ApplicationConfig["APP_DOMAIN"] %>">https://<%= ApplicationConfig["APP_DOMAIN"] %>/a>
+    <li>Navigate to <a href="https://<%= ApplicationConfig["APP_DOMAIN"] %>/settings/organization">https://<%= ApplicationConfig["APP_DOMAIN"] %>/settings/organization</a>
     <li>Paste the secret code below and click <b>Join Organization</b></li>
   </ol>
   <h5>Your secret: (You should rotate this regularly)</h5>
@@ -120,7 +120,7 @@
   </div>      
   <h2>Call-to-action box</h2>
   <h4 style="margin-top:-25px">Customizable text that appears to the right of every post for your organization</h4>
-  <h4 style="margin-top:-15px">See an example from the <a href="https://dev.to/devteam/the-dev-badge-is-available-on-font-awesome-2ihe" target="_blank">DEV Team</a>.</h4>
+  <h4 style="margin-top:-15px">See an example from the <a href="https://<%= ApplicationConfig["APP_DOMAIN"] %>/devteam/the-dev-badge-is-available-on-font-awesome-2ihe" target="_blank">DEV Team</a>.</h4>
   <div class="field">
     <%= f.label "Body text (Limited markdown — bold/italic/etc)" %>
     <%= f.text_area :cta_body_markdown, maxlength: 256, placeholder: "**This is an example**

--- a/app/views/users/_profile.html.erb
+++ b/app/views/users/_profile.html.erb
@@ -16,7 +16,7 @@
   </div>
 <% end %>
 <h4>
-  <a href="https://dev.to/<%= current_user.username %>"><img src="https://d2fltix0v2e0sb.cloudfront.net/dev-badge.svg" height="28" width="28"style="vertical-align:-7px;margin-right:4px;"/></a>
+  <a href="https://<%= ApplicationConfig["APP_DOMAIN"] %>/<%= current_user.username %>"><img src="https://d2fltix0v2e0sb.cloudfront.net/dev-badge.svg" height="28" width="28"style="vertical-align:-7px;margin-right:4px;"/></a>
   Add the DEV badge to your personal site. <a href="/p/badges">Click here for the code</a>
 </h4>
 <%= form_for(@user) do |f| %>

--- a/spec/features/user_delete_a_comment_spec.rb
+++ b/spec/features/user_delete_a_comment_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Deleting Comment", type: :feature, js: true do
     sign_in user
   end
 
-  it "works" do
+  it "works", retry: 3 do
     visit "/"
     visit comment.path + "/delete_confirm"
     click_link("DELETE")

--- a/spec/requests/buffered_articles_spec.rb
+++ b/spec/requests/buffered_articles_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "BufferedArticles", type: :request do
     it "responds with at least one url" do
       create(:article)
       get "/buffered_articles"
-      expect(response.body).to include("https://dev.to/")
+      expect(response.body).to include(ApplicationConfig["APP_DOMAIN"])
     end
   end
 end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Remove hardcoded instances of `dev.to` with `ApplicationConfig["APP_DOMAIN"]` in a few places in the codebase. Some basic work to move towards platform generalization. 🙂

Still plenty to do on this front.