### PR TITLE
Remove hardcoded values in streak reward

### DIFF
--- a/app/labor/badge_rewarder.rb
+++ b/app/labor/badge_rewarder.rb
@@ -44,9 +44,9 @@ module BadgeRewarder
   end
 
   def self.award_streak_badge(num_weeks)
-    article_user_ids = Article.where("published_at > ?", 1.week.ago).pluck(:user_id)
+    article_user_ids = Article.where(published: true).where("published_at > ? AND score > ?", 1.week.ago, -25).pluck(:user_id) # No cred for super low quality
     message = "Congrats on achieving this streak! Consistent writing is hard. The next streak badge you can get is the #{num_weeks * 2} Week Badge. 😉"
-    users = User.where(id: article_user_ids).where("articles_count > ?", 3)
+    users = User.where(id: article_user_ids).where("articles_count >= ?", num_weeks)
     usernames = []
     users.find_each do |user|
       count = 0
@@ -56,7 +56,7 @@ module BadgeRewarder
           count = count + 1
         end
       end
-      if count > 3
+      if count >= num_weeks
         usernames << user.username
       end
     end

--- a/spec/labor/badge_rewarder_spec.rb
+++ b/spec/labor/badge_rewarder_spec.rb
@@ -81,6 +81,7 @@ RSpec.describe BadgeRewarder do
       create(:badge, title: "4 Week Streak", slug: "4-week-streak")
       user = create(:user)
       create(:article, user: user, published: true, published_at: 26.days.ago)
+      create(:article, user: user, published: true, published_at: 19.days.ago)
       create(:article, user: user, published: true, published_at: 5.days.ago)
       described_class.award_streak_badge(4)
       expect(user.badges.size).to eq(0)


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Previous PR in badge rewarding streak had a couple hardcoded values. This removes them so the next step is easier when we want to create the future streak badges.
Also added a guard against low-quality articles.