### PR TITLE
Refactor redirect from the old username or organization slug

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -39,13 +39,8 @@ class StoriesController < ApplicationController
     potential_username = params[:username].tr("@", "").downcase
     user_or_org = User.find_by("old_username = ? OR old_old_username = ?", potential_username, potential_username) ||
       Organization.find_by("old_slug = ? OR old_old_slug = ?", potential_username, potential_username)
-    if user_or_org.class.name == "User"
-      @user = user_or_org
-      redirect_to @user.path
-      return
-    elsif user_or_org.class.name == "Organization"
-      @organization = user_or_org
-      redirect_to @organization.path
+    if user_or_org.present?
+      redirect_to user_or_org.path
       return
     else
       not_found

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -50,21 +50,10 @@ class Organization < ApplicationRecord
   mount_uploader :profile_image, ProfileImageUploader
   mount_uploader :nav_image, ProfileImageUploader
 
-  def username
-    slug
-  end
-
-  def old_username
-    old_slug
-  end
-
-  def old_old_username
-    old_old_slug
-  end
-
-  def website_url
-    url
-  end
+  alias_attribute :username, :slug
+  alias_attribute :old_username, :old_slug
+  alias_attribute :old_old_username, :old_old_slug
+  alias_attribute :website_url, :url
 
   def check_for_slug_change
     if slug_changed?

--- a/spec/requests/stories_show_spec.rb
+++ b/spec/requests/stories_show_spec.rb
@@ -5,44 +5,88 @@ RSpec.describe "StoriesShow", type: :request do
   let(:article)      { create(:article, user_id: user.id) }
 
   describe "GET /:username/:slug" do
-    it "renders to appropriate page" do
-      get article.path
-      expect(response.body).to include CGI.escapeHTML(article.title)
+    context "when story is an article" do
+      it "renders to appropriate page" do
+        get article.path
+        expect(response.body).to include CGI.escapeHTML(article.title)
+      end
+
+      it "renders to appropriate if article belongs to org" do
+        article.update(organization_id: create(:organization).id)
+        get article.path
+        expect(response.body).to include CGI.escapeHTML(article.title)
+      end
+
+      it "redirects to appropriate if article belongs to org and user visits user version" do
+        article.update(organization_id: create(:organization).id)
+        get "/#{article.user.username}/#{article.slug}"
+        expect(response.body).to redirect_to article.reload.path
+      end
+
+      it "renders second and third users if present" do
+        user2 = create(:user)
+        user3 = create(:user)
+        article.update(second_user_id: user2.id, third_user_id: user3.id)
+        get article.path
+        expect(response.body).to include "<em>with <b><a href=\"#{user2.path}\">"
+      end
+
+      it "renders html variant" do
+        html_variant = create(:html_variant, published: true, approved: true)
+        get article.path
+        expect(response.body).to include html_variant.html
+      end
+
+      it "Does not render variant when no variants published" do
+        html_variant = create(:html_variant, published: false, approved: true)
+        get article.path
+        expect(response.body).not_to include html_variant.html
+      end
+
+      it "does not render html variant when user logged in" do
+        html_variant = create(:html_variant, published: true, approved: true)
+        sign_in user
+        get article.path
+        expect(response.body).not_to include html_variant.html
+      end
+
+      # rubocop:disable RSpec/ExampleLength
+      it "renders articles of long length without breaking" do
+        # This is a pretty weak test, just to exercise different lengths with no breakage
+        article.update(title: (0...75).map { rand(65..90).chr }.join)
+        get article.path
+        article.update(title: (0...100).map { rand(65..90).chr }.join)
+        get article.path
+        article.update(title: (0...118).map { rand(65..90).chr }.join)
+        get article.path
+        expect(response.body).to include "title"
+      end
+      # rubocop:enable RSpec/ExampleLength
     end
 
