### PR TITLE
Fix Podcast Liquid Tag

### DIFF
--- a/app/liquid_tags/podcast_tag.rb
+++ b/app/liquid_tags/podcast_tag.rb
@@ -1,5 +1,6 @@
 class PodcastTag < LiquidTagBase
   include ApplicationHelper
+  include CloudinaryHelper
 
   attr_reader :episode, :podcast
 

--- a/spec/liquid_tags/podcast_tag_spec.rb
+++ b/spec/liquid_tags/podcast_tag_spec.rb
@@ -24,6 +24,11 @@ RSpec.describe PodcastTag, type: :liquid_template do
     end
   end
 
+  it "render properly" do
+    rendered = generate_podcast_liquid_tag(valid_long_slug).render
+    expect(rendered).not_to eq "Liquid error: internal"
+  end
+
   it "rejects invalid link" do
     expect do
       generate_podcast_liquid_tag("https://dev.to/toolsday/hardware/test/2")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Fixes the podcast Liquid tag issue.

I opted for testing the error message not rendering since there's too many variables to try to use with Approvals.