### PR TITLE
Use safe navigation for edge cases

### DIFF
--- a/app/sanitizers/rendered_markdown_scrubber.rb
+++ b/app/sanitizers/rendered_markdown_scrubber.rb
@@ -14,7 +14,7 @@ class RenderedMarkdownScrubber < Rails::Html::PermitScrubber
   def valid_codeblock_div?(node)
     node.name == "div" &&
       node.attributes.count == 1 &&
-      node.children.first.name == "pre" &&
+      node.children.first&.name == "pre" &&
       node.parent.name == "#document-fragment" &&
       node.attributes.values.any? do |attribute_value|
         attribute_value.value == "highlight"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Use safe navigation for edge cases where `node.children.first = nil`. Might resolve a few Atom based RSS feeds.