### PR TITLE
Use include instead as a better check

### DIFF
--- a/app/liquid_tags/runkit_tag.rb
+++ b/app/liquid_tags/runkit_tag.rb
@@ -66,13 +66,9 @@ class RunkitTag < Liquid::Block
   end
 
   def sanitized_preamble(markup)
-    raise StandardError, "Runkit tag is invalid" if markup.ends_with? "\">"
+    raise StandardError, "Runkit tag is invalid" if markup.include? "\""
 
-    sanitized = ActionView::Base.full_sanitizer.sanitize(markup, tags: [])
-
-    raise StandardError, "Runkit tag is invalid" if markup.starts_with? "\""
-
-    sanitized
+    ActionView::Base.full_sanitizer.sanitize(markup, tags: [])
   end
 end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
use `include` instead of `start_with` and `end_with` as recommended for a more secure check.