### PR TITLE
Add social.coop

### DIFF
--- a/app/lib/constants.rb
+++ b/app/lib/constants.rb
@@ -49,6 +49,7 @@ module Constants
     "ro-mastodon.puyo.jp",
     "ruby.social",
     "ruhr.social",
+    "social.coop",
     "social.targaryen.house",
     "social.tchncs.de",
     "switter.at",


### PR DESCRIPTION
Closes #2169 

Add the https://social.coop Mastadon instance to trusted list.