### PR TITLE
Remove access_token key for twitter dump on auth

### DIFF
--- a/app/services/authorization_service.rb
+++ b/app/services/authorization_service.rb
@@ -39,6 +39,7 @@ class AuthorizationService
     identity = Identity.find_for_oauth(auth)
     identity.token = auth.credentials.token
     identity.secret = auth.credentials.secret
+    auth["extra"].delete("access_token") if auth["extra"]["access_token"]
     identity.auth_data_dump = auth
     identity.save
     identity


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
Upgrading to Ruby 2.6 creates this one serialization issue. Since we don't use this element of the Twitter auth, and wouldn't need to in the future, it should be cool to make this patch.