### PR TITLE
Minor improvements to tag admin

### DIFF
--- a/app/controllers/admin/tags_controller.rb
+++ b/app/controllers/admin/tags_controller.rb
@@ -33,6 +33,7 @@ module Admin
         bg_color_hex
         text_color_hex
         keywords_for_search
+        buffer_profile_id_code
       ]
       convert_empty_string_to_nil
       params.require(:tag).permit(accessible)

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -26,6 +26,12 @@ class TagsController < ApplicationController
     end
   end
 
+  def admin
+    tag = Tag.find_by!(name: params[:tag])
+    authorize tag
+    redirect_to "/admin/tags/#{tag.id}/edit"
+  end
+
   private
 
   def convert_empty_string_to_nil

--- a/app/dashboards/tag_dashboard.rb
+++ b/app/dashboards/tag_dashboard.rb
@@ -66,6 +66,7 @@ class TagDashboard < Administrate::BaseDashboard
     bg_color_hex
     text_color_hex
     keywords_for_search
+    buffer_profile_id_code
   ].freeze
 
   # FORM_ATTRIBUTES

--- a/app/policies/tag_policy.rb
+++ b/app/policies/tag_policy.rb
@@ -11,6 +11,10 @@ class TagPolicy < ApplicationPolicy
     has_mod_permission?
   end
 
+  def admin?
+    user_admin?
+  end
+
   private
 
   def has_mod_permission?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -280,6 +280,7 @@ Rails.application.routes.draw do
   get "/tag/:tag" => "stories#index"
   get "/t/:tag" => "stories#index"
   get "/t/:tag/edit", to: "tags#edit"
+  get "/t/:tag/admin", to: "tags#admin"
   patch "/tag/:id", to: "tags#update"
   get "/t/:tag/top/:timeframe" => "stories#index"
   get "/t/:tag/:timeframe" => "stories#index",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Add a missing column that wasn't present in the admin tag show page, as well as add it in the strong params list.

Also adds `/t/:tag/admin` route for easier access to a tag's admin page.