### PR TITLE
Standardise tag list data between Articles API endpoints

### DIFF
--- a/app/views/api/v0/articles/show.json.jbuilder
+++ b/app/views/api/v0/articles/show.json.jbuilder
@@ -6,7 +6,7 @@ json.cover_image        cloud_cover_url @article.main_image
 json.published_at       @article.published_at
 json.readable_publish_date @article.readable_publish_date
 json.social_image       cloud_social_image(@article)
-json.tag_list           @article.cached_tag_list
+json.tag_list           @article.cached_tag_list_array
 json.slug               @article.slug
 json.path               @article.path
 json.url                @article.url


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

This brings the "show" endpoint and the "index" endpoints for the Articles API inline with how they represent the tag list data.

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed