### PR TITLE
Add Stripe Cancellation Webhook

### DIFF
--- a/Envfile
+++ b/Envfile
@@ -130,6 +130,7 @@ variable :SLACK_WEBHOOK_URL, :String, default: "Optional"
 # Stripe for payment system
 variable :STRIPE_PUBLISHABLE_KEY, :String, default: "Optional"
 variable :STRIPE_SECRET_KEY, :String, default: "Optional"
+variable :STRIPE_CANCELLATION_SECRET, :String, default: "Optional"
 
 # For browser webpush notifications (webpush gem) (totally random base64 nums)
 variable :VAPID_PUBLIC_KEY, :String, default: "dGhpcyBpcyBkZXYudG8gdGVzdCBkYXRh"

--- a/app/controllers/stripe_cancellations_controller.rb
+++ b/app/controllers/stripe_cancellations_controller.rb
@@ -1,0 +1,15 @@
+class StripeCancellationsController < ApplicationController
+  skip_before_action :verify_authenticity_token, only: :create
+
+  def create
+    event = Stripe::Event.retrieve(params[:id])
+    stripe_id = event.data.object.customer
+    customer = Stripe::Customer.retrieve(stripe_id)
+    monthly_dues = event.data.object.plan.amount
+    user = User.where(stripe_id_code: stripe_id).first
+    MembershipService.new(customer, user, monthly_dues).unsubscribe_customer
+    render body: nil, status: 201
+  rescue Stripe::APIConnectionError, Stripe::StripeError
+    render body: nil, status: 400
+  end
+end

--- a/app/controllers/stripe_cancellations_controller.rb
+++ b/app/controllers/stripe_cancellations_controller.rb
@@ -2,11 +2,11 @@ class StripeCancellationsController < ApplicationController
   skip_before_action :verify_authenticity_token, only: :create
 
   def create
-    verify_stripe_payload
-    event
+    verify_stripe_signature
+    unsubscribe_customer
   end
 
-  def verify_stripe_payload
+  def verify_stripe_signature
     payload = request.body.read
     sig_header = request.env["HTTP_STRIPE_SIGNATURE"]
 
@@ -26,13 +26,13 @@ class StripeCancellationsController < ApplicationController
   end
 
   def unsubscribe_customer
-    Stripe::Event.retrieve(params[:id])
+    event = Stripe::Event.retrieve(params[:id])
     stripe_id = event.data.object.customer
     customer = Stripe::Customer.retrieve(stripe_id)
     monthly_dues = event.data.object.items.data[0].plan.amount
     user = User.where(stripe_id_code: stripe_id).first
     MembershipService.new(customer, user, monthly_dues).unsubscribe_customer
-    render body: nil, status: 201
+    render body: nil, status: 200
   rescue Stripe::APIConnectionError, Stripe::StripeError
     render body: nil, status: 400
   end

--- a/app/services/membership_service.rb
+++ b/app/services/membership_service.rb
@@ -42,6 +42,8 @@ class MembershipService
   end
 
   def cancel_subscription
+    return true if customer.subscriptions.none?
+
     subscription.delete
   end
 

--- a/app/views/users/_membership.html.erb
+++ b/app/views/users/_membership.html.erb
@@ -13,13 +13,11 @@
     <div style="background: white;border: 1px dashed black;padding: 18px;border-radius:3px">
       <span style="font-weight:bold;font-size:1.3em">🎟 25% Off Everything:
       <em style="color:darkcyan;font-weight:700">
-        <%= CouponGenerator.new(current_user.id,"member_discount").generate %>
-      </em></span>
+              </em></span>
       <br/><br/>
       <% if current_user.monthly_dues >= 2500 %>
         <span style="font-weight:bold;font-size:1.3em">🎟 Level 3 Merch Gift (one time use):
         <em style="color:darkcyan;font-weight:700">
-          <%= CouponGenerator.new(current_user.id,"tee_pack").generate %>
         </em></span>
         <br/><br/>
         👆 This coupon will give you 100% off:<br/>
@@ -35,7 +33,6 @@
       <% else %>
         <span style="font-weight:bold;font-size:1.3em">🎟 Level 2 Sticker Gift (one time use):
         <em style="color:darkcyan;font-weight:700">
-          <%= CouponGenerator.new(current_user.id,"sticker_pack").generate %>
         </em></span>
         <br/><br/>
         👆 This coupon will give you 100% off

--- a/app/views/users/_membership.html.erb
+++ b/app/views/users/_membership.html.erb
@@ -13,11 +13,13 @@
     <div style="background: white;border: 1px dashed black;padding: 18px;border-radius:3px">
       <span style="font-weight:bold;font-size:1.3em">🎟 25% Off Everything:
       <em style="color:darkcyan;font-weight:700">
-              </em></span>
+        <%= CouponGenerator.new(current_user.id,"member_discount").generate %>
+      </em></span>
       <br/><br/>
       <% if current_user.monthly_dues >= 2500 %>
         <span style="font-weight:bold;font-size:1.3em">🎟 Level 3 Merch Gift (one time use):
         <em style="color:darkcyan;font-weight:700">
+          <%= CouponGenerator.new(current_user.id,"tee_pack").generate %>
         </em></span>
         <br/><br/>
         👆 This coupon will give you 100% off:<br/>
@@ -33,6 +35,7 @@
       <% else %>
         <span style="font-weight:bold;font-size:1.3em">🎟 Level 2 Sticker Gift (one time use):
         <em style="color:darkcyan;font-weight:700">
