### PR TITLE
WIP Add more data to pro dashboard

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -205,6 +205,11 @@ Style/TrivialAccessors:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#attr_family'
   Enabled: false
 
+Style/Lambda:
+  Description: 'Use the `lambda` method for multiline lambdas'
+  StyleGuide: 'https://github.com/rubocop-hq/ruby-style-guide#lambda-multi-line'
+  Enabled: false
+
 # Layout
 
 Layout/AlignParameters:

--- a/app/decorators/chart_decorator.rb
+++ b/app/decorators/chart_decorator.rb
@@ -1,23 +1,25 @@
-class ChartDecorator < Draper::CollectionDecorator
+class ChartDecorator < Draper::Decorator
+  delegate_all
+
   def total_by_type_per_day(options)
     case options[:type]
     when "Comment"
-      object.group_by { |e| e.created_at.beginning_of_day }.transform_values do |v|
+      group_by { |e| e.created_at.beginning_of_day }.transform_values do |v|
         v.select { |comment| comment.commentable_id == options[:article_id] }.length
       end.values # will be an array of integers: [1,2,3,4]
     when "Reaction"
-      object.group_by { |e| e.created_at.beginning_of_day }.transform_values do |v|
+      group_by { |e| e.created_at.beginning_of_day }.transform_values do |v|
         v.select { |reaction| reaction.category == options[:category] }.length
       end.values # will be an array of integers: [1,2,3,4]
     end
   end
 
   def total_per_day
-    object.group_by { |e| e.created_at.beginning_of_day }.transform_values(&:length).values
+    group_by { |e| e.created_at.beginning_of_day }.transform_values(&:length).values
   end
 
   def formatted_dates
-    object.sort_by(&:created_at).group_by { |e| e.created_at.beginning_of_day }.
+    sort_by(&:created_at).group_by { |e| e.created_at.beginning_of_day }.
       transform_keys { |k| k.strftime("%a, %m/%d") }.keys
   end
 end

--- a/app/facades/dashboard/pro.rb
+++ b/app/facades/dashboard/pro.rb
@@ -1,75 +1,40 @@
 module Dashboard
   class Pro
-    attr_reader :user_or_org
+    attr_reader :user_or_org, :article_data, :article_ids, :reaction_data, :comment_data, :follow_data
 
     def initialize(user_or_org)
       @user_or_org = user_or_org
+      @article_data ||= Article.where("#{user_or_org.class.name.downcase}_id" => user_or_org.id, published: true)
+      @article_ids ||= @article_data.pluck(:id)
+      @reaction_data ||= Reaction.two_months_data(@article_ids)
+      @comment_data ||= Comment.two_months_data(@article_ids)
+      @follow_data ||= Follow.two_months_data(followable_type: user_or_org.class.name, followable_id: user_or_org.id)
     end
 
-    def user_or_org_article_ids
-      @user_or_org_article_ids ||=
-        Article.where("#{user_or_org.class.name.downcase}_id" => user_or_org.id, published: true).pluck(:id)
+    def data_by_time(timeframe, type)
+      ChartDecorator.decorate(
+        send("#{type}_data").select do |model_instance|
+          case timeframe
+          when :this_week
+            model_instance.created_at > 1.week.ago
+          when :last_week
+            model_instance.created_at > 2.weeks.ago && model_instance.created_at < 1.week.ago
+          when :this_month
+            model_instance.created_at > 1.month.ago
+          when :last_month
+            model_instance.created_at > 2.months.ago && model_instance.created_at < 1.month.ago
+          end
+        end.sort_by(&:created_at).reverse, # comma is for last argument because Rubocop
+      )
     end
 
