### PR TITLE
DRY the Active Jobs specs

### DIFF
--- a/spec/jobs/articles/bust_cache_job_spec.rb
+++ b/spec/jobs/articles/bust_cache_job_spec.rb
@@ -1,14 +1,9 @@
 require "rails_helper"
 
 RSpec.describe Articles::BustCacheJob, type: :job do
-  describe "#perform_later" do
-    it "enqueues the job" do
-      ActiveJob::Base.queue_adapter = :test
-      expect do
-        described_class.perform_later([1, 2])
-      end.to have_enqueued_job.with([1, 2]).on_queue("articles_bust_cache")
-    end
+  include_examples "#enqueues_job", "articles_bust_cache", [1, 2]
 
+  describe "#perform_now" do
     it "busts cache" do
       article = create(:article)
       path = article.path

--- a/spec/jobs/articles/score_calc_job_spec.rb
+++ b/spec/jobs/articles/score_calc_job_spec.rb
@@ -1,12 +1,5 @@
 require "rails_helper"
 
 RSpec.describe Articles::ScoreCalcJob, type: :job do
-  describe "#perform_later" do
-    it "enqueues the job" do
-      ActiveJob::Base.queue_adapter = :test
-      expect do
-        described_class.perform_later(1)
-      end.to have_enqueued_job.with(1).on_queue("articles_score_calc")
-    end
-  end
+  include_examples "#enqueues_job", "articles_score_calc", 1
 end

--- a/spec/jobs/follows/create_chat_channel_job_spec.rb
+++ b/spec/jobs/follows/create_chat_channel_job_spec.rb
@@ -1,14 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Follows::CreateChatChannelJob, type: :job do
-  describe "#perform_later" do
-    it "enqueues the job" do
-      ActiveJob::Base.queue_adapter = :test
-      expect do
-        described_class.perform_later(3)
-      end.to have_enqueued_job.with(3).on_queue("create_chat_channel_after_follow")
-    end
-  end
+  include_examples "#enqueues_job", "create_chat_channel_after_follow", 3
 
   describe "#perform_now" do
     let(:user) { create(:user) }

--- a/spec/jobs/follows/send_email_notification_job_spec.rb
+++ b/spec/jobs/follows/send_email_notification_job_spec.rb
@@ -1,14 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Follows::SendEmailNotificationJob, type: :job do
-  describe "#perform_later" do
-    it "enqueues the job" do
-      ActiveJob::Base.queue_adapter = :test
-      expect do
-        described_class.perform_later(3)
-      end.to have_enqueued_job.with(3).on_queue("send_follow_email_notification")
-    end
-  end
+  include_examples "#enqueues_job", "send_follow_email_notification", 3
 
   describe "#perform_now" do
     let(:user) { create(:user) }

--- a/spec/jobs/follows/touch_follower_job_spec.rb
+++ b/spec/jobs/follows/touch_follower_job_spec.rb
@@ -1,14 +1,9 @@
 require "rails_helper"
 
 RSpec.describe Follows::TouchFollowerJob, type: :job do
-  describe "#perform_later" do
-    it "enqueues the job" do
-      ActiveJob::Base.queue_adapter = :test
-      expect do
-        described_class.perform_later(3)
-      end.to have_enqueued_job.with(3).on_queue("touch_follower")
-    end
+  include_examples "#enqueues_job", "touch_follower", 3
 
+  describe "#perform_now" do
     it "touches a follower" do
       user = create(:user)
       user.update_columns(updated_at: Time.now - 1.day, last_followed_at: Time.now - 1.day)

--- a/spec/jobs/notifications/new_follower_job_spec.rb
+++ b/spec/jobs/notifications/new_follower_job_spec.rb
@@ -3,14 +3,7 @@ require "rails_helper"
 RSpec.describe Notifications::NewFollowerJob, type: :job do
   let(:follow_data) { { followable_type: "User", followable_id: 1, follower_id: 2 } }
 
-  describe "#perform_later" do
-    it "enqueues the job" do
-      ActiveJob::Base.queue_adapter = :test
-      expect do
-        described_class.perform_later(follow_data, true)
-      end.to have_enqueued_job.with(follow_data, true).on_queue("send_new_follower_notification")
-    end
-  end
+  include_examples "#enqueues_job", "send_new_follower_notification", [{}, true]
 
   describe "#perform_now" do
     it "calls the service" do

