### PR TITLE
Scout Monitoring - Disable Remote IP Collection

### DIFF
--- a/config/scout_apm.yml
+++ b/config/scout_apm.yml
@@ -19,6 +19,7 @@ common: &defaults
   # - Default: none
   # - Valid Options: true, false
   monitor: true
+  collect_remote_ip: false
 
 production:
   <<: *defaults


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## Description
- We just added scout the other day, didn't realize it was collecting remote ips -- not something we need to collect so disabling.
- Just followed the docs here: http://help.apm.scoutapp.com/#ruby-configuration-options