-    def this_week_reactions
-      ChartDecorator.decorate(Reaction.where(reactable_id: user_or_org_article_ids, reactable_type: "Article").where("created_at > ?", 1.week.ago).order("created_at ASC"))
-    end
-
-    def this_week_reactions_count
-      this_week_reactions.size
-    end
-
-    def last_week_reactions_count
-      Reaction.where(reactable_id: user_or_org_article_ids, reactable_type: "Article").where("created_at > ? AND created_at < ?", 2.weeks.ago, 1.week.ago).size
-    end
-
-    def this_month_reactions_count
-      Reaction.where(reactable_id: user_or_org_article_ids, reactable_type: "Article").where("created_at > ?", 1.month.ago).size
-    end
-
-    def last_month_reactions_count
-      Reaction.where(reactable_id: user_or_org_article_ids, reactable_type: "Article").where("created_at > ? AND created_at < ?", 2.months.ago, 1.months.ago).size
-    end
-
-    def this_week_comments
-      ChartDecorator.decorate(Comment.where(commentable_id: user_or_org_article_ids, commentable_type: "Article").where("created_at > ?", 1.week.ago))
-    end
-
-    def this_week_comments_count
-      this_week_comments.size
-    end
-
-    def last_week_comments_count
-      Comment.where(commentable_id: user_or_org_article_ids, commentable_type: "Article").where("created_at > ? AND created_at < ?", 2.weeks.ago, 1.week.ago).size
-    end
-
-    def this_month_comments_count
-      Comment.where(commentable_id: user_or_org_article_ids, commentable_type: "Article").where("created_at > ?", 1.month.ago).size
-    end
-
-    def last_month_comments_count
-      Comment.where(commentable_id: user_or_org_article_ids, commentable_type: "Article").where("created_at > ? AND created_at < ?", 2.months.ago, 1.months.ago).size
-    end
-
-    def this_week_followers_count
-      Follow.where(followable_id: user_or_org.id, followable_type: user_or_org.class.name).where("created_at > ?", 1.week.ago).size
-    end
-
-    def last_week_followers_count
-      Follow.where(followable_id: user_or_org.id, followable_type: user_or_org.class.name).where("created_at > ? AND created_at < ?", 2.weeks.ago, 1.week.ago).size
-    end
-
-    def this_month_followers_count
-      Follow.where(followable_id: user_or_org.id, followable_type: user_or_org.class.name).where("created_at > ?", 1.month.ago).size
-    end
-
-    def last_month_followers_count
-      Follow.where(followable_id: user_or_org.id, followable_type: user_or_org.class.name).where("created_at > ? AND created_at < ?", 2.months.ago, 1.months.ago).size
+    def total_views
+      article_data.pluck(:organic_page_views_count, :page_views_count).flatten.sum
     end
 
     def reactors
-      User.where(id: Reaction.where(reactable_id: user_or_org_article_ids, reactable_type: "Article").
-        order("created_at DESC").limit(100).pluck(:user_id))
+      User.where(id: Reaction.where(reactable_id: article_ids, reactable_type: "Article").
+        order("created_at DESC").limit(100).pluck(:user_id).uniq)
     end
   end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -34,6 +34,11 @@ class Comment < ApplicationRecord
 
   alias touch_by_reaction save
 
+  scope :two_months_data, ->(commentable_ids) {
+    where(commentable_id: commentable_ids, commentable_type: "Article").
+      where("score > 0 AND created_at > ?", 2.months.ago)
+  }
+
   algoliasearch per_environment: true, enqueue: :trigger_delayed_index do
     attribute :id
     add_index "ordered_comments",

--- a/app/models/follow.rb
+++ b/app/models/follow.rb
@@ -20,6 +20,12 @@ class Follow < ApplicationRecord
     ["follows.followable_type = ?", "Organization"] => "following_orgs_count",
     ["follows.followable_type = ?", "ActsAsTaggableOn::Tag"] => "following_tags_count"
   }
+
+  scope :two_months_data, ->(hash) {
+    where(followable_id: hash[:followable_id], followable_type: hash[:followable_type]).
+      where("created_at > ?", 2.months.ago)
+  }
+
   after_save :touch_follower
   after_create :send_email_notification, :create_chat_channel
   before_destroy :modify_chat_channel_status

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -21,6 +21,11 @@ class Reaction < ApplicationRecord
   before_destroy :update_reactable_without_delay, unless: :destroyed_by_association
   before_destroy :bust_reactable_cache_without_delay
 
