### PR TITLE
Remove `dashboard/following_users` route

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -10,7 +10,7 @@ class DashboardsController < ApplicationController
               current_user
             end
     authorize (@user || User), :dashboard_show?
-    if params[:which] == "following" || params[:which] == "following_users"
+    if params[:which] == "following"
       @follows = @user.follows_by_type("User").
         order("created_at DESC").includes(:followable).limit(80)
       @followed_tags = @user.follows_by_type("ActsAsTaggableOn::Tag").

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -10,7 +10,7 @@
       <span>FOLLOWERS</span>
       <span>(<%= @user.followers_count %>)</span>
     </a>
-    <a class="action <%= "active" if params[:which].to_s.include?("following") %>" href="/dashboard/following">
+    <a class="action <%= "active" if params[:which] == "following" %>" href="/dashboard/following">
       <span>FOLLOWING</span>
       <span>(<%= @user.following_users_count + @user.following_tags_count %>)</span>
     </a>
@@ -43,7 +43,7 @@
     <% @articles.each do |article| %>
       <%= render "dashboard_article", article: article, org_admin: true %>
     <% end %>
-  <% elsif params[:which] == "user_followers" || params[:which] == "following_users" || params[:which] == "following" || params[:which] == "organization_user_followers" %>
+  <% elsif params[:which] == "user_followers" || params[:which] == "following" || params[:which] == "organization_user_followers" %>
     <% if @followed_tags %>
       <h2>Followed tags (<%= @user.following_tags_count %>)</h2>
       <p><em>Adjust <strong>Follow Weight</strong> to make a tag show up less or more in your feed (default 1.0)</em>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -261,7 +261,7 @@ Rails.application.routes.draw do
   get "dashboard/pro/org/:org_id" => "dashboards#pro"
   get "/dashboard/:which" => "dashboards#show",
       constraints: {
-        which: /organization|organization_user_followers|user_followers|following_users|following|reading/
+        which: /organization|organization_user_followers|user_followers|following|reading/
       }
   get "/dashboard/:username" => "dashboards#show"
 

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -56,10 +56,10 @@ RSpec.describe "Dashboards", type: :request do
     end
   end
 
-  describe "GET /dashboard/following_users" do
+  describe "GET /dashboard/following" do
     context "when not logged in" do
       it "redirects to /enter" do
-        get "/dashboard/following_users"
+        get "/dashboard/following"
         expect(response).to redirect_to("/enter")
       end
     end
@@ -69,19 +69,19 @@ RSpec.describe "Dashboards", type: :request do
 
       it "renders users that current user follows" do
         user.follow second_user
-        get "/dashboard/following_users"
+        get "/dashboard/following"
         expect(response.body).to include CGI.escapeHTML(second_user.name)
       end
       it "renders tags that current user follows" do
         tag = create(:tag)
         user.follow tag
-        get "/dashboard/following_users"
+        get "/dashboard/following"
         expect(response.body).to include CGI.escapeHTML(tag.name)
       end
       it "renders organizations that current user follows" do
         organization = create(:organization)
         user.follow organization
-        get "/dashboard/following_users"
+        get "/dashboard/following"
         expect(response.body).to include CGI.escapeHTML(organization.name)
       end
     end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

The `dashboard/following_users` route has been deprecated a while ago and replaced with `dashboard/following` route.
This commit removes the old route and updates the code to reflect it.

## Related Tickets & Documents

This was discussed briefly with @benhalpern here: https://github.com/thepracticaldev/dev.to/pull/2157#issuecomment-475366986

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

No UI changes

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![wintermoon](https://media.giphy.com/media/qY2xET6KdYA9i/giphy.gif)
