### PR TITLE
Disable useless assignment linting in views

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -14,5 +14,7 @@ linters:
         - .rubocop.yml
       Layout/TrailingBlankLines:
         Enabled: false
+      Lint/UselessAssignment:
+        Enabled: false
       Metrics/LineLength:
         Max: 289


### PR DESCRIPTION
I've noticed problems with this cop in a couple of pull requests: it complains on the useless assignments, though variables are actually used.

https://github.com/thepracticaldev/dev.to/pull/1873
https://github.com/thepracticaldev/dev.to/pull/1884