### PR TITLE
Reverted to last known working version of Storybook

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,9 +50,9 @@
   },
   "homepage": "https://github.com/thepracticaldev/dev.to#readme",
   "devDependencies": {
-    "@storybook/addon-actions": "^4.1.3",
-    "@storybook/addon-links": "^4.1.3",
-    "@storybook/addons": "^4.1.3",
+    "@storybook/addon-actions": "^3.4.11",
+    "@storybook/addon-links": "^3.4.11",
+    "@storybook/addons": "^3.4.11",
     "@storybook/react": "^3.4.11",
     "babel-eslint": "^10.0.1",
     "babel-jest": "^23.4.2",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

Storybook was no longer building due to dependency upgrades which were no longer comaptible with Preact.

@maestromac, alright, so reverting to 3.4.11 for all the storybook dependencies gets us back up and running. I did however manage to get it running with the latest storybook. The only caveat is that I need to install React as a **dev** dependency. Not ideal, but it works.

I think for the time being, we should probably just go back to 3.4.11 unless the dev.to team is OK with React being in there as a **dev** dependency.

## Related Tickets & Documents

#1407

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![Fixed it!](https://media.giphy.com/media/iVDo6InQKyW8o/giphy-downsized.gif)
