### PR TITLE
Merge user and give pro users trusted role

### DIFF
--- a/app/controllers/internal/users_controller.rb
+++ b/app/controllers/internal/users_controller.rb
@@ -103,6 +103,16 @@ class Internal::UsersController < Internal::ApplicationController
     redirect_to "/internal/users"
   end
 
+  def merge
+    @user = User.find(params[:id])
+    begin
+      Moderator::MergeUser.call_merge(admin: current_user, keep_user: @user, delete_user_id: user_params["merge_user_id"])
+    rescue StandardError => e
+      flash[:error] = e.message
+    end
+    redirect_to "/internal/users/#{@user.id}/edit"
+  end
+
   private
 
   def user_params
@@ -116,6 +126,7 @@ class Internal::UsersController < Internal::ApplicationController
                             :mentorship_note,
                             :user_status,
                             :toggle_mentorship,
-                            :pro)
+                            :pro,
+                            :merge_user_id)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
   include CloudinaryHelper
 
-  attr_accessor :scholar_email, :new_note, :quick_match, :mentorship_note, :note_for_current_role, :add_mentor, :add_mentee, :user_status, :toggle_mentorship, :pro
+  attr_accessor :scholar_email, :new_note, :quick_match, :mentorship_note, :note_for_current_role, :add_mentor, :add_mentee, :user_status, :toggle_mentorship, :pro, :merge_user_id
 
   rolify
   include AlgoliaSearch

--- a/app/services/moderator/manage_activity_and_roles.rb
+++ b/app/services/moderator/manage_activity_and_roles.rb
@@ -96,7 +96,6 @@ module Moderator
         user.add_role :pro
       end
       create_note(role, note)
-      update_trusted_cache
     end
 
     def remove_negative_roles
@@ -141,6 +140,7 @@ module Moderator
         update_mentorship_status
       else
         handle_user_status(user_params[:user_status], user_params[:note_for_current_role])
+        update_trusted_cache
       end
     end
   end

--- a/app/services/moderator/manage_activity_and_roles.rb
+++ b/app/services/moderator/manage_activity_and_roles.rb
@@ -85,11 +85,14 @@ module Moderator
         remove_privileges
       when "Regular Member"
         remove_negative_roles
+        user.remove_role :pro
       when "Trusted"
         remove_negative_roles
+        user.remove_role :pro
         user.add_role :trusted
       when "Pro"
         remove_negative_roles
+        user.add_role :trusted
         user.add_role :pro
       end
       create_note(role, note)

--- a/app/services/moderator/merge_user.rb
+++ b/app/services/moderator/merge_user.rb
@@ -1,0 +1,69 @@
+module Moderator
+  class MergeUser < ManageActivityAndRoles
+    attr_reader :keep_user, :admin, :delete_user_id
+
+    def initialize(admin:, keep_user:, delete_user_id:)
+      @keep_user = keep_user
+      @admin = admin
+      @delete_user = User.find(delete_user_id.to_i)
+    end
+
+    def self.call_merge(admin:, keep_user:, delete_user_id:)
+      new(keep_user: keep_user, admin: admin, delete_user_id: delete_user_id).merge
+    end
+
+    def merge
+      merge_content
+      merge_relationships
+      merge_profile
+      remove_additional_email
+      update_social
+      @delete_user.delete!
+    end
+
+    def update_social
+      @old_tu = @delete_user.twitter_username
+      @old_gu = @delete_user.github_username
+      @delete_user.update_columns(twitter_username: nil, github_username: nil)
+      @keep_user.update!(twitter_username: @old_tu) if @keep_user.twitter_username.blank?
+      @keep_user.update!(github_username: @old_gu) if @keep_user.github_username.blank?
+    end
+
+    def remove_additional_email
+      return if @delete_user.email.blank?
+
+      email_attr = {
+        email_comment_notifications: false,
+        email_digest_periodic: false,
+        email_follower_notifications: false,
+        email_mention_notifications: false,
+        email_newsletter: false,
+        email_unread_notifications: false,
+        email_badge_notifications: false,
+        email_membership_newsletter: false
+      }
+
+      @delete_user.update(email_attr)
+      @delete_user.unsubscribe_from_newsletters
+    end
+
+    def merge_profile
+      @delete_user.github_repos&.update_all(user_id: @keep_user.id) if @delete_user.github_repos.any?
+      @delete_user.badge_achievements.update_al(user_id: @keep_user.id) if @delete_user.badge_achievements.any?
+    end
+
+    def merge_relationships
+      @delete_user.follows&.update_all(follower_id: @keep_user.id) if @delete_user.follows.any?
+      @delete_user.chat_channel_memberships.update_all(user_id: @keep_user.id) if @delete_user.chat_channel_memberships.any?
+      @delete_user.mentions.update_all(user_id: @keep_user.id) if @delete_user.mentions.any?
+      @delete_user_followers = Follow.where(followable_id: @delete_user.id, followable_type: "User")
+      @delete_user_followers.update_all(@keep_user.id) if @delete_user_followers.any?
+    end
+
+    def merge_content
+      @delete_user.reactions.update_all(user_id: @keep_user.id) if @delete_user.reactions.any?
+      @delete_user.comments.update_all(user_id: @keep_user.id) if @delete_user.comments.any?
+      @delete_user.articles.update_all(user_id: @keep_user.id) if @delete_user.articles.any?
+    end
+  end
+end

