### PR TITLE
Set default colors for organizations

### DIFF
--- a/app/views/users/_org_non_member.html.erb
+++ b/app/views/users/_org_non_member.html.erb
@@ -11,7 +11,7 @@
     <%= submit_tag "Join Organization" %>
   </div>
 <% end %>
-<br/><br/>
+<br /><br />
 <hr class="settings-hr" />
 <h3><em>Or</em> Create An Organization</h3>
 <sub><em>Starred fields are required</em></sub>
@@ -35,16 +35,16 @@
     <%= f.text_field :twitter_username %>
   </div>
   <div class="field">
-    <%= f.label :github_username, "Github Username"%>
+    <%= f.label :github_username, "Github Username" %>
     <%= f.text_field :github_username %>
   </div>
   <div class="field">
-    <%= f.label :text_color_hex, "Text color (hex)"%>
-    <%= text_field_tag "organization[text_color_hex]", nil, placeholder: "Click for color picker", class: "jscolor {hash:true, required:false}" %>
+    <%= f.label :text_color_hex, "Text color (hex)" %>
+    <%= text_field_tag "organization[text_color_hex]", "#000000", placeholder: "Click for color picker", class: "jscolor {hash:true, required:false}" %>
   </div>
   <div class="field">
-    <%= f.label :bg_color_hex, "Background color (hex)"%>
-    <%= text_field_tag "organization[bg_color_hex]", nil, placeholder: "Click for color picker", class: "jscolor {hash:true, required:false}" %>
+    <%= f.label :bg_color_hex, "Background color (hex)" %>
+    <%= text_field_tag "organization[bg_color_hex]", "#FFFFFF", placeholder: "Click for color picker", class: "jscolor {hash:true, required:false}" %>
   </div>
   <div class="field">
     <%= f.label :url, "Website url *" %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Documentation Update

## Description
The default colors of white background and black text have been set for organizations.  This prevents a bug from occurring the stopped users from being able to preview posts.
## Related Tickets & Documents
#1705 
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![image](https://user-images.githubusercontent.com/32000565/52454298-3ed78800-2b19-11e9-8b77-b564333a208f.png)

![image](https://user-images.githubusercontent.com/32000565/52454305-46972c80-2b19-11e9-8769-d9ea83848eb8.png)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed