### PR TITLE
Fix unescaped front matter description in MarkdownFixer

### DIFF
--- a/app/labor/markdown_fixer.rb
+++ b/app/labor/markdown_fixer.rb
@@ -32,6 +32,29 @@ class MarkdownFixer
       end
     end
 
+    def add_quotes_to_description(markdown)
+      # Only add quotes to front matter, or text between triple dashes
+      markdown.gsub(/-{3}.*?-{3}/m) do |front_matter|
+        front_matter.gsub(/description:\s?(.*?)(\r\n|\n)/m) do |target|
+          # $1 is the captured group (.*?)
+          captured_title = $1
+          # The query below checks if the whole title is wrapped in
+          # either single or double quotes.
+          match = captured_title.scan(/(^".*"$|^'.*'$)/)
+          if match.empty?
+            # Double quotes that aren't already escaped will get esacped.
+            # Then the whole title get warped in double quotes.
+            parsed_title = captured_title.gsub(/(?<![\\])["]/, "\\\"")
+            "description: \"#{parsed_title}\"\n"
+          else
+            # if the title comes pre-warped in either single or doublequotes,
+            # no more processing is done
+            target
+          end
+        end
+      end
+    end
+
     # This turns --- into ------- after the first two,
     # because --- messes with front matter
     def modify_hr_tags(markdown)

--- a/app/labor/markdown_fixer.rb
+++ b/app/labor/markdown_fixer.rb
@@ -1,4 +1,6 @@
 class MarkdownFixer
+  FRONT_MATTER_DETECTOR = /-{3}.*?-{3}/m.freeze
+
   class << self
     def fix_all(markdown)
       methods = %i[add_quotes_to_title modify_hr_tags convert_new_lines split_tags]
@@ -10,49 +12,11 @@ class MarkdownFixer
     end
 
     def add_quotes_to_title(markdown)
-      # Only add quotes to front matter, or text between triple dashes
-      markdown.gsub(/-{3}.*?-{3}/m) do |front_matter|
-        front_matter.gsub(/title:\s?(.*?)(\r\n|\n)/m) do |target|
-          # $1 is the captured group (.*?)
-          captured_title = Regexp.last_match(1)
-          # The query below checks if the whole title is wrapped in
-          # either single or double quotes.
-          match = captured_title.scan(/(^".*"$|^'.*'$)/)
-          if match.empty?
-            # Double quotes that aren't already escaped will get esacped.
-            # Then the whole title get warped in double quotes.
-            parsed_title = captured_title.gsub(/(?<![\\])["]/, "\\\"")
-            "title: \"#{parsed_title}\"\n"
-          else
-            # if the title comes pre-warped in either single or doublequotes,
-            # no more processing is done
-            target
-          end
-        end
-      end
+      add_quotes_to_section(markdown, section: "title")
     end
 
     def add_quotes_to_description(markdown)
-      # Only add quotes to front matter, or text between triple dashes
-      markdown.gsub(/-{3}.*?-{3}/m) do |front_matter|
-        front_matter.gsub(/description:\s?(.*?)(\r\n|\n)/m) do |target|
-          # $1 is the captured group (.*?)
-          captured_title = $1
-          # The query below checks if the whole title is wrapped in
-          # either single or double quotes.
-          match = captured_title.scan(/(^".*"$|^'.*'$)/)
-          if match.empty?
-            # Double quotes that aren't already escaped will get esacped.
-            # Then the whole title get warped in double quotes.
-            parsed_title = captured_title.gsub(/(?<![\\])["]/, "\\\"")
-            "description: \"#{parsed_title}\"\n"
-          else
-            # if the title comes pre-warped in either single or doublequotes,
-            # no more processing is done
-            target
-          end
-        end
-      end
+      add_quotes_to_section(markdown, section: "description")
     end
 
     # This turns --- into ------- after the first two,
@@ -70,6 +34,31 @@ class MarkdownFixer
     def split_tags(markdown)
       markdown.gsub(/\ntags:.*\n/) do |tags|
         tags.split(" #").join(",").gsub("#", "").gsub(":,", ": ")
+      end
+    end
+
+    private
+
+    def add_quotes_to_section(markdown, section:)
+      # Only add quotes to front matter, or text between triple dashes
+      markdown.gsub(FRONT_MATTER_DETECTOR) do |front_matter|
+        front_matter.gsub(/#{section}:\s?(.*?)(\r\n|\n)/m) do |target|
+          # $1 is the captured group (.*?)
+          captured_text = $1
+          # The query below checks if the whole text is wrapped in
+          # either single or double quotes.
+          match = captured_text.scan(/(^".*"$|^'.*'$)/)
+          if match.empty?
+            # Double quotes that aren't already escaped will get esacped.
+            # Then the whole text get warped in double quotes.
+            parsed_text = captured_text.gsub(/(?<![\\])["]/, "\\\"")
+            "#{section}: \"#{parsed_text}\"\n"
+          else
+            # if the text comes pre-warped in either single or double quotes,
+            # no more processing is done
+            target
+          end
+        end
       end
     end
   end

--- a/app/labor/markdown_fixer.rb
+++ b/app/labor/markdown_fixer.rb
@@ -11,7 +11,7 @@ class MarkdownFixer
     end
 
     def fix_for_preview(markdown)
-      methods = %i(add_quotes_to_title add_quotes_to_description modify_hr_tags)
+      methods = %i[add_quotes_to_title add_quotes_to_description modify_hr_tags]
       methods.reduce(markdown) { |result, method| send(method, result) }
     end
 
@@ -47,8 +47,8 @@ class MarkdownFixer
       # Only add quotes to front matter, or text between triple dashes
       markdown.gsub(FRONT_MATTER_DETECTOR) do |front_matter|
         front_matter.gsub(/#{section}:\s?(.*?)(\r\n|\n)/m) do |target|
-          # $1 is the captured group (.*?)
-          captured_text = $1
+          # 1 is the captured group (.*?)
+          captured_text = Regexp.last_match(1)
           # The query below checks if the whole text is wrapped in
           # either single or double quotes.
           match = captured_text.scan(/(^".*"$|^'.*'$)/)

--- a/app/labor/markdown_fixer.rb
+++ b/app/labor/markdown_fixer.rb
@@ -3,12 +3,16 @@ class MarkdownFixer
 
   class << self
     def fix_all(markdown)
-      methods = %i[add_quotes_to_title modify_hr_tags convert_new_lines split_tags]
+      methods = %i[
+        add_quotes_to_title add_quotes_to_description
+        modify_hr_tags convert_new_lines split_tags
+      ]
       methods.reduce(markdown) { |result, method| send(method, result) }
     end
 
     def fix_for_preview(markdown)
-      modify_hr_tags(add_quotes_to_title(markdown))
+      methods = %i(add_quotes_to_title add_quotes_to_description modify_hr_tags)
+      methods.reduce(markdown) { |result, method| send(method, result) }
     end
 
     def add_quotes_to_title(markdown)

--- a/spec/labor/markdown_fixer_spec.rb
+++ b/spec/labor/markdown_fixer_spec.rb
@@ -62,26 +62,23 @@ RSpec.describe MarkdownFixer do
 
     it "does not escape a description that came pre-wrapped in single quotes" do
       legacy_description = "'#{sample_text}'"
-      result = described_class.add_quotes_to_description(
-        front_matter(description: legacy_description),
-      )
+      result = described_class.
+        add_quotes_to_description(front_matter(description: legacy_description))
       expect(result).to eq(front_matter(description: legacy_description))
     end
 
     it "does not escape a description that came pre-wrapped in double quotes" do
       legacy_description = "\"#{sample_text}\""
-      result = described_class.add_quotes_to_description(
-        front_matter(description: legacy_description),
-      )
+      result = described_class.
+        add_quotes_to_description(front_matter(description: legacy_description))
       expect(result).to eq(front_matter(description: legacy_description))
     end
 
     it "handles a complex description" do
       legacy_description = %(Book review: "#{sample_text}", part 1 I'm #testing)
       expected_description = "\"Book review: \\\"#{sample_text}\\\", part 1 I'm #testing\""
-      result = described_class.add_quotes_to_description(
-        front_matter(description: legacy_description),
-      )
+      result = described_class.
+        add_quotes_to_description(front_matter(description: legacy_description))
       expect(result).to eq(front_matter(description: expected_description))
     end
 
@@ -98,6 +95,24 @@ RSpec.describe MarkdownFixer do
       expected_title = "\"hmm\"\n"
       result = described_class.convert_new_lines(front_matter(title: title))
       expect(result).to eq(front_matter(title: expected_title))
+    end
+  end
+
+  describe "::fix_all" do
+    it "escapes title and description" do
+      result = described_class.
+        fix_all(front_matter(title: sample_text, description: sample_text))
+      expected_result = front_matter(title: %("#{sample_text}"), description: %("#{sample_text}"))
+      expect(result).to eq(expected_result)
+    end
+  end
+
+  describe "::fix_for_preview" do
+    it "escapes title and description" do
+      result = described_class.
+        fix_for_preview(front_matter(title: sample_text, description: sample_text))
+      expected_result = front_matter(title: %("#{sample_text}"), description: %("#{sample_text}"))
+      expect(result).to eq(expected_result)
     end
   end
 end

--- a/spec/labor/markdown_fixer_spec.rb
+++ b/spec/labor/markdown_fixer_spec.rb
@@ -13,41 +13,51 @@ RSpec.describe MarkdownFixer do
   end
 
   describe "::add_quotes_to_title" do
+    it "does not do anything outside the front matter" do
+      result = described_class.add_quotes_to_title(sample_text)
+      expect(result).to eq(sample_text)
+    end
+
     it "escapes a simple title" do
       result = described_class.add_quotes_to_title(front_matter(title: sample_text))
-      expect(result).to eq front_matter(title: %("#{sample_text}"))
+      expect(result).to eq(front_matter(title: %("#{sample_text}")))
     end
 
     it "does not escape a title that came pre-wrapped in single quotes" do
       legacy_title = "'#{sample_text}'"
       result = described_class.add_quotes_to_title(front_matter(title: legacy_title))
-      expect(result).to eq front_matter(title: legacy_title)
+      expect(result).to eq(front_matter(title: legacy_title))
     end
 
     it "does not escape a title that came pre-wrapped in double quotes" do
       legacy_title = "\"#{sample_text}\""
       result = described_class.add_quotes_to_title(front_matter(title: legacy_title))
-      expect(result).to eq front_matter(title: legacy_title)
+      expect(result).to eq(front_matter(title: legacy_title))
     end
 
     it "handles a complex title" do
       legacy_title = %(Book review: "#{sample_text}", part 1 I'm #testing)
       expected_title = "\"Book review: \\\"#{sample_text}\\\", part 1 I'm #testing\""
       result = described_class.add_quotes_to_title(front_matter(title: legacy_title))
-      expect(result).to eq front_matter(title: expected_title)
+      expect(result).to eq(front_matter(title: expected_title))
     end
 
     it "handles a title with colons" do
       title = "Title: with colons"
       result = described_class.add_quotes_to_title(front_matter(title: title))
-      expect(result).to eq front_matter(title: %("#{title}"))
+      expect(result).to eq(front_matter(title: %("#{title}")))
     end
   end
 
   describe "::add_quotes_to_description" do
+    it "does not do anything outside the front matter" do
+      result = described_class.add_quotes_to_description(sample_text)
+      expect(result).to eq(sample_text)
+    end
+
     it "escapes a simple description" do
       result = described_class.add_quotes_to_description(front_matter(description: sample_text))
-      expect(result).to eq front_matter(description: %("#{sample_text}"))
+      expect(result).to eq(front_matter(description: %("#{sample_text}")))
     end
 
     it "does not escape a description that came pre-wrapped in single quotes" do
@@ -55,7 +65,7 @@ RSpec.describe MarkdownFixer do
       result = described_class.add_quotes_to_description(
         front_matter(description: legacy_description),
       )
-      expect(result).to eq front_matter(description: legacy_description)
+      expect(result).to eq(front_matter(description: legacy_description))
     end
 
     it "does not escape a description that came pre-wrapped in double quotes" do
@@ -63,7 +73,7 @@ RSpec.describe MarkdownFixer do
       result = described_class.add_quotes_to_description(
         front_matter(description: legacy_description),
       )
-      expect(result).to eq front_matter(description: legacy_description)
+      expect(result).to eq(front_matter(description: legacy_description))
     end
 
     it "handles a complex description" do
@@ -72,13 +82,13 @@ RSpec.describe MarkdownFixer do
       result = described_class.add_quotes_to_description(
         front_matter(description: legacy_description),
       )
-      expect(result).to eq front_matter(description: expected_description)
+      expect(result).to eq(front_matter(description: expected_description))
     end
 
     it "handles a description with colons" do
       description = "Description: with colons"
       result = described_class.add_quotes_to_description(front_matter(description: description))
-      expect(result).to eq front_matter(description: %("#{description}"))
+      expect(result).to eq(front_matter(description: %("#{description}")))
     end
   end
 
@@ -87,7 +97,7 @@ RSpec.describe MarkdownFixer do
       title = "\"hmm\"\r\n"
       expected_title = "\"hmm\"\n"
       result = described_class.convert_new_lines(front_matter(title: title))
-      expect(result).to eq front_matter(title: expected_title)
+      expect(result).to eq(front_matter(title: expected_title))
     end
   end
 end

--- a/spec/labor/markdown_fixer_spec.rb
+++ b/spec/labor/markdown_fixer_spec.rb
@@ -1,46 +1,93 @@
 require "rails_helper"
 
 RSpec.describe MarkdownFixer do
-  let(:sample_title) { Faker::Book.title }
+  let(:sample_text) { Faker::Book.title }
 
-  def create_sample_markdown(title)
+  def front_matter(title: "", description: "")
     <<~HEREDOC
       ---
       title: #{title}
+      description: #{description}
       ---
     HEREDOC
   end
 
   describe "::add_quotes_to_title" do
-    it "escapes simple title" do
-      test = described_class.fix_all(create_sample_markdown(sample_title))
-      expect(test).to eq create_sample_markdown(%("#{sample_title}"))
+    it "escapes a simple title" do
+      result = described_class.add_quotes_to_title(front_matter(title: sample_text))
+      expect(result).to eq front_matter(title: %("#{sample_text}"))
     end
 
-    it "does not escape titles that came pre-wrapped in single quotes" do
-      legacy_title = "'#{sample_title}'"
-      test = described_class.fix_all(create_sample_markdown(legacy_title))
-      expect(test).to eq create_sample_markdown(legacy_title)
+    it "does not escape a title that came pre-wrapped in single quotes" do
+      legacy_title = "'#{sample_text}'"
+      result = described_class.add_quotes_to_title(front_matter(title: legacy_title))
+      expect(result).to eq front_matter(title: legacy_title)
     end
 
-    it "does not escape titles that came pre-wrapped in double quotes" do
-      legacy_title = "\"#{sample_title}\""
-      test = described_class.fix_all(create_sample_markdown(legacy_title))
-      expect(test).to eq create_sample_markdown(legacy_title)
+    it "does not escape a title that came pre-wrapped in double quotes" do
+      legacy_title = "\"#{sample_text}\""
+      result = described_class.add_quotes_to_title(front_matter(title: legacy_title))
+      expect(result).to eq front_matter(title: legacy_title)
     end
 
-    it "handles complex title" do
-      legacy_title = %(Book review: "#{sample_title}", part 1 I'm #testing)
-      expected_title = "\"Book review: \\\"#{sample_title}\\\", part 1 I'm #testing\""
-      test = described_class.fix_all(create_sample_markdown(legacy_title))
-      expect(test).to eq create_sample_markdown(expected_title)
+    it "handles a complex title" do
+      legacy_title = %(Book review: "#{sample_text}", part 1 I'm #testing)
+      expected_title = "\"Book review: \\\"#{sample_text}\\\", part 1 I'm #testing\""
+      result = described_class.add_quotes_to_title(front_matter(title: legacy_title))
+      expect(result).to eq front_matter(title: expected_title)
     end
 
-    it "handles title with \r\n" do
+    it "handles a title with colons" do
+      title = "Title: with colons"
+      result = described_class.add_quotes_to_title(front_matter(title: title))
+      expect(result).to eq front_matter(title: %("#{title}"))
+    end
+  end
+
+  describe "::add_quotes_to_description" do
+    it "escapes a simple description" do
+      result = described_class.add_quotes_to_description(front_matter(description: sample_text))
+      expect(result).to eq front_matter(description: %("#{sample_text}"))
+    end
+
+    it "does not escape a description that came pre-wrapped in single quotes" do
+      legacy_description = "'#{sample_text}'"
+      result = described_class.add_quotes_to_description(
+        front_matter(description: legacy_description),
+      )
+      expect(result).to eq front_matter(description: legacy_description)
+    end
+
+    it "does not escape a description that came pre-wrapped in double quotes" do
+      legacy_description = "\"#{sample_text}\""
+      result = described_class.add_quotes_to_description(
+        front_matter(description: legacy_description),
+      )
+      expect(result).to eq front_matter(description: legacy_description)
+    end
+
+    it "handles a complex description" do
+      legacy_description = %(Book review: "#{sample_text}", part 1 I'm #testing)
+      expected_description = "\"Book review: \\\"#{sample_text}\\\", part 1 I'm #testing\""
+      result = described_class.add_quotes_to_description(
+        front_matter(description: legacy_description),
+      )
+      expect(result).to eq front_matter(description: expected_description)
+    end
+
+    it "handles a description with colons" do
+      description = "Description: with colons"
+      result = described_class.add_quotes_to_description(front_matter(description: description))
+      expect(result).to eq front_matter(description: %("#{description}"))
+    end
+  end
+
+  describe "::convert_new_lines" do
+    it "handles text with \r\n" do
       title = "\"hmm\"\r\n"
       expected_title = "\"hmm\"\n"
-      test = described_class.fix_all(create_sample_markdown(title))
-      expect(test).to eq create_sample_markdown(expected_title)
+      result = described_class.convert_new_lines(front_matter(title: title))
+      expect(result).to eq front_matter(title: expected_title)
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

I set out to fix https://github.com/thepracticaldev/dev.to/issues/96 - the initial idea was to create more meaningful error messages, I then realized the front matter is parsed by a third party library, so I abandonded the idea.

I decided to just fix the bug created by unwrapped chars in the description (which triggered the issue in the first place)

## Related Tickets & Documents

Closes #96 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

**Before**

![before](https://user-images.githubusercontent.com/146201/53881915-2e7dd480-4015-11e9-942c-5d7772a6c2bf.gif)

**After**

![after](https://user-images.githubusercontent.com/146201/53881954-49504900-4015-11e9-847b-b388a92bf997.gif)


## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
