### PR TITLE
UX: Better width for footer and small refactors

### DIFF
--- a/app/assets/stylesheets/footer.scss
+++ b/app/assets/stylesheets/footer.scss
@@ -13,7 +13,18 @@ footer{
     font-weight: 500;
     background: transparent;
     &.centered-footer{
-      max-width: 820px;
+      width: 97%;
+      max-width: 722px;
+      @media screen and (min-width: 950px) and (max-width: 1119px) {
+        margin-left: 310px;
+        max-width: calc(100% - 377px);
+      }
+      @media screen and (min-width: 1120px) {
+        max-width: calc(100% - 642px);
+      }
+      @media screen and (min-width: 1240px) {
+        max-width: 606px;
+      }
     }
     a{
       color: $black;

--- a/app/assets/stylesheets/notifications.scss
+++ b/app/assets/stylesheets/notifications.scss
@@ -1,7 +1,7 @@
 @import 'variables';
 .notifications-index {
-  background: $light-gray;
-  background:var(--theme-background, $light-gray);
+  background: $lightest-gray;
+  background:var(--theme-background, $lightest-gray);
   .home{
     .articles-list{
       .signup-cue{

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -3,7 +3,7 @@
     <div class="inner-footer-container">
       <a href="/">Home</a> <a href="/about">About</a> <a href="/privacy">Privacy Policy</a>
       <a href="/terms">Terms of Use</a> <a href="/contact">Contact</a> <a href="/code-of-conduct">Code of Conduct</a> <br/>
-      <%= ApplicationConfig["COMMUNITY_NAME"] %> Community copyright 2016 - <%= Time.new.year %> 🔥
+      <%= ApplicationConfig["COMMUNITY_NAME"] %> Community copyright 2016 - <%= Time.new.year %>&nbsp; 🔥
     </div>
   </div>
 </footer>

--- a/app/views/reading_list_items/index.html.erb
+++ b/app/views/reading_list_items/index.html.erb
@@ -47,11 +47,9 @@
   </div>
   <div class="articles-list" id="articles-list">
     <% if user_signed_in? %>
-      <div class="comments-container" id="comments-container">
-        <div class="substories" id="substories" data-tabs="{}">
-        </div>
-        <button class="load-more-cta cta" id="load-more-cta">LOAD MORE POSTS</button>
+      <div class="substories" id="substories" data-tabs="{}">
       </div>
+      <button class="load-more-cta cta" id="load-more-cta">LOAD MORE POSTS</button>
     <% else %>
       <script>
         window.location.href = "/enter"


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
* Changed width of footer to now be the same as articles
* Changed background color of notifications page from $light-gray to $lightest-gray
* Removed unnecessary `.comments-container` from readlist
* Added `&nbsp` in footer between year and flame emoji since it sometimes switched to a new line

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/issues/1794

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
* Not necessary since its a bugfix

Notifications page `$light-gray` bug ( you have to look closely to see it :smile: ):

![Screenshot from 2019-03-21 21-45-31](https://user-images.githubusercontent.com/13546486/54784399-0fda2900-4c24-11e9-9d32-76632ba05fbc.png)


## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
