### PR TITLE
Sometimes importing posts with gist from medium via RSS does not work

### DIFF
--- a/app/liquid_tags/gist_tag.rb
+++ b/app/liquid_tags/gist_tag.rb
@@ -29,7 +29,7 @@ class GistTag < LiquidTagBase
   def parse_link(link)
     link = ActionController::Base.helpers.strip_tags(link)
     input_no_space = link.delete(" ").gsub(".js", "")
-    if valid_link?(link)
+    if valid_link?(input_no_space)
       input_no_space
     else
       raise StandardError,
@@ -38,7 +38,7 @@ class GistTag < LiquidTagBase
   end
 
   def valid_link?(link)
-    (link =~ /\Ahttps\:\/\/gist\.github\.com\/([a-zA-Z0-9\-]){1,39}\/([a-zA-Z0-9]){32}\s\Z/)&.
+    (link =~ /\Ahttps\:\/\/gist\.github\.com\/([a-zA-Z0-9\-]){1,39}\/([a-zA-Z0-9]){32}\Z/)&.
       zero?
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
Using the RSS feed URL from my Medium account does not import my published posts (my feed: https://medium.com/feed/@jpachitas). While running the dev.to project locally, I managed to find the error by reading the logs and it seems to be a problem with a Gist: the URL is not valid (although using the same URL inside a Liquid tag, it appears in a post).

I fixed this by changing the regex inside the `valid_link?` method on `gist_tag.rb` and by passing the `input_no_space` variable as an argument of `valid_link?`. The current regex requires that the link has a space in the end and no file extensions, something that the link used for the validation has.

Why was the `link` variable used as an argument of `valid_link?` and not `input_no_space` and why does the regex requires that the string must have a space at the end? 

## Related Tickets & Documents

None

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

None
## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed