### PR TITLE
Update pro dashboard permissions for organization members

### DIFF
--- a/app/policies/organization_policy.rb
+++ b/app/policies/organization_policy.rb
@@ -12,6 +12,6 @@ class OrganizationPolicy < ApplicationPolicy
   end
 
   def pro_org_user?
-    user.has_role?(:pro) && user.org_admin && user.organization_id == record.id
+    user.has_role?(:pro) && user.organization_id == record.id
   end
 end

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -22,13 +22,19 @@
       <% if @user.has_role? :pro %>
         <a class="rounded-btn" href="/dashboard/pro">Pro Analytics</a>
       <% end %>
+      <% if @user.has_role?(:pro) && @user.organization_id %>
+        <a class="rounded-btn" href="/dashboard/pro/org/<%= @user.organization_id %>">Pro Analytics for <%= @user.organization.name %></a>
+      <% end %>
     </h1>
   <% elsif @user.org_admin && @user.organization && (params[:which] == "organization_user_followers" || params[:which] == "user_followers") %>
     <h1>
       <a href="/dashboard/user_followers" class="rounded-btn <%= "active" if params[:which] == "user_followers" %>">Personal</a>
       <a href="/dashboard/organization_user_followers" class="rounded-btn <%= "active" if params[:which] == "organization_user_followers" %>"><%= @user.organization.name %> (<%= @user.organization.followers_count %>)</a>
       <% if @user.has_role? :pro %>
-        <a class="rounded-btn" href="/pro">Pro Analytics</a>
+        <a class="rounded-btn" href="/dashboard/pro">Pro Analytics</a>
+      <% end %>
+      <% if @user.has_role?(:pro) && @user.organization_id %>
+        <a class="rounded-btn" href="/dashboard/pro/org/<%= @user.organization_id %>">Pro Analytics for <%= @user.organization.name %></a>
       <% end %>
     </h1>
   <% end %>

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe "Dashboards", type: :request do
   let(:user)          { create(:user) }
   let(:second_user)   { create(:user) }
+  let(:org_admin)     { create(:user, :org_admin) }
   let(:super_admin)   { create(:user, :super_admin) }
   let(:article)       { create(:article, user_id: user.id) }
 
@@ -124,6 +125,26 @@ RSpec.describe "Dashboards", type: :request do
         user.add_role(:pro)
         login_as user
         get "/dashboard/pro"
+        expect(response.body).to include("pro")
+      end
+    end
+
+    context "when user has pro permission and is an org admin" do
+      it "shows page properly" do
+        org_admin.add_role(:pro)
+        login_as org_admin
+        get "/dashboard/pro/org/#{org_admin.organization_id}"
+        expect(response.body).to include("pro")
+      end
+    end
+
+    context "when user has pro permission and is an org member" do
+      it "shows page properly" do
+        org = create :organization
+        user.update(organization_id: org.id)
+        user.add_role(:pro)
+        login_as user
+        get "/dashboard/pro/org/#{org.id}"
         expect(response.body).to include("pro")
       end
     end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
This PR allows organization members who have the `pro` role to view the organization's dashboard as well.