### PR TITLE
Remove useless removing algolia indexing on article destroy

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -97,7 +97,7 @@ class Article < ApplicationRecord
     where("boost_states ->> 'boosted_dev_digest_email' = 'true'")
   }
 
-  algoliasearch per_environment: true, enqueue: :trigger_delayed_index do
+  algoliasearch per_environment: true, auto_remove: false, enqueue: :trigger_delayed_index do
     attribute :title
     add_index "searchables",
                   id: :index_id,
@@ -229,11 +229,10 @@ class Article < ApplicationRecord
   end
 
   def self.trigger_delayed_index(record, remove)
-    if remove
-      record.delay.remove_from_index! if record&.persisted?
-    else
-      record.index_or_remove_from_index_where_appropriate
-    end
+    # on destroy an article is removed from index in a before_destroy callback #before_destroy_actions
+    return if remove
+
+    record.index_or_remove_from_index_where_appropriate
   end
 
   def index_or_remove_from_index_where_appropriate


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
 When an article is destroyed,`trigger_delayed_index` was useless, cause `trigger_delayed_index` runs `after_destroy`, so this check `record.&persisted?` was always false and `record.delay.remove_from_index!` wasn't executed. An article is actually removed from the index in `before_destroy_actions` (`remove_algolia_index`).
This pr removes the useless code to make the logic easier to understand.

## Related Tickets & Documents
Related to the #1641, thought this pr doesn't provide any fixes.