### PR TITLE
Simplify development setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,7 +6,7 @@ tmp/
 node_modules/
 
 ##################################
-# 
+#
 # rest is COPIED from .gitignore
 #
 ##################################
@@ -46,7 +46,6 @@ latest.dump
 /public/packs
 /public/packs-test
 /node_modules
-config/database.yml
 
 # Ignore storybook static site generation
 storybook-static/

--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,6 @@ latest.dump
 /public/packs
 /public/packs-test
 /node_modules
-config/database.yml
 
 # Ignore storybook static site generation
 storybook-static/

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
   global:
     - RAILS_ENV=test
     - CC_TEST_REPORTER_ID=f39e060a8b1a558ebd8aff75d5b9760bf1ae98f3f85d628ae28814f3c66438cd
+    - DATABASE_URL=postgres://postgres@localhost/
 branches:
   only:
     - master
@@ -27,11 +28,10 @@ install:
     > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
 before_script:
-  - cp config/database.yml.travis config/database.yml
-  - psql -c 'create database travis_ci_test;' -U postgres
+  - bundle exec rails db:create
 script:
   - bundle exec rails webpacker:compile
-  - bundle exec rake db:schema:load
+  - bundle exec rails db:schema:load
   - './cc-test-reporter before-build'
   - 'bundle exec rspec spec --color --tty'
   - '[ ! -f .approvals ] || bundle exec approvals verify --ask false'
@@ -48,7 +48,7 @@ deploy:
   app:
     master: practicaldev
   run:
-    - rake db:migrate
+    - rails db:migrate
 after_deploy:
   - bash after_deploy.sh
 notifications:

--- a/Gemfile
+++ b/Gemfile
@@ -110,7 +110,7 @@ group :development do
   gem "bullet", "~> 5.9"
   gem "bundler-audit", "~> 0.6"
   gem "derailed_benchmarks", "~> 1.3"
-  gem "foreman", github: "andrewmcodes/foreman", ref: "b64e401", require: false # Switch to stable release when Thor dependecy is updated to 0.20+
+  gem "foreman", github: "thepracticaldev/foreman", ref: "b64e401", require: false # Switch to stable release when Thor dependecy is updated to 0.20+
   gem "guard", "~> 2.15", require: false
   gem "guard-livereload", "~> 2.5", require: false
   gem "guard-rspec", "~> 4.7", require: false

--- a/Gemfile
+++ b/Gemfile
@@ -110,6 +110,7 @@ group :development do
   gem "bullet", "~> 5.9"
   gem "bundler-audit", "~> 0.6"
   gem "derailed_benchmarks", "~> 1.3"
+  gem "foreman", github: "andrewmcodes/foreman", ref: "b64e401", require: false # Switch to stable release when Thor dependecy is updated to 0.20+
   gem "guard", "~> 2.15", require: false
   gem "guard-livereload", "~> 2.5", require: false
   gem "guard-rspec", "~> 4.7", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,12 @@
 GIT
+  remote: https://github.com/andrewmcodes/foreman.git
+  revision: b64e4019a8ed3cfae7216c3219dc91833845d9c7
+  ref: b64e401
+  specs:
+    foreman (0.85.0)
+      thor (>= 0.19, < 0.21)
+
+GIT
   remote: https://github.com/thepracticaldev/acts_as_follower.git
   revision: 288690cd99bc470eaee493fce5bfa9fe23157692
   branch: master
@@ -1009,6 +1017,7 @@ DEPENDENCIES
   figaro (~> 1.1)
   fix-db-schema-conflicts (~> 3.0)
   fog (~> 1.41)
