### PR TITLE
Remove unnecessary private keyword from tweet

### DIFF
--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -57,8 +57,6 @@ class Tweet < ApplicationRecord
   end
 
   class << self
-    private
-
     def try_to_get_tweet(twitter_id_code)
       c = TwitterBot.new(random_identity).client
       t = c.status(twitter_id_code, tweet_mode: "extended")


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
This is removing a `private` keyword which is unnecessary and _possibly_ causing a bug, but have not been able to reproduce in development. Won't hurt to make this change in attempt to fix prod issue.