### PR TITLE
Ping comments to pre-warm new comment trees

### DIFF
--- a/app/assets/javascripts/initializers/initializeCommentsPage.js.erb
+++ b/app/assets/javascripts/initializers/initializeCommentsPage.js.erb
@@ -166,6 +166,11 @@ function replaceActionButts(el) {
   wrapper.innerHTML = '<span class="current-user-actions">' + loggedInActionButts + '</span><a href="#" class="toggle-reply-form">REPLY</a>';
 }
 
+function warmNewCommentsArea() {
+  var path = '/stories/warm_comments'+ window.location.pathname
+  window.fetch(path)
+}
+
 function handleCommentSubmit(event) {
   event.preventDefault();
   var form = event.target;
@@ -237,6 +242,7 @@ function handleCommentSubmit(event) {
           else {
             window.location.replace(newComment.url)
           }
+          warmNewCommentsArea();
           initializeCommentsPage();
           initializeCommentDropdown();
         })

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -31,6 +31,13 @@ class StoriesController < ApplicationController
     end
   end
 
+  def warm_comments
+    @article = Article.find_by_path("/#{params[:username].downcase}/#{params[:slug]}")&.decorate || not_found
+    @warm_only = true
+    assign_article_show_variables
+    render partial: "articles/full_comment_area"
+  end
+
   private
 
   def redirect_to_changed_username_profile
@@ -195,6 +202,15 @@ class StoriesController < ApplicationController
   end
 
   def handle_article_show
+    assign_article_show_variables
+    set_surrogate_key_header @article.record_key
+    redirect_if_show_view_param
+    return if performed?
+
+    render template: "articles/show"
+  end
+
+  def assign_article_show_variables
     @article_show = true
     @variant_number = params[:variant_version] || rand(2)
     assign_user_and_org
@@ -202,11 +218,6 @@ class StoriesController < ApplicationController
     assign_second_and_third_user
     not_found if permission_denied?
     @comment = Comment.new(body_markdown: @article&.comment_template)
-    set_surrogate_key_header @article.record_key
-    redirect_if_show_view_param
-    return if performed?
-
-    render template: "articles/show"
   end
 
   def permission_denied?

--- a/app/views/articles/_full_comment_area.html.erb
+++ b/app/views/articles/_full_comment_area.html.erb
@@ -1,0 +1,29 @@
+<% cache("whole-comment-area-#{@article.id}-#{@article.last_comment_at}-#{@article.show_comments}", :expires_in => 2.hours) do %>
+  <div id="comments" style="margin-top: -56px;padding-bottom:56px;position:relative;z-index:-100" data-updated-at="<%= Time.current %>"></div>
+  <% if @article.show_comments%>
+    <div class="comments-container-container">
+      <div
+        class="comments-container"
+        id="comments-container"
+        data-commentable-id="<%= @article.id %>"
+        data-commentable-type="Article">
+        <%= render "/comments/form",
+            commentable: @article,
+            commentable_type: "Article" %>
+        <div class="comment-trees" id="comment-trees-container">
+          <% if @article.comments_count > 0  %>
+            <% Comment.rooted_on(@article.id, "Article").order("score DESC").limit(@comments_to_show_count).each_with_index do |comment, i| %>
+              <% cache ["comment_root_cached_tree", comment] do %>
+                <%= tree_for(comment, @article) %>
+              <% end %>
+            <% end %>
+          <% end %>
+        </div>
+      </div>
+      <div class="show-comments-footer">
+        <%= render 'articles/comments_actions' %>
+      </div>
+    </div>
+  <% end %>
+<% end %>
+<% return if @warm_only %>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -178,34 +178,7 @@
       <% end %>
     <% end %>
     <%= render 'articles/org_branding', organization: @organization %>
-    <% cache("whole-comment-area-#{@article.id}-#{@article.last_comment_at}-#{@article.show_comments}", :expires_in => 2.hours) do %>
-      <div id="comments" style="margin-top: -56px;padding-bottom:56px;position:relative;z-index:-100" data-updated-at="<%= Time.current %>"></div>
-      <% if @article.show_comments%>
-        <div class="comments-container-container">
-          <div
-            class="comments-container"
-            id="comments-container"
-            data-commentable-id="<%= @article.id %>"
-            data-commentable-type="Article">
-            <%= render "/comments/form",
-                commentable: @article,
-                commentable_type: "Article" %>
-            <div class="comment-trees" id="comment-trees-container">
-              <% if @article.comments_count > 0  %>
-                <% Comment.rooted_on(@article.id, "Article").order("score DESC").limit(@comments_to_show_count).each_with_index do |comment, i| %>
-                  <% cache ["comment_root_cached_tree", comment] do %>
-                    <%= tree_for(comment, @article) %>
-                  <% end %>
-                <% end %>
-              <% end %>
-            </div>
-          </div>
-          <div class="show-comments-footer">
-            <%= render 'articles/comments_actions' %>
-          </div>
-        </div>
-      <% end %>
-    <% end %>
+    <%= render 'articles/full_comment_area' %>
   </div>
   <% cache("article-bottom-content-#{@article.cached_tag_list_array.sample}", :expires_in => 18.hours) do %>
     <% @classic_article = Suggester::Articles::Classic.new(@article).get.first %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -221,6 +221,7 @@ Rails.application.routes.draw do
   get "/search" => "stories#search"
   post "articles/preview" => "articles#preview"
   post "comments/preview" => "comments#preview"
+  get "/stories/warm_comments/:username/:slug" => "stories#warm_comments"
   get "/freestickers" => "giveaways#new"
   get "/freestickers/edit" => "giveaways#edit"
   get "/scholarship", to: redirect("/p/scholarships")


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
This may be a bit hacky but it will have a pretty immediate impact on cold response times for articles and doesn't make the code less clean.

Basically this pings for a fresh comment tree once a comment is created, triggering a newly warmed cache of the comment section which will be available for subsequent renders of the page. This should eliminate a good deal of variability in the response for an article page.