### PR TITLE
Add areas for DEV Shop displays on left sidebar

### DIFF
--- a/app/models/display_ad.rb
+++ b/app/models/display_ad.rb
@@ -2,7 +2,7 @@ class DisplayAd < ApplicationRecord
   belongs_to :organization
   validates :organization_id, presence: true
   validates :placement_area, presence: true,
-                             inclusion: { in: %w[sidebar] }
+                             inclusion: { in: %w[sidebar_left sidebar_right] }
   validates :body_markdown, presence: true
   before_save :process_markdown
 

--- a/app/views/articles/_sidebar.html.erb
+++ b/app/views/articles/_sidebar.html.erb
@@ -79,11 +79,11 @@
       </div>
     <% end %>
     <% cache("display-area-left-#{rand(5)}", expires_in: 5.minutes) do %>
-      <% @sidebar_ad = DisplayAd.where(approved: true, published: true, placement_area: "sidebar_left").order("RANDOM()").first %>
-      <% if @sidebar_ad %>
+      <% @left_sidebar_ad = DisplayAd.where(approved: true, published: true, placement_area: "sidebar_left").order("RANDOM()").first %>
+      <% if @left_sidebar_ad %>
         <div class="widget">
           <div class="widget-body" style="margin-top:-6px">
-            <%= @sidebar_ad.processed_html.html_safe %>
+            <%= @left_sidebar_ad.processed_html.html_safe %>
           </div>
         </div>
       <% end %>

--- a/app/views/articles/_sidebar.html.erb
+++ b/app/views/articles/_sidebar.html.erb
@@ -78,5 +78,15 @@
         </div>
       </div>
     <% end %>
+    <% cache("display-area-left-#{rand(5)}", expires_in: 5.minutes) do %>
+      <% @sidebar_ad = DisplayAd.where(approved: true, published: true, placement_area: "sidebar_left").order("RANDOM()").first %>
+      <% if @sidebar_ad %>
+        <div class="widget">
+          <div class="widget-body" style="margin-top:-6px">
+            <%= @sidebar_ad.processed_html.html_safe %>
+          </div>
+        </div>
+      <% end %>
+    <% end %>
   </div>
 </div>

--- a/app/views/articles/_sidebar_additional.html.erb
+++ b/app/views/articles/_sidebar_additional.html.erb
@@ -19,7 +19,7 @@
       </div>
     <% end %>
     <% cache("main-article-right-sidebar-discussions-#{params[:timeframe]}", expires_in: (params[:timeframe].blank? ? 120 : 360).seconds) do %>
-      <% @sidebar_ad = DisplayAd.where(approved: true, published: true, placement_area: "sidebar").first %>
+      <% @sidebar_ad = DisplayAd.where(approved: true, published: true, placement_area: "sidebar_right").order("RANDOM()").first %>
       <% if @sidebar_ad %>
         <div class="widget">
           <div class="widget-body" style="margin-top:-6px">

--- a/spec/factories/display_ads.rb
+++ b/spec/factories/display_ads.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :display_ad do
-    placement_area { "sidebar" }
+    placement_area { "sidebar_left" }
     body_markdown { "Hello _hey_ Hey hey" }
   end
 end

--- a/spec/models/display_ad_spec.rb
+++ b/spec/models/display_ad_spec.rb
@@ -15,8 +15,12 @@ RSpec.describe DisplayAd, type: :model do
     display_ad.placement_area = "tsdsdsdds"
     expect(display_ad).not_to be_valid
   end
-  it "only allows acceptable placement_area" do
-    display_ad.placement_area = "sidebar"
+  it "allows sidebar_right" do
+    display_ad.placement_area = "sidebar_right"
+    expect(display_ad).to be_valid
+  end
+  it "allows sidebar_left" do
+    display_ad.placement_area = "sidebar_left"
     expect(display_ad).to be_valid
   end
 end

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -18,16 +18,19 @@ RSpec.describe "StoriesIndex", type: :request do
       expect(response.body).to include(ad.processed_html)
     end
     it "renders right display_ads when published and approved" do
+      org = create(:organization)
       ad = create(:display_ad, published: true, approved: true, placement_area: "sidebar_right", organization: org)
       get "/"
       expect(response.body).to include(ad.processed_html)
     end
     it "does not render left display_ads when not approved" do
+      org = create(:organization)
       ad = create(:display_ad, published: true, approved: false, organization: org)
       get "/"
       expect(response.body).not_to include(ad.processed_html)
     end
     it "does not render right display_ads when not approved" do
+      org = create(:organization)
       ad = create(:display_ad, published: true, approved: false, placement_area: "sidebar_right", organization: org)
       get "/"
       expect(response.body).not_to include(ad.processed_html)

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -11,6 +11,26 @@ RSpec.describe "StoriesIndex", type: :request do
       get "/"
       expect(response.body).to include("min read")
     end
+    it "renders left display_ads when published and approved" do
+      ad = create(:display_ad, published: true, approved: true)
+      get "/"
+      expect(response.body).to include(ad.processed_html)
+    end
+    it "renders right display_ads when published and approved" do
+      ad = create(:display_ad, published: true, approved: true, placement_area: "sidebar_right")
+      get "/"
+      expect(response.body).to include(ad.processed_html)
+    end
+    it "does not render left display_ads when not approved" do
+      ad = create(:display_ad, published: true, approved: false)
+      get "/"
+      expect(response.body).not_to include(ad.processed_html)
+    end
+    it "does not render right display_ads when not approved" do
+      ad = create(:display_ad, published: true, approved: false, placement_area: "sidebar_right")
+      get "/"
+      expect(response.body).not_to include(ad.processed_html)
+    end
   end
 
   describe "GET query page" do

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -12,22 +12,23 @@ RSpec.describe "StoriesIndex", type: :request do
       expect(response.body).to include("min read")
     end
     it "renders left display_ads when published and approved" do
-      ad = create(:display_ad, published: true, approved: true)
+      org = create(:organization)
+      ad = create(:display_ad, published: true, approved: true, organization: org)
       get "/"
       expect(response.body).to include(ad.processed_html)
     end
     it "renders right display_ads when published and approved" do
-      ad = create(:display_ad, published: true, approved: true, placement_area: "sidebar_right")
+      ad = create(:display_ad, published: true, approved: true, placement_area: "sidebar_right", organization: org)
       get "/"
       expect(response.body).to include(ad.processed_html)
     end
     it "does not render left display_ads when not approved" do
-      ad = create(:display_ad, published: true, approved: false)
+      ad = create(:display_ad, published: true, approved: false, organization: org)
       get "/"
       expect(response.body).not_to include(ad.processed_html)
     end
     it "does not render right display_ads when not approved" do
-      ad = create(:display_ad, published: true, approved: false, placement_area: "sidebar_right")
+      ad = create(:display_ad, published: true, approved: false, placement_area: "sidebar_right", organization: org)
       get "/"
       expect(response.body).not_to include(ad.processed_html)
     end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Adds ability to put shop and other theme day content at bottom of left sidebar

![Screen Shot 2019-03-21 at 2 55 56 PM](https://user-images.githubusercontent.com/3102842/54777830-8efe3b80-4be9-11e9-9bc2-0fd8f2a685de.png)
