### PR TITLE
Remove unused Organization#resave_articles method

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -77,16 +77,6 @@ class Organization < ApplicationRecord
     SecureRandom.hex(50)
   end
 
-  # TODO: remove the unused method
-  def resave_articles
-    cache_buster = CacheBuster.new
-    articles.find_each do |article|
-      cache_buster.bust(article.path)
-      cache_buster.bust(article.path + "?i=i")
-      article.save
-    end
-  end
-
   def approved_and_filled_out_cta?
     cta_processed_html?
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor

## Description
This method was kept in the codebase so that the existing jobs wouldn't fail.
Now all old jobs should have run already, so we can remove the method.