### PR TITLE
Remove old methods from reactions #1621

### DIFF
--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -69,6 +69,14 @@ class Reaction < ApplicationRecord
     Reactions::BustHomepageCacheJob.perform_later(id)
   end
 
+  def bust_reactable_cache_without_delay
+    Reactions::BustReactableCacheJob.perform_now(id)
+  end
+
+  def update_reactable_without_delay
+    Reactions::UpdateReactableJob.perform_now(id)
+  end
+
   BASE_POINTS = {
     "vomit" => -50.0,
     "thumbsdown" => -10.0

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -69,43 +69,6 @@ class Reaction < ApplicationRecord
     Reactions::BustHomepageCacheJob.perform_later(id)
   end
 
-  # TODO: remove methods #touch_user_without_delay, #update_reactable_without_delay, #occasionally_sync_reaction_counts
-  # #bust_reactable_cache_without_delay, #async_bust_without_delay
-  def update_reactable_without_delay
-    if reactable_type == "Article"
-      reactable.async_score_calc
-      reactable.index!
-    elsif reactable_type == "Comment" && reactable
-      reactable.save
-    end
-    occasionally_sync_reaction_counts
-  end
-
-  def bust_reactable_cache_without_delay
-    cache_buster.bust user.path
-
-    if reactable_type == "Article"
-      cache_buster.bust "/reactions?article_id=#{reactable_id}"
-    elsif reactable_type == "Comment" && reactable
-      cache_buster.bust "/reactions?commentable_id=#{reactable.commentable_id}&commentable_type=#{reactable.commentable_type}"
-    end
-  end
-
-  def touch_user_without_delay
-    user.touch
-  end
-
-  def async_bust_without_delay
-    featured_articles = Article.where(featured: true).order("hotness_score DESC").limit(3).pluck(:id)
-    if featured_articles.include?(reactable.id)
-      reactable.touch
-      cache_buster.bust "/"
-      cache_buster.bust "/"
-      cache_buster.bust "/?i=i"
-      cache_buster.bust "?i=i"
-    end
-  end
-
   BASE_POINTS = {
     "vomit" => -50.0,
     "thumbsdown" => -10.0
@@ -125,13 +88,6 @@ class Reaction < ApplicationRecord
 
     if reactable_type == "Article" && !reactable&.published
       errors.add(:reactable_id, "is not valid.")
-    end
-  end
-
-  def occasionally_sync_reaction_counts
-    # Fixes any out-of-sync positive_reactions_count
-    if rand(6) == 1 || reactable.positive_reactions_count.negative?
-      reactable.update_column(:positive_reactions_count, reactable.reactions.where("points > ?", 0).size)
     end
   end
 

--- a/spec/models/reaction_destroy_spec.rb
+++ b/spec/models/reaction_destroy_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Reaction, type: :model do
   let(:article) { create(:article, featured: true) }
-  let!(:reaction) { build(:reaction, reactable: article) }
+  let!(:reaction) { create(:reaction, reactable: article) }
 
   it "creates a ScoreCalcJob on article reaction destroy" do
     ActiveJob::Base.queue_adapter = :test


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
Several methods were kept in the `Reaction` model in case there were jobs, which had been created but not yet executed by the deploy time. For now, all the old jobs should be finished, so the methods can be removed.
