### PR TITLE
Add "bsd.network" to Mastodon list

### DIFF
--- a/app/lib/constants.rb
+++ b/app/lib/constants.rb
@@ -2,6 +2,7 @@ module Constants
   ALLOWED_MASTODON_INSTANCES = [
     "acg.mn",
     "bitcoinhackers.org",
+    "bsd.network",
     "chaos.social",
     "cmx.im",
     "framapiaf.org",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Documentation Update

## Description

This adds [bsd.network](https://bsd.network) to the list of allowed Mastodon instances.

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed