### PR TITLE
add markup and styling for skip link

### DIFF
--- a/app/assets/stylesheets/top-bar.scss
+++ b/app/assets/stylesheets/top-bar.scss
@@ -267,6 +267,28 @@
       }
     }
   }
+  
+  .skip-content-link {
+    position: absolute;
+    top: 0;
+    left: 50%;
+    transform: translate(-50%, -100px);
+    background: black;
+    color: white;
+    z-index: 9999;
+    padding: 13px;
+    cursor: default;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.3s $ease-in-cubic, transform 0.3s $ease-in-cubic;
+
+    &:focus {      
+      pointer-events: auto;
+      opacity: 1;
+      transform: translate(-50%, 22px);
+      transition: opacity 0.3s $ease-out-cubic, transform 0.3s $ease-out-cubic;
+    }
+  }
   // border-bottom:2px solid rgb(10, 10, 10);
   .logo-link {
     display: inline-block;

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -32,6 +32,9 @@ $light-shadow: 1px 2px 4px 0 rgba(0, 0, 0, 0.1);
 $dark-shadow: 1px 2px 4px 0 rgba(0, 0, 0, 0.25);
 $bold-shadow: 3px 3px 0px darken($light-medium-gray, 13%);
 
+$ease-in-cubic : cubic-bezier(0.55, 0.055, 0.675, 0.19);
+$ease-out-cubic : cubic-bezier(0.215, 0.61, 0.355, 1);
+
 body.night-theme {
   #top-bar,
   #page-content,

--- a/app/views/layouts/_top_bar.html.erb
+++ b/app/views/layouts/_top_bar.html.erb
@@ -2,6 +2,7 @@
 </div>
 <div class="top-bar" id="top-bar">
   <nav>
+    <a href="#articles-list" class="skip-content-link">Skip to content</a>
     <a href="/" class="logo-link" id="logo-link" aria-label="DEV Home"><%= inline_svg("devplain.svg", class: "logo", size: "20% * 20%") %></a>
     <div id="nav-search-form-root">
       <div class="nav-search-form">


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
This styling and markup change provides a useful link for keyboard only navigation users to jump right to the content of the site. More info and WC3 links in the issue!

If there are any concerns with the transition styling I'm happy to remove! In past experience we've found it draws attention for users who might not catch the UI change. Thanks!

## Related Tickets & Documents
#1153 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![desktop-snapshot](https://user-images.githubusercontent.com/4615840/54328507-8b185b00-45e4-11e9-873b-5e4928a218ec.PNG)
![mobile-snapshot](https://user-images.githubusercontent.com/4615840/54328508-8b185b00-45e4-11e9-8e8d-88d4f45ae15d.PNG)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/3oz8xRsCP14cAnCtIA/giphy.gif)
