### PR TITLE
[WIP] Only bust cache if commentable exists

### DIFF
--- a/app/services/moderator/banisher.rb
+++ b/app/services/moderator/banisher.rb
@@ -35,6 +35,8 @@ module Moderator
     end
 
     def add_banned_role
+      user.remove_role :trusted
+      user.remove_role :tag_moderator
       user.add_role :banned
       unless user.notes.where(reason: "banned").any?
         user.notes.
@@ -47,7 +49,9 @@ module Moderator
 
       user.comments.find_each do |comment|
         comment.reactions.delete_all
-        CacheBuster.new.bust_comment(comment.commentable, user.username)
+        if !comment.commentable.nil?
+          CacheBuster.new.bust_comment(comment.commentable, user.username)
+        end
         comment.delete
       end
     end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

I got here when I was getting an error banishing a user in development -- couldn't delete a comment because the article didn't exist. It's possible this was only happening in development because I didn't have jobs running when the article got destroyed so the comment didn't get deleted but we've had other issues with all the async jobs involved w/ destroying content.

I added this mostly to make sure we don't run into issues fulfilling deletion requests but I'm worried it'll hide the deserialization errors instead of surface them. Regardless, cache wouldn't be busting correctly with or without this conditional if the commentable didn't exist. 

I think @lightalloy might have some clearer thoughts around this.

- The other thing is just making sure any heightened privileges are removed when a user is banished. 

![shrug](https://media.giphy.com/media/5wFHW55Vdk2MCZSMIV/giphy.gif)
