### PR TITLE
Add username to author info in articles

### DIFF
--- a/app/assets/stylesheets/sticky-nav.scss
+++ b/app/assets/stylesheets/sticky-nav.scss
@@ -24,10 +24,14 @@
       height: 35px;
       border-radius: 360px;
       margin-right: 5px;
-      vertical-align: -9px;
+      vertical-align: -2px;
     }
     .primary-sticky-nav-author-name{
       font-size:1.3em;
+      font-weight: bold;
+    }
+    .primary-sticky-nav-author-username {
+      font-size:0.8em;
       font-weight: bold;
     }
     .primary-sticky-nav-author-summary{

--- a/app/views/articles/_about_author.html.erb
+++ b/app/views/articles/_about_author.html.erb
@@ -8,6 +8,9 @@
     <h4><a href="/<%= @user.username %>"><%= @user.name %></a><%= follow_button(@user) %></h4>
     <p><%= @user.summary %></p>
     <p class="social">
+      <a href="/<%= @user.username %>">
+        @<%= @user.username %>
+      </a>
       <% if @user.twitter_username.present? %>
         <a href="http://twitter.com/<%= @user.twitter_username %>" target="_blank" rel="noopener">
           <%= icon("twitter","22") %> <%= @user.twitter_username %>

--- a/app/views/articles/_sticky_nav.html.erb
+++ b/app/views/articles/_sticky_nav.html.erb
@@ -33,16 +33,23 @@
 <div class="primary-sticky-nav" id="article-show-primary-sticky-nav">
   <div class="primary-sticky-nav-element primary-sticky-nav-author">
     <a href="<%= @actor.path %>"><img src="<%= ProfileImage.new(@actor).get(90) %>" class="primary-sticky-nav-author-top-profile-image" /></a>
-    <span class="primary-sticky-nav-author-name">
-      <a href="<%= @actor.path %>">
-        <%= @actor.name %>
-      </a>
-    </span>
-      <div class="primary-sticky-nav-author-summary">
-        <% if @actor.tag_line.present? %>
-          <%= truncate (@actor.tag_line || @actor.summary || "Posts in this tag"), length: 200 %>
-        <% end %>
+    <div style="display:inline-block">
+      <div class="primary-sticky-nav-author-name">
+        <a href="<%= @actor.path %>">
+          <%= @actor.name %>
+        </a>
       </div>
+      <div class="primary-sticky-nav-author-username">
+        <a href="<%= @actor.path %>">
+          @<%= @actor.username %>
+        </a>
+      </div>
+    </div>
+    <div class="primary-sticky-nav-author-summary">
+      <% if @actor.tag_line.present? %>
+        <%= truncate (@actor.tag_line || @actor.summary || "Posts in this tag"), length: 200 %>
+      <% end %>
+    </div>
     <div class="primary-sticky-nav-author-follow">
       <%= follow_button(@actor) %>
     </div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
Added username to author sticky nav and about the author sections. 

## Related Tickets & Documents
Resolves #265 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
<img width="1265" alt="screen shot 2019-02-26 at 16 07 51" src="https://user-images.githubusercontent.com/13403332/53446405-e4776c00-39e0-11e9-919b-31d1ae91405a.png">

About the author section at the end of the article doesn't show up for me in development, but I did make the changes in the file that handles it.

## Added to documentation?

- [x] no documentation needed
