### PR TITLE
Change articles.id type from integer to bigint

### DIFF
--- a/db/migrate/20190313112643_change_articles_id_to_big_int.rb
+++ b/db/migrate/20190313112643_change_articles_id_to_big_int.rb
@@ -1,0 +1,9 @@
+class ChangeArticlesIdToBigInt < ActiveRecord::Migration[5.1]
+  def up
+    change_column :articles, :id, :bigint
+  end
+
+  def down
+    change_column :articles, :id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -45,7 +45,7 @@ ActiveRecord::Schema.define(version: 20190315222044) do
     t.index ["user_id"], name: "index_api_secrets_on_user_id"
   end
 
-  create_table "articles", id: :serial, force: :cascade do |t|
+  create_table "articles", force: :cascade do |t|
     t.string "abuse_removal_reason"
     t.boolean "allow_big_edits", default: true
     t.boolean "allow_small_edits", default: true


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

Changes `articles.id` primary key type from `integer` to `bigint`

## Related Tickets & Documents

Refer to the discussion in #1113 

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