+  scope :two_months_data, ->(reactable_ids) {
+    where(reactable_id: reactable_ids, reactable_type: "Article").
+      where("points > 0 AND created_at > ?", 2.months.ago)
+  }
+
   class << self
     def count_for_article(id)
       Rails.cache.fetch("count_for_reactable-Article-#{id}", expires_in: 1.hour) do

--- a/app/views/dashboards/pro.html.erb
+++ b/app/views/dashboards/pro.html.erb
@@ -19,61 +19,61 @@
     <div class="card">
       <h4>Reactions this week</h4>
       <div class="featured-stat">
-        <%= @dashboard.this_week_reactions_count %>
+        <%= @dashboard.data_by_time(:this_week, :reaction).count %>
       </div>
-      <% week_reaction_rate = @dashboard.this_week_reactions_count.to_f / @dashboard.last_week_reactions_count.to_f %>
+      <% week_reaction_rate = @dashboard.data_by_time(:this_week, :reaction).count.to_f / @dashboard.data_by_time(:last_week, :reaction).count.to_f %>
        <div class="stat-percentage" style="color: <%= week_reaction_rate > 1 ? "green" : "red" %>">
-        <%= week_reaction_rate > 1 ? "\u25b2" : "\u25BC" %> <%= @dashboard.last_week_reactions_count.positive? ? (week_reaction_rate * 100).round(2) : "infinity " %>%
+        <%= week_reaction_rate > 1 ? "\u25b2" : "\u25BC" %> <%= @dashboard.data_by_time(:last_week, :reaction).count.positive? ? (week_reaction_rate * 100).round(2) : "infinity " %>%
       </div>
     </div>
     <div class="card">
       <h4>Reactions this month</h4>
       <div class="featured-stat">
-        <%= @dashboard.this_month_reactions_count %>
+        <%= @dashboard.data_by_time(:this_month, :reaction).count %>
       </div>
-      <% month_reaction_rate = @dashboard.this_month_reactions_count.to_f / @dashboard.last_month_reactions_count.to_f %>
+      <% month_reaction_rate = @dashboard.data_by_time(:this_month, :reaction).count.to_f / @dashboard.data_by_time(:this_month, :reaction).count.to_f %>
        <div class="stat-percentage" style="color: <%= month_reaction_rate > 1 ? "green" : "red" %>">
-        <%= month_reaction_rate > 1 ? "\u25b2" : "\u25BC" %> <%= @dashboard.last_month_reactions_count.positive? ? (month_reaction_rate * 100).round(2) : "infinity " %>%
+        <%= month_reaction_rate > 1 ? "\u25b2" : "\u25BC" %> <%= @dashboard.data_by_time(:this_month, :reaction).count.positive? ? (month_reaction_rate * 100).round(2) : "infinity " %>%
       </div>
     </div>
     <div class="card">
       <h4>New followers this week</h4>
       <div class="featured-stat">
-        <%= @dashboard.this_week_followers_count %>
+        <%= @dashboard.data_by_time(:this_week, :follow).count %>
       </div>
-      <% week_followers_rate = @dashboard.this_week_followers_count.to_f / @dashboard.last_week_followers_count.to_f %>
+      <% week_followers_rate = @dashboard.data_by_time(:this_week, :follow).count.to_f / @dashboard.data_by_time(:last_week, :follow).count.to_f %>
        <div class="stat-percentage" style="color: <%= week_followers_rate > 1 ? "green" : "red" %>">
