### PR TITLE
Add originally_published_at for more accurate crossposted info

### DIFF
--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -141,7 +141,7 @@
                 Originally published at
                 <a href="<%= @article.canonical_url || @article.feed_source_url %>" style="color:#1395b8"><%= get_host_without_www(@article.canonical_url || @article.feed_source_url) %></a>
                 on
-                <span class="posted-date-inline"><%= @article.published_at.strftime("%b %d, %Y") if @article.crossposted_at %></span>
+                <span class="posted-date-inline"><%= (@article.originally_published_at || @article.published_at).strftime("%b %d, %Y") if @article.crossposted_at %></span>
               </em>
             </span>
           <% end %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190315151829) do
+ActiveRecord::Schema.define(version: 20190315222044) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -93,6 +93,7 @@ ActiveRecord::Schema.define(version: 20190315151829) do
     t.string "main_tag_name_for_social"
     t.string "name_within_collection"
     t.integer "organization_id"
+    t.datetime "originally_published_at"
     t.integer "page_views_count", default: 0
     t.boolean "paid", default: false
     t.string "password"


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
Currently we set `published_at` when a post comes in crossposted but the logic is a little messed up in terms of where it fits in the feed. This is not the whole fix, but this is a new column to track the original date more accurately and manually fix a few bad ones.