### PR TITLE
Fix block delimiters Rubocop offense

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -27,18 +27,6 @@ RSpec/FilePath:
 RSpec/MultipleExpectations:
   Max: 6
 
-# Offense count: 2
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, ProceduralMethods, FunctionalMethods, IgnoredMethods.
-# SupportedStyles: line_count_based, semantic, braces_for_chaining
-# ProceduralMethods: benchmark, bm, bmbm, create, each_with_object, measure, new, realtime, tap, with_object
-# FunctionalMethods: let, let!, subject, watch
-# IgnoredMethods: lambda, proc, it
-Style/BlockDelimiters:
-  Exclude:
-    - 'spec/requests/articles_api_spec.rb'
-    - 'spec/requests/internal_reactions_spec.rb'
-
 # Offense count: 5
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/spec/requests/articles_api_spec.rb
+++ b/spec/requests/articles_api_spec.rb
@@ -131,13 +131,17 @@ RSpec.describe "ArticlesApi", type: :request do
     end
 
     it "does not allow user to update a different article" do
-      new_title = "NEW TITLE #{rand(100)}"
       article.update_column(:user_id, user2.id)
 
-      expect {
-        put "/api/articles/#{article.id}",
-          params: { article: { title: new_title, body_markdown: "Yo ho ho#{rand(100)}", tag_list: "yo" } }
-      } .to raise_error(ActionController::RoutingError)
+      invalid_update_request = -> do
+        put "/api/articles/#{article.id}", params: {
+          article: { title: "NEW TITLE #{rand(100)}",
+                     body_markdown: "Yo ho ho#{rand(100)}",
+                     tag_list: "yo" }
+        }
+      end
+
+      expect(invalid_update_request).to raise_error(ActionController::RoutingError)
     end
 
     it "does allow super user to update a different article" do

--- a/spec/requests/internal_reactions_spec.rb
+++ b/spec/requests/internal_reactions_spec.rb
@@ -37,11 +37,13 @@ RSpec.describe "/internal/reactions", type: :request do
     let(:reaction) { create(:reaction, category: "vomit", user_id: user.id, reactable_id: article.id) }
 
     it "updates reaction to be confirmed" do
-      expect {
+      invalid_request = -> do
         put "/internal/reactions/#{reaction.id}", params: {
           reaction: { status: "confirmed" }
         }
-      }.to raise_error(Pundit::NotAuthorizedError)
+      end
+
+      expect(invalid_request).to raise_error(Pundit::NotAuthorizedError)
     end
   end
 end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

Fixes `Style/BlockDelimiters` Rubocop offense.

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
