### PR TITLE
Order my tags by weight, popularity and name

### DIFF
--- a/app/assets/javascripts/initializers/initializeBaseUserData.js
+++ b/app/assets/javascripts/initializers/initializeBaseUserData.js
@@ -16,8 +16,14 @@ function initializeUserSidebar(user) {
     if (followedTags.length === 0) {
         document.getElementById("tag-separator").innerHTML = "Follow tags to improve your feed"
     }
+
+    // sort tags by descending weigth, descending popularity and name
+    followedTags.sort(function(tagA, tagB) {
+      return tagB.points - tagA.points || tagB.hotness_score - tagA.hotness_score || tagA.name.localeCompare(tagB.name);
+    });
+
     followedTags.forEach(function(t){
-      renderedTagsCount++
+      renderedTagsCount++;
       if (t.points > 0.0) {
         tagHTML = tagHTML + '<div class="sidebar-nav-element" id="sidebar-element-'+t.name+'">\
                             <a class="sidebar-nav-link" href="/t/'+t.name+'">\

--- a/app/controllers/async_info_controller.rb
+++ b/app/controllers/async_info_controller.rb
@@ -38,7 +38,7 @@ class AsyncInfoController < ApplicationController
         username: @user.username,
         profile_image_90: ProfileImage.new(@user).get(90),
         followed_tag_names: @user.cached_followed_tag_names,
-        followed_tags: @user.cached_followed_tags.to_json(only: %i[id name bg_color_hex text_color_hex], methods: [:points]),
+        followed_tags: @user.cached_followed_tags.to_json(only: %i[id name bg_color_hex text_color_hex hotness_score], methods: [:points]),
         followed_user_ids: @user.cached_following_users_ids,
         followed_organization_ids: @user.cached_following_organizations_ids,
         reading_list_ids: ReadingList.new(@user).cached_ids_of_articles,

--- a/app/views/articles/_sidebar_nav.html.erb
+++ b/app/views/articles/_sidebar_nav.html.erb
@@ -35,7 +35,7 @@
         <% end %>
     </div>
     <div class="sidebar-nav-block-inner">
-    <div id="sidebar-nav-followed-tags" class="sidebar-nav-followed-tags"></div>
+      <div id="sidebar-nav-followed-tags" class="sidebar-nav-followed-tags"></div>
       <div id="sidebar-nav-default-tags" class="sidebar-nav-default-tags <%= 'showing' unless user_signed_in? %>">
         <% if user_signed_in? %>
           <div class="sidebar-nav-subheader tag-separator" id="tag-separator">Other Popular Tags</div>

--- a/spec/features/homepage/user_visits_homepage_spec.rb
+++ b/spec/features/homepage/user_visits_homepage_spec.rb
@@ -49,6 +49,9 @@ describe "User visits a homepage", type: :feature do
     context "when user follows tags" do
       before do
         user.follows.create!(followable: ruby_tag)
+        user.follows.create!(followable: create(:tag, name: "go", hotness_score: 99))
+        user.follows.create!(followable: create(:tag, name: "javascript"), points: 3)
+
         visit "/"
       end
 
@@ -56,6 +59,12 @@ describe "User visits a homepage", type: :feature do
         expect(page).to have_text("my tags")
         within("#sidebar-nav-followed-tags") do
           expect(page).to have_link("#ruby", href: "/t/ruby")
+        end
+      end
+
+      it "shows followed tags ordered by weight and name", js: true do
+        within("#sidebar-nav-followed-tags") do
+          expect(all(".sidebar-nav-tag-text").map(&:text)).to eq(%w[#javascript #go #ruby])
         end
       end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

This PR sorts the tags in "my tags" on the homepage by three criteria:

* descending weight
* descending popularity
* ascending name

So if two tags share the same weight/points they will be ordered first by their popularity and then alphabetically (more like lexicographically) by using [localeCompare](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare) (supported by all browsers).


Notes:

* the dashboard page hasn't changed, so the other two criteria do not apply (because they are not present in the `Follow` objects, but the attached `Tag`)
* I had to skip the git hooks for the JS file because prettier and eslint were basically rewriting the whole file and blocking me to submit a PR. I'm thinking if it might be useful to disable app/assets/javascript from the git hook until they are migrated to ES6 or at least a sensible set of rules has been defined (eslint rules for pre ES6 are usually separate for ES6+)

## Related Tickets & Documents

Closes #1543 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![screenshot_2019-01-17 dashboard - dev 1](https://user-images.githubusercontent.com/146201/51329423-c3cd0580-1a75-11e9-9cf9-728fc5eae6c3.png)

![screenshot_2019-01-17 the dev community](https://user-images.githubusercontent.com/146201/51333475-127e9d80-1a7e-11e9-85a2-da23fd42890e.png)

Note how computerscience jumped up, because I set its popularity to other than 0:

```ruby
[16] pry(main)> u.decorate.cached_followed_tags.pluck(:name, :hotness_score)
   (0.5ms)  SELECT "follows"."followable_id", "follows"."points" FROM "follows" WHERE "follows"."follower_id" = $1 AND "follows"."followable_type" = $2  [["follower_id", 11], ["followable_type", "ActsAsTaggableOn::Tag"]] [sql_query]
  Tag Load (0.5ms)  SELECT "tags".* FROM "tags" WHERE "tags"."id" IN (7, 10, 4, 3, 11, 9, 5, 2, 12) ORDER BY hotness_score DESC [sql_query]
=> [["computerscience", 44], ["productivity", 0], ["python", 0], ["go", 0], ["javascript", 0], ["career", 0], ["security", 0], ["webdev", 0], ["git", 0]]
```

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
