### PR TITLE
Add 'me' value to 'rel' tag on Mastodon URL on profile

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -47,7 +47,7 @@
             </a>
           <% end %>
           <% if @user.mastodon_url? %>
-            <a href="<%= @user.mastodon_url %>" target="_blank" rel="noopener">
+            <a href="<%= @user.mastodon_url %>" target="_blank" rel="noopener me">
               <%= inline_svg("mastodon-logo.svg", class:"icon-img") %>
             </a>
           <% end %>


### PR DESCRIPTION
Hi there! 👋 

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

Attempting my first contribution here. I noticed that when you set a Mastodon URL on your profile the link does not contain a `rel=me` attribute. This is required for Mastodon instances to recognize the link between instance and dev.to to be real. This should fix it.

## Related Tickets & Documents

None.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

No UI changes. Verify this feature by investigating the generated Mastodon URL from source.

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed (probably?)

## [optional] What gif best describes this PR or how it makes you feel?

![TOOT](https://media.giphy.com/media/5avZzXSxYSf7y/giphy.gif)