-    it "renders to appropriate if article belongs to org" do
-      article.update(organization_id: create(:organization).id)
-      get article.path
-      expect(response.body).to include CGI.escapeHTML(article.title)
-    end
+    context "when story is a user" do
+      it "renders to appropriate page if user changes username" do
+        old_username = user.username
+        user.update(username: "new_hotness_#{rand(10000)}")
+        get "/#{old_username}/#{article.slug}"
+        expect(response.body).to redirect_to("/#{user.username}/#{article.slug}")
+      end
 
-    it "redirects to appropriate if article belongs to org and user visits user version" do
-      article.update(organization_id: create(:organization).id)
-      get "/#{article.user.username}/#{article.slug}"
-      expect(response.body).to redirect_to article.reload.path
-    end
+      it "renders to appropriate page if user changes username twice" do
+        old_username = user.username
+        user.update(username: "new_hotness_#{rand(10000)}")
+        user.update(username: "new_new_username_#{rand(10000)}")
+        get "/#{old_username}/#{article.slug}"
+        expect(response.body).to redirect_to("/#{user.username}/#{article.slug}")
+      end
 
-    it "renders to appropriate page if user changes username" do
-      old_username = user.username
-      user.update(username: "new_hotness_#{rand(10000)}")
-      get "/#{old_username}/#{article.slug}"
-      expect(response.body).to redirect_to("/#{user.username}/#{article.slug}")
-    end
-
-    it "renders to appropriate page if user changes username twice" do
-      old_username = user.username
-      user.update(username: "new_hotness_#{rand(10000)}")
-      user.update(username: "new_new_username_#{rand(10000)}")
-      get "/#{old_username}/#{article.slug}"
-      expect(response.body).to redirect_to("/#{user.username}/#{article.slug}")
-    end
-
-    it "renders to appropriate page if user changes username twice and go to middle username" do
-      user.update(username: "new_hotness_#{rand(10000)}")
-      middle_username = user.username
-      user.update(username: "new_new_username_#{rand(10000)}")
-      get "/#{middle_username}/#{article.slug}"
-      expect(response.body).to redirect_to("/#{user.username}/#{article.slug}")
+      it "renders to appropriate page if user changes username twice and go to middle username" do
+        user.update(username: "new_hotness_#{rand(10000)}")
+        middle_username = user.username
+        user.update(username: "new_new_username_#{rand(10000)}")
+        get "/#{middle_username}/#{article.slug}"
+        expect(response.body).to redirect_to("/#{user.username}/#{article.slug}")
+      end
     end
 
     context "when organization is present" do
@@ -63,45 +107,5 @@ RSpec.describe "StoriesShow", type: :request do
         expect(response.body).to redirect_to organization.path
       end
     end
-
-    it "renders second and third users if present" do
-      user2 = create(:user)
-      user3 = create(:user)
-      article.update(second_user_id: user2.id, third_user_id: user3.id)
-      get article.path
-      expect(response.body).to include "<em>with <b><a href=\"#{user2.path}\">"
-    end
-
-    # rubocop:disable RSpec/ExampleLength
-    it "renders articles of long length without breaking" do
-      # This is a pretty weak test, just to exercise different lengths with no breakage
-      article.update(title: (0...75).map { rand(65..90).chr }.join)
-      get article.path
-      article.update(title: (0...100).map { rand(65..90).chr }.join)
-      get article.path
-      article.update(title: (0...118).map { rand(65..90).chr }.join)
-      get article.path
-      expect(response.body).to include "title"
-    end
-    # rubocop:enable RSpec/ExampleLength
-  end
-
-  it "renders html variant" do
-    html_variant = create(:html_variant, published: true, approved: true)
-    get article.path
-    expect(response.body).to include html_variant.html
-  end
-
-  it "Does not render variant when no variants published" do
-    html_variant = create(:html_variant, published: false, approved: true)
-    get article.path
-    expect(response.body).not_to include html_variant.html
-  end
-
-  it "does not render html variant when user logged in" do
-    html_variant = create(:html_variant, published: true, approved: true)
-    sign_in user
-    get article.path
-    expect(response.body).not_to include html_variant.html
   end
 end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
A small refactoring for the organization and users redirect by the old username or slug.
I also organized the `stories#show` request specs by context.

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed