### PR TITLE
Fix Rubocop Style/MixinUsage and cleanup prefix_all_images

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -22,7 +22,7 @@ RSpec/FilePath:
   Exclude:
     - 'spec/liquid_tags/raw_tag_spec.rb'
 
-# Offense count: 15
+# Offense count: 16
 # Configuration parameters: AggregateFailuresByDefault.
 RSpec/MultipleExpectations:
   Max: 6
@@ -76,12 +76,7 @@ Style/EvalWithLocation:
   Exclude:
     - 'app/controllers/omniauth_callbacks_controller.rb'
 
-# Offense count: 2
-Style/MixinUsage:
-  Exclude:
-    - 'app/models/podcast_episode.rb'
-
-# Offense count: 1180
+# Offense count: 1182
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
 # URISchemes: http, https
 Metrics/LineLength:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -22,7 +22,7 @@ RSpec/FilePath:
   Exclude:
     - 'spec/liquid_tags/raw_tag_spec.rb'
 
-# Offense count: 16
+# Offense count: 15
 # Configuration parameters: AggregateFailuresByDefault.
 RSpec/MultipleExpectations:
   Max: 6
@@ -76,7 +76,7 @@ Style/EvalWithLocation:
   Exclude:
     - 'app/controllers/omniauth_callbacks_controller.rb'
 
-# Offense count: 1182
+# Offense count: 1181
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
 # URISchemes: http, https
 Metrics/LineLength:

--- a/app/models/podcast_episode.rb
+++ b/app/models/podcast_episode.rb
@@ -1,5 +1,3 @@
-include CloudinaryHelper
-
 class PodcastEpisode < ApplicationRecord
   include AlgoliaSearch
 
@@ -172,14 +170,14 @@ class PodcastEpisode < ApplicationRecord
                 end
       if img.attr("src")
         self.processed_html = processed_html.gsub(img.attr("src"),
-          cl_image_path(img.attr("src"),
-           type: "fetch",
-           width: 725,
-           crop: "limit",
-           quality: quality,
-           flags: "progressive",
-           fetch_format: "auto",
-           sign_url: true))
+          ActionController::Base.helpers.cl_image_path(img.attr("src"),
+            type: "fetch",
+            width: 725,
+            crop: "limit",
+            quality: quality,
+            flags: "progressive",
+            fetch_format: "auto",
+            sign_url: true))
       end
     end
   end

--- a/app/models/podcast_episode.rb
+++ b/app/models/podcast_episode.rb
@@ -160,10 +160,8 @@ class PodcastEpisode < ApplicationRecord
     return unless body.present?
 
     self.processed_html = body.
-      gsub("\r\n<p>&nbsp;</p>\r\n", "").
-      gsub("\r\n<p>&nbsp;</p>\r\n", "").
-      gsub("\r\n<h3>&nbsp;</h3>\r\n", "").
-      gsub("\r\n<h3>&nbsp;</h3>\r\n", "")
+      gsub("\r\n<p>&nbsp;</p>\r\n", "").gsub("\r\n<p>&nbsp;</p>\r\n", "").
+      gsub("\r\n<h3>&nbsp;</h3>\r\n", "").gsub("\r\n<h3>&nbsp;</h3>\r\n", "")
 
     self.processed_html = "<p>#{processed_html}</p>" unless processed_html.include?("<p>")
 
@@ -172,11 +170,8 @@ class PodcastEpisode < ApplicationRecord
       img_src = img.attr("src")
 
       if img_src