-        <%= week_followers_rate > 1 ? "\u25b2" : "\u25BC" %> <%= @dashboard.last_week_followers_count.positive? ? (week_followers_rate * 100).round(2) : "infinity " %>%
+        <%= week_followers_rate > 1 ? "\u25b2" : "\u25BC" %> <%= @dashboard.data_by_time(:last_week, :follow).count.positive? ? (week_followers_rate * 100).round(2) : "infinity " %>%
       </div>
     </div>
     <div class="card">
       <h4>New followers this month</h4>
       <div class="featured-stat">
-        <%= @dashboard.this_month_followers_count %>
+        <%= @dashboard.data_by_time(:this_month, :follow).count %>
       </div>
-      <% month_followers_rate = @dashboard.this_month_followers_count.to_f / @dashboard.last_month_followers_count.to_f %>
+      <% month_followers_rate = @dashboard.data_by_time(:this_month, :follow).count.to_f / @dashboard.data_by_time(:last_month, :follow).count.to_f %>
        <div class="stat-percentage" style="color: <%= month_followers_rate > 1 ? "green" : "red" %>">
-        <%= month_followers_rate > 1 ? "\u25b2" : "\u25BC" %> <%= @dashboard.last_month_followers_count.positive? ? (month_followers_rate * 100).round(2) : "infinity " %>%
+        <%= month_followers_rate > 1 ? "\u25b2" : "\u25BC" %> <%= @dashboard.data_by_time(:last_month, :follow).count.positive? ? (month_followers_rate * 100).round(2) : "infinity " %>%
       </div>
     </div>
     <div class="card">
       <h4>New comments this week</h4>
       <div class="featured-stat">
-        <%= @dashboard.this_week_comments_count %>
+        <%= @dashboard.data_by_time(:this_week, :comment).count %>
       </div>
-      <% week_comments_rate = @dashboard.this_week_comments_count.to_f / @dashboard.last_week_comments_count.to_f %>
+      <% week_comments_rate = @dashboard.data_by_time(:this_week, :comment).count.to_f / @dashboard.data_by_time(:last_week, :comment).count.to_f %>
        <div class="stat-percentage" style="color: <%= week_comments_rate > 1 ? "green" : "red" %>">
-        <%= week_comments_rate > 1 ? "\u25b2" : "\u25BC" %> <%= @dashboard.last_week_followers_count.positive? ? (week_comments_rate * 100).round(2) : "infinity " %>%
+        <%= week_comments_rate > 1 ? "\u25b2" : "\u25BC" %> <%= @dashboard.data_by_time(:last_week, :comment).count.positive? ? (week_comments_rate * 100).round(2) : "infinity " %>%
       </div>
     </div>
     <div class="card">
       <h4>New comments this month</h4>
       <div class="featured-stat">
-        <%= @dashboard.this_month_comments_count %>
+        <%= @dashboard.data_by_time(:this_month, :comment).count %>
       </div>
-      <% month_comments_rate = @dashboard.this_month_comments_count.to_f / @dashboard.last_month_comments_count.to_f %>
+      <% month_comments_rate = @dashboard.data_by_time(:this_month, :comment).count.to_f / @dashboard.data_by_time(:last_month, :comment).count.to_f %>
        <div class="stat-percentage" style="color: <%= week_comments_rate > 1 ? "green" : "red" %>">
-        <%= month_comments_rate > 1 ? "\u25b2" : "\u25BC" %> <%= @dashboard.last_month_comments_count.positive? ? (month_comments_rate * 100).round(2) : "infinity " %>%
+        <%= month_comments_rate > 1 ? "\u25b2" : "\u25BC" %> <%= @dashboard.data_by_time(:last_month, :comment).count.positive? ? (month_comments_rate * 100).round(2) : "infinity " %>%
       </div>
     </div>
   </div>
@@ -83,25 +83,54 @@
       <div class="charts-container">
         <canvas
           id="reactionsChart"
