### PR TITLE
WIP Change username column to not null in database

### DIFF
--- a/db/migrate/20190325192116_change_username_to_not_null.rb
+++ b/db/migrate/20190325192116_change_username_to_not_null.rb
@@ -1,0 +1,5 @@
+class ChangeUsernameToNotNull < ActiveRecord::Migration[5.1]
+  def change
+    change_column_null :users, :username, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190318223433) do
+ActiveRecord::Schema.define(version: 20190325192116) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -877,7 +877,7 @@ ActiveRecord::Schema.define(version: 20190318223433) do
     t.string "twitter_username"
     t.string "unconfirmed_email"
     t.datetime "updated_at", null: false
-    t.string "username"
+    t.string "username", null: false
     t.string "website_url"
     t.datetime "workshop_expiration"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This adds a migration and changes the schema to ensure that the `username` column cannot be null.

Closes #2207 

# Don't merge until we ensure that there are no users with `null` usernames.