### PR TITLE
Allow users to configure to use night mode (beta) and sans-serif article body

### DIFF
--- a/app/assets/javascripts/utilities/browserStoreCache.js
+++ b/app/assets/javascripts/utilities/browserStoreCache.js
@@ -1,18 +1,14 @@
-
-
-function browserStoreCache(action,userData) {
+function browserStoreCache(action, userData) {
   try {
-    if (action === "set") {
-      localStorage.setItem("current_user",userData);
+    if (action === 'set') {
+      localStorage.setItem('current_user', userData);
+      localStorage.setItem('config_body_class', JSON.parse(userData)['config_body_class']);
+    } else if (action === 'remove') {
+      localStorage.removeItem('current_user');
+    } else {
+      return localStorage.getItem('current_user');
     }
-    else if (action === "remove") {
-      localStorage.removeItem("current_user");
-    }
-    else {
-      return localStorage.getItem("current_user");
-    }
-  }
-  catch(err) {
-      browserStoreCache("remove");
+  } catch (err) {
+    browserStoreCache('remove');
   }
 }

--- a/app/assets/stylesheets/settings.scss
+++ b/app/assets/stylesheets/settings.scss
@@ -209,6 +209,10 @@
           }
         }
       }
+      select {
+        display: block;
+        font-size: 1.3em;
+      }
       button.big-action {
         width: 130px;
         padding: 3px 0px;

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -57,3 +57,9 @@ body.night-theme {
     }
   }
 }
+
+body.sans-serif-article-body {
+  .body p {
+    font-family: $helvetica;
+  }
+}

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -61,5 +61,6 @@ body.night-theme {
 body.sans-serif-article-body {
   .body p {
     font-family: $helvetica;
+    font-size: 0.98em;
   }
 }

--- a/app/controllers/async_info_controller.rb
+++ b/app/controllers/async_info_controller.rb
@@ -47,7 +47,8 @@ class AsyncInfoController < ApplicationController
         number_of_comments: @user.comments.count,
         display_sponsors: @user.display_sponsors,
         trusted: @user.trusted,
-        experience_level: @user.experience_level
+        experience_level: @user.experience_level,
+        config_body_class: @user.config_body_class
       }
     end
   end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -31,6 +31,13 @@ class UserDecorator < ApplicationDecorator
     end
   end
 
