### PR TITLE
Change not found 404 raised exception in ApplicationController

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,7 @@ class ApplicationController < ActionController::Base
   end
 
   def not_found
-    raise ActionController::RoutingError, "Not Found"
+    raise ActiveRecord::RecordNotFound, "Not Found"
   end
 
   def efficient_current_user_id

--- a/spec/requests/articles_api_spec.rb
+++ b/spec/requests/articles_api_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe "ArticlesApi", type: :request do
         }
       end
 
-      expect(invalid_update_request).to raise_error(ActionController::RoutingError)
+      expect(invalid_update_request).to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it "does allow super user to update a different article" do

--- a/spec/requests/badges_spec.rb
+++ b/spec/requests/badges_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Badges", type: :request do
 
     context "when badge does not exist" do
       it "renders 404" do
-        expect { get "/badge/that-does-not-exists" }.to raise_error(ActionController::RoutingError)
+        expect { get "/badge/that-does-not-exists" }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
   end

--- a/spec/requests/chat_channels_spec.rb
+++ b/spec/requests/chat_channels_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe "ChatChannels", type: :request do
 
     context "when request is invalid" do
       it "returns proper error message" do
-        expect { get "/chat_channels/1200" }.to raise_error(ActionController::RoutingError)
+        expect { get "/chat_channels/1200" }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
   end

--- a/spec/requests/delayed_job_spec.rb
+++ b/spec/requests/delayed_job_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Delayed Job web interface", type: :request do
       it "raises 404" do
         expect do
           get "/delayed_job"
-        end.to raise_error(ActionController::RoutingError)
+        end.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 
@@ -19,7 +19,7 @@ RSpec.describe "Delayed Job web interface", type: :request do
         login_as user
         expect do
           get "/delayed_job"
-        end.to raise_error(ActionController::RoutingError)
+        end.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 

--- a/spec/requests/email_subscriptions_spec.rb
+++ b/spec/requests/email_subscriptions_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "EmailSubscriptions", type: :request do
 
     it "handles error properly" do
       expect { get email_subscriptions_unsubscribe_url }.
-        to raise_error(ActionController::RoutingError)
+        to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it "won't work if it's past expiration date" do

--- a/spec/requests/podcast_episodes_api_spec.rb
+++ b/spec/requests/podcast_episodes_api_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "ArticlesApi", type: :request, vcr: vcr_option do
 
     it "returns nothing is passed invalid podcast slug" do
       expect { get "/api/podcast_episodes?username=nothing_#{rand(1_000_000_000_000_000)}" }.
-        to raise_error(ActionController::RoutingError)
+        to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 end

--- a/spec/requests/user_organization_spec.rb
+++ b/spec/requests/user_organization_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "UserOrganization", type: :request do
 
   it "returns 404 if secret is wrong" do
     expect { post "/users/join_org", params: { org_secret: "NOT SECRET" } }.
-      to raise_error ActionController::RoutingError
+      to raise_error ActiveRecord::RecordNotFound
   end
 
   it "leaves org" do

--- a/spec/requests/user_settings_spec.rb
+++ b/spec/requests/user_settings_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "UserSettings", type: :request do
 
       it "handles unknown settings tab properly" do
         expect { get "/settings/does-not-exist" }.
-          to raise_error(ActionController::RoutingError)
+          to raise_error(ActiveRecord::RecordNotFound)
       end
 
       it "doesn't let user access membership if user has no monthly_dues" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

After the discussion we had around #2066 and this [comment](https://github.com/thepracticaldev/dev.to/pull/2066/files#r266760867) by @lightalloy, I'm submitting this PR to change the default exception raised by the `not_found` method. 

FYI Rails renders the 404 page with both `ActionController::RoutingError` and `ActiveRecord::ActionNotFound` so there's no change in functionality. I'm not even sure the exception raised makes the code clearer because it's transparent to the pattern:

```ruby
Model.find_by_(id) || not_found
```

it just aligns to what the finder methods with the `!` raise.

This aforamentioned pattern appears 15 times in the code, instead the Rails default:

```ruby
Model.find_by!(id)
```

appears only 3 times, all in the `tags_controller.rb` file.

## Related Tickets & Documents

#2066 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
