### PR TITLE
connect width jump fix

### DIFF
--- a/app/assets/stylesheets/chat.scss
+++ b/app/assets/stylesheets/chat.scss
@@ -66,12 +66,8 @@
 }
 
 .chat__channels--expanded{
-  width: 200px;
-  min-width: 200px;
-  @media screen and ( min-width: 400px ){
-    width: 160px;
-    min-width: 160px;
-  }
+  width: 160px;
+  min-width: 160px;
   @media screen and ( min-width: 1000px ){
     width: 200px;
     min-width: 200px;
@@ -170,8 +166,8 @@
 
 .chat__activechat {
   height: inherit;
+  width: calc(100% - 45px);
   max-width: calc(100% - 45px);
-  min-width: calc(100% - 200px);
   @media screen and ( min-width: 1300px ){
     min-width: calc(100% - calc(280px + 3vw));
   }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
Issue #1650 describes a jump in connect when loaded in smaller screens. Based on some testing, it was because of the `min-width` and `max-width` under `.chat__activechat` that created about a 155px range for the chat to expand or contract. It seems when loading it takes the minimum first then adjusts the width to fit the screen—creating that jump. 

I removed that range and allow the chat to fill the screen immediately. Though because of how `.chat__channels` and `.chat__channels--expanded` is implemented, there is an observed growth on the left border of `.chat__activechat` due to the JavaScript side loading and removing `--expanded` from the class to shrink the chat channels on the left and make more space for the chat. I've attached screenshots below on mobile sizes of the app locally running and loading to demonstrate.

## Related Tickets & Documents
resolves #1650 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![screen shot 2019-01-25 at 15 35 10 2](https://user-images.githubusercontent.com/13403332/51771835-542fc980-20b8-11e9-828f-7de039d1bb82.png)
![screen shot 2019-01-25 at 15 35 14 2](https://user-images.githubusercontent.com/13403332/51771846-5d209b00-20b8-11e9-9da3-e2811f7d5b45.png)
![screen shot 2019-01-25 at 15 33 25 2](https://user-images.githubusercontent.com/13403332/51771850-60b42200-20b8-11e9-96e8-ae495e1d02c7.png)
![screen shot 2019-01-25 at 15 34 05 2](https://user-images.githubusercontent.com/13403332/51771856-63af1280-20b8-11e9-9e32-1100184d7999.png)

## Added to documentation?
- [x] no documentation needed

