### PR TITLE
Make Spotify and generic Liquid tags more strict

### DIFF
--- a/app/liquid_tags/null_tag.rb
+++ b/app/liquid_tags/null_tag.rb
@@ -4,7 +4,7 @@ class NullTag < Liquid::Block
   end
 end
 
-disabled_tags = %w(assign capture case comment cycle for if ifchanged include unless)
+disabled_tags = %w(assign break capture case comment cycle decrement for if ifchanged include increment unless tablerow)
 
 disabled_tags.each do |tag|
   Liquid::Template.register_tag(tag, NullTag)

--- a/app/liquid_tags/spotify_tag.rb
+++ b/app/liquid_tags/spotify_tag.rb
@@ -1,5 +1,5 @@
 class SpotifyTag < LiquidTagBase
-  URI_REGEXP = /spotify:(track|user|artist|album|episode).+(?<=:)\w{22}/.freeze
+  URI_REGEXP = /spotify:(track|user|artist|album|episode):\w{22}/.freeze
   TYPE_HEIGHT = {
     track: 80,
     user: 330,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This makes the Spotify regex more strict, and disables a few other Liquid tags from being used.