### PR TITLE
Add initial charts implementation to pro dashboard

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -32,16 +32,22 @@ class DashboardsController < ApplicationController
 
   def pro
     authorize current_user, :pro_user?
-    current_user_article_ids = current_user.articles.pluck(:id)
-    @this_week_reactions_count = Reaction.where(reactable_id: current_user_article_ids, reactable_type: "Article").where("created_at > ?", 1.week.ago).size
-    @last_week_reactions_count = Reaction.where(reactable_id: current_user_article_ids, reactable_type: "Article").where("created_at > ? AND created_at < ?", 2.weeks.ago, 1.week.ago).size
-    @this_month_reactions_count = Reaction.where(reactable_id: current_user_article_ids, reactable_type: "Article").where("created_at > ?", 1.month.ago).size
-    @last_month_reactions_count = Reaction.where(reactable_id: current_user_article_ids, reactable_type: "Article").where("created_at > ? AND created_at < ?", 2.months.ago, 1.months.ago).size
+    @current_user_article_ids = current_user.articles.pluck(:id)
+    @this_week_reactions = ChartDecorator.decorate(Reaction.where(reactable_id: @current_user_article_ids, reactable_type: "Article").where("created_at > ?", 1.week.ago).order("created_at ASC"))
+    @this_week_reactions_count = @this_week_reactions.size
+    @last_week_reactions_count = Reaction.where(reactable_id: @current_user_article_ids, reactable_type: "Article").where("created_at > ? AND created_at < ?", 2.weeks.ago, 1.week.ago).size
+    @this_month_reactions_count = Reaction.where(reactable_id: @current_user_article_ids, reactable_type: "Article").where("created_at > ?", 1.month.ago).size
+    @last_month_reactions_count = Reaction.where(reactable_id: @current_user_article_ids, reactable_type: "Article").where("created_at > ? AND created_at < ?", 2.months.ago, 1.months.ago).size
+    @this_week_comments_count = Comment.where(commentable_id: @current_user_article_ids, commentable_type: "Article").where("created_at > ?", 1.week.ago).size
+    @this_week_comments = ChartDecorator.decorate(Comment.where(commentable_id: @current_user_article_ids, commentable_type: "Article").where("created_at > ?", 1.week.ago))
+    @last_week_comments_count = @this_week_comments.size
+    @this_month_comments_count = Comment.where(commentable_id: @current_user_article_ids, commentable_type: "Article").where("created_at > ?", 1.month.ago).size
+    @last_month_comments_count = Comment.where(commentable_id: @current_user_article_ids, commentable_type: "Article").where("created_at > ? AND created_at < ?", 2.months.ago, 1.months.ago).size
     @this_week_followers_count = Follow.where(followable_id: current_user.id, followable_type: "User").where("created_at > ?", 1.week.ago).size
     @last_week_followers_count = Follow.where(followable_id: current_user.id, followable_type: "User").where("created_at > ? AND created_at < ?", 2.weeks.ago, 1.week.ago).size
     @this_month_followers_count = Follow.where(followable_id: current_user.id, followable_type: "User").where("created_at > ?", 1.month.ago).size
     @last_month_followers_count = Follow.where(followable_id: current_user.id, followable_type: "User").where("created_at > ? AND created_at < ?", 2.months.ago, 1.months.ago).size
     @reactors = User.
-      where(id: Reaction.where(reactable_id: current_user_article_ids, reactable_type: "Article").order("created_at DESC").limit(100).pluck(:user_id))
+      where(id: Reaction.where(reactable_id: @current_user_article_ids, reactable_type: "Article").order("created_at DESC").limit(100).pluck(:user_id))
   end
 end

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -32,15 +32,16 @@ class DashboardsController < ApplicationController
 
   def pro
     authorize current_user, :pro_user?