-        quality = if img_src.include?(".gif")
-                    66
-                  else
-                    "auto"
-                  end
+        quality = "auto"
+        quality = 66 if img_src.include?(".gif")
 
         cloudinary_img_src = ActionController::Base.helpers.
           cl_image_path(img_src,

--- a/app/models/podcast_episode.rb
+++ b/app/models/podcast_episode.rb
@@ -159,25 +159,35 @@ class PodcastEpisode < ApplicationRecord
   def prefix_all_images
     return unless body.present?
 
-    self.processed_html = body.gsub("\r\n<p>&nbsp;</p>\r\n", "").gsub("\r\n<p>&nbsp;</p>\r\n", "").gsub("\r\n<h3>&nbsp;</h3>\r\n", "").gsub("\r\n<h3>&nbsp;</h3>\r\n", "")
+    self.processed_html = body.
+      gsub("\r\n<p>&nbsp;</p>\r\n", "").
+      gsub("\r\n<p>&nbsp;</p>\r\n", "").
+      gsub("\r\n<h3>&nbsp;</h3>\r\n", "").
+      gsub("\r\n<h3>&nbsp;</h3>\r\n", "")
+
     self.processed_html = "<p>#{processed_html}</p>" unless processed_html.include?("<p>")
+
     doc = Nokogiri::HTML(processed_html)
     doc.css("img").each do |img|
-      quality = if img.attr("src") && (img.attr("src").include? ".gif")
-                  66
-                else
-                  "auto"
-                end
-      if img.attr("src")
-        self.processed_html = processed_html.gsub(img.attr("src"),
-          ActionController::Base.helpers.cl_image_path(img.attr("src"),
+      img_src = img.attr("src")
+
+      if img_src
+        quality = if img_src.include?(".gif")
+                    66
+                  else
+                    "auto"
+                  end
+
+        cloudinary_img_src = ActionController::Base.helpers.
+          cl_image_path(img_src,
             type: "fetch",
             width: 725,
             crop: "limit",
             quality: quality,
             flags: "progressive",
             fetch_format: "auto",
-            sign_url: true))
+            sign_url: true)
+        self.processed_html = processed_html.gsub(img_src, cloudinary_img_src)
       end
     end
   end

--- a/app/models/podcast_episode.rb
+++ b/app/models/podcast_episode.rb
@@ -1,5 +1,4 @@
 include CloudinaryHelper
-include ActionView::Helpers::SanitizeHelper
 
 class PodcastEpisode < ApplicationRecord
   include AlgoliaSearch
@@ -92,7 +91,7 @@ class PodcastEpisode < ApplicationRecord
   end
 
   def description
-    strip_tags(body)
+    ActionView::Base.full_sanitizer.sanitize(body)
   end
 
   def main_image

--- a/spec/models/podcast_episode_spec.rb
+++ b/spec/models/podcast_episode_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe PodcastEpisode, type: :model do
   let(:podcast_episode) { create(:podcast_episode) }
 
-  it "accept valid podcast episode" do
+  it "accepts valid podcast episode" do
     expect(podcast_episode).to be_valid
   end
 
@@ -11,6 +11,16 @@ RSpec.describe PodcastEpisode, type: :model do
     it "strips tags from the body" do
       podcast_episode.body = "<h1>Body with HTML tags</h1>"
       expect(podcast_episode.description).to eq("Body with HTML tags")
+    end
+  end
+
+  describe "#processed_html" do
+    it "prefixes an image URL with a Cloudinary path" do
+      image_url = "https://dummyimage.com/10x10"
+      podcast_episode.body = "<img src=\"#{image_url}\">"
+      podcast_episode.validate!
+      expect(podcast_episode.processed_html.include?("res.cloudinary.com")).to be(true)
+      expect(podcast_episode.processed_html.include?(image_url)).to be(true)
     end
   end
 end

--- a/spec/models/podcast_episode_spec.rb
+++ b/spec/models/podcast_episode_spec.rb
@@ -1,9 +1,16 @@
 require "rails_helper"
 
 RSpec.describe PodcastEpisode, type: :model do
-  let(:podcast) { create(:podcast) }
+  let(:podcast_episode) { create(:podcast_episode) }
 
-  it "accept valid podcast" do
-    expect(podcast).to be_valid
+  it "accept valid podcast episode" do
+    expect(podcast_episode).to be_valid
+  end
+
+  describe "#description" do
+    it "strips tags from the body" do
+      podcast_episode.body = "<h1>Body with HTML tags</h1>"
+      expect(podcast_episode.description).to eq("Body with HTML tags")
+    end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

I started by removing the topmost includes in `podcast_episode.rb` and I ended up by cleaning up the method `prefix_all_images` and adding some tests.

Not a huge fan of calling helpers inside models but for now it should stay like it is.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
