### PR TITLE
Add support for mark element in markdown

### DIFF
--- a/app/sanitizers/rendered_markdown_scrubber.rb
+++ b/app/sanitizers/rendered_markdown_scrubber.rb
@@ -1,7 +1,7 @@
 class RenderedMarkdownScrubber < Rails::Html::PermitScrubber
   def initialize
     super
-    self.tags = %w[a abbr add aside b blockquote br button center cite code col colgroup dd del dl dt em em figcaption h1 h2 h3 h4 h5 h6 hr i img kbd li ol p pre q rp rt ruby small source span strong sub sup table tbody td tfoot th thead time tr u ul video]
+    self.tags = %w[a abbr add aside b blockquote br button center cite code col colgroup dd del dl dt em em figcaption h1 h2 h3 h4 h5 h6 hr i img kbd li mark ol p pre q rp rt ruby small source span strong sub sup table tbody td tfoot th thead time tr u ul video]
     self.attributes = %w[alt class colspan data-conversation data-lang data-no-instant data-url em height href id loop name ref rel rowspan size span src start strong title type value width]
   end
 


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Documentation Update

## Description
The `<mark>` is useful for authors to highlight important text. Following the suggestion made by @Link2Twenty, I updated the `tags` list in `rendered_markdown_scrubber.rb`.

## Related Tickets & Documents
The issue number is #1870.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![Text Highlight using mark Element](https://user-images.githubusercontent.com/24629960/54500738-5b27cb00-48f6-11e9-8572-b27e2ae9d5af.png)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed