### PR TITLE
Handle images uploading errors

### DIFF
--- a/app/assets/javascripts/initializers/initializeCommentsPage.js.erb
+++ b/app/assets/javascripts/initializers/initializeCommentsPage.js.erb
@@ -471,9 +471,12 @@ function handleImageUpload(event, randomIdNumber) {
               }
             );
           } else {
-            document.getElementById("image-upload-file-label-" + randomIdNumber).innerHTML = "Invalid file!";
-            document.getElementById("image-upload-file-label-" + randomIdNumber).style.color = '#e05252';
-            document.getElementById("image-upload-submit-" + randomIdNumber).style.display = 'none';
+            response.json().then(function(responseBody) {
+              var errorMessage = responseBody.error || 'Invalid file!';
+              document.getElementById("image-upload-file-label-" + randomIdNumber).innerHTML = errorMessage;
+              document.getElementById("image-upload-file-label-" + randomIdNumber).style.color = '#e05252';
+              document.getElementById("image-upload-submit-" + randomIdNumber).style.display = 'none';
+            });
           }
         })
         .catch(function (err) {

--- a/app/assets/stylesheets/preact/article-form.scss
+++ b/app/assets/stylesheets/preact/article-form.scss
@@ -500,3 +500,8 @@
     color: $black;
   }
 }
+
+.articleform__uploaderror {
+  color: $red;
+  font-size: 0.8em;
+}

--- a/app/controllers/image_uploads_controller.rb
+++ b/app/controllers/image_uploads_controller.rb
@@ -4,13 +4,28 @@ class ImageUploadsController < ApplicationController
 
   def create
     authorize :image_upload
+
     uploader = ArticleImageUploader.new
-    uploader.store!(params[:image])
+    begin
+      uploader.store!(params[:image])
+    rescue CarrierWave::IntegrityError => e # client error
+      respond_to do |format|
+        format.json { render json: { error: e.message }, status: :unprocessable_entity }
+      end
+      return
+    rescue CarrierWave::ProcessingError # server error
+      respond_to do |format|
+        format.json { render json: { error: "A server error has occurred!" }, status: :server_error }
+      end
+      return
+    end
+
     link = if params[:wrap_cloudinary]
              ApplicationController.helpers.cloud_cover_url(uploader.url)
            else
              uploader.url
            end
+
     respond_to do |format|
       format.json { render json: { link: link }, status: 200 }
     end

--- a/app/javascript/article-form/actions.js
+++ b/app/javascript/article-form/actions.js
@@ -45,20 +45,6 @@ export function submitArticle(payload, clearStorage, errorCb, failureCb) {
     .catch(failureCb);
 }
 
-export function generateMainImage(payload, successCb, failureCb) {
-  fetch('/image_uploads', {
-    method: 'POST',
-    headers: {
-      'X-CSRF-Token': csrfToken,
-    },
-    body: generateUploadFormdata(payload),
-    credentials: 'same-origin',
-  })
-    .then(response => response.json())
-    .then(successCb)
-    .catch(failureCb);
-}
-
 function generateUploadFormdata(payload) {
   const token = window.csrfToken;
   const formData = new FormData();
@@ -68,4 +54,24 @@ function generateUploadFormdata(payload) {
     formData.append('wrap_cloudinary', 'true');
   }
   return formData;
+}
+
+export function generateMainImage(payload, successCb, failureCb) {
+  fetch('/image_uploads', {
+    method: 'POST',
+    headers: {
+      'X-CSRF-Token': window.csrfToken,
+    },
+    body: generateUploadFormdata(payload),
+    credentials: 'same-origin',
+  })
+    .then(response => response.json())
+    .then(json => {
+      if (json.error) {
+        throw new Error(json.error);
+      }
+
+      return successCb(json);
+    })
+    .catch(failureCb);
 }

--- a/app/javascript/article-form/elements/imageManagement.jsx
+++ b/app/javascript/article-form/elements/imageManagement.jsx
@@ -5,21 +5,33 @@ import { generateMainImage } from '../actions';
 export default class ImageManagement extends Component {
   constructor(props) {
     super(props);
-    this.state = { insertionImageUrl: null };
+    this.state = {
+      insertionImageUrl: null,
+      uploadError: false,
+      uploadErrorMessage: null,
+    };
   }
 
   handleMainImageUpload = e => {
     e.preventDefault();
 
+    this.clearUploadError();
+
     const payload = { image: e.target.files, wrap_cloudinary: true };
     const { onMainImageUrlChange } = this.props;
 
-    generateMainImage(payload, onMainImageUrlChange, null);
+    generateMainImage(payload, onMainImageUrlChange, this.onUploadError);
   };
 
   handleInsertionImageUpload = e => {
+    this.clearUploadError();
+
     const payload = { image: e.target.files };
-    generateMainImage(payload, this.handleInsertImageUploadSuccess, null);
+    generateMainImage(
+      payload,
+      this.handleInsertImageUploadSuccess,
+      this.onUploadError,
+    );
   };
 
   handleInsertImageUploadSuccess = response => {
@@ -38,9 +50,24 @@ export default class ImageManagement extends Component {
     });
   };
 
