### PR TITLE
Fix reaction notification json data when a reaction is destroyed

### DIFF
--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -33,7 +33,7 @@ class UserDecorator < ApplicationDecorator
 
   def config_body_class
     body_class = ""
-    body_class = body_class + config_theme.gsub("_", "-")
+    body_class += config_theme.gsub("_", "-")
     body_class = body_class + " " + config_font.gsub("_", "-") + "-article-body"
     body_class
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe User, type: :model do
     it { is_expected.to validate_presence_of(:username) }
     it { is_expected.to validate_length_of(:username).is_at_most(30).is_at_least(2) }
     it { is_expected.to validate_length_of(:name).is_at_most(100) }
-    it { is_expected.to validate_inclusion_of(:inbox_type).in_array(["open", "private"]) }
+    it { is_expected.to validate_inclusion_of(:inbox_type).in_array(%w[open private]) }
   end
 
   # the followings are failing


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Keep only persisted data in the notifications `json_data` when a destroyed reaction record is passed to the `Notification#send_reaction_notification`

## Related Tickets & Documents
#2111 