+  foreman!
   front_matter_parser (~> 0.2)
   gemoji (~> 3.0.0)
   gibbon (~> 2.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,18 @@
 GIT
-  remote: https://github.com/andrewmcodes/foreman.git
-  revision: b64e4019a8ed3cfae7216c3219dc91833845d9c7
-  ref: b64e401
-  specs:
-    foreman (0.85.0)
-      thor (>= 0.19, < 0.21)
-
-GIT
   remote: https://github.com/thepracticaldev/acts_as_follower.git
   revision: 288690cd99bc470eaee493fce5bfa9fe23157692
   branch: master
   specs:
     acts_as_follower (0.2.1)
       activerecord (>= 4.0)
+
+GIT
+  remote: https://github.com/thepracticaldev/foreman.git
+  revision: b64e4019a8ed3cfae7216c3219dc91833845d9c7
+  ref: b64e401
+  specs:
+    foreman (0.85.0)
+      thor (>= 0.19, < 0.21)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -152,27 +152,25 @@ This section provides a high-level requirement & quick start guide. For detailed
 
 ### Standard Installation
 
-0.  Make sure all the prerequisites are installed.
-1.  Fork dev.to repository, ie. https://github.com/thepracticaldev/dev.to/fork
-1.  Clone your forked repository, ie. `git clone https://github.com/<your-username>/dev.to.git`
-1.  `gem install foreman`
-1.  Setup your database
-    - Create `config/database.yml` by copying from the provided template (i.e. `cp config/database.yml.sample config/database.yml`)
-    - Update the `config/database.yml` file if needed.
-1.  Set up your environment variables/secrets
-    - Take a look at `Envfile`. This file lists all the `ENV` variables we use and provides a fake default for any missing keys. You'll need to get your own free [Algolia credentials](http://docs.dev.to/get-api-keys-dev-env/#algolia) to get your development environment running.
-    - This [guide](http://docs.dev.to/get-api-keys-dev-env/) will show you how to get free API keys for additional services that may be required to run certain parts of the app.
-    - For any key that you wish to enter/replace:
-      1.  Create `config/application.yml` by copying from the provided template (ie. with bash: `cp config/sample_application.yml config/application.yml`). This is a personal file that is ignored in git.
-      2.  Obtain the development variable and apply the key you wish to enter/replace. ie:
-      ```
-      GITHUB_KEY: "SOME_REAL_SECURE_KEY_HERE"
-      GITHUB_SECRET: "ANOTHER_REAL_SECURE_KEY_HERE"
-      ```
-    - If you are missing `ENV` variables on bootup, `envied` gem will alert you with messages similar to `'error_on_missing_variables!': The following environment variables should be set: A_MISSING_KEY.`.
-    - You do not need "real" keys for basic development. Some features require certain keys, so you may be able to add them as you go.
-1.  Run `bin/setup`
-1.  That's it! Run `bin/startup` to start the application and head to `http://localhost:3000/`
+1. Make sure all the prerequisites are installed.
+1. Fork dev.to repository, ie. https://github.com/thepracticaldev/dev.to/fork
+1. Clone your forked repository, ie. `git clone https://github.com/<your-username>/dev.to.git`
+1. Set up your environment variables/secrets
+
+   - Take a look at `Envfile`. This file lists all the `ENV` variables we use and provides a fake default for any missing keys. You'll need to get your own free [Algolia credentials](http://docs.dev.to/get-api-keys-dev-env/#algolia) to get your development environment running.
+   - This [guide](http://docs.dev.to/get-api-keys-dev-env/) will show you how to get free API keys for additional services that may be required to run certain parts of the app.
+   - For any key that you wish to enter/replace:
+     1. Create `config/application.yml` by copying from the provided template (ie. with bash: `cp config/sample_application.yml config/application.yml`). This is a personal file that is ignored in git.
+     2. Obtain the development variable and apply the key you wish to enter/replace. ie:
+     ```
+     GITHUB_KEY: "SOME_REAL_SECURE_KEY_HERE"
+     GITHUB_SECRET: "ANOTHER_REAL_SECURE_KEY_HERE"
+     ```
+   - If you are missing `ENV` variables on bootup, `envied` gem will alert you with messages similar to `'error_on_missing_variables!': The following environment variables should be set: A_MISSING_KEY.`.
+   - You do not need "real" keys for basic development. Some features require certain keys, so you may be able to add them as you go.
+
+1. Run `bin/setup`
+1. That's it! Run `bin/startup` to start the application and head to `http://localhost:3000/`
 
 [View Full Installation Documentation](https://docs.dev.to/installation/)
 
@@ -208,9 +206,9 @@ Current gotchas: potential environment issues with external services need to be 
 
 We use [Spring](https://github.com/rails/spring) and it is already included in the project.
 
-1.  Use the provided bin stubs to automatically start Spring, i.e. `bin/rails server`, `bin/rspec spec/models/`, `bin/rake db:migrate`.
-2.  If Spring isn't picking up on new changes, use `spring stop`. For example, Spring should always be restarted if there's a change in environment key.
-3.  Check Spring's status whenever with `spring status`.
+1.  Use the provided bin stubs to automatically start Spring, i.e. `bin/rails server`, `bin/rspec spec/models/`, `bin/rails db:migrate`.
+1.  If Spring isn't picking up on new changes, use `spring stop`. For example, Spring should always be restarted if there's a change in environment key.
+1.  Check Spring's status whenever with `spring status`.
 
 Caveat: `bin/rspec` is not equipped with Spring because it affects Simplecov's result. Instead use `bin/spring rspec`.
 

--- a/bin/startup
+++ b/bin/startup
@@ -12,5 +12,5 @@ end
 
 chdir APP_ROOT do
   puts "== STARTING UP =="
-  system! "foreman start -f Procfile.dev"
+  system! "bundle exec foreman start -f Procfile.dev"
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,4 +1,4 @@
-# PostgreSQL. Versions 8.2 and up are supported.
+# PostgreSQL. Versions 9.1 and up are supported.
 #
 # Install the pg driver:
 #   gem install pg
@@ -17,9 +17,9 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  # For details on connection pooling, see rails configuration guide
+  # For details on connection pooling, see Rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
-  pool: 5
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   connect_timeout: 2
   checkout_timeout: 2
   variables:
@@ -61,7 +61,6 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  host: localhost
   url: <%= ENV.fetch('DATABASE_URL', '') %>
   database: PracticalDeveloper_test<%= ENV['TEST_ENV_NUMBER'] %>
 
@@ -87,6 +86,6 @@ test:
 production:
   <<: *default
   database: PracticalDeveloper_production
-  username: PracticalDeveloper
   pool: <%= ENV['DATABASE_POOL_SIZE'] %>
+  username: PracticalDeveloper
   password: <%= ENV['PRACTICALDEVELOPER_DATABASE_PASSWORD'] %>

--- a/config/database.yml.travis
+++ b/config/database.yml.travis
@@ -1,3 +1,0 @@
-test:
-  adapter: postgresql
-  database: travis_ci_test

--- a/docs/additional-postgres-setup.md
+++ b/docs/additional-postgres-setup.md
@@ -3,18 +3,18 @@
 Follow the instructions in the installation guide below that corresponds to your operating system:
 
 1.  macOS
-    * [Postgres.app](https://postgresapp.com/): PostgreSQL installation as a Mac app
-    * [Homebrew](https://brew.sh/): if you use Homebrew you can easily install PostgreSQL with `brew install postgresql`
-2.  Linux (Ubuntu)
-    * [Ubuntu `14.04`](https://www.digitalocean.com/community/tutorials/how-to-install-and-use-postgresql-on-ubuntu-14-04)
-    * [Ubuntu `16.04 and higher`](https://www.digitalocean.com/community/tutorials/how-to-install-and-use-postgresql-on-ubuntu-16-04)
-3.  [Windows](https://www.postgresql.org/download/windows/)
+    - [Postgres.app](https://postgresapp.com/): PostgreSQL installation as a Mac app
+    - [Homebrew](https://brew.sh/): if you use Homebrew you can easily install PostgreSQL with `brew install postgresql`
+1.  Linux (Ubuntu)
+    - [Ubuntu `14.04`](https://www.digitalocean.com/community/tutorials/how-to-install-and-use-postgresql-on-ubuntu-14-04)
+    - [Ubuntu `16.04 and higher`](https://www.digitalocean.com/community/tutorials/how-to-install-and-use-postgresql-on-ubuntu-16-04)
+1.  [Windows](https://www.postgresql.org/download/windows/)
 
 _You can find all installation options for a variety of operating systems [on the official PostgreSQL download page](https://www.postgresql.org/download/)_.
 
 ## Configuration
 
-By default the application is configured to connect to a local database named `PracticalDeveloper_development`. If you need to specify a username and a password you can go about it two ways: using the environment variable `DATABASE_URL` with a connection string (preferred method) or modifying the file `database.yml`.
+By default the application is configured to connect to a local database named `PracticalDeveloper_development`. If you need to specify a username and a password you can go about it by using the environment variable `DATABASE_URL` with a connection string.
 
 The [official Rails guides](https://guides.rubyonrails.org/configuring.html#connection-preference) go into depth on how Rails merges the existing `database.yml` with the connection string.
 
@@ -22,39 +22,20 @@ The [official Rails guides](https://guides.rubyonrails.org/configuring.html#conn
 
 1.  Open your `config/application.yml`
 
-2.  Add the following:
+1.  Add the following:
 
-```yml
-DATABASE_URL: postgresql://USERNAME:PASSWORD@localhost
-```
+    ```yml
+    DATABASE_URL: postgresql://USERNAME:PASSWORD@localhost
+    ```
 
-3.  Replace `USERNAME` with your database username, `PASSWORD` with your database password.
+1.  Replace `USERNAME` with your database username, `PASSWORD` with your database password.
 
 You can find more details on connection strings in [PostgreSQL's own documentation](https://www.postgresql.org/docs/10/static/libpq-connect.html#LIBPQ-CONNSTRING).
 
 NOTE: due to how Rails merges `database.yml` and `DATABASE_URL` it's recommended not to add the database name in the connection string. This will default to your development database name also during tests, which will effectively empty the development DB each time tests are run.
 
-### Modify connection params in `database.yml`
-
-The other option is to change the `database.yml` directly.
-
-Update your `database.yml` file with `username` and `password`:
-
-```yaml
-development:
-    <<: *default
-    username: USERNAME
-    password: PASSWORD
-test:
-    <<: *default
-    username: USERNAME
-    password: PASSWORD
-```
-
-**Keep in mind not to commit your modified `database.yml` containing your credentials under any circumstances to any repository.**
-
 ## Troubleshooting tests
 
-* While running test cases, if you get an error message `postgresql connection timeout`. Go to your `spec/support/database_cleaner.rb` file. And rename `:truncation` with `:deletion`.
+- While running test cases, if you get an error message `postgresql connection timeout`. Go to your `spec/support/database_cleaner.rb` file. And rename `:truncation` with `:deletion`.
 
 _Please, do not commit `database_cleaner.rb` to the repository either._

--- a/docs/installation/linux.md
+++ b/docs/installation/linux.md
@@ -5,7 +5,7 @@ These prerequisites assume you're working on a Linux-based operating system but 
 ### Ruby
 
 1. If you don't already have a Ruby version manager, we highly recommend [rbenv](https://github.com/rbenv/rbenv). Please follow their [installation guide](https://github.com/rbenv/rbenv#installation).
-2. With the Ruby version manager, install the Ruby version listed on our badge. (ie with rbenv: `rbenv install 2.6.1`)
+1. With the Ruby version manager, install the Ruby version listed on our badge. (ie with rbenv: `rbenv install 2.6.1`)
 
 For very detailed rbenv installation directions on several distros, please visit [DigitalOcean's guide](https://www.digitalocean.com/community/tutorials/how-to-install-ruby-on-rails-with-rbenv-on-ubuntu-18-04).
 
@@ -19,39 +19,31 @@ There are two ways to install Yarn.
 ### PostgreSQL
 
 1.  run `sudo apt update && sudo apt install postgresql postgresql-contrib libpq-dev`.
-2.  To test the installation you can run `sudo -u postgres psql` which should open a PostgreSQL prompt. Exit the prompt by running `\q` then run `sudo -u postgres createuser -s $YOUR_USERNAME` where \$YOUR_USERNAME is the username you are currently logged in as. Lastly, at least on Debian based systems, in the codebase under /config/database.yml you'll want to comment out the `host: localhost` to configure the database to use Unix domain sockets as outlined [here](https://stackoverflow.com/questions/23375740/pgconnectionbad-fe-sendauth-no-password-supplied).
+1.  To test the installation you can run `sudo -u postgres psql` which should open a PostgreSQL prompt. Exit the prompt by running `\q` then run `sudo -u postgres createuser -s $YOUR_USERNAME` where \$YOUR_USERNAME is the username you are currently logged in as.
 
 There are more than one way to setup Postgres. For additional configuration, check out our [postgres doc](/additional-postgres-setup) or the official [PostgreSQL](https://www.postgresql.org/) site for more information.
 
 ## Installing Dev.to
 
-1.  Fork dev.to repository, ie. https://github.com/thepracticaldev/dev.to/fork
-2.  Clone your forked repository, ie. `git clone https://github.com/<your-username>/dev.to.git`
-3.  Install bundler with `gem install bundler`
-4.  Install foreman gem with `gem install foreman`
-5.  Install our ruby dependencies with `bundle install`
-6.  Install our frontend dependencies with `bin/yarn`
-7.  Setup your database
+1. Fork dev.to repository, ie. https://github.com/thepracticaldev/dev.to/fork
+1. Clone your forked repository, ie. `git clone https://github.com/<your-username>/dev.to.git`
+1. Install bundler with `gem install bundler`
+1. Set up your environment variables/secrets
 
-- Create `config/database.yml` by copying from the provided template (i.e. `cp config/database.yml.sample config/database.yml`)
-- Update the `config/database.yml` file if needed.
+   - Take a look at `Envfile`. This file lists all the `ENV` variables we use and provides a fake default for any missing keys. You'll need to get your own free [Algolia credentials](http://docs.dev.to/get-api-keys-dev-env/#algolia) to get your development environment running.
+   - This [guide](http://docs.dev.to/get-api-keys-dev-env/) will show you how to get free API keys for additional services that may be required to run certain parts of the app.
+   - For any key that you wish to enter/replace:
 
-8.  Set up your environment variables/secrets
+1. Create `config/application.yml` by copying from the provided template (ie. with bash: `cp config/sample_application.yml config/application.yml`). This is a personal file that is ignored in git.
+1. Obtain the development variable and apply the key you wish to enter/replace. ie:
 
-- Take a look at `Envfile`. This file lists all the `ENV` variables we use and provides a fake default for any missing keys. You'll need to get your own free [Algolia credentials](http://docs.dev.to/get-api-keys-dev-env/#algolia) to get your development environment running.
-- This [guide](http://docs.dev.to/get-api-keys-dev-env/) will show you how to get free API keys for additional services that may be required to run certain parts of the app.
-- For any key that you wish to enter/replace:
+   ```
+   GITHUB_KEY: "SOME_REAL_SECURE_KEY_HERE"
+   GITHUB_SECRET: "ANOTHER_REAL_SECURE_KEY_HERE"
+   ```
 
-9.  Create `config/application.yml` by copying from the provided template (ie. with bash: `cp config/sample_application.yml config/application.yml`). This is a personal file that is ignored in git.
-10. Obtain the development variable and apply the key you wish to enter/replace. ie:
+   - If you are missing `ENV` variables on bootup, `envied` gem will alert you with messages similar to `'error_on_missing_variables!': The following environment variables should be set: A_MISSING_KEY.`.
+   - You do not need "real" keys for basic development. Some features require certain keys, so you may be able to add them as you go.
 
-
-    ```
-    GITHUB_KEY: "SOME_REAL_SECURE_KEY_HERE"
-    GITHUB_SECRET: "ANOTHER_REAL_SECURE_KEY_HERE"
-    ```
-
-- If you are missing `ENV` variables on bootup, `envied` gem will alert you with messages similar to `'error_on_missing_variables!': The following environment variables should be set: A_MISSING_KEY.`.
-- You do not need "real" keys for basic development. Some features require certain keys, so you may be able to add them as you go.
-
-11. Run `bin/setup`
+1. Run `bin/setup`
+   - While installing, you might run into an error due to the pg gem requiring PostgreSQL libraries. If so, please run `sudo apt-get install libpq-dev` before retrying.

--- a/docs/installation/mac-os.md
+++ b/docs/installation/mac-os.md
@@ -17,36 +17,27 @@ For additional configuration, [click here](/additional-postgres-setup)
 
 ## Installing Dev.to
 
-1.  Fork dev.to repository, ie. https://github.com/thepracticaldev/dev.to/fork
-2.  Clone your forked repository, ie. `git clone https://github.com/<your-username>/dev.to.git`
-3.  Install bundler with `gem install bundler`
-4.  Install foreman gem with `gem install foreman`
-5.  Install our ruby dependencies with `bundle install`
-6.  Install our frontend dependencies with `bin/yarn`
-7.  Setup your database
+1. Fork dev.to repository, ie. https://github.com/thepracticaldev/dev.to/fork
+1. Clone your forked repository, ie. `git clone https://github.com/<your-username>/dev.to.git`
+1. Install bundler with `gem install bundler`
+1. Set up your environment variables/secrets
 
-- Create `config/database.yml` by copying from the provided template (i.e. `cp config/database.yml.sample config/database.yml`)
-- Update the `config/database.yml` file if needed.
+   - Take a look at `Envfile`. This file lists all the `ENV` variables we use and provides a fake default for any missing keys. You'll need to get your own free [Algolia credentials](http://docs.dev.to/get-api-keys-dev-env/#algolia) to get your development environment running.
+   - This [guide](http://docs.dev.to/get-api-keys-dev-env/) will show you how to get free API keys for additional services that may be required to run certain parts of the app.
+   - For any key that you wish to enter/replace:
 
-8.  Set up your environment variables/secrets
+1. Create `config/application.yml` by copying from the provided template (ie. with bash: `cp config/sample_application.yml config/application.yml`). This is a personal file that is ignored in git.
+1. Obtain the development variable and apply the key you wish to enter/replace. ie:
 
-- Take a look at `Envfile`. This file lists all the `ENV` variables we use and provides a fake default for any missing keys. You'll need to get your own free [Algolia credentials](http://docs.dev.to/get-api-keys-dev-env/#algolia) to get your development environment running.
-- This [guide](http://docs.dev.to/get-api-keys-dev-env/) will show you how to get free API keys for additional services that may be required to run certain parts of the app.
-- For any key that you wish to enter/replace:
+   ```
+   GITHUB_KEY: "SOME_REAL_SECURE_KEY_HERE"
+   GITHUB_SECRET: "ANOTHER_REAL_SECURE_KEY_HERE"
+   ```
 
-9.  Create `config/application.yml` by copying from the provided template (ie. with bash: `cp config/sample_application.yml config/application.yml`). This is a personal file that is ignored in git.
-10. Obtain the development variable and apply the key you wish to enter/replace. ie:
+   - If you are missing `ENV` variables on bootup, `envied` gem will alert you with messages similar to `'error_on_missing_variables!': The following environment variables should be set: A_MISSING_KEY.`.
+   - You do not need "real" keys for basic development. Some features require certain keys, so you may be able to add them as you go.
 
-
-    ```
-    GITHUB_KEY: "SOME_REAL_SECURE_KEY_HERE"
-    GITHUB_SECRET: "ANOTHER_REAL_SECURE_KEY_HERE"
-    ```
-
-- If you are missing `ENV` variables on bootup, `envied` gem will alert you with messages similar to `'error_on_missing_variables!': The following environment variables should be set: A_MISSING_KEY.`.
-- You do not need "real" keys for basic development. Some features require certain keys, so you may be able to add them as you go.
-
-11. Run `bin/setup`
+1. Run `bin/setup`
 
 #### Possible Error Messages
 

--- a/docs/installation/windows.md
+++ b/docs/installation/windows.md
@@ -97,53 +97,27 @@ Pay attention to the username and password you setup during installation of Post
 
 ## Installing Dev.to
 
-1.  Fork dev.to repository, ie. https://github.com/thepracticaldev/dev.to/fork
-2.  Clone your forked repository, ie. `git clone https://github.com/<your-username>/dev.to.git`
-3.  Install bundler with `gem install bundler`
-4.  Install foreman gem with `gem install foreman`
-5.  Run `rbenv rehash` when foreman installation is done.
-6.  Install our ruby dependencies with `bundle install`
-    While installing, you might run into an error due to the pg gem requiring PostgreSQL libraries. If so, please run `sudo apt-get install libpq-dev` before retrying.
-7.  Setup your database
+1. Fork dev.to repository, ie. https://github.com/thepracticaldev/dev.to/fork
+1. Clone your forked repository, ie. `git clone https://github.com/<your-username>/dev.to.git`
+1. Install bundler with `gem install bundler`
+1. Set up your environment variables/secrets
 
-- Create `config/database.yml` by copying from the provided template (i.e. `cp config/database.yml.sample config/database.yml`)
-- Update the `config/database.yml` file if needed.
+   - Take a look at `Envfile`. This file lists all the `ENV` variables we use and provides a fake default for any missing keys. You'll need to get your own free [Algolia credentials](http://docs.dev.to/get-api-keys-dev-env/#algolia) to get your development environment running.
+   - This [guide](http://docs.dev.to/get-api-keys-dev-env/) will show you how to get free API keys for additional services that may be required to run certain parts of the app.
+   - For any key that you wish to enter/replace:
 
-8.  Install our frontend dependencies with `bin/yarn`
+1. Create `config/application.yml` by copying from the provided template (ie. with bash: `cp config/sample_application.yml config/application.yml`). This is a personal file that is ignored in git.
+1. Obtain the development variable and apply the key you wish to enter/replace. ie:
 
-9.  Set up your environment variables/secrets
+   ```
+   GITHUB_KEY: "SOME_REAL_SECURE_KEY_HERE"
+   GITHUB_SECRET: "ANOTHER_REAL_SECURE_KEY_HERE"
+   ```
 
-- Take a look at `Envfile`. This file lists all the `ENV` variables we use and provides a fake default for any missing keys. You'll need to get your own free [Algolia credentials](http://docs.dev.to/get-api-keys-dev-env/#algolia) to get your development environment running.
-- This [guide](http://docs.dev.to/get-api-keys-dev-env/) will show you how to get free API keys for additional services that may be required to run certain parts of the app.
-- For any key that you wish to enter/replace:
+   - If you are missing `ENV` variables on bootup, `envied` gem will alert you with messages similar to `'error_on_missing_variables!': The following environment variables should be set: A_MISSING_KEY.`.
+   - You do not need "real" keys for basic development. Some features require certain keys, so you may be able to add them as you go.
 
-10. Create `config/application.yml` by copying from the provided template (ie. with bash: `cp config/sample_application.yml config/application.yml`). This is a personal file that is ignored in git.
-11. Obtain the development variable and apply the key you wish to enter/replace. ie:
-
-
-    ```
-    GITHUB_KEY: "SOME_REAL_SECURE_KEY_HERE"
-    GITHUB_SECRET: "ANOTHER_REAL_SECURE_KEY_HERE"
-    ```
-
-- If you are missing `ENV` variables on bootup, `envied` gem will alert you with messages similar to `'error_on_missing_variables!': The following environment variables should be set: A_MISSING_KEY.`.
-- You do not need "real" keys for basic development. Some features require certain keys, so you may be able to add them as you go.
-
-12. Now Configure database.yaml to connect to PostgreSQL run in Windows instead of Ubuntu. Make sure it looks like the following:
-
-    ```
-    development:
-    <<: *default
-    database: PracticalDeveloper_development
-    host: localhost
-    username: # your Postgres username
-    password: # your Postgres password
-    ```
-
-    The database username and password also have to be manually added to test database in database.yml
-    Another possible way to configure database connection is to setup DATABASE_URL in application.yml as documented [here](https://docs.dev.to/additional-postgres-setup/#configuration)
-
-13. Run `bin/setup`
+1. Run `bin/setup`
 
 #### Other Possible Error Messages
 


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Documentation Update

## Description

Reduces the steps for setting up development (11 steps mac/linux and 13 steps windows to 7 steps for mac/linux) by using convention of the default database config, removing manual steps that `bin/setup` handles, and adding `foremen` to development gems group.

## Related Tickets & Documents

https://github.com/thepracticaldev/dev.to/pull/1162

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

n/a

## Added to documentation?

- [x] docs.dev.to
- [x] readme
- [ ] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![working out](https://media.giphy.com/media/3mJyfDFH0BqgbdghWJ/giphy-downsized.gif)