-    @this_week_reactions_count = Reaction.where(reactable_id: current_user.articles.pluck(:id), reactable_type: "Article").where("created_at > ?", 1.week.ago).size
-    @last_week_reactions_count = Reaction.where(reactable_id: current_user.articles.pluck(:id), reactable_type: "Article").where("created_at > ? AND created_at < ?", 2.weeks.ago, 1.week.ago).size
-    @this_month_reactions_count = Reaction.where(reactable_id: current_user.articles.pluck(:id), reactable_type: "Article").where("created_at > ?", 1.month.ago).size
-    @last_month_reactions_count = Reaction.where(reactable_id: current_user.articles.pluck(:id), reactable_type: "Article").where("created_at > ? AND created_at < ?", 2.months.ago, 1.months.ago).size
+    current_user_article_ids = current_user.articles.pluck(:id)
+    @this_week_reactions_count = Reaction.where(reactable_id: current_user_article_ids, reactable_type: "Article").where("created_at > ?", 1.week.ago).size
+    @last_week_reactions_count = Reaction.where(reactable_id: current_user_article_ids, reactable_type: "Article").where("created_at > ? AND created_at < ?", 2.weeks.ago, 1.week.ago).size
+    @this_month_reactions_count = Reaction.where(reactable_id: current_user_article_ids, reactable_type: "Article").where("created_at > ?", 1.month.ago).size
+    @last_month_reactions_count = Reaction.where(reactable_id: current_user_article_ids, reactable_type: "Article").where("created_at > ? AND created_at < ?", 2.months.ago, 1.months.ago).size
     @this_week_followers_count = Follow.where(followable_id: current_user.id, followable_type: "User").where("created_at > ?", 1.week.ago).size
     @last_week_followers_count = Follow.where(followable_id: current_user.id, followable_type: "User").where("created_at > ? AND created_at < ?", 2.weeks.ago, 1.week.ago).size
     @this_month_followers_count = Follow.where(followable_id: current_user.id, followable_type: "User").where("created_at > ?", 1.month.ago).size
     @last_month_followers_count = Follow.where(followable_id: current_user.id, followable_type: "User").where("created_at > ? AND created_at < ?", 2.months.ago, 1.months.ago).size
     @reactors = User.
-      where(id: Reaction.where(reactable_id: current_user.articles.pluck(:id), reactable_type: "Article").order("created_at DESC").limit(100).pluck(:user_id))
+      where(id: Reaction.where(reactable_id: current_user_article_ids, reactable_type: "Article").order("created_at DESC").limit(100).pluck(:user_id))
   end
 end

--- a/app/decorators/chart_decorator.rb
+++ b/app/decorators/chart_decorator.rb
@@ -1,0 +1,22 @@
+class ChartDecorator < Draper::CollectionDecorator
+  def total_by_type_per_day(options)
+    case options[:type]
+    when "Comment"
+      object.group_by(&:created_at).transform_values do |v|
+        v.select { |comment| comment.commentable_id == options[:article_id] }.length
+      end.values # will be an array of integers: [1,2,3,4]
+    when "Reaction"
+      object.group_by(&:created_at).transform_values do |v|
+        v.select { |reaction| reaction.category == options[:category] }.length
+      end.values # will be an array of integers: [1,2,3,4]
+    end
+  end
+
+  def total_per_day
+    object.group_by(&:created_at).transform_values(&:length).values
+  end
+
+  def formatted_dates
+    object.sort_by(&:created_at).group_by(&:created_at).transform_keys { |k| k.strftime("%a, %m/%d") }.keys
+  end
+end

--- a/app/decorators/reaction_decorator.rb
+++ b/app/decorators/reaction_decorator.rb
@@ -1,0 +1,1 @@
+class ReactionDecorator < ApplicationDecorator; end