+          <%= CouponGenerator.new(current_user.id,"sticker_pack").generate %>
         </em></span>
         <br/><br/>
         👆 This coupon will give you 100% off

--- a/config/initializers/stripe.rb
+++ b/config/initializers/stripe.rb
@@ -1,6 +1,7 @@
 Rails.configuration.stripe = {
   publishable_key: ApplicationConfig["STRIPE_PUBLISHABLE_KEY"],
-  secret_key: ApplicationConfig["STRIPE_SECRET_KEY"]
+  secret_key: ApplicationConfig["STRIPE_SECRET_KEY"],
+  stripe_cancellation_secret: ApplicationConfig["STRIPE_CANCELLATION_SECRET"]
 }
 
 Stripe.api_key = Rails.configuration.stripe[:secret_key]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -112,6 +112,7 @@ Rails.application.routes.draw do
   resources :tags, only: [:index]
   resources :stripe_subscriptions, only: %i[create update destroy]
   resources :stripe_active_cards, only: %i[create update destroy]
+  resources :stripe_cancellations, only: [:create]
   resources :live_articles, only: [:index]
   resources :github_repos, only: %i[create update]
   resources :buffered_articles, only: [:index]

--- a/spec/requests/stripe_cancellations_spec.rb
+++ b/spec/requests/stripe_cancellations_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe "StripeCancellations", type: :request do
+  let(:user) { create(:user, :super_admin) }
+  let(:mock_instance) { instance_double(MembershipService) }
+  let(:stripe_helper) { StripeMock.create_test_helper }
+  let(:stripe_event_client) { instance_double (Stripe::Event) }
+  let(:stubbed_stripe_event)
+
+  before do
+    allow_any_instance_of(StripeCancellationsController).to receive(:verify_stripe_payload).and_return(:true)
+    StripeMock.start
+    sign_in user
+    user.update(stripe_id_code: "CUS_123")
+  end
+
+  after { StripeMock.stop }
+
+  it "mocks a stripe cancellation webhook" do
+    event = StripeMock.mock_webhook_event(
+      'customer.subscription.deleted',
+      { :customer => user.stripe_id_code, :total_count => 1 })
+
+    monthly_dues = event.data.object.items.data[0].plan.amount
+      binding.pry
+    post "/stripe_subscriptions", params: {
+      amount: monthly_dues,
+      stripe_token: stripe_helper.generate_card_token
+    }
+
+    post "/stripe_cancellations", params: event.as_json
+    expect(user.monthly_dues).to eq(0)
+  end
+
+end

--- a/spec/requests/stripe_cancellations_spec.rb
+++ b/spec/requests/stripe_cancellations_spec.rb
@@ -1,35 +1,32 @@
 require "rails_helper"
 
 RSpec.describe "StripeCancellations", type: :request do
-  let(:user) { create(:user, :super_admin) }
-  let(:mock_instance) { instance_double(MembershipService) }
+  let(:user) { create(:user) }
   let(:stripe_helper) { StripeMock.create_test_helper }
-  let(:stripe_event_client) { instance_double (Stripe::Event) }
-  let(:stubbed_stripe_event)
 
   before do
-    allow_any_instance_of(StripeCancellationsController).to receive(:verify_stripe_payload).and_return(:true)
     StripeMock.start
-    sign_in user
-    user.update(stripe_id_code: "CUS_123")
+    allow_any_instance_of(StripeCancellationsController).to receive(:verify_stripe_signature).and_return(true)
   end
 
   after { StripeMock.stop }
 
   it "mocks a stripe cancellation webhook" do
+    customer = Stripe::Customer.create(
+      email: user.email,
+      source: stripe_helper.generate_card_token,
+    )
+    MembershipService.new(customer, user, 12).subscribe_customer
+    user.reload
+    expect(user.monthly_dues).not_to eq(0)
+
     event = StripeMock.mock_webhook_event(
-      'customer.subscription.deleted',
-      { :customer => user.stripe_id_code, :total_count => 1 })
-
-    monthly_dues = event.data.object.items.data[0].plan.amount
-      binding.pry
-    post "/stripe_subscriptions", params: {
-      amount: monthly_dues,
-      stripe_token: stripe_helper.generate_card_token
-    }
-
+      "customer.subscription.deleted",
+      customer: user.stripe_id_code, total_count: 1,
+    )
     post "/stripe_cancellations", params: event.as_json
+    user.reload
     expect(user.monthly_dues).to eq(0)
+    expect(response).to have_http_status(200)
   end
-
 end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
- Should remove user membership if subscription is cancelled (through stripe aka card is declined)
- Allows users to cancel memberships even if subscription has already been removed (by stripe)

*After Deploying*
- Run script to remove memberships for users who do not have active subscriptions

```potentially_affected_users = User.where.not(stripe_id_code: nil, monthly_dues: 0).where.not(stripe_id_code: "special")

users_with_no_stripe_sub = potentially_affected_users.select do |user|
  Stripe::Customer.retrieve(user.stripe_id_code).subscriptions.total_count.zero?
end

users_with_no_stripe_sub.each do |user|
  customer = Stripe::Customer.retrieve(user.stripe_id_code)
  MembershipService.new(customer, user, user.monthly_dues).unsubscribe_customer
end
```


- Send email to these members that their memberships have been cancelled
- Add email reminders for users who experience billing issues

