### PR TITLE
Fix ActiveRecord::RecordNotFound in Delayed::Jobs on article destroy #1621

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,0 +1,7 @@
+class ApplicationJob < ActiveJob::Base
+  # Automatically retry jobs that encountered a deadlock
+  # retry_on ActiveRecord::Deadlocked
+
+  # Most jobs are safe to ignore if the underlying records are no longer available
+  # discard_on ActiveJob::DeserializationError
+end

--- a/app/jobs/articles/resave_job.rb
+++ b/app/jobs/articles/resave_job.rb
@@ -1,0 +1,14 @@
+module Articles
+  class ResaveJob < ApplicationJob
+    queue_as :articles_resave
+
+    def perform(article_ids)
+      cache_buster = CacheBuster.new
+      Article.where(id: article_ids).find_each do |article|
+        cache_buster.bust(article.path)
+        cache_buster.bust(article.path + "?i=i")
+        article.save
+      end
+    end
+  end
+end

--- a/app/jobs/articles/resave_job.rb
+++ b/app/jobs/articles/resave_job.rb
@@ -2,8 +2,7 @@ module Articles
   class ResaveJob < ApplicationJob
     queue_as :articles_resave
 
-    def perform(article_ids)
-      cache_buster = CacheBuster.new
+    def perform(article_ids, cache_buster = CacheBuster.new)
       Article.where(id: article_ids).find_each do |article|
         cache_buster.bust(article.path)
         cache_buster.bust(article.path + "?i=i")

--- a/app/jobs/articles/score_calc_job.rb
+++ b/app/jobs/articles/score_calc_job.rb
@@ -1,0 +1,15 @@
+module Articles
+  class ScoreCalcJob < ApplicationJob
+    queue_as :articles_score_calc
+
+    def perform(article_id)
+      article = Article.find_by(id: article_id)
+      return unless article
+
+      article.update_columns(score: article.reactions.sum(:points),
+                             hotness_score: BlackBox.article_hotness_score(article),
+                             spaminess_rating: BlackBox.calculate_spaminess(article))
+      article.index! if article.tag_list.exclude?("hiring")
+    end
+  end
+end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -77,6 +77,16 @@ class Organization < ApplicationRecord
     SecureRandom.hex(50)
   end
 
+  # TODO: remove the unused method
+  def resave_articles
+    cache_buster = CacheBuster.new
+    articles.find_each do |article|
+      cache_buster.bust(article.path)
+      cache_buster.bust(article.path + "?i=i")
+      article.save
+    end
+  end
+
   def approved_and_filled_out_cta?
     cta_processed_html?
   end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -77,15 +77,6 @@ class Organization < ApplicationRecord
     SecureRandom.hex(50)
   end
 
-  def resave_articles
-    cache_buster = CacheBuster.new
-    articles.find_each do |article|
-      cache_buster.bust(article.path)
-      cache_buster.bust(article.path + "?i=i")
-      article.save
-    end
-  end
-
   def approved_and_filled_out_cta?
     cta_processed_html?
   end

--- a/spec/jobs/articles/resave_job_spec.rb
+++ b/spec/jobs/articles/resave_job_spec.rb
@@ -8,5 +8,17 @@ RSpec.describe Articles::ResaveJob, type: :job do
         Articles::ResaveJob.perform_later([1, 2])
       end.to have_enqueued_job.with([1, 2]).on_queue("articles_resave")
     end
+
+    it "busts cache" do
+      article = create(:article)
+      path = article.path
+
+      cache_buster = double
+      allow(cache_buster).to receive(:bust)
+
+      Articles::ResaveJob.perform_now([article.id], cache_buster)
+      expect(cache_buster).to have_received(:bust).with(path).once
+      expect(cache_buster).to have_received(:bust).with(path + "?i=i").once
+    end
   end
 end

--- a/spec/jobs/articles/resave_job_spec.rb
+++ b/spec/jobs/articles/resave_job_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+RSpec.describe Articles::ResaveJob, type: :job do
+  describe "#perform_later" do
+    it "enqueues the job" do
+      ActiveJob::Base.queue_adapter = :test
+      expect do
+        Articles::ResaveJob.perform_later([1, 2])
+      end.to have_enqueued_job.with([1, 2]).on_queue("articles_resave")
+    end
+  end
+end

--- a/spec/jobs/articles/resave_job_spec.rb
+++ b/spec/jobs/articles/resave_job_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Articles::ResaveJob, type: :job do
     it "enqueues the job" do
       ActiveJob::Base.queue_adapter = :test
       expect do
-        Articles::ResaveJob.perform_later([1, 2])
+        described_class.perform_later([1, 2])
       end.to have_enqueued_job.with([1, 2]).on_queue("articles_resave")
     end
 
@@ -16,7 +16,7 @@ RSpec.describe Articles::ResaveJob, type: :job do
       cache_buster = double
       allow(cache_buster).to receive(:bust)
 
-      Articles::ResaveJob.perform_now([article.id], cache_buster)
+      described_class.perform_now([article.id], cache_buster)
       expect(cache_buster).to have_received(:bust).with(path).once
       expect(cache_buster).to have_received(:bust).with(path + "?i=i").once
     end

--- a/spec/jobs/articles/score_calc_job_spec.rb
+++ b/spec/jobs/articles/score_calc_job_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Articles::ScoreCalcJob, type: :job do
     it "enqueues the job" do
       ActiveJob::Base.queue_adapter = :test
       expect do
-        Articles::ScoreCalcJob.perform_later(1)
+        described_class.perform_later(1)
       end.to have_enqueued_job.with(1).on_queue("articles_score_calc")
     end
   end

