### PR TITLE
Add feed_fetched_at for users to not refetch unnecessarily

### DIFF
--- a/db/migrate/20190115155656_add_feed_fetched_at_to_users.rb
+++ b/db/migrate/20190115155656_add_feed_fetched_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddFeedFetchedAtToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :feed_fetched_at, :datetime, default: "2017-01-01 05:00:00"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190109212351) do
+ActiveRecord::Schema.define(version: 20190115155656) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -62,6 +62,7 @@ ActiveRecord::Schema.define(version: 20190109212351) do
     t.string "canonical_url"
     t.integer "collection_id"
     t.integer "collection_position"
+    t.string "comment_template"
     t.integer "comments_count", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "crossposted_at"
@@ -744,6 +745,7 @@ ActiveRecord::Schema.define(version: 20190109212351) do
     t.datetime "exported_at"
     t.string "facebook_url"
     t.boolean "feed_admin_publish_permission", default: true
+    t.datetime "feed_fetched_at", default: "2017-01-01 05:00:00"
     t.boolean "feed_mark_canonical", default: false
     t.string "feed_url"
     t.integer "following_orgs_count", default: 0, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -62,7 +62,6 @@ ActiveRecord::Schema.define(version: 20190115155656) do
     t.string "canonical_url"
     t.integer "collection_id"
     t.integer "collection_position"
-    t.string "comment_template"
     t.integer "comments_count", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "crossposted_at"

--- a/lib/tasks/fetch.rake
+++ b/lib/tasks/fetch.rake
@@ -24,7 +24,7 @@ end
 
 task fetch_all_rss: :environment do
   Rails.application.eager_load!
-  RssReader.get_all_articles
+  RssReader.get_all_articles(false) # False means don't force fetch. Fetch "random" subset instead of all of them.
 end
 
 task resave_supported_tags: :environment do

--- a/spec/services/rss_reader_spec.rb
+++ b/spec/services/rss_reader_spec.rb
@@ -38,6 +38,24 @@ RSpec.describe RssReader, vcr: vcr_option do
       end
     end
 
+    it "sets time current" do
+      described_class.new.get_all_articles
+      expect(User.find_by(feed_url: nonpermanent_link).feed_fetched_at).to be > 2.minutes.ago
+    end
+
+    it "does not refetch same user over and over" do
+      user = User.find_by(feed_url: nonpermanent_link)
+      user.update_column(:feed_fetched_at, Time.current)
+      fetched_at_time = user.feed_fetched_at
+      sleep(1)
+      described_class.new.get_all_articles
+      described_class.new.get_all_articles
+      described_class.new.get_all_articles
+      described_class.new.get_all_articles
+      described_class.new.get_all_articles
+      expect(user.feed_fetched_at).to eq(fetched_at_time)
+    end
+
     it "gets articles for user" do
       # the result within the approval file depends on the feed
       described_class.new.fetch_user(User.first)


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
As our RSS feed fetcher has grown, we have had issues with scaling the current approach, which was re-fetching way too often.

This should fix things by generally fetching less often. Unless _forced_ by a user update, we will not fetch every time. We'll not fetch _very recently_ fetched feeds and we will randomly not check whether to fetch.

This should scale the whole system up a lot more.