### PR TITLE
Fix bug where comment template is undefined instead of empty string

### DIFF
--- a/app/assets/javascripts/initializers/initializeCommentsPage.js.erb
+++ b/app/assets/javascripts/initializers/initializeCommentsPage.js.erb
@@ -222,7 +222,7 @@ function handleCommentSubmit(event) {
             mainCommentsForm.classList.remove("submitting");
             const textArea = document.getElementById("text-area");
             textArea.classList = "";
-            textArea.value = newComment.comment_template;
+            textArea.value = newComment.comment_template || "";
             var preview = document.getElementById("preview-div");
             preview.classList.add("preview-toggle");
             preview.innerHTML = "";


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

The `comment_template` can be undefined, resulting in the `undefined` string appearing as the default text of a new comment. It should be empty string when undefined.

Thanks to @aligoren for the catch!

## Related Tickets & Documents

Closes #1698

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
