### PR TITLE
Fix sidebar-profile-snapshot width

### DIFF
--- a/app/assets/stylesheets/articles.scss
+++ b/app/assets/stylesheets/articles.scss
@@ -850,7 +850,7 @@
         background: var(--theme-container-background, #fff);
         margin-bottom: 14px;
         border-radius: 3px;
-        width: calc(100% - 3px);
+        width: calc(100% - 4px);
         border: 1px solid $outline-color;
         border: var(--theme-container-border, 1px solid $outline-color);
         box-shadow: $bold-shadow;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
The 3 hardest problems programmers face are
  1. Naming things
  2. Off by 1 errors

`.sidebar-profile-snapshot` width was wider than the rest of the sidebar by 1px.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
Before:
![image](https://user-images.githubusercontent.com/3534427/54743006-d9b48f00-4bba-11e9-9679-b239efa0bd97.png)

After:
![image](https://user-images.githubusercontent.com/3534427/54743081-16808600-4bbb-11e9-9883-adbbfb9fc30c.png)


## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

