### PR TITLE
Fix linting issues in views/additional_content_boxes

### DIFF
--- a/app/views/additional_content_boxes/_article_box.html.erb
+++ b/app/views/additional_content_boxes/_article_box.html.erb
@@ -1,6 +1,6 @@
   <div class="container show-page-content-display"
     data-details="<%= article.organization&.slug %>__<%= article.slug %>"
-    id="<%= classification == "boosted" ? "partner-content-display" : "classic_article_#{article.id}"  %>">
+    id="<%= classification == "boosted" ? "partner-content-display" : "classic_article_#{article.id}" %>">
     <div class="content-classification">
       <span class="content-classification-text"><%= classification_text %></span>
     </div>

--- a/app/views/additional_content_boxes/_article_box.html.erb
+++ b/app/views/additional_content_boxes/_article_box.html.erb
@@ -1,20 +1,20 @@
-  <div class="container show-page-content-display"
-    data-details="<%= article.organization&.slug %>__<%= article.slug %>"
-    id="<%= classification == "boosted" ? "partner-content-display" : "classic_article_#{article.id}" %>">
-    <div class="content-classification">
-      <span class="content-classification-text"><%= classification_text %></span>
-    </div>
-    <div class="main-content-display">
-      <%= render "additional_content_boxes/article_content_area",
-        article: article,
-        classification: classification,
-        organization: article.organization %>
-    </div>
-    <div class="secondary-content-display">
-      <%= render "additional_content_boxes/article_followable_area",
-        article: article,
-        followable: article.organization || article.user,
-        classification: classification,
-        follow_cue: follow_cue %>
-    </div>
+<div class="container show-page-content-display"
+  data-details="<%= article.organization&.slug %>__<%= article.slug %>"
+  id="<%= classification == "boosted" ? "partner-content-display" : "classic_article_#{article.id}" %>">
+  <div class="content-classification">
+    <span class="content-classification-text"><%= classification_text %></span>
   </div>
+  <div class="main-content-display">
+    <%= render "additional_content_boxes/article_content_area",
+      article: article,
+      classification: classification,
+      organization: article.organization %>
+  </div>
+  <div class="secondary-content-display">
+    <%= render "additional_content_boxes/article_followable_area",
+      article: article,
+      followable: article.organization || article.user,
+      classification: classification,
+      follow_cue: follow_cue %>
+  </div>
+</div>

--- a/app/views/additional_content_boxes/_article_content_area.html.erb
+++ b/app/views/additional_content_boxes/_article_content_area.html.erb
@@ -1,20 +1,20 @@
-      <h2><a href="<%= article.path + article.decorate.internal_utm_params %>" class="<%= "partner-link" if classification == "boosted" %>" data-details="<%= organization&.slug %>__<%= article.slug %>"><%= article.title %></a></h2>
-      <div class="content-author">
-        <a href="<%= article.user.path + article.decorate.internal_utm_params %>">
-          <img class="profile-pic" src="<%= ProfileImage.new(article.user).get(50) %>" alt="<%= article.user.username %> profile image" />
-          <span><%= article.user.name %></span>
-        </a>
-      </div>
-      <p>
-        <a href="<%= article.path + article.decorate.internal_utm_params %>" class="<%= "partner-link" if classification == "boosted" %>" data-details="<%= organization&.slug %>__<%= article.slug %>">
-          <%= article.description %>
-        </a>
-        <div class="engagement-count">
-          <% if article.positive_reactions_count > 0 %>
-            <img src="<%= asset_path("reactions-stack.png") %>" alt="Reactions" /> <%= article.positive_reactions_count %>
-          <% end %>
-          <% if article.comments_count > 0 %>
-            <img src="<%= asset_path("comments-bubble.png") %>" alt="Reactions" class="comments-bubble" /> <%= article.comments_count %>
-          <% end %>
-        </div>
-      </p>
+<h2><a href="<%= article.path + article.decorate.internal_utm_params %>" class="<%= "partner-link" if classification == "boosted" %>" data-details="<%= organization&.slug %>__<%= article.slug %>"><%= article.title %></a></h2>
+<div class="content-author">
+  <a href="<%= article.user.path + article.decorate.internal_utm_params %>">
+    <img class="profile-pic" src="<%= ProfileImage.new(article.user).get(50) %>" alt="<%= article.user.username %> profile image" />
+    <span><%= article.user.name %></span>
+  </a>
+</div>
+<p>
+  <a href="<%= article.path + article.decorate.internal_utm_params %>" class="<%= "partner-link" if classification == "boosted" %>" data-details="<%= organization&.slug %>__<%= article.slug %>">
+    <%= article.description %>
+  </a>
+  <div class="engagement-count">
+    <% if article.positive_reactions_count > 0 %>
+      <img src="<%= asset_path("reactions-stack.png") %>" alt="Reactions" /> <%= article.positive_reactions_count %>
+    <% end %>
+    <% if article.comments_count > 0 %>
+      <img src="<%= asset_path("comments-bubble.png") %>" alt="Reactions" class="comments-bubble" /> <%= article.comments_count %>
+    <% end %>
+  </div>
+</p>

