### PR TITLE
Log ActiveRecord queries in development

### DIFF
--- a/config/initializers/timber.rb
+++ b/config/initializers/timber.rb
@@ -12,7 +12,7 @@
 
 config = Timber::Config.instance
 config.integrations.action_view.silence = true
-config.integrations.active_record.silence = true
+config.integrations.active_record.silence = !Rails.env.development?
 config.integrations.rack.http_events.collapse_into_single_event = true
 
 # Add additional configuration here.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

While developing locally I noticed I couldn't see which SQL queries ActiveRecord was performing. 
I had even tried to redirect AR loggers to the standard output with the usual

```ruby
ActiveRecord::Base.logger = Logger.new STDOUT
```

It can be useful to see which queries AR is using in order to check if you're over selecting or anything else that can be optimized while developing.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