+  def config_body_class
+    body_class = ""
+    body_class = body_class + config_theme.gsub("_", "-")
+    body_class = body_class + " " + config_font.gsub("_", "-") + "-article-body"
+    body_class
+  end
+
   def assigned_color
     colors = [
       {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -112,6 +112,13 @@ class User < ApplicationRecord
   validates :editor_version,
               inclusion: { in: %w(v1 v2),
                            message: "%{value} must be either v1 or v2" }
+
+  validates :config_theme,
+              inclusion: { in: %w(default night_theme),
+                           message: "%{value} must be either default or night theme" }
+  validates :config_font,
+              inclusion: { in: %w(default sans_serif),
+                           message: "%{value} must be either default or sans serif" }
   validates :shipping_country,
               length: { in: 2..2 },
               allow_blank: true
@@ -138,6 +145,7 @@ class User < ApplicationRecord
   after_create :estimate_default_language!
   before_update :mentorship_status_update
   before_validation :set_username
+  before_validation :set_config_input
   before_validation :downcase_email
   before_validation :check_for_username_change
   before_destroy :remove_from_algolia_index
@@ -438,6 +446,11 @@ class User < ApplicationRecord
 
   def downcase_email
     self.email = email.downcase if email
+  end
+
+  def set_config_input
+    self.config_theme = config_theme.gsub(" ", "_")
+    self.config_font = config_font.gsub(" ", "_")
   end
 
   def check_for_username_change

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -55,6 +55,8 @@ class UserPolicy < ApplicationPolicy
     %i[available_for
        behance_url
        bg_color_hex
+       config_theme
+       config_font
        contact_consent
        currently_hacking_on
        currently_learning

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -77,6 +77,13 @@
   <% end %>
 </head>
 <body data-user-status="<%= user_logged_in_status %>" data-pusher-key="<%= ApplicationConfig["PUSHER_KEY"] %>">
+<script>
+  try {
+    document.body.className = localStorage.getItem('body_class_config');
+  } catch(e) {
+      console.log(e)
+  }
+</script>
 <% unless internal_navigation? %>
   <div id="audiocontent">
     <%= yield(:audio) %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -77,13 +77,15 @@
   <% end %>
 </head>
 <body data-user-status="<%= user_logged_in_status %>" data-pusher-key="<%= ApplicationConfig["PUSHER_KEY"] %>">
-<script>
-  try {
-    document.body.className = localStorage.getItem('body_class_config');
-  } catch(e) {
-      console.log(e)
-  }
-</script>
+<% if user_signed_in? && !internal_navigation? %>
+  <script>
+    try {
+      document.body.className = localStorage.getItem('config_body_class');
+    } catch(e) {
+        console.log(e)
+    }
+  </script>
+<% end %>
 <% unless internal_navigation? %>
   <div id="audiocontent">
     <%= yield(:audio) %>

--- a/app/views/users/_misc.html.erb
+++ b/app/views/users/_misc.html.erb
@@ -35,6 +35,24 @@
     <%= f.submit "SUBMIT", class: "cta" %>
   </div>
 <% end %>
+<h2>Style Customization</h2>
+<%= form_for(@user) do |f| %>
+  <div class="sub-field">
+    <%= f.label :config_theme, "Site Theme" %>
+    <%= f.select(:config_theme, options_for_select(["default", "night theme"], @user.config_theme.gsub("_", " "))) %>
+    <sub><em>Default is light style. Night theme is in public alpha.</em></sub>
+  </div>
+  <div class="sub-field">
+    <%= f.label :config_font, "Base Post Font" %>
+    <%= f.select(:config_font, options_for_select(["default", "sans serif"], @user.config_font.gsub("_", " "))) %>
+    <sub><em>Default is serif style.</em></sub>
+  </div>
+  <div class="field">
+    <label></label>
+    <%= f.hidden_field :tab, value: @tab %>
+    <%= f.submit "SUBMIT", class: "cta" %>
+  </div>
+<% end %>
 <h2>Languages</h2>
 <h3>Select which languages you'd prefer to see in your feed <span style="color:#e05252">(beta)</span></h3>
 <h4 style="font-weight:400">

--- a/db/migrate/20190315151829_add_config_to_users.rb
+++ b/db/migrate/20190315151829_add_config_to_users.rb
@@ -1,0 +1,4 @@
+class AddConfigToUsers < ActiveRecord::Migration[5.1]
+  def change
+  end
+end

--- a/db/migrate/20190315151829_add_config_to_users.rb
+++ b/db/migrate/20190315151829_add_config_to_users.rb
@@ -1,4 +1,6 @@
 class AddConfigToUsers < ActiveRecord::Migration[5.1]
   def change
+    add_column :users, :config_theme, :string, default: "default"
+    add_column :users, :config_font, :string, default: "default"
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190306082543) do
+ActiveRecord::Schema.define(version: 20190315151829) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -37,7 +37,7 @@ ActiveRecord::Schema.define(version: 20190306082543) do
 
   create_table "api_secrets", force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.string "description", null: false
+    t.string "description"
     t.string "secret"
     t.datetime "updated_at", null: false
     t.integer "user_id"
@@ -445,12 +445,25 @@ ActiveRecord::Schema.define(version: 20190306082543) do
   create_table "messages", force: :cascade do |t|
     t.bigint "chat_channel_id", null: false
     t.datetime "created_at", null: false
+    t.text "encrypted_message_html"
+    t.text "encrypted_message_html_iv"
+    t.text "encrypted_message_markdown"
+    t.text "encrypted_message_markdown_iv"
     t.string "message_html", null: false
     t.string "message_markdown", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.index ["chat_channel_id"], name: "index_messages_on_chat_channel_id"
     t.index ["user_id"], name: "index_messages_on_user_id"
+  end
+
+  create_table "mutes", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "mutable_id"
+    t.integer "mutable_type"
+    t.datetime "updated_at", null: false
+    t.integer "user_id"
+    t.index ["user_id", "mutable_id", "mutable_type"], name: "index_mutes_on_user_id_and_mutable_id_and_mutable_type"
   end
 
   create_table "notes", id: :serial, force: :cascade do |t|
@@ -747,6 +760,8 @@ ActiveRecord::Schema.define(version: 20190306082543) do
     t.string "bg_color_hex"
     t.boolean "checked_code_of_conduct", default: false
     t.integer "comments_count", default: 0, null: false
+    t.string "config_font", default: "default"
+    t.string "config_theme", default: "default"
     t.datetime "confirmation_sent_at"
     t.string "confirmation_token"
     t.datetime "confirmed_at"
@@ -790,7 +805,6 @@ ActiveRecord::Schema.define(version: 20190306082543) do
     t.datetime "github_repos_updated_at", default: "2017-01-01 05:00:00"
     t.string "github_username"
     t.string "gitlab_url"
-    t.string "inbox_type", default: "private"
     t.jsonb "language_settings", default: {}, null: false
     t.datetime "last_article_at", default: "2017-01-01 05:00:00"
     t.datetime "last_comment_at", default: "2017-01-01 05:00:00"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -37,7 +37,7 @@ ActiveRecord::Schema.define(version: 20190315151829) do
 
   create_table "api_secrets", force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.string "description"
+    t.string "description", null: false
     t.string "secret"
     t.datetime "updated_at", null: false
     t.integer "user_id"
@@ -445,25 +445,12 @@ ActiveRecord::Schema.define(version: 20190315151829) do
   create_table "messages", force: :cascade do |t|
     t.bigint "chat_channel_id", null: false
     t.datetime "created_at", null: false
-    t.text "encrypted_message_html"
-    t.text "encrypted_message_html_iv"
-    t.text "encrypted_message_markdown"
-    t.text "encrypted_message_markdown_iv"
     t.string "message_html", null: false
     t.string "message_markdown", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.index ["chat_channel_id"], name: "index_messages_on_chat_channel_id"
     t.index ["user_id"], name: "index_messages_on_user_id"
-  end
-
-  create_table "mutes", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.integer "mutable_id"
-    t.integer "mutable_type"
-    t.datetime "updated_at", null: false
-    t.integer "user_id"
-    t.index ["user_id", "mutable_id", "mutable_type"], name: "index_mutes_on_user_id_and_mutable_id_and_mutable_type"
   end
 
   create_table "notes", id: :serial, force: :cascade do |t|
@@ -805,6 +792,7 @@ ActiveRecord::Schema.define(version: 20190315151829) do
     t.datetime "github_repos_updated_at", default: "2017-01-01 05:00:00"
     t.string "github_username"
     t.string "gitlab_url"
+    t.string "inbox_type", default: "private"
     t.jsonb "language_settings", default: {}, null: false
     t.datetime "last_article_at", default: "2017-01-01 05:00:00"
     t.datetime "last_comment_at", default: "2017-01-01 05:00:00"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -265,6 +265,26 @@ RSpec.describe User, type: :model do
       user.summary = "0" * 999
       expect(user).not_to be_valid
     end
+
+    it "accepts valid theme" do
+      user.config_theme = "night theme"
+      expect(user).to be_valid
+    end
+
+    it "does not accept invalid theme" do
+      user.config_theme = "no night mode"
+      expect(user).not_to be_valid
+    end
+
+    it "accepts valid font" do
+      user.config_font = "sans serif"
+      expect(user).to be_valid
+    end
+
+    it "does not accept invalid font" do
+      user.config_theme = "goobledigook"
+      expect(user).not_to be_valid
+    end
   end
 
   ## Registration
@@ -399,6 +419,20 @@ RSpec.describe User, type: :model do
       Follow.last.update(points: 0.1)
       expect(user.decorate.cached_followed_tags.first.points).to eq(0.1)
     end
+  end
+
+  it "creates proper body class with defaults" do
+    expect(user.decorate.config_body_class).to eq("default default-article-body")
+  end
+
+  it "creates proper body class with sans serif config" do
+    user.config_font = "sans_serif"
+    expect(user.decorate.config_body_class).to eq("default sans-serif-article-body")
+  end
+
+  it "creates proper body class with night theme" do
+    user.config_theme = "night_theme"
+    expect(user.decorate.config_body_class).to eq("night-theme default-article-body")
   end
 
   it "inserts into mailchimp" do


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Some users may want night mode for reading or sans-serif fonts for any number of reasons: personal preference, accessibility, etc.

This config gives that option 😄

Sans serif:
![](https://cl.ly/30d191e39707/Image%202019-03-15%20at%2012.22.11%20PM.png)

There's still work to be done to get night mode looking just right, but this PR should speed that up, as more folks will start using it. Thanks to @Link2Twenty for the great work on themes.

The implementation of the sans serif css could be done theme style but I wasn't sure, so I did it this way. We can change later.