### PR TITLE
full published\created dates in title attr. for comments and articles

### DIFF
--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -124,7 +124,7 @@
           <% if @user.github_username.present? %>
             <a href="http://github.com/<%= @user.github_username %>"><%= image_tag_or_inline_svg "github" %></a>
           <% end %>
-          <span class="published-at" itemprop="datePublished"><%= @article.readable_publish_date if @article.published_at %></span>
+          <span class="published-at" itemprop="datePublished" title="<%= @article.published_at&.to_formatted_s(:long) %>"><%= @article.readable_publish_date if @article.published_at %></span>
           <% if @second_user.present? %>
             <em>with <b><a href="<%= @second_user.path %>"><%= @second_user.name %></a></b></em>
           <% end %>

--- a/app/views/comments/_comment_proper.html.erb
+++ b/app/views/comments/_comment_proper.html.erb
@@ -44,7 +44,7 @@
                                     commentable.decorate.cached_tag_list_array.include?("ama") %>
               <span class="op-marker">ASK ME ANYTHING</span>
             <% end %>
-            <div class="comment-date">
+            <div class="comment-date" title="<%= comment.created_at&.to_formatted_s(:long) %>">
               <a href="<%= comment.path %>"><%= comment.readable_publish_date %></a>
             </div>
             <button class="dropbtn">

--- a/app/views/users/_comments_section.html.erb
+++ b/app/views/users/_comments_section.html.erb
@@ -26,7 +26,7 @@
         <a href="<%= comment.path %>">
           <div class="single-comment <%= "strong-comment" if comment.ancestry == nil%>">
             <span class="comment-title">re: <%= comment.commentable.title %></span>
-            <span class="comment-date"><%= comment.readable_publish_date %></span>
+            <span class="comment-date" title="<%= comment.created_at&.to_formatted_s(:long) %>"><%= comment.readable_publish_date %></span>
             <div class="comment-preview"><%= truncate(strip_tags(comment.processed_html), length:64).html_safe %></div>
           </div>
         </a>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Adding `title` attributes to Comment `created_at` and Article `published_at` elements displaying the full time\date. 

It's currently displaying in UTC, and I don't see in the code base how you deal with time zones to ensure times\dates are displayed in the user's correct zone. That would be a nice next step for this feature.

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/issues/406

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
When you hover over the published date: https://www.dropbox.com/s/0fyqvf7up63a2u5/Screenshot%202019-01-27%2015.11.39.png?dl=0
When you hover over the created date: https://www.dropbox.com/s/aeryrw8hvu0knz9/Screenshot%202019-01-27%2015.11.48.png?dl=0

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?
It's my first pull request for Dev, so...
![nervous](https://media.giphy.com/media/3ohhwF34cGDoFFhRfy/giphy.gif)
