### PR TITLE
Redirect to 404 if badge not found

### DIFF
--- a/app/controllers/badges_controller.rb
+++ b/app/controllers/badges_controller.rb
@@ -3,7 +3,7 @@ class BadgesController < ApplicationController
   # No authorization required for entirely public controller
 
   def show
-    @badge = Badge.find_by_slug(params[:slug])
+    @badge = Badge.find_by_slug(params[:slug]) || not_found
     set_surrogate_key_header "badges-show-action"
   end
 end

--- a/spec/requests/badges_spec.rb
+++ b/spec/requests/badges_spec.rb
@@ -5,9 +5,17 @@ RSpec.describe "Badges", type: :request do
   let(:badge) { create(:badge) }
 
   describe "GET /badge/:slug" do
-    it "shows the badge" do
-      get "/badge/#{badge.slug}"
-      expect(response.body).to include CGI.escapeHTML(badge.title)
+    context "when badge exists" do
+      it "shows the badge" do
+        get "/badge/#{badge.slug}"
+        expect(response.body).to include CGI.escapeHTML(badge.title)
+      end
+    end
+
+    context "when badge does not exist" do
+      it "renders 404" do
+        expect { get "/badge/that-does-not-exists" }.to raise_error(ActionController::RoutingError)
+      end
     end
   end
 end


### PR DESCRIPTION
Previouly we do not check if `@badge` exists before redirecting to
`:show`, this commit fixes that by redirecting to 404.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

## Related Tickets & Documents
#2051 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![image](https://user-images.githubusercontent.com/20277437/54376050-27159580-46bd-11e9-8ee9-4f183d533a73.png)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![squash bugs!](https://media.giphy.com/media/oSUtmrhRz5te0/giphy.gif)
