### PR TITLE
Simplify ArticlesController#feed

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -18,7 +18,7 @@ class ArticlesController < ApplicationController
       if @user = User.find_by_username(params[:username])
         @articles.where(user_id: @user.id)
       elsif @user = Organization.find_by_slug(params[:username])
-        @articles.where(user_id: @organization.id).includes(:user)
+        @articles.where(organization_id: @user.id).includes(:user)
       else
         render body: nil
         return


### PR DESCRIPTION
There's unneeded complexity in the logic of the feed method, this way what separates each path should be clearer.

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

I came across ArticlesController#feed and noticed that the ORM logic was a bit convoluted and repeated in each if/else clause. Since AR is a lazy and composable ORM, I decided to simplify the logic.

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
