### PR TITLE
[Theme] Inverted social icons in night theme

### DIFF
--- a/app/assets/stylesheets/articles.scss
+++ b/app/assets/stylesheets/articles.scss
@@ -1348,6 +1348,8 @@
         border: none;
         padding-left: 12px;
         margin-right: 3px;
+        filter: invert(0);
+        filter: var(--theme-social-icon-invert, invert(0));
       }
       .row {
         position: relative;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -101,7 +101,8 @@
           --theme-gradient-background: linear-gradient(to right, #293d56 8%, #282833 18%, #293d56 33%);\
           --theme-container-color: #fff;\
           --theme-container-box-shadow: none;\
-          --theme-container-border: 1px solid #141d26;</style>'
+          --theme-container-border: 1px solid #141d26;\
+          --theme-social-icon-invert: invert(100)</style>'
       }
     } catch(e) {
         console.log(e)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Inverted the social icons in the sidebar so they will be more visible when using night theme. Inverting them will remove the need to provide icons in a different colour.

I know `filter: var(--theme-social-icon-invert, invert(0));` looks ugly, I tried it this way first: `filter: invert(var(--theme-social-icon-invert, 0));` but it kept giving me a SASS error.
```
Sass::SyntaxError at /
$color: "var(--theme-icon-invert, 0)" is not a color for `invert'
```
I think it is related to this issue: https://github.com/sass/libsass/issues/151 but it was fixed this this PR: https://github.com/sass/libsass/pull/515
Any suggestions are welcome to clean it up.

## Related Tickets & Documents
/

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

### Before
<img width="290" alt="Screenshot at Mar 25 21-40-50" src="https://user-images.githubusercontent.com/11406433/54954544-2dbccc00-4f4b-11e9-8b5e-a6f5401ee3bc.png">

### After
<img width="286" alt="Screenshot at Mar 25 22-06-56" src="https://user-images.githubusercontent.com/11406433/54954559-36150700-4f4b-11e9-9fa3-adf4468e0518.png">


## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
