### PR TITLE
Frontend Profile fields match backend maxlength

### DIFF
--- a/app/views/users/_profile.html.erb
+++ b/app/views/users/_profile.html.erb
@@ -60,7 +60,7 @@
   </div>
   <div class="field">
     <%= f.label :website_url %>
-    <%= f.url_field :website_url, maxlength: 64, placeholder: "http://yoursite.com" %>
+    <%= f.url_field :website_url, maxlength: 100, placeholder: "http://yoursite.com" %>
   </div>
   <div class="field">
     <%= f.label :summary %>
@@ -78,39 +78,39 @@
   </div>
   <div class="field">
     <%= f.label :location %>
-    <%= f.text_field :location, maxlength: 64 %>
+    <%= f.text_field :location, maxlength: 100 %>
   </div>
   <div class="field">
     <%= f.label :education %>
-    <%= f.text_field :education, maxlength: 64 %>
+    <%= f.text_field :education, maxlength: 100 %>
   </div>
   <div class="field">
     <%= f.label :employer_name %>
-    <%= f.text_field :employer_name, maxlength: 64 %>
+    <%= f.text_field :employer_name, maxlength: 100 %>
   </div>
   <div class="field">
     <%= f.label :employer_url, "Employer URL" %>
-    <%= f.text_field :employer_url, maxlength: 64 %>
+    <%= f.text_field :employer_url, maxlength: 100 %>
   </div>
   <div class="field">
     <%= f.label :employment_title %>
-    <%= f.text_field :employment_title, maxlength: 64 %>
+    <%= f.text_field :employment_title, maxlength: 100 %>
   </div>
   <div class="field">
     <%= f.label :mostly_work_with, "Skills/Languages" %>
-    <%= f.text_area :mostly_work_with, placeholder: "What tools and languages are you most experienced with? are you specialized or more of a generalist?", maxlength: 640 %>
+    <%= f.text_area :mostly_work_with, placeholder: "What tools and languages are you most experienced with? are you specialized or more of a generalist?", maxlength: 500 %>
   </div>
   <div class="field">
     <%= f.label :currently_learning, "I'm getting into" %>
-    <%= f.text_area :currently_learning, placeholder: "What are you learning right now? what are the new tools and languages you're picking up in #{Time.new.year}?", maxlength: 640 %>
+    <%= f.text_area :currently_learning, placeholder: "What are you learning right now? what are the new tools and languages you're picking up in #{Time.new.year}?", maxlength: 500 %>
   </div>
   <div class="field">
     <%= f.label :currently_hacking_on, "My projects and hacks" %>
-    <%= f.text_area :currently_hacking_on, placeholder: "What projects are currently occupying most of your time?", maxlength: 640 %>
+    <%= f.text_area :currently_hacking_on, placeholder: "What projects are currently occupying most of your time?", maxlength: 500 %>
   </div>
   <div class="field">
     <%= f.label :available_for %>
-    <%= f.text_area :available_for, placeholder: "What kinds of collaborations or discussions are you available for? what's a good reason to say hey to you these days?", maxlength: 640 %>
+    <%= f.text_area :available_for, placeholder: "What kinds of collaborations or discussions are you available for? what's a good reason to say hey to you these days?", maxlength: 500 %>
   </div>
   <p><strong>Links</strong></p>
   <div class="field">


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

Currently, the frontend Profile fields do not match the maxlength imposed by the backend. This can lead to the form being submitted with an invalid value (`mostly_work_with`, `currently_learning`, `currently_hacking_on`, `available_for`). The other fields were also updated for consistency's sake.

## Related Tickets & Documents
Related: https://github.com/thepracticaldev/dev.to/issues/763

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed