### PR TITLE
Unsubscribe deleted/banished user from Mailchimp newsletters

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -396,6 +396,10 @@ class User < ApplicationRecord
     index.delay.delete_object("users-#{id}")
   end
 
+  def unsubscribe_from_newsletters
+    MailchimpBot.new(self).unsubscribe_all_newsletters
+  end
+
   private
 
   def send_welcome_notification
@@ -577,10 +581,6 @@ class User < ApplicationRecord
     follower_relationships = Follow.where(followable_id: id, followable_type: "User")
     follower_relationships.destroy_all
     follows.destroy_all
-  end
-
-  def unsubscribe_from_newsletters
-    MailchimpBot.new(self).unsubscribe_all_newsletters
   end
 
   def mentorship_status_update

--- a/app/services/moderator/banisher.rb
+++ b/app/services/moderator/banisher.rb
@@ -83,12 +83,14 @@ module Moderator
     end
 
     def full_delete
+      user.unsubscribe_from_newsletters
       delete_user_activity
       CacheBuster.new.bust("/#{user.old_username}")
       user.delete
     end
 
     def banish
+      user.unsubscribe_from_newsletters
       reassign_and_bust_username
       remove_profile_info
       add_banned_role


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
- Makes `unsubscribe_from_newsletters` a public? method in the user model. 
- Unsubscribes users being banished or deleted
