### PR TITLE
Fix long lines doesn't wrap bug for user profiles. #1710

### DIFF
--- a/app/assets/stylesheets/articles.scss
+++ b/app/assets/stylesheets/articles.scss
@@ -1076,6 +1076,7 @@
         font-size:0.9em;
         line-height: 1.2em;
         padding-bottom:5px;
+        overflow-wrap: break-word;
         &.body-scrollable{
           height: calc(100vh - 300px);
           max-height: 390px;


### PR DESCRIPTION


<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

 Long lines are getting cut off on the left sidebar for user profiles. @jessleenyc  Also caught it.

## Related Tickets & Documents

Closed #1710

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Before

![sidebar1](https://user-images.githubusercontent.com/4205423/52167654-6dc3b780-272f-11e9-8dd7-3d48940d5aa7.png)

After

![sidebar2](https://user-images.githubusercontent.com/4205423/52167655-6dc3b780-272f-11e9-8435-e557f8865c1a.png)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
