### PR TITLE
Fix possible race condition with page view tracking

### DIFF
--- a/app/controllers/page_views_controller.rb
+++ b/app/controllers/page_views_controller.rb
@@ -19,6 +19,8 @@ class PageViewsController < ApplicationController
   def update
     if user_signed_in?
       page_view = PageView.where(article_id: params[:id], user_id: current_user.id).last
+      page_view ||= PageView.create(user_id: current_user.id,
+                                    article_id: page_view_params[:article_id]) # pageview is sometimes missing if failure on prior creation.
       page_view.update_column(:time_tracked_in_seconds, page_view.time_tracked_in_seconds + 15)
     end
     head :ok
@@ -27,7 +29,7 @@ class PageViewsController < ApplicationController
   private
 
   def update_article_page_views
-    return if Rails.env.production? && rand(5) != 1 # We don't need to update the article page views every time.
+    return if Rails.env.production? && rand(8) != 1 # We don't need to update the article page views every time.
 
     article = Article.find(page_view_params[:article_id])
     new_page_views_count = article.page_views.sum(:counts_for_number_of_views)

--- a/lib/tasks/fetch.rake
+++ b/lib/tasks/fetch.rake
@@ -106,6 +106,6 @@ task remove_old_html_variant_data: :environment do
   HtmlVariantTrial.where("created_at < ?", 1.week.ago).destroy_all
   HtmlVariantSuccess.where("created_at < ?", 1.week.ago).destroy_all
   HtmlVariant.find_each do |html_variant|
-    html_variant.calculate_success_rate! if html_variant.html_variant_successes.size > 3
+    html_variant.calculate_success_rate! if html_variant.html_variant_successes.any?
   end
 end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
When a page view is tracked, we later update that view to track that the user was still on the page.

But sometimes there is an issue creating that first page view. This PR helps account for that scenario.