-          data-labels="<%= @dashboard.this_week_reactions.formatted_dates %>"
-          data-total-count="<%= @dashboard.this_week_reactions.total_per_day %>"
-          data-total-likes="<%= @dashboard.this_week_reactions.total_by_type_per_day(type: "Reaction", category: "like") %>"
-          data-total-unicorns="<%= @dashboard.this_week_reactions.total_by_type_per_day(type: "Reaction", category: "unicorn") %>"
-          data-total-readinglist="<%= @dashboard.this_week_reactions.total_by_type_per_day(type: "Reaction", category: "readinglist") %>">
+          data-labels="<%= @dashboard.data_by_time(:this_week, :reaction).formatted_dates %>"
+          data-total-count="<%= @dashboard.data_by_time(:this_week, :reaction).total_per_day %>"
+          data-total-likes="<%= @dashboard.data_by_time(:this_week, :reaction).total_by_type_per_day(type: "Reaction", category: "like") %>"
+          data-total-unicorns="<%= @dashboard.data_by_time(:this_week, :reaction).total_by_type_per_day(type: "Reaction", category: "unicorn") %>"
+          data-total-readinglist="<%= @dashboard.data_by_time(:this_week, :reaction).total_by_type_per_day(type: "Reaction", category: "readinglist") %>">
+        </canvas>
+      </div> 
+    </div>
+    <div class="card">
+      <h2>Comments Summary 💬</h2>
+      <div class="charts-container">
+        <canvas
+          id="commentsChart"
+          data-labels="<%= @dashboard.data_by_time(:this_week, :comment).formatted_dates %>"
+          data-total-count="<%= @dashboard.data_by_time(:this_week, :comment).total_per_day %>">
         </canvas>
       </div>
+    </div>
+    <div class="card" style="display: none;">
+      <div class="charts-container">
+          <canvas
+            id="followsChart"
+            data-labels="<%= @dashboard.data_by_time(:this_week, :follow).formatted_dates %>"
+            data-total-count="<%= @dashboard.data_by_time(:this_week, :follow).total_per_day %>">
+          </canvas>
+        </div>
+    </div>
     <%= javascript_pack_tag "proCharts", defer: true %>
   </div>
   <div class="card">
-    <h2>Comments Summary 💬</h2>
-    <div class="charts-container">
-      <canvas
-        id="commentsChart"
-        data-labels="<%= @dashboard.this_week_comments.formatted_dates %>"
-        data-total-count="<%= @dashboard.this_week_comments.total_per_day %>">
-      </canvas>
+    <h2>View Count 👀</h2>
+    <h3>Total views across all posts: <%= @dashboard.total_views %></h3>
+    <div class="recent-reactors-container" style="<%= "display: none;" %>">
+      <% @dashboard.article_data.each do |article| %>
+        <div class="single-article">
+          <h2><a href="<%= article.path %>"><%= article.title %></a></h2>
+          <p>Total views: <%= article.organic_page_views_count + article.page_views_count %></p>
+          <p>Organic views in the past week: <%= article.organic_page_views_past_week_count %></p>
+          <p>Organic views in the past month: <%= article.organic_page_views_past_month_count %></p>
+          <p>
+            Tags used:
+            <% article.decorate.cached_tag_list_array.each do |tag| %>
+              <a href="/t/<%= tag %>"><span class="tag">#<%= tag %></span></a>
+            <% end %>
+          </p>
+        </div>
+      <% end %>
     </div>
-  </div>
   </div>
   <h2>Activity</h2>
   <h3>People who recently reacted ❤🦄🔖 to your content:</h3>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor

## Description
This adds view data to the pro dashboard, as well as use a more flexible way of getting data from the dashboard. It should theoretically also make the dashboard more performant, since the data is calculated with Ruby and not hitting the database with multiple SQL queries.

Here's a very rough version of the total views card:
![Image 2019-03-21 at 1 27 56 PM](https://user-images.githubusercontent.com/17884966/54772669-383f3480-4bde-11e9-9a10-f122a82d5d6f.png)

I also added a `followers` chart, but that and the total views card are hidden behind a simple `style=<%= "display: none" %>`. I suggest replacing the ERB `=` sign with a `#` in development to play around with it.