### PR TITLE
Fixes Github Repositories not visible #2227

### DIFF
--- a/app/assets/stylesheets/settings.scss
+++ b/app/assets/stylesheets/settings.scss
@@ -375,6 +375,7 @@
   max-height:400px;
   overflow-y: auto;
   background: white;
+  background: var(--theme-container-background, #fff);
   box-shadow: $shadow;
   &.loading-repos {
     height: 400px;
@@ -386,6 +387,7 @@
   }
   .github-repo-row {
     background:white;
+    background: var(--theme-container-background, #fff);
     padding: 12px;
     margin:5px 0px;
     &.github-repo-row-selected {


### PR DESCRIPTION

<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
Add theme container background color to GitHub repositories container in settings/integrations page.
Used background color variable used by sidebar containers. 
```css 
--theme-container-background 
```
## Related Tickets & Documents
#2227 