### PR TITLE
Dashboard: use numerical input for tags points

### DIFF
--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -58,7 +58,7 @@
               </a>
               <%= form_for(follow) do |f| %>
                 <%= f.label(:points, "Follow Weight:") %>
-                <%= f.text_field(:points) %>
+                <%= f.number_field(:points, step: :any) %>
                 <%= f.submit "Submit" %>
               <% end %>
             </h2>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

Currently the Dashboard -> Following page tags allow inputing text instead of numbers. Since those are floating points they will be rejected after the submission of the page, using a HTML numerical input with `step` set to `any` any valid number (integer or float) is accepted. 

This was inspired by @Link2Twenty's [comment](https://github.com/thepracticaldev/dev.to/issues/1346#issuecomment-449409607) on #1346 (in the spirit of submitting smaller PRs eheh)

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Positive numbers

![followed_tags](https://user-images.githubusercontent.com/146201/54295357-21cc2400-45b3-11e9-8795-17e627460701.gif)

Negative numbers

![followed_tags_negative](https://user-images.githubusercontent.com/146201/54295535-82f3f780-45b3-11e9-8512-450e76c6162f.gif)


## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
