### PR TITLE
Feature : `SEND_LOGS_TO_TIMBER` env variable to enable or disable timber logging

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -89,9 +89,9 @@ Rails.application.configure do
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   # Install the Timber.io logger
-  send_logs_to_timber = false # <---- set to false to stop sending dev logs to Timber.io
+  send_logs_to_timber = ENV["SEND_LOGS_TO_TIMBER"] || "false" # <---- set to false to stop sending dev logs to Timber.io
 
-  log_device = send_logs_to_timber ? Timber::LogDevices::HTTP.new(ENV["TIMBER"]) : STDOUT
+  log_device = (send_logs_to_timber == "true") ? Timber::LogDevices::HTTP.new(ENV["TIMBER"]) : STDOUT
   logger = Timber::Logger.new(log_device)
   logger.level = config.log_level
   config.logger = ActiveSupport::TaggedLogging.new(logger)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -90,7 +90,6 @@ Rails.application.configure do
 
   # Install the Timber.io logger
   send_logs_to_timber = ENV["SEND_LOGS_TO_TIMBER"] || "false" # <---- set to false to stop sending dev logs to Timber.io
-
   log_device = (send_logs_to_timber == "true") ? Timber::LogDevices::HTTP.new(ENV["TIMBER"]) : STDOUT
   logger = Timber::Logger.new(log_device)
   logger.level = config.log_level

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -92,7 +92,8 @@ Rails.application.configure do
   end
 
   # Timber.io logger
-  log_device = Timber::LogDevices::HTTP.new(ENV["TIMBER"])
+  send_logs_to_timber = ENV["SEND_LOGS_TO_TIMBER"] || "true" # <---- production should send timber logs by default
+  log_device = (send_logs_to_timber == "true") ? Timber::LogDevices::HTTP.new(ENV["TIMBER"]) : STDOUT
   logger = Timber::Logger.new(log_device)
   logger.level = config.log_level
   config.logger = ActiveSupport::TaggedLogging.new(logger)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

Added the `SEND_LOGS_TO_TIMBER` environment variable with false/true default for dev/production modes.

This allows configuration disabling of TIMBER - in "production" mode. 

PS : Im not a ruby dev - so someone should really double check before merging

## Related Tickets & Documents

https://github.com/thepracticaldev/dev.to/pull/1844 - to streamline production mode for docker build 

## Added to documentation?

- [x] no documentation needed

## [optional] What gif best describes how it makes you feel?

![minion-be-the-banana-142323434084gkn](https://user-images.githubusercontent.com/17175484/53615928-44f1ed80-3c1b-11e9-9afb-1829441ac069.jpg)

