### PR TITLE
Remove notifications when banishing and deleting a user

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -185,16 +185,16 @@ class Comment < ApplicationRecord
     commentable.index!
   end
 
-  private
-
-  def update_notifications
-    Notification.update_notifications(self)
-  end
-
   def remove_notifications
     Notification.remove_all_without_delay(notifiable_id: id, notifiable_type: "Comment")
     Notification.remove_all_without_delay(notifiable_id: id, notifiable_type: "Comment", action: "Moderation")
     Notification.remove_all_without_delay(notifiable_id: id, notifiable_type: "Comment", action: "Reaction")
+  end
+
+  private
+
+  def update_notifications
+    Notification.update_notifications(self)
   end
 
   def send_to_moderator

--- a/app/services/moderator/banisher.rb
+++ b/app/services/moderator/banisher.rb
@@ -49,6 +49,7 @@ module Moderator
         comment.reactions.delete_all
         CacheBuster.new.bust_comment(comment.commentable, user.username)
         comment.delete
+        comment.remove_notifications
       end
     end
 
@@ -61,6 +62,7 @@ module Moderator
           comment.reactions.delete_all
           CacheBuster.new.bust_comment(comment.commentable, comment.user.username)
           comment.delete
+          comment.remove_notifications
         end
         CacheBuster.new.bust_article(article)
         article.remove_algolia_index


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This properly removes notifications for related comments when a comment has been destroyed by the banisher or deletion process.