### PR TITLE
Fix for issue #1608

### DIFF
--- a/app/liquid_tags/codepen_tag.rb
+++ b/app/liquid_tags/codepen_tag.rb
@@ -22,7 +22,7 @@ class CodepenTag < LiquidTagBase
   private
 
   def valid_option(option)
-    option.match(/(default-tab\=\w(\,\w)?)/)
+    option.match(/(default-tab\=\w+(\,\w+)?)/)
   end
 
   def parse_options(input)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Documentation Update

## Description

Updated the regexp in `def valid_option(option)` to match whole tab names in the `default-tab` option instead of just single characters.

## Related Tickets & Documents

https://github.com/thepracticaldev/dev.to/issues/1608

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed

