### PR TITLE
Fix widths and add controls to <video> tag

### DIFF
--- a/app/assets/stylesheets/article-show.scss
+++ b/app/assets/stylesheets/article-show.scss
@@ -68,6 +68,7 @@ article {
     background: #45525c;
   }
   video {
+    width: 100%;
     max-width: 100%;
     padding: 0.2em;
     margin: 0.5em 0;

--- a/app/assets/stylesheets/article-show.scss
+++ b/app/assets/stylesheets/article-show.scss
@@ -67,6 +67,11 @@ article {
     height: 250px;
     background: #45525c;
   }
+  video {
+    max-width: 100%;
+    padding: 0.2em;
+    margin: 0.5em 0;
+  }
 }
 
 .home .container {

--- a/app/assets/stylesheets/article_form.scss
+++ b/app/assets/stylesheets/article_form.scss
@@ -430,6 +430,7 @@
   margin-top:-50px;
   margin-bottom:70px;
   video {
+    width: 100%;
     max-width: 100%;
     padding: 0.2em;
     margin: 0.5em 0;

--- a/app/assets/stylesheets/article_form.scss
+++ b/app/assets/stylesheets/article_form.scss
@@ -59,10 +59,10 @@
         cursor:default;
         box-shadow: 0px 3px 6px rgba(0,0,0,0.4);
         // color:white;
-        &::before { 
+        &::before {
           content: "<";
         }
-        &::after { 
+        &::after {
           content: ">";
         }
       }
@@ -429,6 +429,11 @@
 .editor-article-view{
   margin-top:-50px;
   margin-bottom:70px;
+  video {
+    max-width: 100%;
+    padding: 0.2em;
+    margin: 0.5em 0;
+  }
 }
 
 

--- a/app/assets/stylesheets/preact/article-form.scss
+++ b/app/assets/stylesheets/preact/article-form.scss
@@ -30,6 +30,7 @@
     }
   }
   video {
+    width: 100%;
     max-width: 100%;
     padding: 0.2em;
     margin: 0.5em 0;

--- a/app/assets/stylesheets/preact/article-form.scss
+++ b/app/assets/stylesheets/preact/article-form.scss
@@ -29,6 +29,11 @@
       background: $yellow;
     }
   }
+  video {
+    max-width: 100%;
+    padding: 0.2em;
+    margin: 0.5em 0;
+  }
 }
 
 .articleform__form {

--- a/app/sanitizers/rendered_markdown_scrubber.rb
+++ b/app/sanitizers/rendered_markdown_scrubber.rb
@@ -2,7 +2,7 @@ class RenderedMarkdownScrubber < Rails::Html::PermitScrubber
   def initialize
     super
     self.tags = %w(a abbr add aside b blockquote br button center cite code col colgroup dd del dl dt em em figcaption h1 h2 h3 h4 h5 h6 hr i img kbd li ol p pre q rp rt ruby small source span strong sub sup table tbody td tfoot th thead time tr u ul video)
-    self.attributes = %w(alt class colspan data-conversation data-lang data-no-instant data-url em height href id loop name ref rel rowspan size span src start strong title type value width)
+    self.attributes = %w(alt class colspan controls data-conversation data-lang data-no-instant data-url em height href id loop name ref rel rowspan size span src start strong title type value width)
   end
 
   def allowed_node?(node)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Adding max-widths to prevent videos from extending past article body and controls for non-Youtube/Vimeo sources.

Update on __Caveat__: seems like the video doesn't load for Safari either because of authorization or ~the file size I'm testing for the example~ due to unfulfilled byte range requests where the video is served. 

Update: Looks good on mobile/tablet based on Chrome. Works on Firefox as well. 

## Related Tickets & Documents
resolves #1885 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
### v2 - editor -> preview -> published article
<img width="1280" alt="screen shot 2019-02-28 at 11 14 54" src="https://user-images.githubusercontent.com/13403332/53580862-823a7a80-3b4a-11e9-9422-f96d7027ef99.png">
<img width="1280" alt="screen shot 2019-02-28 at 11 15 13" src="https://user-images.githubusercontent.com/13403332/53580871-86669800-3b4a-11e9-9892-b1f4702eba47.png">
<img width="1280" alt="screen shot 2019-02-28 at 11 16 41" src="https://user-images.githubusercontent.com/13403332/53580873-89618880-3b4a-11e9-9760-06d0a16724f9.png">

### v1 - editor -> preview -> published article
<img width="1280" alt="screen shot 2019-02-28 at 11 15 54" src="https://user-images.githubusercontent.com/13403332/53580949-a8601a80-3b4a-11e9-80b9-5871423c2818.png">
<img width="1280" alt="screen shot 2019-02-28 at 11 16 08" src="https://user-images.githubusercontent.com/13403332/53580963-b1e98280-3b4a-11e9-8612-37265fcba761.png">
<img width="1280" alt="screen shot 2019-02-28 at 11 16 24" src="https://user-images.githubusercontent.com/13403332/53580986-bd3cae00-3b4a-11e9-80fe-60e4af0c52b5.png">

## Added to documentation?
- [x] no documentation needed