### PR TITLE
Fixed sticky nav summary color to use custom property.

### DIFF
--- a/app/assets/stylesheets/sticky-nav.scss
+++ b/app/assets/stylesheets/sticky-nav.scss
@@ -156,6 +156,7 @@
   .primary-sticky-nav-org-summary{
     font-weight: 400;
     color: $black;
+    color: var(--theme-container-color, $black);
     padding: 4px 0px;
     font-size:0.95em;
     margin-top: 20px;


### PR DESCRIPTION
## What type of PR is this?

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Documentation Update

## Description

The sticky nav summary text is black, even in dark mode. This fix lets it use the custom property, with black text color as a fallback.

## Screenshots

### Before
![Screenshot of before change](https://user-images.githubusercontent.com/613931/55257390-bb3f3b00-522d-11e9-92d4-bddc25c2b708.png)

### After
![Screenshot of after change](https://user-images.githubusercontent.com/613931/55257407-cbefb100-522d-11e9-82db-30cd4e60ebd1.png)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed
