### PR TITLE
Fix articles feed not filtering articles by user/organization

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -16,15 +16,15 @@ class ArticlesController < ApplicationController
 
     if params[:username]
       if @user = User.find_by_username(params[:username])
-        @articles.where(user_id: @user.id)
+        @articles = @articles.where(user_id: @user.id)
       elsif @user = Organization.find_by_slug(params[:username])
-        @articles.where(organization_id: @user.id).includes(:user)
+        @articles = @articles.where(organization_id: @user.id).includes(:user)
       else
         render body: nil
         return
       end
     else
-      @articles.where(featured: true).includes(:user)
+      @articles = @articles.where(featured: true).includes(:user)
     end
 
     set_surrogate_key_header "feed", @articles.map(&:record_key)

--- a/spec/controllers/articles_controller_spec.rb
+++ b/spec/controllers/articles_controller_spec.rb
@@ -6,9 +6,56 @@ RSpec.describe ArticlesController, type: :controller do
   let(:user) { create(:user) }
 
   describe "GET #feed" do
+    render_views
+
     it "works" do
       get :feed, format: :rss
       expect(response.status).to eq(200)
+    end
+
+    context "when :username param is not given" do
+      let!(:featured_article) { create(:article, featured: true) }
+      let!(:not_featured_article) { create(:article, featured: false) }
+
+      before { get :feed, format: :rss }
+
+      it "returns only featured articles" do
+        expect(response.body).to include(featured_article.title)
+        expect(response.body).not_to include(not_featured_article.title)
+      end
+    end
+
+    shared_context "when user/organization articles exist" do
+      let(:organization) { create(:organization) }
+      let!(:user_article) { create(:article, user_id: user.id) }
+      let!(:organization_article) { create(:article, organization_id: organization.id) }
+    end
+
+    context "when :username param is given and belongs to a user" do
+      include_context "when user/organization articles exist"
+      before { get :feed, params: { username: user.username }, format: :rss }
+
+      it "returns only articles for that user" do
+        expect(response.body).to include(user_article.title)
+        expect(response.body).not_to include(organization_article.title)
+      end
+    end
+
+    context "when :username param is given and belongs to an organization" do
+      include_context "when user/organization articles exist"
+      before { get :feed, params: { username: organization.slug }, format: :rss }
+
+      it "returns only articles for that organization" do
+        expect(response.body).not_to include(user_article.title)
+        expect(response.body).to include(organization_article.title)
+      end
+    end
+
+    context "when :username param is given but it belongs to nither user nor organization" do
+      include_context "when user/organization articles exist"
+      before { get :feed, params: { username: "unknown" }, format: :rss }
+
+      it("renders empty body") { expect(response.body).to be_empty }
     end
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

A bug was introduced in #1932, leading to unwanted articles in user/organization feeds. `@articles` scope was not being updated propperly depending on `:username` param.

## Related Tickets & Documents

#1940 

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

fix #1940