### PR TITLE
Activate eslint-plugin-jsx-a11y

### DIFF
--- a/app/javascript/.eslintrc.js
+++ b/app/javascript/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
   parser: 'babel-eslint',
-  extends: ['airbnb', 'prettier'],
+  extends: ['airbnb', 'prettier', 'plugin:jsx-a11y/recommended'],
   parserOptions: {
     ecmaVersion: 2017,
   },
@@ -13,7 +13,7 @@ module.exports = {
     jest: true,
     browser: true,
   },
-  plugins: ['import'],
+  plugins: ['import', 'jsx-a11y'],
   rules: {
     'import/no-extraneous-dependencies': [
       'error',


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

After wanting to try [eslint-plugin-jsx-a11y](https://github.com/evcohen/eslint-plugin-jsx-a11y) I ran dev.to through the [web version of Lighthouse](https://web.dev/measure) and gotten this score:

![screenshot_2019-01-30 measure web dev](https://user-images.githubusercontent.com/146201/51985093-579ec880-249d-11e9-9521-78617f57ccda.png)

You can see the report here https://lighthouse-dot-webdotdevsite.appspot.com/lh/html?url=https://dev.to

I then noticed the plugin had been already installed but not activated. So I've enabled it.

There might be a reason why it was kept off. Worst case this is a useless PR :D

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
