### PR TITLE
Fix notifications about the new child comments

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -51,8 +51,8 @@ class Notification < ApplicationRecord
     def send_new_comment_notifications(comment)
       return if comment.commentable_type == "PodcastEpisode"
 
-      user_ids = comment.ancestors.select(:receive_notifications, :user_id).select(&:receive_notifications).pluck(:user_id).to_set
-      user_ids.add(comment.commentable.user_id) if user_ids.empty? && comment.commentable.receive_notifications
+      user_ids = comment.ancestors.select(:user_id).where(receive_notifications: true).pluck(:user_id).to_set
+      user_ids.add(comment.commentable.user_id) if comment.commentable.receive_notifications
       json_data = {
         user: user_data(comment.user),
         comment: comment_data(comment)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
When a child comment is posted, the article (commentable) author is notified about it only if there are no other users to notify about this comment.
I suppose that sending a notification to an article author should not depend on if it's sent to other users.
If the `receive_notifications` is true, the article author should be either notified about the child comments or not notified about them.
I added a couple of tests to illustrate this issue and a fix assuming that the article author should be notified about the child comments.
