### PR TITLE
Fixed fluid-comments in dark mode

### DIFF
--- a/app/assets/stylesheets/ltags/DevCommentTag.scss
+++ b/app/assets/stylesheets/ltags/DevCommentTag.scss
@@ -62,13 +62,13 @@
       width:100px;
       a{
         color:$medium-gray;
-        color: var(--theme-secondary-color, $medium-grey);
+        color: var(--theme-secondary-color, $medium-gray);
       }
     }
 
     a {
       color: lighten($dark-gray,3%);
-      color: var(--theme-secondary-color, $dark-grey);
+      color: var(--theme-secondary-color, $dark-gray);
       line-height: initial;
       align-self: center;
       margin-right: 6px;

--- a/app/assets/stylesheets/ltags/DevCommentTag.scss
+++ b/app/assets/stylesheets/ltags/DevCommentTag.scss
@@ -68,7 +68,7 @@
 
     a {
       color: lighten($dark-gray,3%);
-      color: var(--theme-secondary-color, $dark-gray);
+      color: var(--theme-secondary-color, lighten($dark-gray,3%));
       line-height: initial;
       align-self: center;
       margin-right: 6px;

--- a/app/assets/stylesheets/ltags/DevCommentTag.scss
+++ b/app/assets/stylesheets/ltags/DevCommentTag.scss
@@ -2,11 +2,12 @@
 
 .liquid-comment {
   padding: 0px;
-  background: white;
+  background: inherit;
   font-family: $helvetica;
   margin:0.95em 0 1.20em;
   position: relative;
   border:1px solid $light-medium-gray;
+  border:1px solid var(--theme-color, $light-medium-gray);
   box-shadow: $shadow;
   border-radius:3px;
   @media screen and (min-width: 760px) {
@@ -61,11 +62,13 @@
       width:100px;
       a{
         color:$medium-gray;
+        color: var(--theme-secondary-color, $medium-grey);
       }
     }
 
     a {
       color: lighten($dark-gray,3%);
+      color: var(--theme-secondary-color, $dark-grey);
       line-height: initial;
       align-self: center;
       margin-right: 6px;
@@ -81,6 +84,7 @@
   .body {
     font-family: $helvetica;
     color: $black;
+    color: var(--theme-color, $black);
     font-size: 0.95em;
     line-height: 1.35em;
     overflow: hidden;


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
the inline fluid-comments in dark mode are now matching the syntax followed in the default theme.

I couldn't manage to setup a local environment (faced some problems and I have not much experience in ruby) so as to test the changes I have been making but I have made the changes to css at the best of my abilities in hopes that a local dev environment won't matter. I have been able to test changes using dev tools in firefox, I have included screenshots for the same.

The `fluid-comment` class is now working for the dark mode in the same way it was working for the default mode.

Fixes #2221 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
In default mode:
<img width="745" alt="Screenshot 2019-03-31 at 5 47 19 PM" src="https://user-images.githubusercontent.com/35738138/55288939-09df0780-53dd-11e9-9fe5-bfa75c12c047.png">

Now in dark mode:
<img width="767" alt="Screenshot 2019-03-31 at 5 46 29 PM" src="https://user-images.githubusercontent.com/35738138/55288931-ed42cf80-53dc-11e9-9e82-4b8fc5088da6.png">


## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![don't give up](https://media.giphy.com/media/3o85xs8qEtiqFPjrUc/source.gif)
![first time understanding ruby, so tired](https://media.giphy.com/media/eBCnpuRGBhQGY/giphy-downsized-large.gif)