### PR TITLE
Added unique index to notifications #2124

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -8,7 +8,7 @@ class Notification < ApplicationRecord
 
   before_create :mark_notified_at_time
 
-  validates :user_id, uniqueness: { scope: %i[notifiable_id notifiable_type action] }
+  validates :user_id, uniqueness: { scope: %i[organization_id notifiable_id notifiable_type action] }
 
   class << self
     def send_new_follower_notification(follow, is_read = false)

--- a/app/services/notifications/new_follower/send.rb
+++ b/app/services/notifications/new_follower/send.rb
@@ -37,7 +37,7 @@ module Notifications
           notification = Notification.find_by(notification_params)&.destroy
         else
           json_data = { user: user_data(follower), aggregated_siblings: aggregated_siblings }
-          notification = Notification.find_or_create_by(notification_params)
+          notification = Notification.find_or_initialize_by(notification_params)
           notification.notifiable_id = recent_follows.first.id
           notification.notifiable_type = "Follow"
           notification.json_data = json_data

--- a/db/migrate/20190326085046_add_unique_index_to_notifications.rb
+++ b/db/migrate/20190326085046_add_unique_index_to_notifications.rb
@@ -1,5 +1,5 @@
 class AddUniqueIndexToNotifications < ActiveRecord::Migration[5.1]
   def change
-    add_index :notifications, %i[user_id organization_id notifiable_id notifiable_type action], unique: true
+    add_index :notifications, %i[user_id organization_id notifiable_id notifiable_type action], unique: true, name: "index_notifications_on_user_organization_notifiable_and_action"
   end
 end

--- a/db/migrate/20190326085046_add_unique_index_to_notifications.rb
+++ b/db/migrate/20190326085046_add_unique_index_to_notifications.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToNotifications < ActiveRecord::Migration[5.1]
+  def change
+    add_index :notifications, %i[user_id organization_id notifiable_id notifiable_type action], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -483,6 +483,7 @@ ActiveRecord::Schema.define(version: 20190327090030) do
     t.index ["json_data"], name: "index_notifications_on_json_data", using: :gin
     t.index ["notifiable_id"], name: "index_notifications_on_notifiable_id"
     t.index ["notifiable_type"], name: "index_notifications_on_notifiable_type"
+    t.index ["user_id", "organization_id", "notifiable_id", "notifiable_type", "action"], name: "index_notifications_on_user_organization_notifiable_and_action", unique: true
     t.index ["user_id"], name: "index_notifications_on_user_id"
   end
 

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -8,15 +8,7 @@ RSpec.describe Notification, type: :model do
   let(:article)         { create(:article, user_id: user.id, page_views_count: 4000, positive_reactions_count: 70) }
   let(:follow_instance) { user.follow(user2) }
 
-  describe "validations" do
-    it "allows 2 create 2 organization notifications" do
-      create(:notification, organization_id: organization.id, user: nil, notifiable: article, action: "Reaction")
-      # same notification for another organization
-      org2 = create(:organization)
-      notification = create(:notification, organization_id: org2.id, user: nil, notifiable: article, action: "Reaction")
-      expect(notification).to be_valid
-    end
-  end
+  it { is_expected.to validate_uniqueness_of(:user_id).scoped_to(%i[organization_id notifiable_id notifiable_type action]) }
 
   describe "when trying to #send_new_follower_notification after following a tag" do
     let(:tag) { create(:tag) }

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -8,6 +8,16 @@ RSpec.describe Notification, type: :model do
   let(:article)         { create(:article, user_id: user.id, page_views_count: 4000, positive_reactions_count: 70) }
   let(:follow_instance) { user.follow(user2) }
 
+  describe "validations" do
+    it "allows 2 create 2 organization notifications" do
+      create(:notification, organization_id: organization.id, user: nil, notifiable: article, action: "Reaction")
+      # same notification for another organization
+      org2 = create(:organization)
+      notification = create(:notification, organization_id: org2.id, user: nil, notifiable: article, action: "Reaction")
+      expect(notification).to be_valid
+    end
+  end
+
   describe "when trying to #send_new_follower_notification after following a tag" do
     let(:tag) { create(:tag) }
     let(:tag_follow) { user.follow(tag) }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
- added a unique index on for the notifications
- 1 write into the database instead of 2 on creating/updating notification

## Related Tickets & Documents
#2124 

## Concerns
- Probably, the `notifications` table is large (can't check that), so adding index will take a lot of time.
- Need to update or delete the invalid notifications (with non-unique fields) before deploying