### PR TITLE
The issue 'Styling of Edit Post button on your own post' fixed. Close…

### DIFF
--- a/app/assets/stylesheets/article-show.scss
+++ b/app/assets/stylesheets/article-show.scss
@@ -219,11 +219,11 @@ article{
           line-height:1.1em;
           font-family: $helvetica-condensed;
           font-stretch:condensed;
-          @media screen and ( max-width: 340px ){
+          @media screen and ( max-width: 376px ){
             padding:2px 3px 3px;
             margin-left:3px;
             margin-left:5px;
-            margin-top: 10px;
+            margin-top: 5px;
             .post-word{
               display:none;
             }

--- a/app/assets/stylesheets/article-show.scss
+++ b/app/assets/stylesheets/article-show.scss
@@ -223,6 +223,7 @@ article{
             padding:2px 3px 3px;
             margin-left:3px;
             margin-left:5px;
+            margin-top: 10px;
             .post-word{
               display:none;
             }


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

@sarthology opened an issue 

>  In all the devices, below the size of _475px_, the *Edit Post" button have every small top margin.

I added a margin-top value into media query of action-space like below

```css
@media screen and ( max-width: 340px ){
     padding:2px 3px 3px;
     margin-left:3px;
     margin-left:5px;
     margin-top: 10px;
     .post-word{
         display:none;
    }
}
```

If this isn't enough, I can change. But looks enought.

## Related Tickets & Documents

Closed #1740

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

### Before

![before_fix](https://user-images.githubusercontent.com/4205423/52353904-83432500-2a40-11e9-89a7-4e73eef0b11f.png)

### After

![after_fix](https://user-images.githubusercontent.com/4205423/52353913-89390600-2a40-11e9-8b94-ef9b13edb2fd.png)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
