### PR TITLE
Podcast episode comment refresh

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -64,6 +64,8 @@ class Notification < ApplicationRecord
     handle_asynchronously :send_to_followers
 
     def send_new_comment_notifications(comment)
+      return if comment.commentable_type == "PodcastEpisode"
+
       user_ids = comment.ancestors.select(:receive_notifications, :user_id).select(&:receive_notifications).pluck(:user_id).to_set
       user_ids.add(comment.commentable.user_id) if user_ids.empty? && comment.commentable.receive_notifications
       json_data = {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Spent a few minutes trying to figure out #1788 and saw Andy's comment after I'd scrolled down... so I inserted the line where he suggested. I suppose there will be a future PR that would intended behavior to `send_new_comment_notifications` for comments on podcast episodes.

There's some console errors that don't break anything in development that I attached in the screenshots below. 

## Related Tickets & Documents
resolves #1788 

## Mobile & Desktop Screenshots/Recordings
### @Zhao-Andy comment on 1788
<img width="680" alt="screen shot 2019-02-28 at 15 01 14" src="https://user-images.githubusercontent.com/13403332/53594858-ce48e780-3b69-11e9-99d7-3cfd2824f994.png">

### Console
<img width="774" alt="screen shot 2019-02-28 at 15 02 43" src="https://user-images.githubusercontent.com/13403332/53594914-f5071e00-3b69-11e9-9a76-6ee667ea0009.png">
<img width="461" alt="screen shot 2019-02-28 at 15 02 51" src="https://user-images.githubusercontent.com/13403332/53594918-f89aa500-3b69-11e9-9d58-497341913c60.png">

## Added to documentation?
- [x] no documentation needed