--- a/app/views/additional_content_boxes/_article_content_area.html.erb
+++ b/app/views/additional_content_boxes/_article_content_area.html.erb
@@ -1,12 +1,12 @@
-      <h2><a href="<%= article.path + article.decorate.internal_utm_params %>" class="<%= 'partner-link' if classification == "boosted" %>" data-details="<%= organization&.slug %>__<%= article.slug %>"><%= article.title %></a></h2>
+      <h2><a href="<%= article.path + article.decorate.internal_utm_params %>" class="<%= "partner-link" if classification == "boosted" %>" data-details="<%= organization&.slug %>__<%= article.slug %>"><%= article.title %></a></h2>
       <div class="content-author">
-        <a href="<%= article.user.path + article.decorate.internal_utm_params %>"> 
-          <img class="profile-pic" src="<%= ProfileImage.new(article.user).get(50)%>" alt="<%= article.user.username %> profile image"/>
+        <a href="<%= article.user.path + article.decorate.internal_utm_params %>">
+          <img class="profile-pic" src="<%= ProfileImage.new(article.user).get(50) %>" alt="<%= article.user.username %> profile image" />
           <span><%= article.user.name %></span>
         </a>
       </div>
       <p>
-        <a href="<%= article.path + article.decorate.internal_utm_params%>" class="<%= 'partner-link' if classification == "boosted" %>" data-details="<%= organization&.slug %>__<%= article.slug %>">
+        <a href="<%= article.path + article.decorate.internal_utm_params %>" class="<%= "partner-link" if classification == "boosted" %>" data-details="<%= organization&.slug %>__<%= article.slug %>">
           <%= article.description %>
         </a>
         <div class="engagement-count">
@@ -14,7 +14,7 @@
             <img src="<%= asset_path("reactions-stack.png") %>" alt="Reactions" /> <%= article.positive_reactions_count %>
           <% end %>
           <% if article.comments_count > 0 %>
-            <img src="<%= asset_path("comments-bubble.png") %>" alt="Reactions" class="comments-bubble"/> <%= article.comments_count %>
+            <img src="<%= asset_path("comments-bubble.png") %>" alt="Reactions" class="comments-bubble" /> <%= article.comments_count %>
           <% end %>
         </div>
       </p>

--- a/app/views/additional_content_boxes/_article_followable_area.html.erb
+++ b/app/views/additional_content_boxes/_article_followable_area.html.erb
@@ -15,7 +15,7 @@
   <div class="profile-pic-wrapper">
       <a href="<%= followable.path + article.decorate.internal_utm_params %>"
         class="<%= "partner-link" if classification == "boosted" %>"
-        data-details="<%= followable&.slug if classification == "boosted" %>__PROFILE"/>
+        data-details="<%= followable&.slug if classification == "boosted" %>__PROFILE" />
     <img class="profile-image"
       src="<%= ProfileImage.new(followable).get(200) %>"
       data-details="<%= followable&.slug if classification == "boosted" %>__PROFILE"
@@ -28,6 +28,5 @@
   </div>
 <% end %>
 <button class="cta follow-action-button user-profile-follow-button <%= "partner-link" if classification == "boosted" %>"
-  style="color:<%= user_colors(followable)[:text] %>;background-color:<%=user_colors(followable)[:bg] %>"
-  data-info='{"id":<%= followable.id %>,"className":"<%= followable.class.name %>"}'
-  >&nbsp;</button>
+  style="color:<%= user_colors(followable)[:text] %>;background-color:<%= user_colors(followable)[:bg] %>"
+  data-info='{"id":<%= followable.id %>,"className":"<%= followable.class.name %>"}'>&nbsp;</button>


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

Fix linting issues in the views located in `app/views/additional_content_boxes`.

```bash
🐈 bin/bundle exec erblint app/views/additional_content_boxes
warning: parser/current is loading parser/ruby26, which recognizes
warning: 2.6.0-compliant syntax, but you are running 2.6.1.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
Linting 4 files with 12 linters...

.erblint-rubocop20190222-7517-2zlp5: RSpec/FilePath has the wrong namespace - should be Rails
Warning: unrecognized cop RSpec/MultipleExpectations found in .erblint-rubocop20190222-7517-2zlp5
No errors were found in ERB files
```

**Additional question:**

Some views, such as [`_article_content_area.html.erb`](https://github.com/thepracticaldev/dev.to/blob/master/app/views/additional_content_boxes/_article_content_area.html.erb) has the entire file indented by several levels. `erblint` doesn't complain about this indentation, so I'm wondering if this is intentional and should be left like this, or should the indentation be fixed?

## Related Tickets & Documents

#1842 

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed