### PR TITLE
Replace each with find_each for ActiveRecord queries

### DIFF
--- a/app/labor/badge_rewarder.rb
+++ b/app/labor/badge_rewarder.rb
@@ -5,7 +5,7 @@ module BadgeRewarder
   end
 
   def self.award_beloved_comment_badges
-    Comment.where("positive_reactions_count > ?", 24).each do |comment|
+    Comment.where("positive_reactions_count > ?", 24).find_each do |comment|
       message = "You're DEV famous! [This is the comment](https://dev.to#{comment.path}) for which you are being recognized. 😄"
       achievement = BadgeAchievement.create(
         user_id: comment.user_id,
@@ -35,7 +35,7 @@ module BadgeRewarder
     ["thepracticaldev/dev.to", "thepracticaldev/DEV-ios"].each do |repo|
       commits = client.commits repo, since: since.iso8601
       authors_uids = commits.map { |c| c.author.id }
-      Identity.where(provider: "github").where(uid: authors_uids).each do |i|
+      Identity.where(provider: "github", uid: authors_uids).find_each do |i|
         BadgeAchievement.where(user_id: i.user_id, badge_id: badge.id).first_or_create(
           rewarding_context_message_markdown: message_markdown,
         )
@@ -44,7 +44,7 @@ module BadgeRewarder
   end
 
   def self.award_badges(usernames, slug, message_markdown)
-    User.where(username: usernames).each do |user|
+    User.where(username: usernames).find_each do |user|
       BadgeAchievement.create(
         user_id: user.id,
         badge_id: Badge.find_by_slug(slug).id,
@@ -56,7 +56,7 @@ module BadgeRewarder
 
   def self.award_one_year_badges
     message = "Happy DEV birthday!"
-    User.where("created_at < ? AND created_at > ?", 1.year.ago, 367.days.ago).each do |user|
+    User.where("created_at < ? AND created_at > ?", 1.year.ago, 367.days.ago).find_each do |user|
       achievement = BadgeAchievement.create(
         user_id: user.id,
         badge_id: Badge.find_by_slug("one-year-club").id,
@@ -68,7 +68,7 @@ module BadgeRewarder
 
   def self.award_two_year_badges
     message = "Happy DEV birthday! Can you believe it's been two years?"
-    User.where("created_at < ? AND created_at > ?", 2.year.ago, 732.days.ago).each do |user|
+    User.where("created_at < ? AND created_at > ?", 2.year.ago, 732.days.ago).find_each do |user|
       achievement = BadgeAchievement.create(
         user_id: user.id,
         badge_id: Badge.find_by_slug("two-year-club").id,

--- a/app/labor/bufferizer.rb
+++ b/app/labor/bufferizer.rb
@@ -6,7 +6,7 @@ class Bufferizer
   end
 
   def satellite_tweet!
-    article.tags.each do |tag|
+    article.tags.find_each do |tag|
       if tag.buffer_profile_id_code.present?
         BufferUpdate.buff!(article.id, twitter_buffer_text, tag.buffer_profile_id_code, "twitter", tag.id)
       end

--- a/app/labor/cache_buster.rb
+++ b/app/labor/cache_buster.rb
@@ -24,7 +24,7 @@ class CacheBuster
     end
     bust("#{commentable.path}/comments/")
     bust(commentable.path.to_s)
-    commentable.comments.each do |c|
+    commentable.comments.find_each do |c|
       bust(c.path)
       bust(c.path + "?i=i")
     end
@@ -51,7 +51,7 @@ class CacheBuster
     bust("/api/articles/#{article.id}")
     bust("/api/articles/by_path?url=#{article.path}")
 
-    article.collection&.articles&.each do |a|
+    article.collection&.articles&.find_each do |a|
       bust(a.path)
     end
   end

--- a/app/models/chat_channel.rb
+++ b/app/models/chat_channel.rb
@@ -44,7 +44,7 @@ class ChatChannel < ApplicationRecord
   end
 
   def clear_channel
-    messages.each(&:destroy!)
+    messages.find_each(&:destroy!)
     Pusher.trigger(pusher_channels, "channel-cleared", { chat_channel_id: id }.to_json)
     true
   rescue Pusher::Error => e

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -22,9 +22,10 @@ class Message < ApplicationRecord
   end
 
   def send_push
-    reciever_ids = chat_channel.chat_channel_memberships.
+    receiver_ids = chat_channel.chat_channel_memberships.
       where.not(user_id: user.id).pluck(:user_id)
-    PushNotificationSubscription.where(user_id: reciever_ids).each do |sub|
+
+    PushNotificationSubscription.where(user_id: receiver_ids).find_each do |sub|
       return if no_push_necessary?(sub)
 
       Webpush.payload_send(

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -79,7 +79,7 @@ class Organization < ApplicationRecord
 
   def resave_articles
     cache_buster = CacheBuster.new
-    articles.each do |article|
+    articles.find_each do |article|
       cache_buster.bust(article.path)
       cache_buster.bust(article.path + "?i=i")
       article.save
@@ -113,7 +113,7 @@ class Organization < ApplicationRecord
     cache_buster = CacheBuster.new
     cache_buster.bust("/#{slug}")
     begin
-      articles.each do |article|
+      articles.find_each do |article|
         cache_buster.bust(article.path)
       end
     rescue StandardError

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -356,7 +356,7 @@ class User < ApplicationRecord
 
   def resave_articles
     cache_buster = CacheBuster.new
-    articles.each do |article|
+    articles.find_each do |article|
       cache_buster.bust(article.path) if article.path
       cache_buster.bust(article.path + "?i=i") if article.path
       article.save
@@ -365,7 +365,7 @@ class User < ApplicationRecord
 
   def cache_bust_all_articles
     cache_buster = CacheBuster.new
-    articles.each do |article|
+    articles.find_each do |article|
       cache_buster.bust(article.path)
       cache_buster.bust(article.path + "?i=i")
     end

--- a/app/services/moderator/banisher.rb
+++ b/app/services/moderator/banisher.rb
@@ -40,28 +40,28 @@ module Moderator
     end
 
     def delete_reactions
-      user.reactions.each &:delete
+      user.reactions.find_each(&:delete)
     end
 
     def delete_comments
       return unless user.comments.count.positive?
 
-      user.comments.each do |comment|
-        comment.reactions.each &:delete
+      user.comments.find_each do |comment|
+        comment.reactions.find_each(&:delete)
         CacheBuster.new.bust_comment(comment.commentable, user.username)
         comment.delete
       end
     end
 
     def delete_follows
-      user.follows.each &:delete
+      user.follows.find_each(&:delete)
     end
 
     def delete_articles
-      user.articles.each do |article|
-        article.reactions.each &:delete
-        article.comments.each do |comment|
-          comment.reactions.each &:delete
+      user.articles.find_each do |article|
+        article.reactions.find_each(&:delete)
+        article.comments.find_each do |comment|
+          comment.reactions.find_each(&:delete)
           CacheBuster.new.bust_comment(comment.commentable, comment.user.username)
           comment.delete
         end

--- a/app/services/user_role_service.rb
+++ b/app/services/user_role_service.rb
@@ -26,7 +26,7 @@ class UserRoleService
     tag.tag_moderator_ids.each do |id|
       User.find(id).remove_role(:tag_moderator, tag)
     end
-    users.each do |user|
+    users.find_each do |user|
       user.add_role(:tag_moderator, tag)
     end
     true

--- a/spec/labor/cache_buster_spec.rb
+++ b/spec/labor/cache_buster_spec.rb
@@ -10,12 +10,13 @@ RSpec.describe CacheBuster do
     username = User.find(comment.user_id).username
     described_class.new.bust_comment(commentable, username)
   end
+
   it "busts article" do
     described_class.new.bust_article(article)
   end
+
   it "busts featured article" do
-    article.featured = true
-    article.save
+    article.update(featured: true)
     described_class.new.bust_article(article)
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

Using `.each` on an ActiveRecord relation object means that AR is going to load all objects in memory, which is almost always not the intended behavior. It can also be problematic if such queries load **a lot** of objects in memory when executed.

I've replaced it with `.find_each` which by default [loads only 1000 rows at a time](https://api.rubyonrails.org/classes/ActiveRecord/Batches.html#method-i-find_each), and then moves on to the next 1000. 

This scales well when there are just too many rows to process all at once.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

