### PR TITLE
Render codespans properly in markdown

### DIFF
--- a/app/labor/markdown_parser.rb
+++ b/app/labor/markdown_parser.rb
@@ -119,10 +119,12 @@ class MarkdownParser
   end
 
   def escape_liquid_tags_in_codeblock(content)
-    # Escape BOTH codeblock and inline code
-    content.gsub(/`{3}.*?`{3}|`{1}.+?`{1}/m) do |codeblock|
-      if codeblock.include?("```")
+    # Escape codeblocks, code spans, and inline code
+    content.gsub(/`{3}.*?`{3}|`{2}.+?`{2}|`{1}.+?`{1}/m) do |codeblock|
+      if codeblock[0..2] == "```"
         "\n{% raw %}\n" + codeblock + "\n{% endraw %}\n"
+      elsif codeblock[0..1] == "``"
+        "{% raw %}" + codeblock + "{% endraw %}"
       else
         "{% raw %}" + codeblock + "{% endraw %}"
       end

--- a/spec/labor/markdown_parser_spec.rb
+++ b/spec/labor/markdown_parser_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe MarkdownParser do
     described_class.new(raw_markdown).finalize
   end
 
-  it "works" do
+  it "renders plain text as-is" do
     expect(basic_parsed_markdown.finalize).to include(random_word)
   end
 

--- a/spec/labor/markdown_parser_spec.rb
+++ b/spec/labor/markdown_parser_spec.rb
@@ -12,12 +12,27 @@ RSpec.describe MarkdownParser do
     expect(basic_parsed_markdown.finalize).to include(random_word)
   end
 
-  it "escape liquid tags in codeblock" do
+  it "escapes liquid tags in codeblock" do
     code_block = "```\n{% what %}\n```"
     expect(generate_and_parse_markdown(code_block)).to include("{% what %}")
   end
 
-  it "escape liquid tags in inline code" do
+  it "escapes liquid tags in code spans" do
+    code_span = "``{% what %}``"
+    expect(generate_and_parse_markdown(code_span)).to include("{% what %}")
+  end
+
+  it "renders double backtick code spans properly" do
+    code_span = "``#{random_word}``"
+    expect(generate_and_parse_markdown(code_span)).to include random_word
+  end
+
+  it "renders a double backtick codespan with a word wrapped in single backticks properly" do
+    code_span = "`` `#{random_word}` ``"
+    expect(generate_and_parse_markdown(code_span)).to include "`#{random_word}`"
+  end
+
+  it "escapes liquid tags in inline code" do
     inline_code = "`{% what %}`"
     expect(generate_and_parse_markdown(inline_code)).to include(inline_code[1..-2])
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This allows code spans to render properly again in Markdown.

Some context -- it's kind of long winded:

Originally, code spans were rendered properly, but an edge case with attempting to render a code block/code span/inline code example for Liquid tags or anything with `{% %}` would be parsed as a Liquid tag. For example, if we wanted to show someone how to use the YouTube Liquid tag:
```
{% youtube id_code %}
```
That code block wouldn't work.

Our previous workaround resolved that issue for code blocks and inline code, but not code spans. In the future, we might want to separate Liquid tag parsing from Markdown parsing.

## [optional] What gif best describes this PR or how it makes you feel?

![A person with a TV for a head stands in space.](https://media.giphy.com/media/3o7ZerwmoQUdMdPE7S/giphy-downsized.gif)