### PR TITLE
Add discernible text for organization link

### DIFF
--- a/app/assets/javascripts/utilities/buildArticleHTML.js.erb
+++ b/app/assets/javascripts/utilities/buildArticleHTML.js.erb
@@ -49,7 +49,7 @@ function buildArticleHTML(article) {
     var profileUsername = article.user.username
     var orgHeadline = "";
     if (article.organization && !document.getElementById("organization-article-index")) {
-      orgHeadline = '<div class="article-organization-headline"><a href="/'+article.organization.slug+'" class="article-organization-headline-inner"><img src="'+article.organization.profile_image_90+'" alt="'+article.organization.name+' logo" />'+article.organization.name+'</a><a class="org-headline-filler" href="'+article.path+'">&nbsp;</a></div>'
+      orgHeadline = '<div class="article-organization-headline"><a class="org-headline-filler" href="/'+article.organization.slug+'"><span class="article-organization-headline-inner"><img alt="'+article.organization.name+' logo" src="'+article.organization.profile_image_90+'">'+article.organization.name+'</span></a></div>'
     }
     var bodyTextSnippet = "";
     var commentsBlobSnippet = "";

--- a/app/views/articles/_single_story.html.erb
+++ b/app/views/articles/_single_story.html.erb
@@ -7,9 +7,13 @@
   <% end %>
   <% if story.organization && !@organization_article_index %>
     <div class="article-organization-headline">
-      <a href="/<%= story.organization.slug %>" class="article-organization-headline-inner">
-      <img src="<%= story.organization.profile_image_90 %>" alt="<%= story.organization.name %> logo"><%= story.organization.name %>
-      </a><a class="org-headline-filler" href="<%= story.path %>">&nbsp;</a></div>
+      <a class="org-headline-filler" href="/<%= story.organization.slug %>">
+        <span class="article-organization-headline-inner">
+          <img alt="<%= story.organization.name %> logo" src="<%= story.organization.profile_image_90 %>">
+          <%= story.organization.name %>
+        </span>
+      </a>
+    </div>
   <% end %>
   <a href="<%= story.user.path %>" class="small-pic-link-wrapper">
     <div class="small-pic">

--- a/app/views/notifications/_article.html.erb
+++ b/app/views/notifications/_article.html.erb
@@ -6,11 +6,13 @@
   <% json_data = notification.json_data %>
   <% if json_data["organization"] %>
     <div class="article-organization-headline">
-      <a href="<%= json_data["organization"]["path"] %>" class="article-organization-headline-inner">
-        <img src="<%= json_data["organization"]["profile_image_90"] %>" alt="<%= json_data["organization"]["name"] %> logo"> <%= json_data["organization"]["name"] %>
+      <a class="org-headline-filler" href="<%= json_data["organization"]["path"] %>">
+        <span class="article-organization-headline-inner">
+          <img alt="<%= json_data["organization"]["name"] %> logo" src="<%= json_data["organization"]["profile_image_90"] %>">
+          <%= json_data["organization"]["name"] %>
+        </span>
       </a>
-      <a class="org-headline-filler" href="<%= json_data["organization"]["path"] %>">&nbsp;</a>
-    </div>
+   </div>
   <% end %>
   <% cache "activity-profile-pic-#{json_data['user']['id']}-#{json_data['user']['profile_image_90']}" do %>
     <a href="<%= json_data["user"]["path"] %>" class="small-pic-link-wrapper">


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Refactor `article-organization-headline` to allow for only one anchor that contains text for a11y

## Related Tickets & Documents
Closes #1278 
References #2148 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

The first post is amended but the second is not, UI change is not really noticeable.

![image](https://user-images.githubusercontent.com/3534427/54813088-a2121980-4c84-11e9-9904-f29f11b6adce.png)


## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

