### PR TITLE
Rename notification arguments

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -172,6 +172,7 @@ class Notification < ApplicationRecord
     handle_asynchronously :send_welcome_notification
 
     def send_moderation_notification(notifiable)
+      # notifiable is currently only comment
       available_moderators = User.with_role(:trusted).where("last_moderation_notification < ?", 28.hours.ago)
       return if available_moderators.empty?
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -27,6 +27,7 @@ class Notification < ApplicationRecord
     handle_asynchronously :send_new_follower_notification
 
     def send_to_followers(notifiable, action = nil)
+      # most often, notifiable = article, action = "Published"
       # followers is an array and not an activerecord object
       notifiable.user.followers.sort_by(&:updated_at).reverse[0..10000].each do |follower|
         json_data = {

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -193,19 +193,19 @@ class Notification < ApplicationRecord
     end
     handle_asynchronously :send_moderation_notification
 
-    def send_tag_adjustment_notification(notifiable)
-      article = notifiable.article
+    def send_tag_adjustment_notification(tag_adjustment)
+      article = tag_adjustment.article
       json_data = {
         article: { title: article.title, path: article.path },
-        adjustment_type: notifiable.adjustment_type,
-        status: notifiable.status,
-        reason_for_adjustment: notifiable.reason_for_adjustment,
-        tag_name: notifiable.tag_name
+        adjustment_type: tag_adjustment.adjustment_type,
+        status: tag_adjustment.status,
+        reason_for_adjustment: tag_adjustment.reason_for_adjustment,
+        tag_name: tag_adjustment.tag_name
       }
       Notification.create(
         user_id: article.user_id,
-        notifiable_id: notifiable.id,
-        notifiable_type: notifiable.class.name,
+        notifiable_id: tag_adjustment.id,
+        notifiable_type: tag_adjustment.class.name,
         json_data: json_data,
       )
       article.user.update_column(:last_moderation_notification, Time.current)

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -134,15 +134,15 @@ class Notification < ApplicationRecord
     end
     handle_asynchronously :send_reaction_notification
 
-    def send_mention_notification(notifiable)
-      mentioner = notifiable.mentionable.user
+    def send_mention_notification(mention)
+      mentioner = mention.mentionable.user
       json_data = {
         user: user_data(mentioner)
       }
-      json_data[:comment] = comment_data(notifiable.mentionable) if notifiable.mentionable_type == "Comment"
+      json_data[:comment] = comment_data(mention.mentionable) if mention.mentionable_type == "Comment"
       Notification.create(
-        user_id: notifiable.user_id,
-        notifiable_id: notifiable.id,
+        user_id: mention.user_id,
+        notifiable_id: mention.id,
         notifiable_type: "Mention",
         action: nil,
         json_data: json_data,

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -68,22 +68,22 @@ class Notification < ApplicationRecord
     end
     handle_asynchronously :send_new_comment_notifications
 
-    def send_new_badge_notification(notifiable)
+    def send_new_badge_notification(badge_achievement)
       json_data = {
-        user: user_data(notifiable.user),
+        user: user_data(badge_achievement.user),
         badge_achievement: {
-          badge_id: notifiable.badge_id,
-          rewarding_context_message: notifiable.rewarding_context_message,
+          badge_id: badge_achievement.badge_id,
+          rewarding_context_message: badge_achievement.rewarding_context_message,
           badge: {
-            title: notifiable.badge.title,
-            description: notifiable.badge.description,
-            badge_image_url: notifiable.badge.badge_image_url
+            title: badge_achievement.badge.title,
+            description: badge_achievement.badge.description,
+            badge_image_url: badge_achievement.badge.badge_image_url
           }
         }
       }
       Notification.create(
-        user_id: notifiable.user.id,
-        notifiable_id: notifiable.id,
+        user_id: badge_achievement.user.id,
+        notifiable_id: badge_achievement.id,
         notifiable_type: "BadgeAchievement",
         action: nil,
         json_data: json_data,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
I renamed the arguments for each method for clarity. I think it's up for debate whether or not it makes the code clearer.

Personally, I think `notifiable` is unnecessarily vague in these scenarios, and think that the new argument names make more sense.