### PR TITLE
connect chat message markdown styling

### DIFF
--- a/app/assets/stylesheets/chat.scss
+++ b/app/assets/stylesheets/chat.scss
@@ -714,7 +714,7 @@
   }
   code {
     background: #29292e;
-    padding:0.1em 0.3em 0px;
+    padding:0.1em 0.3em;
     border-radius:2px;
     color: #eff0f9;
     font-size:0.95em;

--- a/app/assets/stylesheets/chat.scss
+++ b/app/assets/stylesheets/chat.scss
@@ -288,7 +288,7 @@
   justify-content: space-between;
   border: 1px solid $outline-color;
   border: var(--theme-container-border, 1px solid $outline-color);
-  box-shadow: $bold-shadow;  
+  box-shadow: $bold-shadow;
   box-shadow: var(--theme-container-box-shadow, $bold-shadow);
   background: white;
 }
@@ -710,13 +710,13 @@
   word-wrap: break-word;
   word-break: break-word;
   pre{
-    background:$lightest-gray;
+    background: #29292e;
   }
   code {
-    background:$lightest-gray;
+    background: #29292e;
     padding:0.1em 0.3em 0px;
     border-radius:2px;
-    color:#333842;
+    color: #eff0f9;
     font-size:0.95em;
     vertical-align:0.05em;
     max-width:100%;

--- a/app/labor/markdown_parser.rb
+++ b/app/labor/markdown_parser.rb
@@ -57,24 +57,6 @@ class MarkdownParser
     attributes: allowed_attributes
   end
 
-  def evaluate_inline_markdown
-    return if @content.blank?
-
-    renderer_options = {
-      hard_wrap: true,
-      filter_html: false,
-      link_attributes: { rel: "noopener noreferrer", target: "_blank" }
-    }
-    renderer = Redcarpet::Render::HTMLRouge.new(renderer_options)
-    markdown = Redcarpet::Markdown.new(renderer, REDCARPET_CONFIG)
-    allowed_tags = %w(strong abbr aside em p h1 h2 h3 h4 h5 h6 i u b code pre
-                      br ul ol li small sup sub img a span hr blockquote)
-    allowed_attributes = %w(href strong em ref rel src title alt)
-    ActionController::Base.helpers.sanitize(markdown.render(@content).html_safe,
-      tags: allowed_tags,
-      attributes: allowed_attributes)
-  end
-
   def tags_used
     return [] unless @content.present?
 

--- a/app/labor/markdown_parser.rb
+++ b/app/labor/markdown_parser.rb
@@ -67,8 +67,12 @@ class MarkdownParser
     }
     renderer = Redcarpet::Render::HTMLRouge.new(renderer_options)
     markdown = Redcarpet::Markdown.new(renderer, REDCARPET_CONFIG)
+    allowed_tags = %w(strong abbr aside em p h1 h2 h3 h4 h5 h6 i u b code pre
+                      br ul ol li small sup sub img a span hr blockquote)
+    allowed_attributes = %w(href strong em ref rel src title alt)
     ActionController::Base.helpers.sanitize(markdown.render(@content).html_safe,
-      tags: %w(strong i u b em code a br pre), attributes: %w(href rel target))
+      tags: allowed_tags,
+      attributes: allowed_attributes)
   end
 
   def tags_used

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -66,7 +66,7 @@ class Message < ApplicationRecord
   end
 
   def evaluate_markdown
-    html = MarkdownParser.new(message_markdown)
+    html = MarkdownParser.new(message_markdown).evaluate_inline_markdown
     html = append_rich_links(html)
     self.message_html = html
   end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -66,7 +66,7 @@ class Message < ApplicationRecord
   end
 
   def evaluate_markdown
-    html = MarkdownParser.new(message_markdown).evaluate_inline_markdown
+    html = MarkdownParser.new(message_markdown).evaluate_markdown
     html = append_rich_links(html)
     self.message_html = html
   end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -66,7 +66,7 @@ class Message < ApplicationRecord
   end
 
   def evaluate_markdown
-    html = MarkdownParser.new(message_markdown).evaluate_inline_markdown
+    html = MarkdownParser.new(message_markdown)
     html = append_rich_links(html)
     self.message_html = html
   end

--- a/spec/labor/markdown_parser_spec.rb
+++ b/spec/labor/markdown_parser_spec.rb
@@ -22,19 +22,6 @@ RSpec.describe MarkdownParser do
     expect(generate_and_parse_markdown(inline_code)).to include(inline_code[1..-2])
   end
 
-  context "when provided with a link in inline code" do
-    inline_code = "[dev.to](https://dev.to)"
-    let(:evaluated_markdown) { described_class.new(inline_code).evaluate_inline_markdown }
-
-    it "renders with target _blank" do
-      expect(evaluated_markdown).to include("target=\"_blank\"")
-    end
-
-    it "avoids the traget _blank vulnerability" do
-      expect(evaluated_markdown).to include("noopener", "noreferrer")
-    end
-  end
-
   context "when provided with an @username" do
     it "links to a user if user exist" do
       username = create(:user).username


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
Currently, messages sent in DEV Connect go through a markdown parser that allows for pre and code blocks, but non-inline elements like lists are ignored and broken down into one line as seen in issue #655. 

This PR removes rules against non-inline elements and adds styling to prevent for example extremely large headers in messages. Examples made using [Markdown Cheatsheet](https://github.com/adam-p/markdown-here/wiki/Markdown-Here-Cheatsheet#headers)

## Related Tickets & Documents
resolves #655 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
### Markdown now available in connect messages.
<img width="1052" alt="screen shot 2019-01-08 at 16 23 20" src="https://user-images.githubusercontent.com/13403332/50859608-d2bf0400-1361-11e9-9270-cdf97a2b1427.png">
<img width="1054" alt="screen shot 2019-01-08 at 16 23 32" src="https://user-images.githubusercontent.com/13403332/50859614-d6eb2180-1361-11e9-9b5c-241745f041ed.png">
<img width="1053" alt="screen shot 2019-01-08 at 16 23 45" src="https://user-images.githubusercontent.com/13403332/50859616-d94d7b80-1361-11e9-9a12-bf1028cfe5fe.png">

## Added to documentation?
- [x] no documentation needed
