### PR TITLE
Add "101010.pl" to Mastodon list

### DIFF
--- a/app/lib/constants.rb
+++ b/app/lib/constants.rb
@@ -1,5 +1,6 @@
 module Constants
   ALLOWED_MASTODON_INSTANCES = [
+    "101010.pl",
     "acg.mn",
     "bitcoinhackers.org",
     "chaos.social",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Documentation Update

## Description

This adds [101010.pl](https://101010.pl) to the list of allowed Mastodon instances.

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed