### PR TITLE
[WIP][PoC] Make Liquid#render utilize erb

### DIFF
--- a/app/liquid_tags/dev_comment_tag.rb
+++ b/app/liquid_tags/dev_comment_tag.rb
@@ -1,32 +1,17 @@
 class DevCommentTag < LiquidTagBase
-  attr_reader :id_code, :comment
+  PARTIAL = "comments/liquid".freeze
 
   def initialize(_tag_name, id_code, _tokens)
-    @id_code = parse_id(id_code)
-    @comment = find_comment
+    @id_code = id_code.strip
   end
 
   def render(_context)
-    raise_error unless @comment
-    <<-HTML
-    <div class="liquid-comment">
-      <div class="details">
-        <a href="/#{@comment.user.username}">
-          <img class="profile-pic" src="#{ProfileImage.new(@comment.user).get(50)}"
-            alt="#{@comment.user.username} profile image"/>
-        </a>
-        <a href="/#{@comment.user.username}">
-          <span class="comment-username">#{@comment.user.name}</span>
-        </a>
-        <div class="comment-date">
-          <a href="#{@comment.path}">#{@comment.readable_publish_date}</a>
-        </div>
-      </div>
-      <div class="body">
-        #{@comment.processed_html.html_safe}
-      </div>
-    </div>
-    HTML
+    comment = find_comment
+
+    ActionController::Base.new.render_to_string(
+      partial: PARTIAL,
+      locals: { comment: comment },
+    )
   end
 
   def render_twitter_and_github
@@ -45,23 +30,9 @@ class DevCommentTag < LiquidTagBase
 
   private
 
-  def parse_id(id)
-    id_no_space = id.delete(" ")
-    raise_error unless valid_id?(id_no_space)
-    id_no_space
-  end
-
   def find_comment
-    comment = Comment.find_by_id(@id_code.to_i(26))
-    raise_error unless comment
-    comment
-  end
-
-  def valid_id?(id)
-    id.length < 10 && id =~ /^[a-zA-Z0-9]*$/
-  end
-
-  def raise_error
+    Comment.find(@id_code.to_i(26))
+  rescue ActiveRecord::RecordNotFound
     raise StandardError, "Invalid comment ID or comment does not exist"
   end
 end

--- a/app/views/comments/_liquid.html.erb
+++ b/app/views/comments/_liquid.html.erb
@@ -1,0 +1,16 @@
+<div class="liquid-comment">
+  <div class="details">
+    <a href="/<%= comment.user.username %>">
+      <img class="profile-pic" src="<%= ProfileImage.new(comment.user).get(50) %>" alt="<%= comment.user.username %> profile image"/>
+    </a>
+    <a href="/<%= comment.user.username %>">
+      <span class="comment-username"><%= comment.user.name %></span>
+    </a>
+    <div class="comment-date">
+      <a href="<%= comment.path %>"><%= comment.readable_publish_date %></a>
+    </div>
+  </div>
+  <div class="body">
+    <%= comment.processed_html.html_safe %>
+  </div>
+</div>

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -5,6 +5,7 @@ require "carrierwave/storage/fog"
 CarrierWave.configure do |config|
   if Rails.env.development? || Rails.env.test?
     config.storage = :file
+    config.enable_processing = false
   else
     # config.fog_provider = 'fog-aws'
     config.storage = :fog

--- a/spec/fixtures/approvals/devcommenttag/renders_properly.approved.html
+++ b/spec/fixtures/approvals/devcommenttag/renders_properly.approved.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <body>
+    <div class="liquid-comment">
+  <div class="details">
+    <a href="/devcommenttagtest">
+      <img class="profile-pic" src="/uploads/user/profile_image/2/bf5fa42e-c40c-4060-a2c9-2c065108b964.jpeg" alt="devcommenttagtest profile image" /></a>
+    <a href="/devcommenttagtest">
+      <span class="comment-username">DevCommentTag Test</span>
+    </a>
+    <div class="comment-date">
+      <a href="/devcommenttagtest/comment/1">Jan 10</a>
+    </div>
+  </div>
+  <div class="body">
+    
+
+<p>DevCommentTagTest</p>
+
+
+
+  </div>
+</div>
+  </body>
+</html>

--- a/spec/fixtures/approvals/devcommenttag/renders_properly.received.html
+++ b/spec/fixtures/approvals/devcommenttag/renders_properly.received.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <body>
+    <div class="liquid-comment">
+  <div class="details">
+    <a href="/devcommenttagtest">
+      <img class="profile-pic" src="/uploads/user/profile_image/2/97e06441-ce5b-457c-adb4-6b307f9e8760.jpeg" alt="devcommenttagtest profile image" /></a>
+    <a href="/devcommenttagtest">
+      <span class="comment-username">DevCommentTag Test</span>
+    </a>
+    <div class="comment-date">
+      <a href="/devcommenttagtest/comment/1">Jan  9</a>
+    </div>
+  </div>
+  <div class="body">
+    
+
+<p>DevCommentTagTest</p>
+
+
+
+  </div>
+</div>
+  </body>
+</html>

--- a/spec/liquid_tags/dev_comment_tag_spec.rb
+++ b/spec/liquid_tags/dev_comment_tag_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
 RSpec.describe DevCommentTag, type: :liquid_template do
-  let(:user)        { create(:user) }
-  let(:article)     { create(:article, user_id: user.id) }
-  let(:comment)     { create(:comment, user_id: user.id, commentable_id: article.id) }
+  let(:user) { create(:user, username: "DevCommentTagTest", name: "DevCommentTag Test") }
+  let(:article)     { create(:article) }
+  let(:comment)     { create(:comment, commentable: article, body_markdown: "DevCommentTagTest", user: user) }
 
   setup             { Liquid::Template.register_tag("devcomment", DevCommentTag) }
 
@@ -11,22 +11,17 @@ RSpec.describe DevCommentTag, type: :liquid_template do
     Liquid::Template.parse("{% devcomment #{id_code} %}")
   end
 
-  context "when given valid id_code" do
-    it "fetches the target comment" do
-      liquid = generate_comment_tag(comment.id_code_generated)
-      expect(liquid.root.nodelist.first.comment).to eq(comment)
-    end
-
-    it "raise error if comment does not exist" do
-      expect do
-        generate_comment_tag("this should fail")
-      end.to raise_error(StandardError)
+  it "renders properly" do
+    liquid = generate_comment_tag(comment.id_code_generated)
+    # Approvals.verify(liquid.render, format: :html)
+    verify format: :html do
+      liquid.render
     end
   end
 
-  it "rejects invalid id_code" do
-    expect do
-      generate_comment_tag("this should fail")
-    end.to raise_error(StandardError)
+  it "raise error if comment does not exist" do
+    liquid = generate_comment_tag("this should fail")
+    liquid.render
+    expect(liquid.errors).not_to be_empty
   end
 end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature

## Description
I'm proposing changing most of our custom liquid tag's render to render a partial .erb file. The partial can either be placed in the folder under its category ( ie `app/views/comments/_liquid.html.erb`) or in its own liquid folder (ie `app/view/liquids/_comments.html.erb`). These partial could include local styling, javascript, and can be utilized in other parts of the site.

## Related Tickets & Documents
n/a

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
n/a
## Added to documentation?
i'm thinking about adding it to docs.dev.to
- [ ] docs.dev.to

