### PR TITLE
fix(runkit): Allow double quotes in preamble

### DIFF
--- a/app/liquid_tags/runkit_tag.rb
+++ b/app/liquid_tags/runkit_tag.rb
@@ -66,7 +66,7 @@ class RunkitTag < Liquid::Block
   end
 
   def sanitized_preamble(markup)
-    raise StandardError, "Runkit tag is invalid" if markup.include? "\""
+    raise StandardError, "Runkit tag is invalid" if markup.include? "\">"
 
     ActionView::Base.full_sanitizer.sanitize(markup, tags: [])
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

**NB: This is not a WIP per se; however, it should not be merged without verifying that it still addresses whatever (unspecified) security concerns motivated the original PR (#1808)**.

## Description

Restore `>` character to sanitization string for runkit preamble, consequently re-allowing double quotes as a valid JS token.

## Related Tickets & Documents

Closes #1937.

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed