### PR TITLE
UX: Changed editor_version to a select field

### DIFF
--- a/app/assets/stylesheets/settings.scss
+++ b/app/assets/stylesheets/settings.scss
@@ -211,7 +211,13 @@
       }
       select {
         display: block;
-        font-size: 1.3em;
+        font-size:19px;
+        width:650px;
+        max-width:calc(100% - 4px);
+        padding:12px;
+        border:1px solid rgb(222, 230, 233);
+        border-radius:3px;
+        background-color:white;
       }
       button.big-action {
         width: 130px;

--- a/app/views/users/_misc.html.erb
+++ b/app/views/users/_misc.html.erb
@@ -13,7 +13,7 @@
 <%= form_for(@user) do |f| %>
   <div class="sub-field">
     <%= f.label :editor_version, "Editor version: v1 or v2" %>
-    <%= f.text_field :editor_version %>
+    <%= f.select :editor_version, options_for_select(["v1", "v2"], @user.editor_version) %>
     <sub><em>v2 is currently in beta</em></sub>
   </div>
   <div class="field">


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Changed the `editor_version` input is `settings/misc` to a `select` field

## Related Tickets & Documents
Issue #1775

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![Screenshot from 2019-03-18 22-29-23](https://user-images.githubusercontent.com/13546486/54564917-4f5b0800-49cd-11e9-9c9c-02d97602a795.png)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [ x] no documentation needed

**This is also my first PR to dev.to** 🥳