### PR TITLE
Adjust article ranking algorithm to use crossposted_at where available

### DIFF
--- a/app/black_box/black_box.rb
+++ b/app/black_box/black_box.rb
@@ -3,12 +3,13 @@ class BlackBox
     def article_hotness_score(article)
       return (article.featured_number || 10000) / 10000 unless Rails.env.production?
 
+      usable_date = article.crossposted_at || article.published_at
       reaction_points = article.score
-      super_super_recent_bonus = article.published_at > 1.hours.ago ? 28 : 0
-      super_recent_bonus = article.published_at > 8.hours.ago ? 31 : 0
-      recency_bonus = article.published_at > 12.hours.ago ? 70 : 0
-      today_bonus = article.published_at > 26.hours.ago ? 385 : 0
-      two_day_bonus = article.published_at > 48.hours.ago ? 320 : 0
+      super_super_recent_bonus = usable_date > 1.hours.ago ? 28 : 0
+      super_recent_bonus = usable_date > 8.hours.ago ? 31 : 0
+      recency_bonus = usable_date > 12.hours.ago ? 80 : 0
+      today_bonus = usable_date > 26.hours.ago ? 395 : 0
+      two_day_bonus = usable_date > 48.hours.ago ? 330 : 0
       FunctionCaller.new("blackbox-production-articleHotness",
         { article: article, user: article.user }.to_json).call +
         reaction_points + recency_bonus + super_recent_bonus + super_super_recent_bonus + today_bonus + two_day_bonus


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
Currently crossposted articles take a hit in the algorithm if the post was first published elsewhere. This fixes it.