### PR TITLE
Fix issue with boosted article in email digest

### DIFF
--- a/app/labor/email_logic.rb
+++ b/app/labor/email_logic.rb
@@ -36,7 +36,7 @@ class EmailLogic
                    where(published: true, email_digest_eligible: true).
                    where.not(user_id: @user.id).
                    where("score > ?", 12).
-                   where("experience_level_rating > ? AND experience_level_rating > ?", @user.experience_level - 3.5, @user.experience_level + 3.5).
+                   where("experience_level_rating > ? AND experience_level_rating > ?", (@user.experience_level || 5) - 3.6, (@user.experience_level || 5) + 3.6).
                    order("score DESC").
                    limit(6)
                else

--- a/app/labor/email_logic.rb
+++ b/app/labor/email_logic.rb
@@ -36,7 +36,7 @@ class EmailLogic
                    where(published: true, email_digest_eligible: true).
                    where.not(user_id: @user.id).
                    where("score > ?", 12).
-                   where("experience_level_rating > ? AND experience_level_rating > ?", (@user.experience_level || 5) - 3.6, (@user.experience_level || 5) + 3.6).
+                   where("experience_level_rating > ? AND experience_level_rating < ?", (@user.experience_level || 5) - 3.6, (@user.experience_level || 5) + 3.6).
                    order("score DESC").
                    limit(6)
                else

--- a/app/labor/email_logic.rb
+++ b/app/labor/email_logic.rb
@@ -35,16 +35,17 @@ class EmailLogic
                    where("published_at > ?", fresh_date).
                    where(published: true, email_digest_eligible: true).
                    where.not(user_id: @user.id).
-                   where("positive_reactions_count > ?", 15).
-                   order("positive_reactions_count DESC").
+                   where("score > ?", 12).
+                   where("experience_level_rating > ? AND experience_level_rating > ?", @user.experience_level - 3.5, @user.experience_level + 3.5).
+                   order("score DESC").
                    limit(6)
                else
                  Article.
                    where("published_at > ?", fresh_date).
                    where(published: true, featured: true, email_digest_eligible: true).
                    where.not(user_id: @user.id).
-                   where("positive_reactions_count > ?", 30).
-                   order("positive_reactions_count DESC").
+                   where("score > ?", 25).
+                   order("score DESC").
                    limit(6)
                end
     if articles.length < 3

--- a/app/mailers/digest_mailer.rb
+++ b/app/mailers/digest_mailer.rb
@@ -5,12 +5,6 @@ class DigestMailer < ApplicationMailer
     @user = user
     @articles = articles.first(6)
     @unsubscribe = generate_unsubscribe_token(@user.id, :email_digest_periodic)
-    @boosted_article = Suggester::Articles::Boosted.new(
-      @user,
-      @articles.first,
-      not_ids: @articles.pluck(:id),
-      area: "dev_digest_email",
-    ).suggest
     subject = generate_title
     mail(to: @user.email, subject: subject)
   end

--- a/app/views/mailers/digest_mailer/digest_email.html.erb
+++ b/app/views/mailers/digest_mailer/digest_email.html.erb
@@ -8,12 +8,6 @@
       <a href="https://dev.to<%= article.path %>" style="font-weight: bold;color:#0045ff;font-size:1.06em;"><%= article.title.strip %></a> <%= truncate(article.description, length: 80) %>
     </li>
   <% end %>
-  <% if @boosted_article && @user.display_sponsors %>
-    <h4 style="background:#e3fffc;display:inline-block;margin:0;">And sponsor-boosted</h4>
-    <li style="margin:18px auto">
-      <a href="https://dev.to<%= @boosted_article.path %>?booster_org=<%= @boosted_article.organization&.slug || "generic" %>" style="font-weight: bold;color:#0045ff;font-size:1.06em;"><%= @boosted_article.title.strip %></a> <%= truncate(@boosted_article.description, length: 80) %>
-    </li>
-  <% end %>
 </ul>
 
 <center style="margin-top:50px;">

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -17,6 +17,7 @@ FactoryBot.define do
     description   { Faker::Hipster.paragraph(1)[0..100] }
     main_image    { Faker::Avatar.image }
     language { "en" }
