### PR TITLE
Don't send new follower notification when followable is a tag #2041

### DIFF
--- a/app/controllers/follows_controller.rb
+++ b/app/controllers/follows_controller.rb
@@ -24,13 +24,14 @@ class FollowsController < ApplicationController
                    User.find(params[:followable_id])
                  end
     add_param_context(:followable_type, :followable_id, :verb)
+    need_notification = Follow.need_new_follower_notification_for?(followable.class.name)
     @result = if params[:verb] == "unfollow"
                 follow = current_user.stop_following(followable)
-                Notification.send_new_follower_notification_without_delay(follow, true)
+                Notification.send_new_follower_notification_without_delay(follow, true) if need_notification
                 "unfollowed"
               else
                 follow = current_user.follow(followable)
-                Notification.send_new_follower_notification(follow)
+                Notification.send_new_follower_notification(follow) if need_notification
                 "followed"
               end
     current_user.touch

--- a/app/models/follow.rb
+++ b/app/models/follow.rb
@@ -26,6 +26,10 @@ class Follow < ApplicationRecord
 
   validates :followable_id, uniqueness: { scope: %i[followable_type follower_id] }
 
+  def self.need_new_follower_notification_for?(followable_type)
+    %w[User Organization].include?(followable_type)
+  end
+
   private
 
   def touch_follower

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -12,6 +12,8 @@ class Notification < ApplicationRecord
 
   class << self
     def send_new_follower_notification(follow, is_read = false)
+      return unless Follow.need_new_follower_notification_for?(follow.followable_type)
+
       recent_follows = Follow.where(followable_type: follow.followable_type, followable_id: follow.followable_id).where("created_at > ?", 24.hours.ago).order("created_at DESC")
 
       notification_params = { action: "Follow" }

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -8,6 +8,25 @@ RSpec.describe Notification, type: :model do
   let(:article)         { create(:article, user_id: user.id, page_views_count: 4000, positive_reactions_count: 70) }
   let(:follow_instance) { user.follow(user2) }
 
+  describe "when trying to #send_new_follower_notification after following a tag" do
+    let(:tag) { create(:tag) }
+    let(:tag_follow) { user.follow(tag) }
+
+    it "runs fine" do
+      run_background_jobs_immediately do
+        Notification.send_new_follower_notification(tag_follow)
+      end
+    end
+
+    it "doesn't create a notification" do
+      run_background_jobs_immediately do
+        expect do
+          Notification.send_new_follower_notification(tag_follow)
+        end.not_to change(Notification, :count)
+      end
+    end
+  end
+
   describe "#send_new_follower_notification" do
     before do
       run_background_jobs_immediately do

--- a/spec/requests/follows_create_spec.rb
+++ b/spec/requests/follows_create_spec.rb
@@ -13,7 +13,9 @@ RSpec.describe "Following/Unfollowing", type: :request do
       let(:tag) { create(:tag) }
 
       before do
-        post "/follows", params: { followable_type: "Tag", followable_id: tag.id }
+        run_background_jobs_immediately do
+          post "/follows", params: { followable_type: "Tag", followable_id: tag.id }
+        end
       end
 
       it "follows" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
- added checks to ensure followable is a `User` or an `Organization` before sending a notification
- added specs

## Related Tickets & Documents
#2041