### PR TITLE
Add organic page view sums and modify seo boostables

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -367,11 +367,11 @@ class Article < ApplicationRecord
   def self.seo_boostable(tag = nil)
     if tag
       Article.where(published: true).
-        cached_tagged_with(tag).order("organic_page_views_count DESC").limit(20).
+        cached_tagged_with(tag).order("organic_page_views_count DESC").limit(20).where("score > ?", 10).
         pluck(:path, :title, :comments_count, :created_at)
     else
       Article.where(published: true).
-        order("organic_page_views_count DESC").limit(20).
+        order("organic_page_views_count DESC").limit(20).where("score > ?", 10).
         pluck(:path, :title, :comments_count, :created_at)
     end
   end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -365,16 +365,13 @@ class Article < ApplicationRecord
   end
 
   def self.seo_boostable(tag = nil)
-    keyword_paths = SearchKeyword.
-      where("google_position > ? AND google_position < ? AND google_volume > ? AND google_difficulty < ?",
-      3, 20, 1000, 40).pluck(:google_result_path)
     if tag
-      Article.where(path: keyword_paths, published: true, featured: true).
-        tagged_with(tag).
+      Article.where(published: true).
+        cached_tagged_with(tag).order("organic_page_views_count DESC").limit(20).
         pluck(:path, :title, :comments_count, :created_at)
-
     else
-      Article.where(path: keyword_paths, published: true, featured: true).
+      Article.where(published: true).
+        order("organic_page_views_count DESC").limit(20).
         pluck(:path, :title, :comments_count, :created_at)
     end
   end

--- a/app/views/articles/_sidebar_additional.html.erb
+++ b/app/views/articles/_sidebar_additional.html.erb
@@ -145,7 +145,7 @@
         </div>
       <% end %>
     <% else %>
-      <% cache("seo-boostable-posts-homepage", expires_in: 18.hours) do %>
+      <% cache("seo-boostable-posts-homepage-xoxo", expires_in: 18.hours) do %>
         <% @boostable_posts = Article.seo_boostable %>
         <% if @boostable_posts.any? %>
           <div class="widget">
@@ -154,7 +154,7 @@
             </header>
             <div class="widget-body">
               <div class="widget-link-list">
-                <% @boostable_posts.first(12).each do |plucked_article| %>
+                <% @boostable_posts.each do |plucked_article| %>
                   <%= render "articles/widget_list_item", plucked_article: plucked_article, show_comment_count: false %>
                 <% end %>
               </div>

--- a/app/views/articles/tags/_sidebar_additional.html.erb
+++ b/app/views/articles/tags/_sidebar_additional.html.erb
@@ -20,7 +20,7 @@
       <div id="sidebarWidget__pack" data-tag-info="<%= @tag_model.attributes.slice("id", "text_color_hex", "bg_color_hex", "name").to_json %>">
       </div>
     <% else %>
-      <% cache("seo-boostable-posts-for-tag#{@tag}", expires_in: 18.hours) do %>
+      <% cache("seo-boostable-posts-for-tag-#{@tag}", expires_in: 18.hours) do %>
         <% @boostable_posts = Article.seo_boostable(@tag) %>
         <% if @boostable_posts.any? %>
           <div class="widget">
@@ -29,7 +29,7 @@
             </header>
             <div class="widget-body">
               <div class="widget-link-list">
-                <% @boostable_posts.first(8).each do |plucked_article| %>
+                <% @boostable_posts.each do |plucked_article| %>
                   <%= render "articles/widget_list_item", plucked_article: plucked_article, show_comment_count: false %>
                 <% end %>
               </div>

--- a/db/migrate/20190318223433_add_organic_page_views_to_articles.rb
+++ b/db/migrate/20190318223433_add_organic_page_views_to_articles.rb
@@ -1,0 +1,7 @@
+class AddOrganicPageViewsToArticles < ActiveRecord::Migration[5.1]
+  def change
+    add_column :articles, :organic_page_views_count, :integer, default: 0
+    add_column :articles, :organic_page_views_past_month_count, :integer, default: 0
+    add_column :articles, :organic_page_views_past_week_count, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190315222044) do
+ActiveRecord::Schema.define(version: 20190318223433) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -92,6 +92,9 @@ ActiveRecord::Schema.define(version: 20190315222044) do
     t.string "main_image_background_hex_color", default: "#dddddd"
     t.string "main_tag_name_for_social"
     t.string "name_within_collection"
+    t.integer "organic_page_views_count", default: 0
+    t.integer "organic_page_views_past_month_count", default: 0
+    t.integer "organic_page_views_past_week_count", default: 0
     t.integer "organization_id"
     t.datetime "originally_published_at"
     t.integer "page_views_count", default: 0

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -240,24 +240,24 @@ RSpec.describe Article, type: :model do
 
   describe "queries" do
     it "returns articles ordered by organic_page_views_count" do
-      create(:article)
-      create(:article)
-      top_article = create(:article, organic_page_views_count: 20)
+      create(:article, score: 30)
+      create(:article, score: 30)
+      top_article = create(:article, organic_page_views_count: 20, score: 30)
       articles = Article.seo_boostable
       expect(articles.first[0]).to eq(top_article.path)
     end
     it "returns articles ordered by organic_page_views_count by tag" do
-      create(:article)
-      create(:article, organic_page_views_count: 30)
-      top_article = create(:article, organic_page_views_count: 20)
+      create(:article, score: 30)
+      create(:article, organic_page_views_count: 30, score: 30)
+      top_article = create(:article, organic_page_views_count: 20, score: 30)
       top_article.update_column(:cached_tag_list, "good, greatalicious")
       articles = Article.seo_boostable("greatalicious")
       expect(articles.first[0]).to eq(top_article.path)
     end
     it "returns nothing if no tagged articles" do
-      create(:article)
+      create(:article, score: 30)
       create(:article, organic_page_views_count: 30)
-      top_article = create(:article, organic_page_views_count: 20)
+      top_article = create(:article, organic_page_views_count: 20, score: 30)
       top_article.update_column(:cached_tag_list, "good, greatalicious")
       articles = Article.seo_boostable("godsdsdsdsgoo")
       expect(articles.size).to eq(0)

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -239,49 +239,27 @@ RSpec.describe Article, type: :model do
   end
 
   describe "queries" do
-    let(:search_keyword) do
-      create(:search_keyword,
-        google_result_path: article.path,
-        google_position: 8,
-        google_volume: 2000,
-        google_difficulty: 10)
-    end
-
-    it "returns article plucked objects that match keyword query" do
-      search_keyword
-      article.update(featured: true)
+    it "returns articles ordered by organic_page_views_count" do
+      create(:article)
+      create(:article)
+      top_article = create(:article, organic_page_views_count: 20)
       articles = Article.seo_boostable
-      expect(articles.flatten[0]).to eq(article.path)
+      expect(articles.first[0]).to eq(top_article.path)
     end
-
-    it "returns keyword articles by tag" do
-      search_keyword
-      article.update(featured: true)
-      articles = Article.seo_boostable(article.tags.first)
-      expect(articles.flatten[0]).to eq(article.path)
+    it "returns articles ordered by organic_page_views_count by tag" do
+      create(:article)
+      create(:article, organic_page_views_count: 30)
+      top_article = create(:article, organic_page_views_count: 20)
+      top_article.update_column(:cached_tag_list, "good, greatalicious")
+      articles = Article.seo_boostable("greatalicious")
+      expect(articles.first[0]).to eq(top_article.path)
     end
-
-    it "does not return articles when none match based on tag" do
-      search_keyword
-      article.update(featured: true)
-      articles = Article.seo_boostable("woozle-wozzle-20000")
-      expect(articles.size).to eq(0)
-    end
-
-    it "doesn't return keywords that don't match criteria plucked objects matching keyword query" do
-      search_keyword.update_attributes(google_position: 33) # too high of a position
-      articles = Article.seo_boostable
-      expect(articles.size).to eq(0)
-    end
-
-    it "does not return unpublished articles" do
-      search_keyword
-      articles = Article.seo_boostable
-      article.update(published: false)
-      expect(articles.size).to eq(0)
-    end
-    it "returns empty relation if no articles match" do
-      articles = Article.seo_boostable
+    it "returns nothing if no tagged articles" do
+      create(:article)
+      create(:article, organic_page_views_count: 30)
+      top_article = create(:article, organic_page_views_count: 20)
+      top_article.update_column(:cached_tag_list, "good, greatalicious")
+      articles = Article.seo_boostable("godsdsdsdsgoo")
       expect(articles.size).to eq(0)
     end
   end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
This allows us to store data about organic page views (recent and all time) and display trends this way. For use on side bar to help maintain SEO to pages already doing well with Google.