### PR TITLE
Add profile_updated_at to banisher to clear cache key

### DIFF
--- a/app/services/moderator/banisher.rb
+++ b/app/services/moderator/banisher.rb
@@ -22,7 +22,7 @@ module Moderator
         new_name = "spam_#{rand(10000)}"
         new_username = "spam_#{rand(10000)}"
       end
-      user.update_columns(name: new_name, username: new_username, old_username: user.username)
+      user.update_columns(name: new_name, username: new_username, old_username: user.username, profile_updated_at: Time.current)
       CacheBuster.new.bust("/#{user.old_username}")
     end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
The profile page has a new cache key wrapping it. This changes updates the `profile_updated_at` as part of the last step of banishing.