--- a/app/javascript/packs/proCharts.js
+++ b/app/javascript/packs/proCharts.js
@@ -67,8 +67,7 @@ export const commentsChart = new Chart(commentsCanvas, {
     datasets: [
       {
         label: 'Total Comments',
-        // data: JSON.parse(commentsCanvas.dataset.totalCount),
-        data: [5, 10, 15, 17, 25, 23, 55],
+        data: JSON.parse(commentsCanvas.dataset.totalCount),
         fill: false,
         borderColor: 'rgb(75, 192, 192)',
         lineTension: 0.1,

--- a/app/javascript/packs/proCharts.js
+++ b/app/javascript/packs/proCharts.js
@@ -1,0 +1,94 @@
+import Chart from 'chart.js';
+
+const reactionsCanvas = document.getElementById('reactionsChart');
+const commentsCanvas = document.getElementById('commentsChart');
+
+export const reactionsChart = new Chart(reactionsCanvas, {
+  type: 'line',
+  data: {
+    labels: JSON.parse(reactionsCanvas.dataset.labels),
+    datasets: [
+      {
+        label: 'Reaction Total',
+        data: JSON.parse(reactionsCanvas.dataset.totalCount),
+        // data: [5, 10, 15, 17, 25, 23],
+        fill: false,
+        borderColor: 'rgb(75, 192, 192)',
+        lineTension: 0.1,
+      },
+      {
+        label: 'Total Likes',
+        data: JSON.parse(reactionsCanvas.dataset.totalLikes),
+        // data: [2, 5, 10, 10, 15, 13],
+        fill: false,
+        borderColor: 'rgb(229, 100, 100)',
+        lineTension: 0.1,
+      },
+      {
+        label: 'Total Unicorns',
+        data: JSON.parse(reactionsCanvas.dataset.totalUnicorns),
+        // data: [1, 2, 2, 4, 5, 3],
+        fill: false,
+        borderColor: 'rgb(157, 57, 233)',
+        lineTension: 0.1,
+      },
+      {
+        label: 'Total Bookmarks',
+        data: JSON.parse(reactionsCanvas.dataset.totalReadinglist),
+        // data: [2, 3, 3, 3, 5, 7],
+        fill: false,
+        borderColor: 'rgb(10, 133, 255)',
+        lineTension: 0.1,
+      },
+    ],
+  },
+  options: {
+    title: {
+      display: true,
+      text: 'Reactions over the Last Week',
+    },
+    scales: {
+      yAxes: [
+        {
+          ticks: {
+            suggestedMin: 0,
+            precision: 0,
+          },
+        },
+      ],
+    },
+  },
+});
+
+export const commentsChart = new Chart(commentsCanvas, {
+  type: 'line',
+  data: {
+    labels: JSON.parse(commentsCanvas.dataset.labels),
+    datasets: [
+      {
+        label: 'Total Comments',
+        // data: JSON.parse(commentsCanvas.dataset.totalCount),
+        data: [5, 10, 15, 17, 25, 23, 55],
+        fill: false,
+        borderColor: 'rgb(75, 192, 192)',
+        lineTension: 0.1,
+      },
+    ],
+  },
+  options: {
+    title: {
+      display: true,
+      text: 'Comments over the Last Week',
+    },
+    scales: {
+      yAxes: [
+        {
+          ticks: {
+            suggestedMin: 0,
+            precision: 0,
+          },
+        },
+      ],
+    },
+  },
+});

--- a/app/views/dashboards/pro.html.erb
+++ b/app/views/dashboards/pro.html.erb
@@ -4,23 +4,50 @@
   <p>This dashboard will highlight deep insights especially relevant to dev rel.</p>
   <hr />
   <h2>Reactions Summary (❤🦄🔖)</h2>
-  <ul>
-    <li>
-      <%= @this_week_reactions_count %> reactions this week (<%= @last_week_reactions_count.positive? ? (@this_week_reactions_count.to_f / @last_week_reactions_count.to_f) * 100 : "infinity " %>% of previous week)
-    </li>
-    <li>
-      <%= @this_month_reactions_count %> reactions this month (<%= @last_month_reactions_count.positive? ? (@this_month_reactions_count.to_f / @last_month_reactions_count.to_f) * 100 : "infinity " %>% of previous month)
-    </li>
-  </ul>
-    <h2>New Followers Summary (👩‍💻👨‍💻)</h2>
-  <ul>
-    <li>
-      <%= @this_week_followers_count %> new followers this week (<%= @last_week_followers_count.positive? ? (@this_week_followers_count.to_f / @last_week_followers_count.to_f) * 100 : "infinity " %>% of previous week)
-    </li>
-    <li>
-      <%= @this_month_followers_count %> new followers this month (<%= @last_month_followers_count.positive? ? (@this_month_followers_count.to_f / @last_month_followers_count.to_f) * 100 : "infinity " %>% of previous month)
-    </li>
-  </ul>
+    <ul>
+      <li>
+        <%= @this_week_reactions_count %> reactions this week (<%= @last_week_reactions_count.positive? ? (@this_week_reactions_count.to_f / @last_week_reactions_count.to_f) * 100 : "infinity " %>% of previous week)
+      </li>
+      <li>
+        <%= @this_month_reactions_count %> reactions this month (<%= @last_month_reactions_count.positive? ? (@this_month_reactions_count.to_f / @last_month_reactions_count.to_f) * 100 : "infinity " %>% of previous month)
+      </li>
+        <div style="width: 500px; height: 250px; margin: 0 auto;">
+          <canvas
+            id="reactionsChart"
+            data-labels="<%= @this_week_reactions.formatted_dates %>"
+            data-total-count="<%= @this_week_reactions.total_per_day %>"
+            data-total-likes="<%= @this_week_reactions.total_by_type_per_day(type: "Reaction", category: "like") %>"
+            data-total-unicorns="<%= @this_week_reactions.total_by_type_per_day(type: "Reaction", category: "unicorn") %>"
+            data-total-readinglist="<%= @this_week_reactions.total_by_type_per_day(type: "Reaction", category: "readinglist") %>">
+          </canvas>
+        </div>
+      <%= javascript_pack_tag "proCharts", defer: true %>
+    </ul>
+  <h2>New Followers Summary (👩‍💻👨‍💻)</h2>
+    <ul>
+      <li>
+        <%= @this_week_followers_count %> new followers this week (<%= @last_week_followers_count.positive? ? (@this_week_followers_count.to_f / @last_week_followers_count.to_f) * 100 : "infinity " %>% of previous week)
+      </li>
+      <li>
+        <%= @this_month_followers_count %> new followers this month (<%= @last_month_followers_count.positive? ? (@this_month_followers_count.to_f / @last_month_followers_count.to_f) * 100 : "infinity " %>% of previous month)
+      </li>
+    </ul>
+  <h2>Comments Summary (💬)</h2>
+    <ul>
+      <li>
+      <%= @this_week_comments_count %> new comments this week (<%= @last_week_comments_count.positive? ? (@this_week_comments_count.to_f / @last_week_comments_count.to_f) * 100 : "infinity " %>% of previous week)
+      </li>
+      <li>
+        <%= @this_month_comments_count %> new comments this month (<%= @last_month_comments_count.positive? ? (@this_month_comments_count.to_f / @last_month_comments_count.to_f) * 100 : "infinity " %>% of previous month)
+      </li>
+        <div style="width: 500px; height: 250px; margin: 0 auto;">
+          <canvas
+            id="commentsChart"
+            data-labels="<%= @this_week_comments.formatted_dates %>"
+            data-total-count="<%= @this_week_comments.total_per_day %>">
+          </canvas>
+        </div>
+    </ul>
   <h2>Activity</h2>
   <h3>People who recently reacted (❤🦄🔖) to your content:</h3>
   <div style="height: 400px; overflow: scroll;">

--- a/app/views/dashboards/pro.html.erb
+++ b/app/views/dashboards/pro.html.erb
@@ -26,7 +26,7 @@
   <h2>New Followers Summary (👩‍💻👨‍💻)</h2>
     <ul>
       <li>
-        <%= @this_week_followers_count %> new followers this week (<%= @last_week_followers_count.positive? ? (@this_week_followers_count.to_f / @last_week_followers_count.to_f) * 100 : "infinity " %>% of previous week)
+        <%= @this_week_followers_count %> new followers this week (<%= @last_week_followers_count.positive? ? ((@this_week_followers_count.to_f / @last_week_followers_count.to_f) * 100).round(2) : "infinity " %>% of previous week)
       </li>
       <li>
         <%= @this_month_followers_count %> new followers this month (<%= @last_month_followers_count.positive? ? (@this_month_followers_count.to_f / @last_month_followers_count.to_f) * 100 : "infinity " %>% of previous month)

--- a/app/views/dashboards/pro.html.erb
+++ b/app/views/dashboards/pro.html.erb
@@ -6,10 +6,10 @@
   <h2>Reactions Summary (❤🦄🔖)</h2>
     <ul>
       <li>
-        <%= @this_week_reactions_count %> reactions this week (<%= @last_week_reactions_count.positive? ? (@this_week_reactions_count.to_f / @last_week_reactions_count.to_f) * 100 : "infinity " %>% of previous week)
+        <%= @this_week_reactions_count %> reactions this week (<%= @last_week_reactions_count.positive? ? ((@this_week_reactions_count.to_f / @last_week_reactions_count.to_f) * 100).round(2) : "infinity " %>% of previous week)
       </li>
       <li>
-        <%= @this_month_reactions_count %> reactions this month (<%= @last_month_reactions_count.positive? ? (@this_month_reactions_count.to_f / @last_month_reactions_count.to_f) * 100 : "infinity " %>% of previous month)
+        <%= @this_month_reactions_count %> reactions this month (<%= @last_month_reactions_count.positive? ? ((@this_month_reactions_count.to_f / @last_month_reactions_count.to_f) * 100).round(2) : "infinity " %>% of previous month)
       </li>
         <div style="width: 500px; height: 250px; margin: 0 auto;">
           <canvas
@@ -29,16 +29,16 @@
         <%= @this_week_followers_count %> new followers this week (<%= @last_week_followers_count.positive? ? ((@this_week_followers_count.to_f / @last_week_followers_count.to_f) * 100).round(2) : "infinity " %>% of previous week)
       </li>
       <li>
-        <%= @this_month_followers_count %> new followers this month (<%= @last_month_followers_count.positive? ? (@this_month_followers_count.to_f / @last_month_followers_count.to_f) * 100 : "infinity " %>% of previous month)
+        <%= @this_month_followers_count %> new followers this month (<%= @last_month_followers_count.positive? ? ((@this_month_followers_count.to_f / @last_month_followers_count.to_f) * 100).round(2) : "infinity " %>% of previous month)
       </li>
     </ul>
   <h2>Comments Summary (💬)</h2>
     <ul>
       <li>
-      <%= @this_week_comments_count %> new comments this week (<%= @last_week_comments_count.positive? ? (@this_week_comments_count.to_f / @last_week_comments_count.to_f) * 100 : "infinity " %>% of previous week)
+      <%= @this_week_comments_count %> new comments this week (<%= @last_week_comments_count.positive? ? ((@this_week_comments_count.to_f / @last_week_comments_count.to_f) * 100).round(2) : "infinity " %>% of previous week)
       </li>
       <li>
-        <%= @this_month_comments_count %> new comments this month (<%= @last_month_comments_count.positive? ? (@this_month_comments_count.to_f / @last_month_comments_count.to_f) * 100 : "infinity " %>% of previous month)
+        <%= @this_month_comments_count %> new comments this month (<%= @last_month_comments_count.positive? ? ((@this_month_comments_count.to_f / @last_month_comments_count.to_f) * 100).round(2) : "infinity " %>% of previous month)
       </li>
         <div style="width: 500px; height: 250px; margin: 0 auto;">
           <canvas

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "faker": "^4.1.0",
     "husky": "^1.3.1",
     "jest": "^23.5.0",
-    "jest-localstorage-mock": "^2.4.0",
     "jest-fetch-mock": "^2.1.1",
     "jsdom": "^14.0.0",
     "lint-staged": "^8.1.5",
@@ -89,6 +88,7 @@
     "@rails/webpacker": "^3.5.5",
     "babel-plugin-transform-react-jsx": "^6.24.1",
     "babel-preset-preact": "^1.1.0",
+    "chart.js": "^2.7.3",
     "codemirror": "^5.44.0",
     "intersection-observer": "^0.5.1",
     "linkstate": "^1.1.1",
@@ -98,10 +98,12 @@
     "preact-textarea-autosize": "^4.0.7",
     "prop-types": "^15.7.2",
     "pusher-js": "^4.4.0",
-    "web-share-wrapper": "^0.2.1",
-    "twilio-video": "^1.15.2"
+    "twilio-video": "^1.15.2",
+    "web-share-wrapper": "^0.2.1"
   },
   "jest": {
-    "setupFiles": ["jest-localstorage-mock"]
+    "setupFiles": [
+      "jest-localstorage-mock"
+    ]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2370,6 +2370,29 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
+chart.js@^2.7.3:
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-2.7.3.tgz#cdb61618830bf216dc887e2f7b1b3c228b73c57e"
+  integrity sha512-3+7k/DbR92m6BsMUYP6M0dMsMVZpMnwkUyNSAbqolHKsbIzH2Q4LWVEHHYq7v0fmEV8whXE0DrjANulw9j2K5g==
+  dependencies:
+    chartjs-color "^2.1.0"
+    moment "^2.10.2"
+
+chartjs-color-string@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/chartjs-color-string/-/chartjs-color-string-0.5.0.tgz#8d3752d8581d86687c35bfe2cb80ac5213ceb8c1"
+  integrity sha512-amWNvCOXlOUYxZVDSa0YOab5K/lmEhbFNKI55PWc4mlv28BDzA7zaoQTGxSBgJMHIW+hGX8YUrvw/FH4LyhwSQ==
+  dependencies:
+    color-name "^1.0.0"
+
+chartjs-color@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/chartjs-color/-/chartjs-color-2.2.0.tgz#84a2fb755787ed85c39dd6dd8c7b1d88429baeae"
+  integrity sha1-hKL7dVeH7YXDndbdjHsdiEKbrq4=
+  dependencies:
+    chartjs-color-string "^0.5.0"
+    color-convert "^0.5.3"
+
 chokidar@^2.0.0, chokidar@^2.0.2:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.0.4.tgz#356ff4e2b0e8e43e322d18a372460bbcf3accd26"
@@ -2533,6 +2556,11 @@ collection-visit@^1.0.0:
   dependencies:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
+
+color-convert@^0.5.3:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-0.5.3.tgz#bdb6c69ce660fadffe0b0007cc447e1b9f7282bd"
+  integrity sha1-vbbGnOZg+t/+CwAHzER+G59ygr0=
 
 color-convert@^1.3.0, color-convert@^1.8.2, color-convert@^1.9.0, color-convert@^1.9.1:
   version "1.9.3"
@@ -5848,11 +5876,6 @@ jest-leak-detector@^23.6.0:
   dependencies:
     pretty-format "^23.6.0"
 
-jest-localstorage-mock@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/jest-localstorage-mock/-/jest-localstorage-mock-2.4.0.tgz#c6073810735dd3af74020ea6c3885ec1cc6d0d13"
-  integrity sha512-/mC1JxnMeuIlAaQBsDMilskC/x/BicsQ/BXQxEOw+5b1aGZkkOAqAF3nu8yq449CpzGtp5jJ5wCmDNxLgA2m6A==
-
 jest-matcher-utils@^23.6.0:
   version "23.6.0"
   resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-23.6.0.tgz#726bcea0c5294261a7417afb6da3186b4b8cac80"
@@ -6936,6 +6959,11 @@ mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkd
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
+
+moment@^2.10.2:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
 
 move-concurrently@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
This PR adds some basic time-series charts to the pro dashboard. It also lays some groundwork for code to be reused for other charts/data-visualizations.

Code/implementation-detail-wise there are a lot of individual queries, which would grow as we want more and different kinds of data. What we might want to do is move them into `javascript_pack_tags` that call an API endpoint for the specific data, and then have it render afterward.

There's more to add for sure, but I think this will be a good start. 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![charts dashboard example](https://user-images.githubusercontent.com/17884966/54158898-041b8500-4422-11e9-89ec-639d57a0ad8a.png)