--- a/app/views/internal/users/edit.html.erb
+++ b/app/views/internal/users/edit.html.erb
@@ -41,7 +41,7 @@
 <%= render "notes" %>
 <div class="row">
   <h2>Merge User</h2>
-  <p>To merge a duplicate account, make sure you are on the page of the user you want to KEEP. Below, add the user id of the account to merge information from, and delete.</p>
+  <p>To merge a duplicate account, make sure you are currently on the page of the user you want to KEEP. Below, add the user id of the account to merge information from, and delete.</p>
   <%= form_for(@user, url: merge_internal_user_path(@user), html: { method: :post, onsubmit: "return confirm('Are you sure? This is extremely destructive and irreversible. Merging will delete all the other users content and combine it with this user')" }) do |f| %>
     <%= f.label "User to be deleted:" %>
     <%= f.text_field :merge_user_id, placeholder: "#ID" %>

--- a/app/views/internal/users/edit.html.erb
+++ b/app/views/internal/users/edit.html.erb
@@ -40,6 +40,15 @@
 </div>
 <%= render "notes" %>
 <div class="row">
+  <h2>Merge User</h2>
+  <p>To merge a duplicate account, make sure you are on the page of the user you want to KEEP. Below, add the user id of the account to merge information from, and delete.</p>
+  <%= form_for(@user, url: merge_internal_user_path(@user), html: { method: :post, onsubmit: "return confirm('Are you sure? This is extremely destructive and irreversible. Merging will delete all the other users content and combine it with this user')" }) do |f| %>
+    <%= f.label "User to be deleted:" %>
+    <%= f.text_field :merge_user_id, placeholder: "#ID" %>
+    <%= f.submit "Merge Users" %>
+  <% end %>
+</div>
+<div class="row">
   <h2>Banish User</h2>
   <% if @user.banished? %>
     <p>User has been banished.</p>

--- a/app/views/internal/users/show.html.erb
+++ b/app/views/internal/users/show.html.erb
@@ -12,7 +12,7 @@
   <h1>
     <%= @user.name %><a href="/<%= @user.username %>" target="_blank"> (@<%= @user.username %>)</a>
   </h1>
-  <p><u><a style="color: red" href="/internal/users/<%= @user.id %>/edit">click here to banish or delete user</a></u>
+  <p><u><a style="color: red" href="/internal/users/<%= @user.id %>/edit">click here to merge, banish, or delete user.</a></u>
   </p>
   <p><em>Member since <%= @user.created_at.strftime("%b %e '%y") %></em></p>
   <p><strong><u>General Info</u></strong></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,7 @@ Rails.application.routes.draw do
         post "banish"
         post "full_delete"
         patch "user_status"
+        post "merge"
       end
     end
     resources :events


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
- Automatically give "PRO" users trusted role. I'm sure PRO stuff will be moved out of this area soon but I think this makes sense for now.
- Add merge user functionality to /internal. 
- Prevent merge if account to be deleted has two identities (likely indicator that this account shouldn't be deleted)

![](https://cl.ly/2ebb59e85397/download/Image%202019-03-22%20at%201.50.29%20PM.png)
