### PR TITLE
Add default locale to i18n fallbacks

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -77,7 +77,7 @@ Rails.application.configure do
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
-  config.i18n.fallbacks = true
+  config.i18n.fallbacks = [I18n.default_locale]
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

Since the gem i18n hit v1.1.0 the configuration for `config.i18n.fallbacks = true` is not valid anymore and does not include the default locale as a fallback.

It should be a harmless change because dev.to AFAIK is not using the i18n fallback mechanism in the first place.

DEV is using [version 1.5.3](https://github.com/thepracticaldev/dev.to/blob/master/Gemfile.lock#L532)

I've noticed this, thanks to a `bundle install` post message:

```text
HEADS UP! i18n 1.1 changed fallbacks to exclude default locale.
But that may break your application.

Please check your Rails app for 'config.i18n.fallbacks = true'.
If you're using I18n (>= 1.1.0) and Rails (< 5.2.2), this should be
'config.i18n.fallbacks = [I18n.default_locale]'.
If not, fallbacks will be broken in your app by I18n 1.1.x.

For more info see:
https://github.com/svenfuchs/i18n/releases/tag/v1.1.0
```

## Related Tickets & Documents

See the [release notes for i18n 1.1.0](https://github.com/svenfuchs/i18n/releases/tag/v1.1.0)

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