--- a/spec/jobs/articles/score_calc_job_spec.rb
+++ b/spec/jobs/articles/score_calc_job_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+RSpec.describe Articles::ScoreCalcJob, type: :job do
+  describe "#perform_later" do
+    it "enqueues the job" do
+      ActiveJob::Base.queue_adapter = :test
+      expect do
+        Articles::ScoreCalcJob.perform_later(1)
+      end.to have_enqueued_job.with(1).on_queue("articles_score_calc")
+    end
+  end
+end

--- a/spec/models/article_destroy_spec.rb
+++ b/spec/models/article_destroy_spec.rb
@@ -15,9 +15,8 @@ RSpec.describe Article, type: :model do
     before { create(:reaction, reactable: article) }
 
     it "doesn't create ScoreCalcJob on destroy" do
-      expect do
-        article.destroy
-      end.not_to change(Delayed::Job.where(queue: "articles_score_calc"), :count)
+      allow(Articles::ScoreCalcJob).to receive(:perform_later)
+      expect(Articles::ScoreCalcJob).not_to have_received(:perform_later)
     end
   end
 
@@ -27,6 +26,7 @@ RSpec.describe Article, type: :model do
     let!(:another_article) { create(:article, organization: organization) }
 
     it "creates Articles::ResaveJob for organization articles on destroy" do
+      allow(Articles::ResaveJob).to receive(:perform_later)
       article.destroy
       expect(Articles::ResaveJob).to have_received(:perform_later).with([another_article.id])
     end

--- a/spec/models/article_destroy_spec.rb
+++ b/spec/models/article_destroy_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe Article, type: :model do
+  before do
+    Delayed::Worker.delay_jobs = true
+  end
+
+  after do
+    Delayed::Worker.delay_jobs = false
+  end
+
+  context "when no organization" do
+    let(:article) { create(:article) }
+
+    before { create(:reaction, reactable: article) }
+
+    it "doesn't create ScoreCalcJob on destroy" do
+      expect do
+        article.destroy
+      end.not_to change(Delayed::Job.where(queue: "articles_score_calc"), :count)
+    end
+  end
+
+  context "with organization" do
+    let(:organization) { create(:organization) }
+    let!(:article) { create(:article, organization: organization) }
+    let!(:another_article) { create(:article, organization: organization) }
+
+    it "creates Articles::ResaveJob for organization articles on destroy" do
+      article.destroy
+      expect(Articles::ResaveJob).to have_received(:perform_later).with([another_article.id])
+    end
+  end
+end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -432,12 +432,16 @@ RSpec.describe Article, type: :model do
 
       it "updates the hotness score" do
         run_background_jobs_immediately { article.save }
+        article.reload
         expect(article.hotness_score > 0).to eq(true)
       end
 
       it "updates the spaminess score" do
         article.spaminess_rating = -1
         run_background_jobs_immediately { article.save }
+        article.update_column(:spaminess_rating, -1)
+        article.save
+        article.reload
         expect(article.spaminess_rating).to eq(0)
       end
     end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -428,20 +428,19 @@ RSpec.describe Article, type: :model do
 
   describe "#async_score_calc" do
     context "when published" do
+      before { ActiveJob::Base.queue_adapter = :inline }
+
       let(:article) { build(:article) }
 
       it "updates the hotness score" do
-        run_background_jobs_immediately { article.save }
+        article.save
         article.reload
         expect(article.hotness_score > 0).to eq(true)
       end
 
       it "updates the spaminess score" do
         article.spaminess_rating = -1
-        run_background_jobs_immediately { article.save }
-        article.update_column(:spaminess_rating, -1)
         article.save
-        article.reload
         expect(article.spaminess_rating).to eq(0)
       end
     end

--- a/spec/models/reaction_destroy_spec.rb
+++ b/spec/models/reaction_destroy_spec.rb
@@ -4,17 +4,8 @@ RSpec.describe Reaction, type: :model do
   let(:article) { create(:article, featured: true) }
   let!(:reaction) { build(:reaction, reactable: article) }
 
-  before do
-    Delayed::Worker.delay_jobs = true
-  end
-
-  after do
-    Delayed::Worker.delay_jobs = false
-  end
-
   it "creates a ScoreCalcJob on article reaction destroy" do
-    expect do
-      reaction.destroy
-    end.to change(Delayed::Job.where(queue: "articles_score_calc"), :count).by(1)
+    ActiveJob::Base.queue_adapter = :test
+    expect { reaction.destroy }.to have_enqueued_job(Articles::ScoreCalcJob).exactly(:once)
   end
 end

--- a/spec/models/reaction_destroy_spec.rb
+++ b/spec/models/reaction_destroy_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe Reaction, type: :model do
+  let(:article) { create(:article, featured: true) }
+  let(:reaction) { build(:reaction, reactable: article) }
+
+  before do
+    Delayed::Worker.delay_jobs = true
+  end
+
+  after do
+    Delayed::Worker.delay_jobs = false
+  end
+
+  it "creates a ScoreCalcJob on article reaction destroy" do
+    expect do
+      reaction.destroy
+    end.to change(Delayed::Job.where(queue: "articles_score_calc"), :count).by(1)
+  end
+end

--- a/spec/models/reaction_destroy_spec.rb
+++ b/spec/models/reaction_destroy_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Reaction, type: :model do
   let(:article) { create(:article, featured: true) }
-  let(:reaction) { build(:reaction, reactable: article) }
+  let!(:reaction) { build(:reaction, reactable: article) }
 
   before do
     Delayed::Worker.delay_jobs = true


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Bug Fix

## Description
- fixed `ActiveRecord::NotFound` issue for articles, on article destroy
- extracted ActiveJobs from article callbacks
- added specs for article and reaction deletions

## Related Tickets & Documents
#1621 