### PR TITLE
Fix error with articles API and unknown username

### DIFF
--- a/app/services/article_api_index_service.rb
+++ b/app/services/article_api_index_service.rb
@@ -1,8 +1,9 @@
 class ArticleApiIndexService
   attr_accessor :tag, :username, :page, :state, :top
+
   def initialize(params)
-    @page =     params[:page]
-    @tag =      params[:tag]
+    @page = params[:page]
+    @tag = params[:tag]
     @username = params[:username]
     @state = params[:state]
     @top = params[:top]
@@ -18,8 +19,8 @@ class ArticleApiIndexService
                else
                  base_articles
                end
-    articles.
-      decorate
+
+    articles.decorate
   end
 
   private
@@ -30,6 +31,7 @@ class ArticleApiIndexService
           else
             30
           end
+
     if (user = User.find_by(username: username))
       user.articles.
         where(published: true).
@@ -45,7 +47,7 @@ class ArticleApiIndexService
         page(page).
         per(num)
     else
-      not_found
+      Article.none
     end
   end
 

--- a/spec/requests/api/v0/articles_spec.rb
+++ b/spec/requests/api/v0/articles_spec.rb
@@ -26,6 +26,12 @@ RSpec.describe "Api::V0::Articles", type: :request do
       expect(JSON.parse(response.body).size).to eq(2)
     end
 
+    it "returns no articles if username param is unknown" do
+      create(:article, user_id: user1.id)
+      get "/api/articles?username=foobar"
+      expect(JSON.parse(response.body).size).to eq(0)
+    end
+
     it "returns organization articles if username param is present" do
       org = create(:organization)
       create(:article, user_id: user1.id)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

Currently the articles API breaks with a 500 error if the server is called with an unknown username because `not_found` is a controller method, not part of the service. 

I believe it should return nothing like when the API is called with an unknown tag.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
