### PR TITLE
Update Skylight badge to point to correct URL [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@
   <a href="https://codeclimate.com/github/thepracticaldev/dev.to/test_coverage">
     <img src="https://api.codeclimate.com/v1/badges/ce45bf63293073364bcb/test_coverage" />
   </a>
-  <a href="https://www.skylight.io/app/applications/K9H5IV3RqKGu">
-    <img src="https://badges.skylight.io/status/K9H5IV3RqKGu.svg?token=Ofd-9PTSyus3BqEZZZbM1cWKJ94nHWaPiTphGsWJMAY" />
+  <a href="https://oss.skylight.io/app/applications/K9H5IV3RqKGu">
+    <img src="https://badges.skylight.io/status/K9H5IV3RqKGu.svg?token=Ofd-9PTSyus3BqEZZZbM1cWKJ94nHWaPiTphGsWJMAY" alt="Skylight badge" />
   </a>
   <a href="https://www.codetriage.com/thepracticaldev/dev.to">
     <img src="https://www.codetriage.com/thepracticaldev/dev.to/badges/users.svg" alt="CodeTriage badge" />


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] ~Refactor~
- [ ] ~Feature~
- [ ] ~Bug Fix~
- [x] Documentation Update

## Description

Hello! 👋 I work at Skylight, and am making this PR as a part of the [setup process](https://www.skylight.io/support/skylight-for-open-source#setup) for the [Skylight for Open Source Program](https://oss.skylight.io). Now that this app is running on open source in Skylight, the url that this badge links to is outdated. This commit updates the url to point to the public dashboard so that all dev.to contributors can view the open source performance data.


## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] ~docs.dev.to~
- [x] readme
- [ ] ~no documentation needed~
