### PR TITLE
Disable erblint cops for the editor guide

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -1,6 +1,12 @@
 linters:
   SelfClosingTag:
     enabled: false
+  ParserErrors:
+    exclude:
+      - '**/app/views/pages/_editor_guide_text.html.erb'
+  SpaceInHtmlTag:
+    exclude:
+      - '**/app/views/pages/_editor_guide_text.html.erb'
   Rubocop:
     enabled: true
     rubocop_config:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Erblint parses the html in pre instead of treating it as a code block (more information in the [pr](https://github.com/thepracticaldev/dev.to/pull/1784) and [an issue](https://github.com/thepracticaldev/dev.to/issues/1828#issuecomment-465041370)
This pr disables the corresponding erblint cops to prevent `lint-stage` from failing.