### PR TITLE
Fix liquid tag parsing error

### DIFF
--- a/app/liquid_tags/tweet_tag.rb
+++ b/app/liquid_tags/tweet_tag.rb
@@ -1,4 +1,5 @@
 class TweetTag < LiquidTagBase
+  include ActionView::Helpers::AssetTagHelper
   attr_reader :tweet
 
   def initialize(tag_name, id, tokens)

--- a/spec/liquid_tags/tweet_tag_spec.rb
+++ b/spec/liquid_tags/tweet_tag_spec.rb
@@ -16,6 +16,13 @@ RSpec.describe TweetTag, type: :liquid_template do
     end
   end
 
+  it "render properly", :vcr do
+    VCR.use_cassette("twitter_gem") do
+      liquid = generate_tweet_liquid_tag(twitter_id)
+      expect(liquid.render).not_to eq("liquid error: internal")
+    end
+  end
+
   context "when given invalid id" do
     it "rejects it (normal invalid id)" do
       expect do

--- a/spec/liquid_tags/tweet_tag_spec.rb
+++ b/spec/liquid_tags/tweet_tag_spec.rb
@@ -18,8 +18,10 @@ RSpec.describe TweetTag, type: :liquid_template do
 
   it "render properly", :vcr do
     VCR.use_cassette("twitter_gem") do
-      liquid = generate_tweet_liquid_tag(twitter_id)
-      expect(liquid.render).not_to eq("liquid error: internal")
+      Time.use_zone("Asia/Tokyo") do
+        rendered = generate_tweet_liquid_tag(twitter_id).render
+        Approvals.verify(rendered, name: "liquid_tweet_tag_spec", format: :html)
+      end
     end
   end
 

--- a/spec/support/fixtures/approvals/liquid_tweet_tag_spec.approved.html
+++ b/spec/support/fixtures/approvals/liquid_tweet_tag_spec.approved.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <body>
+    <blockquote class="ltag__twitter-tweet" data-url="https://twitter.com/thepracticaldev/status/1018911886862057472">
+      <div class="ltag__twitter-tweet__media ltag__twitter-tweet__media__video-wrapper">
+        <div class="ltag__twitter-tweet__media--video-preview">
+          <img src="https://pbs.twimg.com/tweet_video_thumb/DiPm8-WXcAI3_qS.jpg" />
+          <img class="ltag__twitter-tweet__play-butt" src="/assets/play-butt.svg" alt="Play butt" />
+        </div>
+        <div class="ltag__twitter-tweet__video">
+          <video loop="">
+            <source src="https://video.twimg.com/tweet_video/DiPm8-WXcAI3_qS.mp4" type="video/mp4"></source>
+          </video>
+        </div>
+      </div>
+      <div class="ltag__twitter-tweet__main" data-url="https://twitter.com/thepracticaldev/status/1018911886862057472">
+        <div class="ltag__twitter-tweet__header">
+          <img class="ltag__twitter-tweet__profile-image" src="https://pbs.twimg.com/profile_images/1002604104194056192/IEoNsLNM_normal.jpg" />
+          <div class="ltag__twitter-tweet__full-name">The Practical Dev</div>
+          <div class="ltag__twitter-tweet__username">@thepracticaldev</div>
+          <div class="ltag__twitter-tweet__twitter-logo">
+            <img src="/assets/twitter-eb8b335b75231c6443385ac04fdfcaed8ca5423c3990e89dc0178a4090ac1908.svg" />
+          </div>
+        </div>
+        <div class="ltag__twitter-tweet__body">When GitHub goes down </div>
+        <div class="ltag__twitter-tweet__date">02:34 AM - 17 Jul 2018</div>
+        <div class="ltag__twitter-tweet__actions"><a href="https://twitter.com/intent/tweet?in_reply_to=1018911886862057472" class="ltag__twitter-tweet__actions__button"><img src="/assets/twitter-reply-action.svg" alt="Twitter reply action" /></a><a href="https://twitter.com/intent/retweet?tweet_id=1018911886862057472" class="ltag__twitter-tweet__actions__button"><img src="/assets/twitter-retweet-action.svg" alt="Twitter retweet action" /></a>91<a href="https://twitter.com/intent/like?tweet_id=1018911886862057472" class="ltag__twitter-tweet__actions__button"><img src="/assets/twitter-like-action.svg" alt="Twitter like action" /></a>276</div>
+      </div>
+    </blockquote>
+  </body>
+</html>


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Liquid tag error is caused by `TweetTag`'s inability to use `#image_tag`. Including the proper view helper should fixes it.

## Related Tickets & Documents
resolves #1472 

## Added to documentation?
- [x] no documentation needed
