### PR TITLE
Replace data with content in export email copy

### DIFF
--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -103,7 +103,7 @@ class NotifyMailer < ApplicationMailer
     @user = user
     export_filename = "devto-export-#{Date.current.iso8601}.zip"
     attachments[export_filename] = attachment
-    mail(to: @user.email, subject: "The export of your data is ready")
+    mail(to: @user.email, subject: "The export of your content is ready")
   end
 
   def tag_moderator_confirmation_email(user, tag_name)

--- a/app/views/mailers/notify_mailer/export_email.html.erb
+++ b/app/views/mailers/notify_mailer/export_email.html.erb
@@ -1,4 +1,4 @@
-<h3 style="font-weight:300">Your data has been exported.</h3>
+<h3 style="font-weight:300">Your content has been exported.</h3>
 <p>
 Please check the attached file.
 </p>

--- a/app/views/mailers/notify_mailer/export_email.text.erb
+++ b/app/views/mailers/notify_mailer/export_email.text.erb
@@ -1,3 +1,3 @@
-Your data has been exported.
+Your content has been exported.
 
 Please check the attached file.

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe NotifyMailer, type: :mailer do
     describe "#export_email" do
       it "renders proper subject" do
         export_email = described_class.export_email(user, "attachment")
-        expect(export_email.subject).to include("export of your data is ready")
+        expect(export_email.subject).to include("export of your content is ready")
       end
 
       it "renders proper receiver" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

Since we've replaced the word `data` with the word `content` in https://github.com/thepracticaldev/dev.to/pull/1471 - we should align the export email as well

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
