### PR TITLE
quick css hiccup fix

### DIFF
--- a/app/assets/stylesheets/articles.scss
+++ b/app/assets/stylesheets/articles.scss
@@ -12,9 +12,6 @@
   @media screen and ( min-width: 950px ){
     margin-top:26px;
   }
-  @media screen and ( min-width: 2650px ){
-    max-width: 1300px;
-  }
   &.sub-home{
     margin-top:10px;
     .side-bar{
@@ -891,7 +888,7 @@
               font-family: $helvetica;
               padding-bottom: 10px;
               padding-left:8px;
-              
+
               a{
                 color: $medium-gray;
                 padding: 7px 12px;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Removing `max-width` property from `.home` in `articles.scss` at large screen widths seems to fix the overlap of the reactions and the article content when viewing content on larger screens. 

## Related Tickets & Documents
resolves #1516 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
<img width="807" alt="screen shot 2019-01-11 at 15 22 16" src="https://user-images.githubusercontent.com/13403332/51057941-2d9c6980-15b5-11e9-95b5-5294e19eab1c.png">
<img width="806" alt="screen shot 2019-01-11 at 15 22 31" src="https://user-images.githubusercontent.com/13403332/51057947-342ae100-15b5-11e9-93d4-1d7ac99ca3eb.png">

## Added to documentation?
- [x] no documentation needed
