### PR TITLE
Add logging if oauth fails

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -10,6 +10,17 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     callback_for("github")
   end
 
+  def failure
+    logger.error "Log in error",
+      log_in_error: {
+        omniauth_error: request.env["omniauth.error"],
+        omniauth_error_type: request.env["omniauth.error.type"],
+        omniauth_strategy: request.env["omniauth.strategy"],
+        cookie: request.env["rack.request.cookie_hash"]
+      }
+    super
+  end
+
   private
 
   def callback_for(provider)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
For any OAuth failures  -- 401 unauthorized or otherwise unsuccessful OAuth authorizations -- log it into Timber.