### PR TITLE
Fix typo in surrogate key header

### DIFF
--- a/app/controllers/api/v0/articles_controller.rb
+++ b/app/controllers/api/v0/articles_controller.rb
@@ -17,7 +17,7 @@ module Api
           "articles_api",
           params[:tag],
           params[:page],
-          params[:userame],
+          params[:username],
           params[:signature],
           params[:state],
         ]


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

There was a typo in the surrogate key header in that it referred to the username parameter as "userame" which affects the usefulness of the key.