### PR TITLE
Add link for tags everywhere they appear

### DIFF
--- a/app/views/dashboards/_dashboard_article.html.erb
+++ b/app/views/dashboards/_dashboard_article.html.erb
@@ -12,7 +12,7 @@
     <% if article.published %>
       <%= article.readable_publish_date %>
       <% article.cached_tag_list_array.each do |tag| %>
-        #<%= tag %>
+        <a href="/t/<%= tag %>"><span class="tag">#<%= tag %></span></a>
       <% end %>
     <% end %>
   </div>

--- a/spec/features/link_for_tags_in_posts_in_notifications_spec.rb
+++ b/spec/features/link_for_tags_in_posts_in_notifications_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+describe "Link on tags for post in notifications", type: :feature do
+  let(:js_tag) { create(:tag, name: "javascript") }
+  let(:ruby_tag) { create(:tag, name: "ruby") }
+
+  let(:article) do
+    create(:article, tags: "javascript, ruby")
+  end
+
+  context "when user hasn't logged in" do
+    before do
+      visit "/dashboard"
+    end
+
+    it "shows the sign-with page" do
+      expect(page).to have_content(/Sign In With/i, count: 2)
+    end
+  end
+
+  context "when logged in user" do
+    before do
+      sign_in article.user
+    end
+
+    it "shows articles with tags" do
+      visit "/dashboard"
+
+      expect(page).to have_selector("div.single-article", count: 1)
+      expect(page).to have_link("#ruby", href: "/t/ruby")
+      expect(page).to have_link("#javascript", href: "/t/javascript")
+    end
+  end
+end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)
- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
To keep the expectation of tags being clickable, I updated _dashboard_article.html.erb so tags on posts on the dashboard are wrapped in a link tag and link to their respective pages.

## Related Tickets & Documents
The issue number is #1991

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed