### PR TITLE
Add alternative text for organization logo

### DIFF
--- a/app/assets/javascripts/utilities/buildArticleHTML.js.erb
+++ b/app/assets/javascripts/utilities/buildArticleHTML.js.erb
@@ -49,7 +49,7 @@ function buildArticleHTML(article) {
     var profileUsername = article.user.username
     var orgHeadline = "";
     if (article.organization && !document.getElementById("organization-article-index")) {
-      orgHeadline = '<div class="article-organization-headline"><a href="/'+article.organization.slug+'" class="article-organization-headline-inner"><img src="'+article.organization.profile_image_90+'" />'+article.organization.name+'</a><a class="org-headline-filler" href="'+article.path+'">&nbsp;</a></div>'
+      orgHeadline = '<div class="article-organization-headline"><a href="/'+article.organization.slug+'" class="article-organization-headline-inner"><img src="'+article.organization.profile_image_90+'" alt="'+article.organization.name+' logo" />'+article.organization.name+'</a><a class="org-headline-filler" href="'+article.path+'">&nbsp;</a></div>'
     }
     var bodyTextSnippet = "";
     var commentsBlobSnippet = "";

--- a/app/views/articles/_single_story.html.erb
+++ b/app/views/articles/_single_story.html.erb
@@ -7,7 +7,8 @@
   <% end %>
   <% if story.organization && !@organization_article_index %>
     <div class="article-organization-headline">
-      <a href="/<%= story.organization.slug %>" class="article-organization-headline-inner"><img src="<%= story.organization.profile_image_90 %>"><%= story.organization.name %>
+      <a href="/<%= story.organization.slug %>" class="article-organization-headline-inner">
+      <img src="<%= story.organization.profile_image_90 %>" alt="<%= story.organization.name %> logo"><%= story.organization.name %>
       </a><a class="org-headline-filler" href="<%= story.path %>">&nbsp;</a></div>
   <% end %>
   <a href="<%= story.user.path %>" class="small-pic-link-wrapper">

--- a/app/views/notifications/_article.html.erb
+++ b/app/views/notifications/_article.html.erb
@@ -7,7 +7,7 @@
   <% if json_data["organization"] %>
     <div class="article-organization-headline">
       <a href="<%= json_data["organization"]["path"] %>" class="article-organization-headline-inner">
-        <img src="<%= json_data["organization"]["profile_image_90"] %>" alt="link to <%= json_data["organization"]["name"] %>"> <%= json_data["organization"]["name"] %>
+        <img src="<%= json_data["organization"]["profile_image_90"] %>" alt="<%= json_data["organization"]["name"] %> logo"> <%= json_data["organization"]["name"] %>
       </a>
       <a class="org-headline-filler" href="<%= json_data["organization"]["path"] %>">&nbsp;</a>
     </div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

Organizations logos are missing the alternative texts in a few places.

Thanks to Lighthouse for catching this on the homepage.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![Screenshot 2019-03-21 at 11 04 29 AM](https://user-images.githubusercontent.com/146201/54745152-299a5280-4bc9-11e9-9866-b9acef3176c0.png)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