--- a/spec/jobs/notifications/new_reaction_job_spec.rb
+++ b/spec/jobs/notifications/new_reaction_job_spec.rb
@@ -5,14 +5,7 @@ RSpec.describe Notifications::NewReactionJob, type: :job do
   let(:org) { create(:organization) }
   let(:receiver_data) { { klass: "Organization", id: org.id } }
 
-  describe "#perform_later" do
-    it "enqueues the job" do
-      ActiveJob::Base.queue_adapter = :test
-      expect do
-        described_class.perform_later(reaction_data, receiver_data)
-      end.to have_enqueued_job.with(reaction_data, receiver_data).on_queue("send_new_reaction_notification")
-    end
-  end
+  include_examples "#enqueues_job", "send_new_reaction_notification", [{}, {}, true]
 
   describe "#perform_now" do
     let(:reaction_service) { double }

--- a/spec/jobs/reactions/bust_homepage_cache_job_spec.rb
+++ b/spec/jobs/reactions/bust_homepage_cache_job_spec.rb
@@ -1,14 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Reactions::BustHomepageCacheJob, type: :job do
-  describe "#perform_later" do
-    it "enqueues the job" do
-      ActiveJob::Base.queue_adapter = :test
-      expect do
-        described_class.perform_later(2)
-      end.to have_enqueued_job.with(2).on_queue("bust_homepage_cache_from_reactions")
-    end
-  end
+  include_examples "#enqueues_job", "bust_homepage_cache_from_reactions", 2
 
   describe "#perform_now" do
     let(:user) { create(:user) }

--- a/spec/jobs/reactions/bust_reactable_cache_job_spec.rb
+++ b/spec/jobs/reactions/bust_reactable_cache_job_spec.rb
@@ -1,14 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Reactions::BustReactableCacheJob, type: :job do
-  describe "#perform_later" do
-    it "enqueues the job" do
-      ActiveJob::Base.queue_adapter = :test
-      expect do
-        described_class.perform_later(2)
-      end.to have_enqueued_job.with(2).on_queue("bust_reactable_cache")
-    end
-  end
+  include_examples "#enqueues_job", "bust_reactable_cache", 2
 
   describe "#perform_now" do
     let(:user) { create(:user) }

--- a/spec/jobs/reactions/update_reactable_job_spec.rb
+++ b/spec/jobs/reactions/update_reactable_job_spec.rb
@@ -1,14 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Reactions::UpdateReactableJob, type: :job do
-  describe "#perform_later" do
-    it "enqueues the job" do
-      ActiveJob::Base.queue_adapter = :test
-      expect do
-        described_class.perform_later(2)
-      end.to have_enqueued_job.with(2).on_queue("update_reactable")
-    end
-  end
+  include_examples "#enqueues_job", "update_reactable", 2
 
   describe "#perform_now" do
     let(:article) { create(:article) }

--- a/spec/jobs/shared_examples/enqueues_job.rb
+++ b/spec/jobs/shared_examples/enqueues_job.rb
@@ -1,0 +1,10 @@
+RSpec.shared_examples "#enqueues_job" do |queue_name, args|
+  describe "#perform_later" do
+    it "enqueues the job" do
+      ActiveJob::Base.queue_adapter = :test
+      expect do
+        described_class.perform_later(*args)
+      end.to have_enqueued_job.with(*args).on_queue(queue_name)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -29,6 +29,7 @@ require "test_prof/recipes/rspec/before_all"
 Dir[Rails.root.join("spec", "support", "**", "*.rb")].each { |f| require f }
 Dir[Rails.root.join("spec", "features", "shared_examples", "**", "*.rb")].each { |f| require f }
 Dir[Rails.root.join("spec", "models", "shared_examples", "**", "*.rb")].each { |f| require f }
+Dir[Rails.root.join("spec", "jobs", "shared_examples", "**", "*.rb")].each { |f| require f }
 
 # Checks for pending migrations before tests are run.
 # If you are not using ActiveRecord, you can remove this line.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor

## Description
Created a shared example to test that the ActiveJobs are enqueued when `#perform_later` is called