+  clearUploadError = () => {
+    this.setState({
+      uploadError: false,
+      uploadErrorMessage: null,
+    });
+  };
+
+  onUploadError = error => {
+    this.setState({
+      insertionImageUrl: null,
+      uploadError: true,
+      uploadErrorMessage: error.message,
+    });
+  };
+
   render() {
     const { onExit, mainImageUrl } = this.props;
-    const { insertionImageUrl } = this.state;
+    const { insertionImageUrl, uploadError, uploadErrorMessage } = this.state;
     let mainImageArea;
 
     if (mainImageUrl) {
@@ -89,6 +116,9 @@ export default class ImageManagement extends Component {
         >
           ×
         </button>
+        {uploadError && (
+          <span className="articleform__uploaderror">{uploadErrorMessage}</span>
+        )}
         <h2>Cover Image</h2>
         {mainImageArea}
         <h2>Body Images</h2>

--- a/app/views/articles/_markdown_form.html.erb
+++ b/app/views/articles/_markdown_form.html.erb
@@ -350,9 +350,12 @@
           if (response.status === 200) {
             return response.json().then(uploadImageCb);
           } else {
-            document.getElementById('image-upload-file-label').innerHTML = "Invalid file!";
-            document.getElementById('image-upload-file-label').style.color = '#e05252';
-            document.getElementById('image-upload-submit').style.display = 'none';
+            response.json().then(function(responseBody) {
+              var errorMessage = responseBody.error || "Invalid file!";
+              document.getElementById('image-upload-file-label').innerHTML = errorMessage;
+              document.getElementById('image-upload-file-label').style.color = '#e05252';
+              document.getElementById('image-upload-submit').style.display = 'none';
+            });
           }
         })
         .catch(function (err) {

--- a/spec/requests/image_uploads_spec.rb
+++ b/spec/requests/image_uploads_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "ImageUploads", type: :request do
     context "when not logged-in" do
       it "responds with 401" do
         post "/image_uploads", headers: headers
-        expect(response).to have_http_status(401)
+        expect(response).to have_http_status(:unauthorized)
       end
     end
 
@@ -41,8 +41,14 @@ RSpec.describe "ImageUploads", type: :request do
       end
 
       it "prevents image with resolutions larger than 4096x4096" do
-        expect { post("/image_uploads", headers: headers, params: { image: bad_image }) }.
-          to raise_error(CarrierWave::IntegrityError)
+        post "/image_uploads", headers: headers, params: { image: bad_image }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "returns a JSON error if something goes wrong" do
+        post "/image_uploads", headers: headers, params: { image: bad_image }
+        result = JSON.parse(response.body)
+        expect(result["error"]).not_to be_nil
       end
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

Currently, when an image upload results in an error, the server "breaks", a HTTP 500 unhandled error is generated and the user is shown a generic "invalid file" for the comment editor and editor v1 and nothing at all for editor v2.

In this PR I added/changed the following:

* a proper error handling server side (an image upload error shouldn't result in HTTP 500, because the error is fine, it's the client that sent something wrong)

* errors that are not client dependent should indeed generate HTTP 500

* messages returned by CarrierWave that are related to client errors are directly shown to the user (I checked the from CarrierWave's own [locale/en.yml](https://github.com/carrierwaveuploader/carrierwave/blob/master/lib/carrierwave/locale/en.yml) and they seem ok to be consumed by the user

* messages returned by CarrierWave that are related to server errors are still handled but a generic "a server error has occurred" is sent to the client (should these by sent to a bug tracker as well?)

* I added error handling to the client side

A note: I'm not super confident in the way I chose to display the upload error in the editor v2, let me know if it should be displayed in a different way or if it should have a better styling.

I added screen recordings for the three cases

## Related Tickets & Documents

Closes #936, closes #2008

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

**Editor v1**

![editor-v1](https://user-images.githubusercontent.com/146201/54086770-c0a31700-434c-11e9-960c-86df017ae158.gif)

**Editor v2**

![editor-v2](https://user-images.githubusercontent.com/146201/54086785-d9133180-434c-11e9-94c7-8d7988fc9d39.gif)

**Comment editor**

![comment-editor](https://user-images.githubusercontent.com/146201/54086792-e7f9e400-434c-11e9-939a-e5701dbe01f6.gif)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
