### PR TITLE
Order my tags by weight and name

### DIFF
--- a/app/assets/javascripts/initializers/initializeBaseUserData.js
+++ b/app/assets/javascripts/initializers/initializeBaseUserData.js
@@ -16,8 +16,14 @@ function initializeUserSidebar(user) {
     if (followedTags.length === 0) {
         document.getElementById("tag-separator").innerHTML = "Follow tags to improve your feed"
     }
+
+    // sort tags by descending weigth and lexicographical order
+    followedTags.sort(function(tagA, tagB) {
+      return tagB.points - tagA.points || tagA.name.localeCompare(tagB.name);
+    });
+
     followedTags.forEach(function(t){
-      renderedTagsCount++
+      renderedTagsCount++;
       if (t.points > 0.0) {
         tagHTML = tagHTML + '<div class="sidebar-nav-element" id="sidebar-element-'+t.name+'">\
                             <a class="sidebar-nav-link" href="/t/'+t.name+'">\

--- a/app/views/articles/_sidebar_nav.html.erb
+++ b/app/views/articles/_sidebar_nav.html.erb
@@ -35,7 +35,7 @@
         <% end %>
     </div>
     <div class="sidebar-nav-block-inner">
-    <div id="sidebar-nav-followed-tags" class="sidebar-nav-followed-tags"></div>
+      <div id="sidebar-nav-followed-tags" class="sidebar-nav-followed-tags"></div>
       <div id="sidebar-nav-default-tags" class="sidebar-nav-default-tags <%= 'showing' unless user_signed_in? %>">
         <% if user_signed_in? %>
           <div class="sidebar-nav-subheader tag-separator" id="tag-separator">Other Popular Tags</div>

--- a/spec/features/homepage/user_visits_homepage_spec.rb
+++ b/spec/features/homepage/user_visits_homepage_spec.rb
@@ -49,6 +49,9 @@ describe "User visits a homepage", type: :feature do
     context "when user follows tags" do
       before do
         user.follows.create!(followable: ruby_tag)
+        user.follows.create!(followable: create(:tag, name: "go"), points: 3)
+        user.follows.create!(followable: create(:tag, name: "javascript"))
+
         visit "/"
       end
 
@@ -56,6 +59,12 @@ describe "User visits a homepage", type: :feature do
         expect(page).to have_text("my tags")
         within("#sidebar-nav-followed-tags") do
           expect(page).to have_link("#ruby", href: "/t/ruby")
+        end
+      end
+
+      it "shows followed tags ordered by weight and name", js: true do
+        within("#sidebar-nav-followed-tags") do
+          expect(all(".sidebar-nav-tag-text").map(&:text)).to eq(%w[#go #javascript #ruby])
         end
       end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

This PR sorts the tags in "my tags" on the homepage by two criteria:

* descending weight
* ascending name

So if two tags share the same weight/points they will be ordered alphabetically (more lexicographically) by using [localeCompare](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare) (supported by all browsers).

Notes:

* the dashboard page hasn't changed, so the second sorted criteria is not the name (because it's not present in the `Follow` objects, but the attached tag)
* I had to skip the git hooks for the JS file because prettier and eslint were basically rewriting the whole file and blocking me to submit a PR. I'm thinking if it might be useful to disable app/assets/javascript from the git hook until they are migrated to ES6 or at least a sensible set of rules has been defined (eslint rules for pre ES6 are usually separate for ES6+)

## Related Tickets & Documents

Closes #1543 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![screenshot_2019-01-17 dashboard - dev 1](https://user-images.githubusercontent.com/146201/51329423-c3cd0580-1a75-11e9-9cf9-728fc5eae6c3.png)


![screenshot_2019-01-17 the dev community 1](https://user-images.githubusercontent.com/146201/51328917-a9def300-1a74-11e9-9e9c-dbc576232c32.png)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
