### PR TITLE
Add form validation for follow 'points'

### DIFF
--- a/app/views/dashboards/following.html.erb
+++ b/app/views/dashboards/following.html.erb
@@ -1,8 +1,7 @@
 <% title "Dashboard - DEV" %>
 
 <div class="dashboard-container" id="user-dashboard">
-  <%= render 'actions' %>
-  
+  <%= render "actions" %>
   <h2>Followed tags (<%= @user.following_tags_count %>)</h2>
   <p><em>Adjust <strong>Follow Weight</strong> to make a tag show up less or more in your feed (default 1.0)</em>
   </p>
@@ -22,7 +21,7 @@
           </a>
           <%= form_for(follow) do |f| %>
             <%= f.label(:points, "Follow Weight:") %>
-            <%= f.number_field(:points, step: :any) %>
+            <%= f.number_field(:points, step: :any, required: true) %>
             <%= f.submit "Submit" %>
           <% end %>
         </h2>


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x ] Bug Fix
- [ ] Documentation Update

## Description
- If a user submits a nil/blank field for follow weight on dashboard/following, it'll give them a 500 next time they try to visit.
- This adds a form validation but no validations on the server side. We should probably do that too but when i added presence: true on the Follow model, it did some weird stuff so thought getting a quick fix in made more sense.