### PR TITLE
Update Faker and fix deprecated Faker::Overwatch use

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -122,8 +122,8 @@ group :development, :test do
   gem "capybara", "~> 3.13"
   gem "derailed", "~> 0.1"
   gem "erb_lint", "~> 0.0", require: false
-  gem "faker", git: "https://github.com/stympy/faker.git", branch: "master"
-  gem "fix-db-schema-conflicts", github: "thepracticaldev/fix-db-schema-conflicts", branch: "master"
+  gem "faker", "~> 1.9"
+  gem "fix-db-schema-conflicts", github: "thepracticaldev/fix-db-schema-conflicts", ref: "4172392"
   gem "memory_profiler", "~> 0.9"
   gem "parallel_tests", "~> 2.27"
   gem "pry-byebug", "~> 3.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,4 @@
 GIT
-  remote: https://github.com/stympy/faker.git
-  revision: 9910aa58d92c018abab25d491191576fcc1a7707
-  branch: master
-  specs:
-    faker (1.9.1)
-      i18n (>= 0.7)
-
-GIT
   remote: https://github.com/thepracticaldev/acts_as_follower.git
   revision: 288690cd99bc470eaee493fce5bfa9fe23157692
   branch: master
@@ -17,7 +9,7 @@ GIT
 GIT
   remote: https://github.com/thepracticaldev/fix-db-schema-conflicts.git
   revision: 4172392392e1a8d907f7ab673cb5ddd9a4a31940
-  branch: master
+  ref: 4172392
   specs:
     fix-db-schema-conflicts (3.0.2)
       rubocop (>= 0.38.0)
@@ -329,6 +321,8 @@ GEM
       capybara
       sinatra
       webmock
+    faker (1.9.3)
+      i18n (>= 0.7)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.13.1)
@@ -1014,7 +1008,7 @@ DEPENDENCIES
   erb_lint (~> 0.0)
   factory_bot_rails (~> 4.11)
   fake_stripe (~> 0.2)
-  faker!
+  faker (~> 1.9)
   fastly (~> 1.15)
   fastly-rails (~> 0.8)
   feedjira (~> 2.2)

--- a/spec/factories/badges.rb
+++ b/spec/factories/badges.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   )
 
   factory :badge do
-    title { Faker::Overwatch.quote }
+    title { Faker::Games::Overwatch.quote }
     description { Faker::Lorem.sentence }
     badge_image { image }
   end

--- a/spec/models/badge_spec.rb
+++ b/spec/models/badge_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Badge, type: :model do
   describe "validations" do
-    subject { Badge.create(title: Faker::Overwatch.quote, description: Faker::Lorem.sentence) }
+    subject { create(:badge) }
 
     it { is_expected.to have_many(:users).through(:badge_achievements) }
     it { is_expected.to have_many(:badge_achievements) }


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

Update `Faker::Overwatch.quote` and fix deprecation notices in tests.

> NOTE: Faker::Overwatch.quote is deprecated; use Faker::Games::Overwatch.quote instead. It will be removed on or after 2019-01-01.
Faker::Overwatch.quote called from /home/travis/build/abraham/dev.to/spec/factories/badges.rb:7.

## Related Tickets & Documents
n/a
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
n/a
## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
