### PR TITLE
Remove stray forward slashes in RSS feed builder

### DIFF
--- a/app/views/articles/feed.rss.builder
+++ b/app/views/articles/feed.rss.builder
@@ -14,8 +14,8 @@ xml.rss version: "2.0" do
         xml.title article.title
         xml.author (@user && @user.class.name == "User") ? @user.name : article.user.name
         xml.pubDate article.published_at.to_s(:rfc822) if article.published_at
-        xml.link "https://dev.to/#{article.path}"
-        xml.guid "https://dev.to/#{article.path}"
+        xml.link "https://dev.to#{article.path}"
+        xml.guid "https://dev.to#{article.path}"
         xml.description sanitize article.processed_html.html_safe,
           tags: %w(strong em a table tbody thead tfoot th tr td col colgroup del p h1 h2 h3 h4 h5 h6 blockquote iframe time div span i em u b ul ol li dd dl dt q code pre img sup cite center br small),
           attributes: %w(href strong em class ref rel src title alt colspan height width size rowspan span value start data-conversation data-lang id)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

- URLs in the Link and GUID field in RSS have an extra slash. This PR removes stray `/` from lines 17 and 18.

## Related Tickets & Documents

closes #1942

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![slash](https://media0.giphy.com/media/l2SpZviPSdcokCDbG/giphy.gif)
