### PR TITLE
Improved article slug generation

### DIFF
--- a/app/labor/podcast_feed.rb
+++ b/app/labor/podcast_feed.rb
@@ -27,7 +27,7 @@ class PodcastFeed
     ep = PodcastEpisode.new
     ep.title = item.title
     ep.podcast_id = podcast.id
-    ep.slug = item.title.downcase.gsub(/[^0-9a-z ]/i, "").tr(" ", "-")
+    ep.slug = item.title.parameterize
     ep.subtitle = item.itunes_subtitle
     ep.summary = item.itunes_summary
     ep.website_url = item.link

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -537,7 +537,7 @@ class Article < ApplicationRecord
   end
 
   def title_to_slug
-    title.to_s.downcase.tr(" ", "-").gsub(/[^\w-]/, "").tr("_", "") + "-" + rand(100_000).to_s(26)
+    title.to_s.downcase.parameterize + "-" + rand(100_000).to_s(26)
   end
 
   def bust_cache

--- a/app/models/badge.rb
+++ b/app/models/badge.rb
@@ -18,7 +18,7 @@ class Badge < ApplicationRecord
   private
 
   def generate_slug
-    self.slug = title.to_s.downcase.tr(" ", "-").gsub(/[^\w-]/, "").tr("_", "")
+    self.slug = title.to_s.parameterize
   end
 
   def bust_path

--- a/app/models/chat_channel.rb
+++ b/app/models/chat_channel.rb
@@ -68,7 +68,7 @@ class ChatChannel < ApplicationRecord
       contrived_name = "Direct chat between " + usernames.join(" and ")
       slug = usernames.join("/")
     else
-      slug = contrived_name.to_s.downcase.tr(" ", "-").gsub(/[^\w-]/, "").tr("_", "") + "-" + rand(100_000).to_s(26)
+      slug = contrived_name.to_s.parameterize + "-" + rand(100_000).to_s(26)
     end
 
     if (channel = ChatChannel.find_by(slug: slug))

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -40,7 +40,8 @@ class Event < ApplicationRecord
   end
 
   def title_to_slug
-    downcase = (id.to_s + "-" + category + "-" + title).to_s.parameterize + "-" + starts_at.strftime("%m-%d-%Y")
+    downcase = (id.to_s + "-" + category + "-" + title).to_s
+    downcase.parameterize + "-" + starts_at.strftime("%m-%d-%Y")
   end
 
   def bust_cache

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -40,8 +40,7 @@ class Event < ApplicationRecord
   end
 
   def title_to_slug
-    downcase = (id.to_s + "-" + category + "-" + title).to_s.downcase
-    downcase.tr(" ", "-").gsub(/[^\w-]/, "").tr("_", "") + "-" + starts_at.strftime("%m-%d-%Y")
+    downcase = (id.to_s + "-" + category + "-" + title).to_s.parameterize + "-" + starts_at.strftime("%m-%d-%Y")
   end
 
   def bust_cache


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [X] Bug Fix
- [ ] Documentation Update

## Description

Ruby on Rails has a built-in slug generator since Rails 2.2 https://www.rubydoc.info/github/rails/rails/String:parameterize

This generator fix the slug generation when non english characters are used on title improving SEO. For example: https://dev.to/lito_ordes/redimensionando-imgenes-en-tiempo-de-ejecucin-con-packer-57c6
