### PR TITLE
Include Article ID in Bottom Content Cache Key 

### DIFF
--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -180,7 +180,7 @@
     <%= render 'articles/org_branding', organization: @organization %>
     <%= render 'articles/full_comment_area' %>
   </div>
-  <% cache("article-bottom-content-#{@article.cached_tag_list_array.sample}-#{@article.id}", :expires_in => 18.hours) do %>
+  <% cache("article-bottom-content-#{@article.id}", :expires_in => 18.hours) do %>
     <% @classic_article = Suggester::Articles::Classic.new(@article, not_ids: [@article.id]).get.first %>
     <% if @classic_article %>
       <%= render "additional_content_boxes/article_box",

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -180,8 +180,8 @@
     <%= render 'articles/org_branding', organization: @organization %>
     <%= render 'articles/full_comment_area' %>
   </div>
-  <% cache("article-bottom-content-#{@article.cached_tag_list_array.sample}", :expires_in => 18.hours) do %>
-    <% @classic_article = Suggester::Articles::Classic.new(@article).get.first %>
+  <% cache("article-bottom-content-#{@article.cached_tag_list_array.sample}-#{@article.id}", :expires_in => 18.hours) do %>
+    <% @classic_article = Suggester::Articles::Classic.new(@article, not_ids: [@article.id]).get.first %>
     <% if @classic_article %>
       <%= render "additional_content_boxes/article_box",
         article: @classic_article,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
If the additional bottom content on the Article show page is being stored under a cache key that is created only using an article's tags, then one could end up seeing a suggested article on the actual article page itself if the tags were the same as a previous article that was viewed. This does mean the cache will be reused less since it is article specific which will affect performance. I am not sure how often this cache is hit across different articles, but that is something to consider.

I also added the article ID to the list of `:not_ids` for grabbing the `@classic_article`

I did read the contributing guidelines about adding specs around bug fixes, but since none of the cacheing I saw was tested in the specs and because I could not come up with a good clean test I choose to forgo it. If you determine tests are needed let me know and I can close the PR and reopen after they are added.

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/issues/1697

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
N/A

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## What gif best describes this PR or how it makes you feel?
Something something, first one is always the worst no matter how many times you have contributed to other repos.... 
![](https://media.giphy.com/media/7zxglTM4sjy9y/giphy.gif)
