### PR TITLE
Improve User profile form labels capitalization

### DIFF
--- a/app/views/users/_profile.html.erb
+++ b/app/views/users/_profile.html.erb
@@ -90,7 +90,7 @@
     <%= f.text_field :employer_name, maxlength: 64 %>
   </div>
   <div class="field">
-    <%= f.label :employer_url %>
+    <%= f.label :employer_url, "Employer URL" %>
     <%= f.text_field :employer_url, maxlength: 64 %>
   </div>
   <div class="field">
@@ -115,35 +115,35 @@
   </div>
   <p><strong>Links</strong></p>
   <div class="field">
-    <%= f.label :facebook_url %>
+    <%= f.label :facebook_url, "Facebook URL" %>
     <%= f.text_field :facebook_url  %>
   </div>
   <div class="field">
-    <%= f.label :stackoverflow_url %>
+    <%= f.label :stackoverflow_url, "Stack Overflow URL" %>
     <%= f.url_field :stackoverflow_url %>
   </div>
   <div class="field">
-    <%= f.label :linkedin_url %>
+    <%= f.label :linkedin_url, "LinkedIn URL" %>
     <%= f.url_field :linkedin_url %>
   </div>
   <div class="field">
-    <%= f.label :behance_url %>
+    <%= f.label :behance_url, "Behance URL" %>
     <%= f.url_field :behance_url %>
   </div>
   <div class="field">
-    <%= f.label :dribbble_url %>
+    <%= f.label :dribbble_url, "Dribbble URL" %>
     <%= f.url_field :dribbble_url %>
   </div>
   <div class="field">
-    <%= f.label :medium_url %>
+    <%= f.label :medium_url, "Medium URL" %>
     <%= f.url_field :medium_url %>
   </div>
   <div class="field">
-    <%= f.label :gitlab_url %>
+    <%= f.label :gitlab_url, "GitLab URL" %>
     <%= f.url_field :gitlab_url %>
   </div>
   <div class="field">
-    <%= f.label :mastodon_url %>
+    <%= f.label :mastodon_url, "Mastodon URL" %>
     <%= f.url_field :mastodon_url %>
   </div>
   <div class="field">


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
This PR improves the links section in the User profile form. The labels had some capitalization problems that could be improved, such as "Facebook url" and "Stackoverflow url". With the changes, these labels now are "Facebook URL" and "Stack Overflow URL"

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed