### PR TITLE
Add secondary color to .sidebar-nav-subheader

### DIFF
--- a/app/assets/stylesheets/articles.scss
+++ b/app/assets/stylesheets/articles.scss
@@ -919,6 +919,7 @@
           background: var(--theme-background, darken($light-gray, 4%));
           a {
             color: $black;
+            color: var(--theme-secondary-color, $black);
           }
         }
         .sidebar-nav-default-tags {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Add --theme-secondary-color to .sidebar-nav-subheader

## Related Tickets & Documents
#1377 

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
