### PR TITLE
Allow non-logged-in proper redirect for template posts

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -47,7 +47,7 @@ class ArticlesController < ApplicationController
                  Article.new(body_markdown: @tag.submission_template_customized(@user.name),
                              processed_html: "", user_id: current_user&.id)
                elsif @tag.present?
-                 authorize Article
+                 skip_authorization
                  Article.new(
                    body_markdown: "---\ntitle: \npublished: false\ndescription: \ntags: " + @tag.name + "\n---\n\n",
                    processed_html: "", user_id: current_user&.id


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
We wrongly de-authorized the non-logged in `/new` page for tag templates. This fixes it.