### PR TITLE
Ignore unnecessary airbrake notices

### DIFF
--- a/app/assets/javascripts/base.js.erb
+++ b/app/assets/javascripts/base.js.erb
@@ -687,7 +687,11 @@ var instantClick
       airbrake.addFilter(function(notice) {
         notice.context.environment = "<%= Rails.env %>";
         var file = notice.errors[0].backtrace[0].file;
+        var randomNumber = Math.floor(Math.random() * 10);
         if ((file || "").startsWith("https://stats.pusher.com")) {
+          return null;
+        }
+        if (randomNumber > 4) { // We don't need to collect every JS error.
           return null;
         }
         return notice;

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -57,4 +57,5 @@ end
 
 Airbrake.add_filter do |notice|
   notice.ignore! if notice[:errors].any? { |error| error[:type] == "Pundit::NotAuthorizedError" }
+  notice.ignore! if notice[:errors].any? { |error| error[:type] == "ActiveRecord::RecordNotFound" }
 end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
We don't need to log every recordnotfound, as a lot are natural from articles that are unpublished. They represent a small number of overall requests but a large number of our error tracking. This cleans up some of the mess.

Also adds a filter to randomly not track all JS errors. We're okay to only track _some_ and still get a pretty accurate look in general IMO. We can revisit later.