### PR TITLE
Bust cache on article destroy instead of resave articles #1621

### DIFF
--- a/app/jobs/articles/bust_cache_job.rb
+++ b/app/jobs/articles/bust_cache_job.rb
@@ -1,6 +1,6 @@
 module Articles
   class BustCacheJob < ApplicationJob
-    queue_as :articles_resave
+    queue_as :articles_bust_cache
 
     def perform(article_ids, cache_buster = CacheBuster.new)
       Article.select(:id, :path).where(id: article_ids).find_each do |article|

--- a/app/jobs/articles/bust_cache_job.rb
+++ b/app/jobs/articles/bust_cache_job.rb
@@ -1,12 +1,11 @@
 module Articles
-  class ResaveJob < ApplicationJob
+  class BustCacheJob < ApplicationJob
     queue_as :articles_resave
 
     def perform(article_ids, cache_buster = CacheBuster.new)
-      Article.where(id: article_ids).find_each do |article|
+      Article.select(:id, :path).where(id: article_ids).find_each do |article|
         cache_buster.bust(article.path)
         cache_buster.bust(article.path + "?i=i")
-        article.save
       end
     end
   end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -399,8 +399,15 @@ class Article < ApplicationRecord
   def before_destroy_actions
     bust_cache
     remove_algolia_index
-    user.cache_bust_all_articles
-    Articles::ResaveJob.perform_later(organization.article_ids - [id]) if organization
+    article_ids = user.article_ids.dup
+    if organization
+      organization.touch(:last_article_at)
+      article_ids.concat organization.article_ids
+    end
+    # perform busting cache in chunks in case there're a lot of articles
+    (article_ids.uniq.sort - [id]).each_slice(10) do |ids|
+      Articles::BustCacheJob.perform_later(ids)
+    end
   end
 
   def evaluate_front_matter(front_matter)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -371,14 +371,6 @@ class User < ApplicationRecord
     end
   end
 
-  def cache_bust_all_articles
-    cache_buster = CacheBuster.new
-    articles.find_each do |article|
-      cache_buster.bust(article.path)
-      cache_buster.bust(article.path + "?i=i")
-    end
-  end
-
   def settings_tab_list
     tab_list = %w(
       Profile

--- a/spec/jobs/articles/bust_cache_job_spec.rb
+++ b/spec/jobs/articles/bust_cache_job_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Articles::ResaveJob, type: :job do
+RSpec.describe Articles::BustCacheJob, type: :job do
   describe "#perform_later" do
     it "enqueues the job" do
       ActiveJob::Base.queue_adapter = :test

--- a/spec/jobs/articles/bust_cache_job_spec.rb
+++ b/spec/jobs/articles/bust_cache_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Articles::BustCacheJob, type: :job do
       ActiveJob::Base.queue_adapter = :test
       expect do
         described_class.perform_later([1, 2])
-      end.to have_enqueued_job.with([1, 2]).on_queue("articles_resave")
+      end.to have_enqueued_job.with([1, 2]).on_queue("articles_bust_cache")
     end
 
     it "busts cache" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
In the current implementation, when an article is destroyed, all the "sibling" articles of the (destroyed) article organization are resaved. Resaving triggers several callbacks, which create a lot of delayed_jobs. That takes plenty of time and resources. There's no need to resave articles, it's enough to bust their cache.

What happens on article destroy after the refactoring:
- instead of resaving organization articles, their cache is busted
- user articles cache is busted asynchronously

## Related Tickets & Documents
#1621 
Not directly related to the ticket (not fixing errors), but contains refactoring for the related code.