### PR TITLE
Fix undefined returned by timeAgo, showing up after the post date of older posts

### DIFF
--- a/app/assets/javascripts/utilities/timeAgo.js
+++ b/app/assets/javascripts/utilities/timeAgo.js
@@ -1,13 +1,3 @@
-function timeAgo(oldTimeInSeconds, maxDisplayedAge = 60*60*24-1) {
-  const timeNow = new Date() / 1000;
-  const diff = Math.round(timeNow - oldTimeInSeconds);
-
-  if(diff > maxDisplayedAge)
-    return '';
-
-  return "<span class='time-ago-indicator'>(" + secondsToHumanUnitAgo(diff) + ")</span>";
-}
-
 function secondsToHumanUnitAgo(seconds) {
 	const times = [
 		['second', 1],
@@ -23,14 +13,25 @@ function secondsToHumanUnitAgo(seconds) {
 		return "Just now";
 
 	let scale = 0;
-	//If the amount of seconds is more than a minute, we change the scale to minutes
-	//If the amount of seconds then is more than an hour, we change the scale to hours
-	//This continues until the unit above our current scale is longer than `seconds`, or doesn't exist
+	// If the amount of seconds is more than a minute, we change the scale to minutes
+	// If the amount of seconds then is more than an hour, we change the scale to hours
+	// This continues until the unit above our current scale is longer than `seconds`, or doesn't exist
 	while(scale+1 < times.length && seconds >= times[scale+1][1])
-		scale++;
+		scale+=1;
 
 	const wholeUnits = Math.floor(seconds / times[scale][1]);
 	const unitName = times[scale][0] + (wholeUnits === 1 ? '' : 's');
 
 	return wholeUnits + " " + unitName + " ago";
 }
+
+function timeAgo(oldTimeInSeconds, maxDisplayedAge = 60*60*24-1) {
+  const timeNow = new Date() / 1000;
+  const diff = Math.round(timeNow - oldTimeInSeconds);
+
+  if(diff > maxDisplayedAge)
+    return '';
+
+  return "<span class='time-ago-indicator'>(" + secondsToHumanUnitAgo(diff) + ")</span>";
+}
+

--- a/app/assets/javascripts/utilities/timeAgo.js
+++ b/app/assets/javascripts/utilities/timeAgo.js
@@ -1,33 +1,33 @@
-function timeAgo(oldTimeInSeconds) {
-  var seconds = new Date() / 1000;
-  var times = [
-    ['second', 1],
-    ['min', 60],
-    ['hour', 3600],
-    ['day', 86400],
-    ['week', 604800],
-    ['month', 2592000],
-    ['year', 31536000],
-  ];
-  var t;
-  var diff = Math.round(seconds - oldTimeInSeconds);
-  for (t = 0; t < times.length; t++) {
-    if (diff < times[t][1]) {
-      if (t === 0) {
-        return "<span class='time-ago-indicator'>(Just now)</span>";
-      }
-      if (t < 4) {
-        diff = Math.round(diff / times[t - 1][1]);
-        return (
-          "<span class='time-ago-indicator'>(" +
-          diff +
-          ' ' +
-          times[t - 1][0] +
-          (diff === 1 ? ' ago' : 's ago') +
-          ')</span>'
-        );
-      }
-      return '';
-    }
-  }
+function timeAgo(oldTimeInSeconds, maxDisplayedAge = 60*60*24-1) {
+  const timeNow = new Date() / 1000;
+  const diff = Math.round(timeNow - oldTimeInSeconds);
+
+  if(diff > maxDisplayedAge)
+    return '';
+
+  return "<span class='time-ago-indicator'>(" + secondsToHumanUnitAgo(diff) + ")</span>";
+}
+
+function secondsToHumanUnitAgo(seconds) {
+	const times = [
+		['second', 1],
+		['min', 60],
+		['hour', 60*60],
+		['day', 60*60*24],
+		['week', 60*60*24*7],
+		['month', 60*60*24*30],
+		['year', 60*60*24*365],
+	];
+
+	if(seconds < times[0][1])
+		return "Just now";
+
+	let scale = 0;
+	while(scale+1 < times.length && seconds >= times[scale+1][1])
+		scale++;
+
+	const wholeUnits = Math.floor(seconds / times[scale][1]);
+	const unitName = times[scale][0] + (wholeUnits === 1 ? '' : 's');
+
+	return wholeUnits + " " + unitName + " ago";
 }

--- a/app/assets/javascripts/utilities/timeAgo.js
+++ b/app/assets/javascripts/utilities/timeAgo.js
@@ -23,6 +23,9 @@ function secondsToHumanUnitAgo(seconds) {
 		return "Just now";
 
 	let scale = 0;
+	//If the amount of seconds is more than a minute, we change the scale to minutes
+	//If the amount of seconds then is more than an hour, we change the scale to hours
+	//This continues until the unit above our current scale is longer than `seconds`, or doesn't exist
 	while(scale+1 < times.length && seconds >= times[scale+1][1])
 		scale++;
 

--- a/app/assets/javascripts/utilities/timeAgo.js
+++ b/app/assets/javascripts/utilities/timeAgo.js
@@ -10,7 +10,7 @@ function secondsToHumanUnitAgo(seconds) {
 	];
 
 	if(seconds < times[0][1])
-		return "Just now";
+		return "just now";
 
 	let scale = 0;
 	// If the amount of seconds is more than a minute, we change the scale to minutes


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

Rewrite the timeAgo function such that it never returns undefined.
The new optional parameter allows the caller to specify what the cutoff is for including a time ago-string. The default value is extracted from the previous code

## Related Tickets & Documents

Fixes Issue #1995 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