+    experience_level_rating { rand(4..6) }
     body_markdown do
       <<~HEREDOC
         ---

--- a/spec/labor/email_digest_spec.rb
+++ b/spec/labor/email_digest_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe EmailDigest do
       before { user.follow(author) }
 
       it "send digest email when there's atleast 3 hot articles" do
-        create_list(:article, 3, user_id: author.id, positive_reactions_count: 20)
+        create_list(:article, 3, user_id: author.id, positive_reactions_count: 20, score: 20)
         described_class.send_periodic_digest_email
         expect(DigestMailer).to have_received(:digest_email).with(
           user, [instance_of(Article), instance_of(Article), instance_of(Article)]

--- a/spec/labor/email_logic_spec.rb
+++ b/spec/labor/email_logic_spec.rb
@@ -10,24 +10,24 @@ RSpec.describe EmailLogic do
       it "returns 0.5 for open_percentage" do
         author = create(:user)
         user.follow(author)
-        create_list(:article, 3, user_id: author.id, positive_reactions_count: 20)
+        create_list(:article, 3, user_id: author.id, positive_reactions_count: 20, score: 20)
         h = described_class.new(user).analyze
         expect(h.open_percentage).to eq(0.5)
       end
 
       it "provides top 3 articles" do
-        create_list(:article, 3, positive_reactions_count: 40, featured: true)
+        create_list(:article, 3, positive_reactions_count: 40, featured: true, score: 40)
         h = described_class.new(user).analyze
         expect(h.articles_to_send.length).to eq(3)
       end
 
       it "marks as not ready if there isn't atleast 3 articles" do
-        create_list(:article, 2, positive_reactions_count: 40)
+        create_list(:article, 2, positive_reactions_count: 40, score: 40)
         h = described_class.new(user).analyze
         expect(h.should_receive_email?).to eq(false)
       end
       it "marks as not ready if there isn't at least 3 email-digest-eligible articles" do
-        create_list(:article, 2, positive_reactions_count: 40)
+        create_list(:article, 2, positive_reactions_count: 40, score: 40)
         create_list(:article, 2, positive_reactions_count: 40, email_digest_eligible: false)
         h = described_class.new(user).analyze
         expect(h.should_receive_email?).to eq(false)
@@ -38,7 +38,7 @@ RSpec.describe EmailLogic do
       before do
         author = create(:user)
         user.follow(author)
-        create_list(:article, 3, user_id: author.id, positive_reactions_count: 20)
+        create_list(:article, 3, user_id: author.id, positive_reactions_count: 20, score: 20)
         10.times do
           Ahoy::Message.create(mailer: "DigestMailer#digest_email",
                                user_id: user.id, sent_at: Time.current.utc)
@@ -58,7 +58,7 @@ RSpec.describe EmailLogic do
                                sent_at: Time.current.utc, opened_at: Time.current.utc)
           author = create(:user)
           user.follow(author)
-          create_list(:article, 3, user_id: author.id, positive_reactions_count: 40)
+          create_list(:article, 3, user_id: author.id, positive_reactions_count: 40, score: 40)
         end
       end
 
@@ -75,7 +75,7 @@ RSpec.describe EmailLogic do
     it "refelcts @ready_to_receive_email" do
       author = create(:user)
       user.follow(author)
-      create_list(:article, 3, user_id: author.id, positive_reactions_count: 20)
+      create_list(:article, 3, user_id: author.id, positive_reactions_count: 20, score: 20)
       h = described_class.new(user).analyze
       expect(h.should_receive_email?).to eq(true)
     end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
There was an issue with some digest emails not going out because of the `@boosted_article` API changing. This should fix the bug.

Also added experience level as an indicator for digest emails which could help provide relevant emails. Most users will not be affected by this until we have more use of that feature.