### PR TITLE
Clean relative paths for both anchors and images in GitHub liquid tag embeds

### DIFF
--- a/app/liquid_tags/github_tag/github_readme_tag.rb
+++ b/app/liquid_tags/github_tag/github_readme_tag.rb
@@ -46,10 +46,11 @@ class GithubTag
 
     def clean_relative_path!(readme_html, url)
       readme = Nokogiri::HTML(readme_html)
-      readme.css("img").each do |img_tag|
-        path = img_tag.attributes["src"].value
+      readme.css("img, a").each do |element|
+        attribute = element.name == "img" ? "src" : "href"
+        path = element.attributes[attribute].value
         if path[0, 4] != "http"
-          img_tag.attributes["src"].value = url.gsub(/\/README.md/, "") + "/" + path
+          element.attributes[attribute].value = url.gsub(/\/README.md/, "") + "/" + path
         end
       end
       readme.to_html


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

Run `clean_relative_path!` for both `a` and `img` elements.

## Related Tickets & Documents

Fixes #1976 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

