### PR TITLE
Added GitHub PR liquid tag support

### DIFF
--- a/app/liquid_tags/github_tag.rb
+++ b/app/liquid_tags/github_tag.rb
@@ -8,7 +8,7 @@ class GithubTag < LiquidTagBase
   end
 
   def issue_or_readme
-    if @link.include?("issues")
+    if @link.include?("issues") || @link.include?("pull")
       "issue"
     else
       "readme"

--- a/app/models/github_issue.rb
+++ b/app/models/github_issue.rb
@@ -20,7 +20,7 @@ class GithubIssue < ApplicationRecord
     client = Octokit::Client.new(access_token: random_token)
     issue = GithubIssue.new(url: url)
     if !!(url !~ /\/issues\/comments/)
-      repo, issue_id = url.gsub(/.*github\.com\/repos\//, "").split("/issues/")
+      repo, issue_id = url.gsub(/.*github\.com\/repos\//, "").split(issue_or_pull(url))
       issue.issue_serialized = get_issue_serialized(client, repo, issue_id)
       issue.category = "issue"
     else
@@ -54,6 +54,14 @@ class GithubIssue < ApplicationRecord
       Identity.where(provider: "github").last(250).sample
     else
       Identity.where(provider: "github").last
+    end
+  end
+
+  def self.issue_or_pull(url)
+    if !url.include?("pull")
+      "/issues/"
+    else
+      "/pull/"
     end
   end
 end

--- a/app/views/pages/_editor_guide_text.html.erb
+++ b/app/views/pages/_editor_guide_text.html.erb
@@ -105,8 +105,8 @@
     <p>All you need is the GitHub username and repo:</p>
     <code>{% github thepracticaldev/dev.to %}</code>
 
-    <h3><strong>GitHub Issue or Comment Embed</strong></h3>
-    <p>All you need is the GitHub issue or comment URL:</p>
+    <h3><strong>GitHub Issue, Pull request or Comment Embed</strong></h3>
+    <p>All you need is the GitHub issue, PR or comment URL:</p>
     <code>{% github https://github.com/thepracticaldev/dev.to/issues/9 %}</code>
 
     <h3><strong>GitHub Gist Embed</strong></h3>

--- a/app/views/pages/_editor_guide_text.html.erb
+++ b/app/views/pages/_editor_guide_text.html.erb
@@ -72,32 +72,32 @@
     <dl>
       <dt><code>app</code></dt>
       <dd>
-        Shows the app preview without the code.<br/>
+        Shows the app preview without the code.<br>
         <code>{% glitch earthy-course app %}</code>
       </dd>
       <dt><code>code</code></dt>
       <dd>
-        Shows the code without the app preview.<br/>
+        Shows the code without the app preview.<br>
         <code>{% glitch earthy-course code %}</code>
       </dd>
       <dt><code>preview-first</code></dt>
       <dd>
-        Hides the file browser.<br/>
+        Hides the file browser.<br>
         <code>{% glitch earthy-course preview-first %}</code>
       </dd>
       <dt><code>no-attribution</code></dt>
       <dd>
-        Hides the file browser.<br/>
+        Hides the file browser.<br>
         <code>{% glitch earthy-course no-attribution %}</code>
       </dd>
       <dt><code>no-files</code></dt>
       <dd>
-        Hides the file browser.<br/>
+        Hides the file browser.<br>
         <code>{% glitch earthy-course no-files %}</code>
       </dd>
       <dt><code>file</code></dt>
       <dd>
-        Lets you choose which file to display in the code panel. Defaults to index.html.<br/>
+        Lets you choose which file to display in the code panel. Defaults to index.html.<br>
         <code>{% glitch earthy-course file=script.js %}</code>
       </dd>
 
@@ -121,7 +121,7 @@
       <li><strong>YouTube:</strong> <code>{% youtube dQw4w9WgXcQ %}</code></li>
       <li><strong>Vimeo:</strong> <code>{% vimeo 193110695 %}</code></li>
     </ul>
-      
+
     <h3><strong>SlideShare Embed</strong></h3>
     <p>All you need is the SlideShare <code>key</code></p>
     <code>{% slideshare rdOzN9kr1yK5eE %}</code>
@@ -133,7 +133,7 @@
     <dl>
     <dt><code>default-tab</code></dt>
     <dd>
-      Add default-tab parameter to your CodePen embed tag. Default to <i>result</i><br/>
+      Add default-tab parameter to your CodePen embed tag. Default to <i>result</i><br>
       <code>{% codepen https://codepen.io/twhite96/pen/XKqrJX default-tab=js,result %}</code>
     </dd>
 
@@ -146,7 +146,7 @@
     <code>{% stackblitz ball-demo %}</code>
     <dt><code>Default view</code></dt>
     <dd>
-      You can change the default view, the options are <i>both</i>, <i>preview</i>, <i>editor</i>. Defaults to <i>both</i><br/>
+      You can change the default view, the options are <i>both</i>, <i>preview</i>, <i>editor</i>. Defaults to <i>both</i><br>
       <code>{% stackblitz ball-demo view=preview %}</code>
     </dd>
 
@@ -157,15 +157,15 @@
     <dl>
       <dt><code>initialpath</code></dt>
       <dd>
-        Which url to initially load in address bar.<br/>
+        Which url to initially load in address bar.<br>
         <code>{% codesandbox ppxnl191zx initialpath=/initial/load/path %}</code>
       </dd>
       <dt><code>module</code></dt>
       <dd>
-        Which module to open by default.<br/>
+        Which module to open by default.<br>
         <code>{% codesandbox ppxnl191zx module=/path/to/module %}</code>
       </dd>
-      
+
     <h3><strong>JSFiddle Embed</strong></h3>
     <p>All you need is the full JSFiddle <code>link</code>, ending in the fiddle ID code, as follows:</p>
     <code>{% jsfiddle https://jsfiddle.net/link2twenty/v2kx9jcd %}</code>
@@ -173,7 +173,7 @@
     <dl>
     <dt><code>Custom tabs</code></dt>
     <dd>
-      You can add a custom tab order to you JSFiddle embed tag. Defaults to <i>js,html,css,result</i><br/>
+      You can add a custom tab order to you JSFiddle embed tag. Defaults to <i>js,html,css,result</i><br>
       <code>{% jsfiddle https://jsfiddle.net/webdevem/Q8KVC result,html,css %}</code>
     </dd>
 
@@ -190,8 +190,8 @@
     <pre>
       <span style="color: gray;"># Given this embed link:</span>
       < script async class="speakerdeck-embed"
-      data-id="<span style="color: orange;">7e9f8c0fa0c949bd8025457181913fd0</span>"
-      data-ratio="1.77777777777778" src="//speakerdeck.com/assets/embed.js">< /script >
+            data-id="<span style='color: orange;'>7e9f8c0fa0c949bd8025457181913fd0</span>"
+            data-ratio="1.77777777777778" src="//speakerdeck.com/assets/embed.js">< /script >
     </pre>
     <pre>
       {% speakerdeck <span style="color: orange;">7e9f8c0fa0c949bd8025457181913fd0</span> %}
@@ -229,8 +229,8 @@
 
     <h4><a href="https://github.com/adam-p/markdown-here/wiki/Markdown-Here-Cheatsheet" target="_blank" rel="noopener">Here's the Markdown cheatsheet again for reference.</a></h4>
     Happy posting! 📝
-    <br/>
-    <br/>
+    <br>
+    <br>
     <div class="blank-space"></div>
   </div>
 </div>


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

Add support for Github pull request via liquid tags in markdown.
`{% github https://github.com/thepracticaldev/dev.to/pull/1633 %}`

My first time setting up a Ruby environment and actually developing in Ruby, so let me know if I should have done things differently.

I also fixed a couple of pre-commit errors, strange that the thrown errors where from parts that I didn't edit. So I assume that a lot of people skip the pre-commit check with `--no-verify`.
Anyways the only error I couldn't fix was this section because it would parse the html instead of showing it in the codeblock:
https://github.com/thepracticaldev/dev.to/blob/7c369facf183fb236f47333e0fe913e565b12d2a/app/views/pages/_editor_guide_text.html.erb#L192-L194

## Related Tickets & Documents

Closes #1760 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![Desktop](https://user-images.githubusercontent.com/11406433/52585069-18c12900-2e34-11e9-8dd3-878220c069fa.png)

## Added to documentation?

- [x] help tab in the markdown editor
- [ ] docs.dev.to
- [ ] readme
- [ ] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![THUMBS UP](https://media.giphy.com/media/1gqDQUaLe3mCc/giphy.gif)
