### PR TITLE
Add more strict sanitization

### DIFF
--- a/app/liquid_tags/runkit_tag.rb
+++ b/app/liquid_tags/runkit_tag.rb
@@ -1,7 +1,7 @@
 class RunkitTag < Liquid::Block
   def initialize(tag_name, markup, tokens)
     super
-    @preamble = ActionView::Base.full_sanitizer.sanitize(markup, tags: [])
+    @preamble = sanitized_preamble(markup)
   end
 
   def render(context)
@@ -63,6 +63,16 @@ class RunkitTag < Liquid::Block
         }
       }, 200);
     JAVASCRIPT
+  end
+
+  def sanitized_preamble(markup)
+    raise StandardError, "Runkit tag is invalid" if markup.ends_with? "\">"
+
+    sanitized = ActionView::Base.full_sanitizer.sanitize(markup, tags: [])
+
+    raise StandardError, "Runkit tag is invalid" if markup.starts_with? "\""
+
+    sanitized
   end
 end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This sanitizes the Runkit tag inputs a bit more. The second argument should be safe for now.

In general, the Runkit tag has other bugs, and the implementation will need to be reworked with security considerations in mind.