### PR TITLE
Allow users to resize edit comment textarea element

### DIFF
--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -244,13 +244,12 @@ a.header-link {
       width: calc(100% - 52px);
       margin: 15px auto 2px;
       display: block;
-      resize: none;
+      resize: vertical;
       border-radius: 3px;
       border: 1px solid rgb(232, 229, 229);
-      height: 75px;
+      height: 125px;
       font-size: 16px;
       padding: 6px;
-      transition: height 0.3s ease;
       cursor: text;
       &.embiggened {
         height: calc(2vw + 115px);


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Based on complaints, this allows users to resize the text area element while editing a comment.

## Related Tickets & Documents
#1554 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![edit_comment](https://user-images.githubusercontent.com/6568078/53306389-3dbd8f00-386b-11e9-969a-ed170ad49293.gif)


## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
