### PR TITLE
Add Milestone Notifications

### DIFF
--- a/app/assets/stylesheets/notifications.scss
+++ b/app/assets/stylesheets/notifications.scss
@@ -79,10 +79,7 @@
             }
             img.milestone-gif{
                 margin: 10px 0px 10px;
-                max-width: 300px;
-                max-height: 200px;
-                width: auto;
-                height: auto;
+                width: 300px;
               }
             p.badge-reward-message{
               margin: 8px auto;

--- a/app/assets/stylesheets/notifications.scss
+++ b/app/assets/stylesheets/notifications.scss
@@ -79,6 +79,7 @@
             }
             img.milestone-gif{
                 margin: 10px 0px 10px;
+                border-radius: 8px;
                 width: 300px;
               }
             p.badge-reward-message{

--- a/app/assets/stylesheets/notifications.scss
+++ b/app/assets/stylesheets/notifications.scss
@@ -76,11 +76,14 @@
             img.badge-image{
               margin:10px 0px 20px;
               height: 150px;
-              &.milestone-gif{
-                height: 200px;
-                margin-bottom: 10px;
-              }
             }
+            img.milestone-gif{
+                margin: 10px 0px 10px;
+                max-width: 300px;
+                max-height: 200px;
+                width: auto;
+                height: auto;
+              }
             p.badge-reward-message{
               margin: 8px auto;
               width: 90%;

--- a/app/assets/stylesheets/notifications.scss
+++ b/app/assets/stylesheets/notifications.scss
@@ -67,10 +67,19 @@
               margin: 10px auto;
               width: 90%;
               color:#666666;
+              &.milestone-emojis{
+                font-size: xx-large;
+                padding-top: 10px;
+                padding-bottom: 0px;
+              }
             }
             img.badge-image{
               margin:10px 0px 20px;
               height: 150px;
+              &.milestone-gif{
+                height: 200px;
+                margin-bottom: 10px;
+              }
             }
             p.badge-reward-message{
               margin: 8px auto;

--- a/app/decorators/notification_decorator.rb
+++ b/app/decorators/notification_decorator.rb
@@ -10,4 +10,12 @@ class NotificationDecorator < Draper::Decorator
     end
     struct.new(json_data[type]["class"]["name"], json_data[type]["id"])
   end
+
+  def milestone_type
+    action.split("::")[1]
+  end
+
+  def milestone_count
+    action.split("::")[2]
+  end
 end

--- a/app/labor/article_analytics_fetcher.rb
+++ b/app/labor/article_analytics_fetcher.rb
@@ -22,6 +22,7 @@ class ArticleAnalyticsFetcher
         next if article.page_views_count > page_views_obj[article.id].to_i
 
         article.update_columns(page_views_count: page_views_obj[article.id].to_i)
+        Notification.send_milestone_notification(type: "View", article: article)
       end
     end
   end

--- a/app/labor/article_analytics_fetcher.rb
+++ b/app/labor/article_analytics_fetcher.rb
@@ -19,6 +19,7 @@ class ArticleAnalyticsFetcher
       page_views_obj = pageviews.to_h
       chunk.each do |article|
         article.update_columns(previous_positive_reactions_count: article.positive_reactions_count)
+        Notification.send_milestone_notification(type: "Reaction", article: article)
         next if article.page_views_count > page_views_obj[article.id].to_i
 
         article.update_columns(page_views_count: page_views_obj[article.id].to_i)

--- a/app/labor/random_gif.rb
+++ b/app/labor/random_gif.rb
@@ -1,0 +1,27 @@
+class RandomGif
+  def initialize(_action = "congratulations")
+    @random_gifs = {
+      "xjZtu4qi1biIo" => { aspect_ratio: 1.000 },
+      "12P29BwtrvsbbW" => { aspect_ratio: 0.760 },
+      "9PyhoXey73EpW" => { aspect_ratio: 0.753 },
+      "OcZp0maz6ALok" => { aspect_ratio: 1.000 },
+      "Is1O1TWV0LEJi" => { aspect_ratio: 0.565 },
+      "xjZtu4qi1biIo" => { aspect_ratio: 1.0000 },
+      "lz24Z42jLcTa8" => { aspect_ratio: 0.776 },
+      "g9582DNuQppxC" => { aspect_ratio: 0.562 },
+      "l4HodBpDmoMA5p9bG" => { aspect_ratio: 1.000 },
+      "3oxOCfV7z28QtXXAtO" => { aspect_ratio: 0.750 },
+      "y8Mz1yj13s3kI" => { aspect_ratio: 0.750 },
+      "111ebonMs90YLu" => { aspect_ratio: 0.750 },
+      "Sk5uipPXyBjfW" => { aspect_ratio: 0.422 }
+    }
+  end
+
+  def random_id
+    @random_gifs.keys.sample
+  end
+
+  def get_aspect_ratio(id)
+    (@random_gifs[id] || "xjZtu4qi1biIo")[:aspect_ratio]
+  end
+end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -256,11 +256,20 @@ class Notification < ApplicationRecord
       milestone_hash[:next_milestone] = next_milestone(milestone_hash)
       return unless should_send_milestone?(milestone_hash)
 
+      random_giphy_id = %w(
+        nXxOjZrbnbRxS
+        y8Mz1yj13s3kI
+        9PyhoXey73EpW
+        OcZp0maz6ALok
+        111ebonMs90YLu
+        xjZtu4qi1biIo
+      ).sample
+
       Notification.create!(
         user_id: milestone_hash[:article].user_id,
         notifiable_id: milestone_hash[:article].id,
         notifiable_type: "Article",
-        json_data: { article: article_data(milestone_hash[:article]) },
+        json_data: { article: article_data(milestone_hash[:article]), gif_id: random_giphy_id },
         action: "Milestone::#{milestone_hash[:type]}::#{milestone_hash[:next_milestone]}",
       )
       if milestone_hash[:article].organization_id

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -386,6 +386,8 @@ class Notification < ApplicationRecord
     end
 
     def should_send_milestone?(milestone_hash)
+      return if milestone_hash[:article].published_at < DateTime.new(2019, 2, 25)
+
       last_milestone_notification = Notification.find_by(
         user_id: milestone_hash[:article].user_id,
         notifiable_type: "Article",

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -263,6 +263,13 @@ class Notification < ApplicationRecord
         OcZp0maz6ALok
         111ebonMs90YLu
         xjZtu4qi1biIo
+        Is1O1TWV0LEJi
+        lz24Z42jLcTa8
+        Sk5uipPXyBjfW
+        g9582DNuQppxC
+        l4HodBpDmoMA5p9bG
+        3oxOCfV7z28QtXXAtO
+        12P29BwtrvsbbW
       ).sample
 
       Notification.create!(

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -387,10 +387,10 @@ class Notification < ApplicationRecord
     def next_milestone(milestone_hash)
       case milestone_hash[:type]
       when "View"
-        milestones = [1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144]
+        milestones = [1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576]
         milestone_count = milestone_hash[:article].page_views_count
       when "Reaction"
-        milestones = [64, 128, 256, 512, 1024, 2048, 4096]
+        milestones = [64, 128, 256, 512, 1024, 2048, 4096, 8192]
         milestone_count = milestone_hash[:article].positive_reactions_count
       end
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -256,27 +256,11 @@ class Notification < ApplicationRecord
       milestone_hash[:next_milestone] = next_milestone(milestone_hash)
       return unless should_send_milestone?(milestone_hash)
 
-      random_giphy_id = %w(
-        nXxOjZrbnbRxS
-        y8Mz1yj13s3kI
-        9PyhoXey73EpW
-        OcZp0maz6ALok
-        111ebonMs90YLu
-        xjZtu4qi1biIo
-        Is1O1TWV0LEJi
-        lz24Z42jLcTa8
-        Sk5uipPXyBjfW
-        g9582DNuQppxC
-        l4HodBpDmoMA5p9bG
-        3oxOCfV7z28QtXXAtO
-        12P29BwtrvsbbW
-      ).sample
-
       Notification.create!(
         user_id: milestone_hash[:article].user_id,
         notifiable_id: milestone_hash[:article].id,
         notifiable_type: "Article",
-        json_data: { article: article_data(milestone_hash[:article]), gif_id: random_giphy_id },
+        json_data: { article: article_data(milestone_hash[:article]), gif_id: RandomGif.new.random_id },
         action: "Milestone::#{milestone_hash[:type]}::#{milestone_hash[:next_milestone]}",
       )
       if milestone_hash[:article].organization_id

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -252,6 +252,29 @@ class Notification < ApplicationRecord
     end
     handle_asynchronously :send_tag_adjustment_notification
 
+    def send_milestone_notification(milestone_hash)
+      milestone_hash[:next_milestone] = next_milestone(milestone_hash)
+      return unless should_send_milestone?(milestone_hash)
+
+      Notification.create!(
+        user_id: milestone_hash[:article].user_id,
+        notifiable_id: milestone_hash[:article].id,
+        notifiable_type: "Article",
+        json_data: { article: article_data(milestone_hash[:article]) },
+        action: "Milestone::#{milestone_hash[:type]}::#{milestone_hash[:next_milestone]}",
+      )
+      if milestone_hash[:article].organization_id
+        Notification.create!(
+          organization_id: milestone_hash[:article].organization_id,
+          notifiable_id: milestone_hash[:article].id,
+          notifiable_type: "Article",
+          json_data: { article: article_data(milestone_hash[:article]) },
+          action: "Milestone::#{milestone_hash[:type]}::#{milestone_hash[:next_milestone]}",
+        )
+      end
+    end
+    handle_asynchronously :send_milestone_notification
+
     def remove_all(notifiable_hash)
       Notification.where(
         notifiable_id: notifiable_hash[:notifiable_id],
@@ -344,6 +367,39 @@ class Notification < ApplicationRecord
         path: article.path,
         updated_at: article.updated_at
       }
+    end
+
+    def should_send_milestone?(milestone_hash)
+      last_milestone_notification = Notification.find_by(
+        user_id: milestone_hash[:article].user_id,
+        notifiable_type: "Article",
+        notifiable_id: milestone_hash[:article].id,
+        action: "Milestone::#{milestone_hash[:type]}::#{milestone_hash[:next_milestone]}",
+      )
+
+      if milestone_hash[:type] == "View"
+        last_milestone_notification.blank? && milestone_hash[:article].page_views_count > milestone_hash[:next_milestone]
+      elsif milestone_hash[:type] == "Reaction"
+        last_milestone_notification.blank? && milestone_hash[:article].positive_reactions_count > milestone_hash[:next_milestone]
+      end
+    end
+
+    def next_milestone(milestone_hash)
+      case milestone_hash[:type]
+      when "View"
+        milestones = [1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144]
+        milestone_count = milestone_hash[:article].page_views_count
+      when "Reaction"
+        milestones = [64, 128, 256, 512, 1024, 2048, 4096]
+        milestone_count = milestone_hash[:article].positive_reactions_count
+      end
+
+      closest_number = milestones.min_by { |num| (milestone_count - num).abs }
+      if milestone_count > closest_number
+        closest_number
+      else
+        milestones[milestones.index(closest_number) - 1]
+      end
     end
 
     def send_push_notifications(user_id, title, body, path)

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -116,6 +116,7 @@ class Reaction < ApplicationRecord
     # Fixes any out-of-sync positive_reactions_count
     if rand(6) == 1 || reactable.positive_reactions_count.negative?
       reactable.update_column(:positive_reactions_count, reactable.reactions.where("points > ?", 0).size)
+      Notification.send_milestone_notification(type: "Reaction", article: article) if reactable_type == "Article"
     end
   end
 

--- a/app/views/notifications/_article.html.erb
+++ b/app/views/notifications/_article.html.erb
@@ -1,16 +1,18 @@
 <% if notification.action == "Reaction" %>
   <%= render "reaction", notification: notification %>
+<% elsif notification.action.include? "Milestone" %>
+  <%= render "milestone", notification: notification %>
 <% else %>
   <% json_data = notification.json_data %>
   <% if json_data["organization"] %>
     <div class="article-organization-headline">
       <a href="<%= json_data["organization"]["path"] %>" class="article-organization-headline-inner">
-        <img src="<%= json_data["organization"]["profile_image_90"] %>" alt="link to <%= json_data["organization"]["name"] %>"> <%= json_data["organization"]["name"]  %>
+        <img src="<%= json_data["organization"]["profile_image_90"] %>" alt="link to <%= json_data["organization"]["name"] %>"> <%= json_data["organization"]["name"] %>
       </a>
       <a class="org-headline-filler" href="<%= json_data["organization"]["path"] %>">&nbsp;</a>
     </div>
   <% end %>
-  <% cache "activity-profile-pic-#{json_data["user"]["id"]}-#{json_data["user"]["profile_image_90"]}" do %>
+  <% cache "activity-profile-pic-#{json_data['user']['id']}-#{json_data['user']['profile_image_90']}" do %>
     <a href="<%= json_data["user"]["path"] %>" class="small-pic-link-wrapper">
       <div class="small-pic">
         <img src="<%= json_data["user"]["profile_image_90"] %>" alt="link to <%= json_data["user"]["username"] %>'s profile">

--- a/app/views/notifications/_milestone.html.erb
+++ b/app/views/notifications/_milestone.html.erb
@@ -4,7 +4,7 @@
     Your post <a href="<%= json_data["article"]["path"] %>"><%= json_data["article"]["title"] %></a> just passed <%= notification.milestone_count %> <%= notification.milestone_type.pluralize.downcase %>!
   </div>
   <p class="badge-description milestone-emojis">🎉🎉🎉🎉🎉🎉🎉🎉</p>
-  <a href="https://media.giphy.com/media/<%= json_data["gif_id"] %>/giphy-downsized.gif" rel="noopener noreferrer" target="_blank">
+  <a href="https:/giphy.com/gifs/<%= json_data["gif_id"] %>" rel="noopener noreferrer" target="_blank">
     <img class="milestone-gif" src="https://media.giphy.com/media/<%= json_data["gif_id"] %>/giphy-downsized.gif" alt="A random celebratory gif!">
   </a>
   <br>

--- a/app/views/notifications/_milestone.html.erb
+++ b/app/views/notifications/_milestone.html.erb
@@ -4,8 +4,9 @@
     Your post <a href="<%= json_data["article"]["path"] %>"><%= json_data["article"]["title"] %></a> just passed <%= notification.milestone_count %> <%= notification.milestone_type.pluralize.downcase %>!
   </div>
   <p class="badge-description milestone-emojis">🎉🎉🎉🎉🎉🎉🎉🎉</p>
+
   <a href="https:/giphy.com/gifs/<%= json_data["gif_id"] %>" rel="noopener noreferrer" target="_blank">
-    <img class="milestone-gif" src="https://media.giphy.com/media/<%= json_data["gif_id"] %>/giphy-downsized.gif" alt="A random celebratory gif!">
+    <img style="height: <%= RandomGif.new.get_aspect_ratio(json_data["gif_id"]) * 300 %>px;" class="milestone-gif" src="https://media.giphy.com/media/<%= json_data["gif_id"] %>/giphy-downsized.gif" alt="A random celebratory gif!">
   </a>
   <br>
   <a href="/dashboard">

--- a/app/views/notifications/_milestone.html.erb
+++ b/app/views/notifications/_milestone.html.erb
@@ -1,0 +1,13 @@
+<% json_data = notification.json_data %>
+<div class="content notification-content badge-content">
+  <div class="badge-title">
+    Your post <a href="<%= json_data["article"]["path"] %>"><%= json_data["article"]["title"] %></a> just passed <%= notification.milestone_count %> <%= notification.milestone_type.pluralize.downcase %>!
+  </div>
+  <br>
+  <p style="font-size: xx-large">🎉🎉🎉🎉🎉🎉🎉🎉</p>
+  <a href="/dashboard">
+    <button class="cta follow-action-button badge-button">
+      CHECK YOUR DASHBOARD
+    </button>
+  </a>
+</div>

--- a/app/views/notifications/_milestone.html.erb
+++ b/app/views/notifications/_milestone.html.erb
@@ -5,7 +5,7 @@
   </div>
   <p class="badge-description milestone-emojis">🎉🎉🎉🎉🎉🎉🎉🎉</p>
   <a href="https://media.giphy.com/media/<%= json_data["gif_id"] %>/giphy-downsized.gif" rel="noopener noreferrer" target="_blank">
-    <img class="badge-image milestone-gif" src="https://media.giphy.com/media/<%= json_data["gif_id"] %>/giphy-downsized.gif" alt="A random celebratory gif!">
+    <img class="milestone-gif" src="https://media.giphy.com/media/<%= json_data["gif_id"] %>/giphy-downsized.gif" alt="A random celebratory gif!">
   </a>
   <br>
   <a href="/dashboard">

--- a/app/views/notifications/_milestone.html.erb
+++ b/app/views/notifications/_milestone.html.erb
@@ -3,8 +3,11 @@
   <div class="badge-title">
     Your post <a href="<%= json_data["article"]["path"] %>"><%= json_data["article"]["title"] %></a> just passed <%= notification.milestone_count %> <%= notification.milestone_type.pluralize.downcase %>!
   </div>
+  <p class="badge-description milestone-emojis">🎉🎉🎉🎉🎉🎉🎉🎉</p>
+  <a href="https://media.giphy.com/media/<%= json_data["gif_id"] %>/giphy-downsized.gif" rel="noopener noreferrer" target="_blank">
+    <img class="badge-image milestone-gif" src="https://media.giphy.com/media/<%= json_data["gif_id"] %>/giphy-downsized.gif" alt="A random celebratory gif!">
+  </a>
   <br>
-  <p style="font-size: xx-large">🎉🎉🎉🎉🎉🎉🎉🎉</p>
   <a href="/dashboard">
     <button class="cta follow-action-button badge-button">
       CHECK YOUR DASHBOARD

--- a/yarn.lock
+++ b/yarn.lock
@@ -10472,7 +10472,7 @@ tweetnacl@^1.0.0:
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-1.0.0.tgz#713d8b818da42068740bf68386d0479e66fc8a7b"
   integrity sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins=
 
-twilio-video@^1.15.1:
+twilio-video@^1.15.2:
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/twilio-video/-/twilio-video-1.15.2.tgz#da3379c0e256def317689d9a980c683277f61baf"
   integrity sha512-C3KQcHmqqJObFWU2I+bMVqwIEUISXV+DSFJHdPrrw9Z+tDE7Y5SNNj+r4e9ArABx7mtWZlEUa4+Ela/dOQLEjA==


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
This PR adds milestone notifications! Milestones are achieved when your post reaches the following:
- 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288, or 1048576 total views
- 64, 128, 256, 512, 1024, 2048, 4096, or 8192  total reactions

This feature accounts for users and organization posts, and is flexible for any other sort of milestones we want to add.

## Related Tickets & Documents
Resolves #1647 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![Screenshot of reaction and view milestone notifications](https://user-images.githubusercontent.com/17884966/53517619-15b57200-3a9d-11e9-8285-9f1138fbe60e.png)


## [optional] What gif best describes this PR or how it makes you feel?
![It's the classic Oprah "You get a car! You get a car! YOU GET A CAR!" gif](https://media.giphy.com/media/y8Mz1yj13s3kI/giphy-downsized.gif)
