### PR TITLE
Add API Analytics Endpoints

### DIFF
--- a/app/controllers/api/v0/analytics_controller.rb
+++ b/app/controllers/api/v0/analytics_controller.rb
@@ -53,7 +53,7 @@ module Api
 
       def get_authenticated_user!
         api_secret = ApiSecret.find_by(secret: request.headers["HTTP_API_KEY"])
-        user = api_secret.user
+        user = api_secret&.user || current_user
 
         raise UnauthorizedError unless user.has_role? :pro
 

--- a/app/controllers/api/v0/analytics_controller.rb
+++ b/app/controllers/api/v0/analytics_controller.rb
@@ -53,10 +53,7 @@ module Api
 
       def get_authenticated_user!
         api_token = ApiSecret.find_by(secret: params[:api_token])
-
-        raise UnauthorizedError if api_token.blank?
-
-        user = api_token.user
+        user = api_token&.user || current_user
 
         raise UnauthorizedError unless user.has_role? :pro
 

--- a/app/controllers/api/v0/analytics_controller.rb
+++ b/app/controllers/api/v0/analytics_controller.rb
@@ -52,8 +52,8 @@ module Api
       private
 
       def get_authenticated_user!
-        api_token = ApiSecret.find_by(secret: params[:api_token])
-        user = api_token&.user || current_user
+        api_secret = ApiSecret.find_by(secret: request.headers["HTTP_API_KEY"])
+        user = api_secret.user
 
         raise UnauthorizedError unless user.has_role? :pro
 

--- a/app/controllers/api/v0/analytics_controller.rb
+++ b/app/controllers/api/v0/analytics_controller.rb
@@ -1,0 +1,77 @@
+module Api
+  module V0
+    include Pundit
+
+    class AnalyticsController < ApplicationController
+      after_action :verify_authorized
+
+      def totals
+        api_token = ApiSecret.find_by(secret: params[:api_token])
+        user = api_token.user
+
+        not_found if api_token.blank?
+
+        authorize user, :pro_user?
+
+        # head :too_many_requests if RateLimitChecker.new(user).limit_by_situation("analytics")
+        data = if params[:organization_id]
+                 org = Organization.find_by(id: params[:organization_id])
+                 head :unauthorized unless org && belongs_to_org?(user, org)
+
+                 AnalyticsService.new(org: org).totals
+               else
+                 AnalyticsService.new(user: user).totals
+               end
+        render json: data.to_json
+      end
+
+      def historical
+        raise ArgumentError if params[:start].blank?
+
+        api_token = ApiSecret.find_by(secret: params[:api_token])
+        user = api_token.user
+
+        not_found if api_token.blank?
+
+        authorize user, :pro_user?
+
+        # head :too_many_requests if RateLimitChecker.new(user).limit_by_situation("analytics")
+        data = if params[:organization_id]
+                 org = Organization.find_by(id: params[:organization_id])
+                 not_found unless org && belongs_to_org?(user, org)
+
+                 AnalyticsService.new(org: org, start: params[:start], end: params[:end]).stats_grouped_by_day
+               else
+                 AnalyticsService.new(user: user, start: params[:start], end: params[:end]).stats_grouped_by_day
+               end
+        render json: data.to_json
+      end
+
+      def past_day
+        api_token = ApiSecret.find_by(secret: params[:api_token])
+        user = api_token.user
+
+        not_found if api_token.blank?
+
+        authorize user, :pro_user?
+
+        # head :too_many_requests if RateLimitChecker.new(user).limit_by_situation("analytics")
+        data = if params[:organization_id]
+                 org = Organization.find_by(id: params[:organization_id])
+                 not_found unless org && belongs_to_org?(user, org)
+
+                 AnalyticsService.new(org: org, start: DateTime.current - 1.day).stats_grouped_by_day
+               else
+                 AnalyticsService.new(user: user, start: DateTime.current - 1.day).stats_grouped_by_day
+               end
+        render json: data.to_json
+      end
+
+      private
+
+      def belongs_to_org?(user, org)
+        user.organization == org
+      end
+    end
+  end
+end

--- a/app/controllers/api/v0/analytics_controller.rb
+++ b/app/controllers/api/v0/analytics_controller.rb
@@ -8,12 +8,9 @@ module Api
       def totals
         api_token = ApiSecret.find_by(secret: params[:api_token])
         user = api_token.user
-
         not_found if api_token.blank?
 
         authorize user, :pro_user?
-
-        # head :too_many_requests if RateLimitChecker.new(user).limit_by_situation("analytics")
         data = if params[:organization_id]
                  org = Organization.find_by(id: params[:organization_id])
                  head :unauthorized unless org && belongs_to_org?(user, org)
@@ -30,12 +27,9 @@ module Api
 
         api_token = ApiSecret.find_by(secret: params[:api_token])
         user = api_token.user
-
         not_found if api_token.blank?
 
         authorize user, :pro_user?
-
-        # head :too_many_requests if RateLimitChecker.new(user).limit_by_situation("analytics")
         data = if params[:organization_id]
                  org = Organization.find_by(id: params[:organization_id])
                  not_found unless org && belongs_to_org?(user, org)
@@ -50,12 +44,10 @@ module Api
       def past_day
         api_token = ApiSecret.find_by(secret: params[:api_token])
         user = api_token.user
-
         not_found if api_token.blank?
 
         authorize user, :pro_user?
 
-        # head :too_many_requests if RateLimitChecker.new(user).limit_by_situation("analytics")
         data = if params[:organization_id]
                  org = Organization.find_by(id: params[:organization_id])
                  not_found unless org && belongs_to_org?(user, org)

--- a/app/controllers/api/v0/analytics_controller.rb
+++ b/app/controllers/api/v0/analytics_controller.rb
@@ -1,7 +1,5 @@
 module Api
   module V0
-    include Pundit
-
     class AnalyticsController < ApplicationController
       def totals
         user = get_authenticated_user!

--- a/app/controllers/api/v0/analytics_controller.rb
+++ b/app/controllers/api/v0/analytics_controller.rb
@@ -20,6 +20,7 @@ module Api
 
       def historical
         raise ArgumentError, "Required 'start' parameter is missing" if params[:start].blank?
+        raise ArgumentError, "Date parameters 'start' or 'end' must be in the format of 'yyyy-mm-dd'" unless valid_date_params?
 
         user = get_authenticated_user!
 
@@ -64,6 +65,15 @@ module Api
 
       def belongs_to_org?(user, org)
         user.organization_id == org.id
+      end
+
+      def valid_date_params?
+        date_regex = /\A\d{4}-\d{1,2}-\d{1,2}\Z/ # for example, 2019-03-22 or 2019-2-1
+        if params[:end]
+          (params[:start] =~ date_regex)&.zero? && (params[:end] =~ date_regex)&.zero?
+        else
+          (params[:start] =~ date_regex)&.zero?
+        end
       end
     end
   end

--- a/app/controllers/api/v0/analytics_controller.rb
+++ b/app/controllers/api/v0/analytics_controller.rb
@@ -6,7 +6,7 @@ module Api
 
         data = if params[:organization_id]
                  org = Organization.find_by(id: params[:organization_id])
-                 not_found unless org && belongs_to_org?(user, org)
+                 not_authorized unless org && belongs_to_org?(user, org)
 
                  AnalyticsService.new(organization: org).totals
                else
@@ -22,7 +22,7 @@ module Api
 
         data = if params[:organization_id]
                  org = Organization.find_by(id: params[:organization_id])
-                 not_found unless org && belongs_to_org?(user, org)
+                 not_authorized unless org && belongs_to_org?(user, org)
 
                  AnalyticsService.new(organization: org, start: params[:start], end: params[:end]).stats_grouped_by_day
                else
@@ -36,7 +36,7 @@ module Api
 
         data = if params[:organization_id]
                  org = Organization.find_by(id: params[:organization_id])
-                 not_found unless org && belongs_to_org?(user, org)
+                 not_authorized unless org && belongs_to_org?(user, org)
 
                  AnalyticsService.new(organization: org, start: DateTime.current - 1.day).stats_grouped_by_day
                else
@@ -49,10 +49,10 @@ module Api
 
       def get_authenticated_user!
         api_token = ApiSecret.find_by(secret: params[:api_token])
-        not_found if api_token.blank?
+        not_authorized if api_token.blank?
         user = api_token.user
 
-        not_found unless user.has_role? :pro
+        not_authorized unless user.has_role? :pro
         user
       end
 

--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -16,4 +16,14 @@ class Api::V0::ApiController < ApplicationController
 
     render text: "", content_type: "text/plain"
   end
+
+  def unprocessable_entity(exception)
+    render json: { error: exception, status: 422 },
+           status: :unprocessable_entity
+  end
+
+  def not_authorized
+    render json: { error: "Not authorized", status: 401 },
+           status: :unauthorized
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,6 +14,11 @@ class ApplicationController < ActionController::Base
     raise ActiveRecord::RecordNotFound, "Not Found"
   end
 
+  def not_authorized
+    render json: "Error: not authorized", status: :unauthorized
+    raise NotAuthorizedError, "Unauthorized"
+  end
+
   def efficient_current_user_id
     session["warden.user.user.key"].flatten[0] if session["warden.user.user.key"].present?
   end

--- a/app/errors/unauthorized_error.rb
+++ b/app/errors/unauthorized_error.rb
@@ -1,0 +1,1 @@
+class UnauthorizedError < StandardError; end

--- a/app/services/analytics_service.rb
+++ b/app/services/analytics_service.rb
@@ -1,6 +1,4 @@
 class AnalyticsService
-  attr_reader :options, :user_or_org, :article_data, :article_ids, :reaction_data, :comment_data, :follow_data, :page_view_data
-
   def initialize(options)
     @options = options
     @user_or_org = options[:user] || options[:organization]
@@ -78,6 +76,10 @@ class AnalyticsService
 
     final_hash
   end
+
+  private
+
+  attr_reader :options, :user_or_org, :article_data, :article_ids, :reaction_data, :comment_data, :follow_data, :page_view_data
 
   def start_date
     options[:start].to_datetime.beginning_of_day

--- a/app/services/analytics_service.rb
+++ b/app/services/analytics_service.rb
@@ -1,0 +1,104 @@
+class AnalyticsService
+  attr_reader :options, :user_or_org, :article_data, :article_ids, :reaction_data, :comment_data, :follow_data, :page_view_data
+
+  def initialize(options)
+    @options = options
+    @user_or_org = options[:user] || options[:organization]
+    @article_data ||= Article.where("#{user_or_org.class.name.downcase}_id" => user_or_org.id, published: true)
+    @article_ids ||= @article_data.pluck(:id)
+    if options[:start]
+      @reaction_data ||= Reaction.where(reactable_id: article_ids, reactable_type: "Article").where("created_at >= ? AND created_at <= ? AND points > 0", start_date, end_date)
+      @comment_data ||= Comment.where(commentable_id: article_ids, commentable_type: "Article").where("created_at >= ? AND created_at <= ? AND score > 0", start_date, end_date)
+      @follow_data ||= Follow.where(followable_type: user_or_org.class.name, followable_id: user_or_org.id)
+      @page_view_data ||= PageView.where(article_id: article_ids).where("created_at > ? AND created_at < ?", start_date, end_date)
+    else
+      @reaction_data ||= Reaction.where(reactable_id: article_ids, reactable_type: "Article").where("points > 0")
+      @comment_data ||= Comment.where(commentable_id: article_ids, commentable_type: "Article").where("score > 0")
+      @follow_data ||= Follow.where(followable_type: user_or_org.class.name, followable_id: user_or_org.id)
+      @page_view_data ||= PageView.where(article_id: article_ids)
+    end
+  end
+
+  def totals
+    total_views = article_data.sum(:page_views_count)
+    logged_in_page_view_data = page_view_data.select { |pv| pv.user_id.present? }
+    average_read_time_in_seconds = logged_in_page_view_data.size.positive? ? logged_in_page_view_data.sum(&:time_tracked_in_seconds) / logged_in_page_view_data.size : 0
+
+    {
+      comments: {
+        total: comment_data.size
+      },
+      reactions: {
+        total: reaction_data.size,
+        like: reaction_data.count { |rxn| rxn.category == "like" },
+        readinglist: reaction_data.count { |rxn| rxn.category == "readinglist" },
+        unicorn: reaction_data.count { |rxn| rxn.category == "unicorn" }
+      },
+      follows: {
+        total: follow_data.size
+      },
+      page_views: {
+        total: total_views,
+        average_read_time_in_seconds: average_read_time_in_seconds,
+        total_read_time_in_seconds: average_read_time_in_seconds * total_views
+      }
+    }
+  end
+
+  def stats_grouped_by_day
+    final_hash = {}
+
+    dates.each do |date|
+      string_date = date.strftime("%a, %m/%d")
+      reaction_data_of_date = reaction_data.select { |rxn| rxn.created_at.beginning_of_day.to_i == date.to_i }
+      logged_in_page_view_data = page_view_data.select { |pv| pv.created_at.beginning_of_day.to_i == date.to_i && pv.user_id.present? }
+      average_read_time_in_seconds = logged_in_page_view_data.size.positive? ? logged_in_page_view_data.sum(&:time_tracked_in_seconds) / logged_in_page_view_data.size : 0
+      total_views = page_view_data.select { |pv| pv.created_at.beginning_of_day.to_i == date.to_i }.sum(&:counts_for_number_of_views)
+
+      final_hash[string_date] = {
+        comments: {
+          total: comment_data.count { |c| c.created_at.beginning_of_day.to_i == date.to_i }
+        },
+        reactions: {
+          total: reaction_data_of_date.count,
+          like: reaction_data_of_date.count { |rxn| rxn.category == "like" },
+          readinglist: reaction_data_of_date.count { |rxn| rxn.category == "readinglist" },
+          unicorn: reaction_data_of_date.count { |rxn| rxn.category == "unicorn" }
+        },
+        page_views: {
+          total: total_views,
+          total_read_time_in_seconds: average_read_time_in_seconds * total_views,
+          average_read_time_in_seconds: average_read_time_in_seconds
+        },
+        follows: {
+          total: follow_data.count { |f| f.created_at.beginning_of_day.to_i == date.to_i }
+        }
+      }
+    end
+
+    final_hash
+  end
+
+  private
+
+  def start_date
+    options[:start].to_datetime.beginning_of_day.in_time_zone
+  end
+
+  def end_date
+    if options[:end].present?
+      options[:end].to_datetime.end_of_day.in_time_zone
+    else
+      DateTime.current.end_of_day.in_time_zone
+    end
+  end
+
+  def dates
+    date_range = (start_date - end_date.beginning_of_day).to_i
+    dates_array = []
+    date_range.times do |index|
+      dates_array.push(start_date + index.days)
+    end
+    dates_array.push(end_date)
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,6 +30,7 @@ module PracticalDeveloper
     config.autoload_paths += Dir["#{config.root}/app/black_box/"]
     config.autoload_paths += Dir["#{config.root}/app/sanitizers"]
     config.autoload_paths += Dir["#{config.root}/app/facades"]
+    config.autoload_paths += Dir["#{config.root}/app/errors"]
     config.autoload_paths += Dir["#{config.root}/lib/"]
 
     config.active_record.observers = :article_observer, :reaction_observer, :comment_observer

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,6 +89,9 @@ Rails.application.routes.draw do
           post "/update_or_create", to: "github_repos#update_or_create"
         end
       end
+      get "/analytics/totals", to: "analytics#totals"
+      get "/analytics/historical", to: "analytics#historical"
+      get "/analytics/past_day", to: "analytics#past_day"
     end
   end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -54,6 +54,17 @@ FactoryBot.define do
       after(:build) { |user| user.add_role(:analytics_beta_tester) }
     end
 
+    trait :pro do
+      after(:build) { |user| user.add_role :pro }
+    end
+
+    trait :org_member do
+      after(:build) do |user|
+        org = create(:organization)
+        user.organization_id = org.id
+      end
+    end
+
     trait :org_admin do
       after(:build) do |user|
         org = create(:organization)

--- a/spec/requests/api/v0/analytics_spec.rb
+++ b/spec/requests/api/v0/analytics_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe "Api::V0::Analytics", type: :request do
+  let(:user)              { create(:user) }
+  let(:api_token)         { create(:api_secret, user: user) }
+  let(:org)               { create(:organization) }
+  let(:pro_user)          { create(:user, :pro) }
+  let(:pro_api_token)     { create(:api_secret, user: pro_user) }
+  let(:pro_org_member)    { create(:user, :pro, :org_member) }
+  let(:org_member_token)  { create(:api_secret, user: pro_org_member) }
+
+  describe "GET /api/analytics/totals" do
+    include_examples "GET /api/analytics/:endpoint authorization examples", "totals"
+  end
+
+  describe "GET /api/analytics/historical" do
+    include_examples "GET /api/analytics/:endpoint authorization examples", "historical", "&start=2019-03-29"
+
+    context "when the start parameter is not included" do
+      it "raises an ArgumentError" do
+        expect { get "/api/analytics/historical" }.to raise_error ArgumentError
+      end
+    end
+  end
+
+  describe "GET /api/analytics/past_day" do
+    include_examples "GET /api/analytics/:endpoint authorization examples", "past_day"
+  end
+end

--- a/spec/requests/api/v0/analytics_spec.rb
+++ b/spec/requests/api/v0/analytics_spec.rb
@@ -1,14 +1,6 @@
 require "rails_helper"
 
 RSpec.describe "Api::V0::Analytics", type: :request do
-  let(:user)              { create(:user) }
-  let(:api_token)         { create(:api_secret, user: user) }
-  let(:org)               { create(:organization) }
-  let(:pro_user)          { create(:user, :pro) }
-  let(:pro_api_token)     { create(:api_secret, user: pro_user) }
-  let(:pro_org_member)    { create(:user, :pro, :org_member) }
-  let(:org_member_token)  { create(:api_secret, user: pro_org_member) }
-
   describe "GET /api/analytics/totals" do
     include_examples "GET /api/analytics/:endpoint authorization examples", "totals"
   end
@@ -17,8 +9,28 @@ RSpec.describe "Api::V0::Analytics", type: :request do
     include_examples "GET /api/analytics/:endpoint authorization examples", "historical", "&start=2019-03-29"
 
     context "when the start parameter is not included" do
-      it "raises an ArgumentError" do
-        expect { get "/api/analytics/historical" }.to raise_error ArgumentError
+      before { get "/api/analytics/historical" }
+
+      it "renders a status of 422" do
+        expect(response.status).to eq 422
+      end
+
+      it "renders the proper error message in JSON" do
+        error_message = "Required 'start' parameter is missing"
+        expect(JSON.parse(response.body)["error"]).to eq error_message
+      end
+    end
+
+    context "when the start parameter has the incorrect format" do
+      before { get "/api/analytics/historical?start=2019/2/2" }
+
+      it "renders a status of 422" do
+        expect(response.status).to eq 422
+      end
+
+      it "renders the proper error message in JSON" do
+        error_message = "Date parameters 'start' or 'end' must be in the format of 'yyyy-mm-dd'"
+        expect(JSON.parse(response.body)["error"]).to eq error_message
       end
     end
   end

--- a/spec/support/api_analytics_shared_examples.rb
+++ b/spec/support/api_analytics_shared_examples.rb
@@ -1,0 +1,49 @@
+RSpec.shared_examples "GET /api/analytics/:endpoint authorization examples" do |endpoint, extra_params|
+  context "when an invalid token is given" do
+    it "raises the ActiveRecord::RecordNotFound error" do
+      invalid_token = "abadskajdlsak"
+      expect { get "/api/analytics/#{endpoint}?api_token=#{invalid_token}#{extra_params}" }.
+        to raise_error ActiveRecord::RecordNotFound
+    end
+  end
+
+  context "when a valid token is given but the user is not a pro" do
+    it "raises the ActiveRecord::RecordNotFound error" do
+      expect { get "/api/analytics/#{endpoint}?api_token=#{api_token.secret}#{extra_params}" }.
+        to raise_error ActiveRecord::RecordNotFound
+    end
+  end
+
+  context "when a valid token is given and the user is a pro" do
+    before { get "/api/analytics/#{endpoint}?api_token=#{pro_api_token.secret}#{extra_params}" }
+
+    it "renders JSON as the content type" do
+      expect(response.content_type).to eq "application/json"
+    end
+  end
+
+  context "when attempting to view organization analytics without belonging to the organization" do
+    it "raises the ActiveRecord::RecordNotFound error" do
+      expect { get "/api/analytics/#{endpoint}?api_token=#{pro_api_token.secret}&organization_id=#{org.id}#{extra_params}" }.
+        to raise_error ActiveRecord::RecordNotFound
+    end
+  end
+
+  context "when attempting to view organization analytics and being a member of the organization" do
+    before do
+      get "/api/analytics/#{endpoint}?api_token=#{org_member_token.secret}&organization_id=#{pro_org_member.organization_id}#{extra_params}"
+    end
+
+    it "renders JSON as the content type" do
+      expect(response.content_type).to eq "application/json"
+    end
+  end
+
+  context "when attempting to view another organization analytics and not belonging to that organization" do
+    it "raises the ActiveRecord::RecordNotFound error" do
+      org = create(:organization)
+      expect { get "/api/analytics/#{endpoint}?api_token=#{org_member_token.secret}&organization_id=#{org.id}#{extra_params}" }.
+        to raise_error ActiveRecord::RecordNotFound
+    end
+  end
+end

--- a/spec/support/api_analytics_shared_examples.rb
+++ b/spec/support/api_analytics_shared_examples.rb
@@ -1,21 +1,38 @@
-RSpec.shared_examples "GET /api/analytics/:endpoint authorization examples" do |endpoint, extra_params|
+RSpec.shared_examples "GET /api/analytics/:endpoint authorization examples" do |endpoint, params|
+  let(:user)              { create(:user) }
+  let(:api_token)         { create(:api_secret, user: user) }
+  let(:org)               { create(:organization) }
+  let(:pro_user)          { create(:user, :pro) }
+  let(:pro_api_token)     { create(:api_secret, user: pro_user) }
+  let(:pro_org_member)    { create(:user, :pro, :org_member) }
+  let(:org_member_token)  { create(:api_secret, user: pro_org_member) }
+
   context "when an invalid token is given" do
-    it "raises the ActiveRecord::RecordNotFound error" do
-      invalid_token = "abadskajdlsak"
-      expect { get "/api/analytics/#{endpoint}?api_token=#{invalid_token}#{extra_params}" }.
-        to raise_error ActiveRecord::RecordNotFound
+    before { get "/api/analytics/#{endpoint}?#{params}", headers: { "HTTP_API_KEY" => "abadskajdlsak" } }
+
+    it "renders an error message: 'Not authorized' in JSON" do
+      expect(JSON.parse(response.body)["error"]).to eq "Not authorized"
+    end
+
+    it "has a status 401" do
+      expect(response.status).to eq 401
     end
   end
 
   context "when a valid token is given but the user is not a pro" do
-    it "raises the ActiveRecord::RecordNotFound error" do
-      expect { get "/api/analytics/#{endpoint}?api_token=#{api_token.secret}#{extra_params}" }.
-        to raise_error ActiveRecord::RecordNotFound
+    before { get "/api/analytics/#{endpoint}?#{params}", headers: { "HTTP_API_KEY" => "abadskajdlsak" } }
+
+    it "renders an error message: 'Not authorized' in JSON" do
+      expect(JSON.parse(response.body)["error"]).to eq "Not authorized"
+    end
+
+    it "has a status 401" do
+      expect(response.status).to eq 401
     end
   end
 
   context "when a valid token is given and the user is a pro" do
-    before { get "/api/analytics/#{endpoint}?api_token=#{pro_api_token.secret}#{extra_params}" }
+    before { get "/api/analytics/#{endpoint}?#{params}", headers: { "HTTP_API_KEY" => pro_api_token.secret } }
 
     it "renders JSON as the content type" do
       expect(response.content_type).to eq "application/json"
@@ -23,15 +40,22 @@ RSpec.shared_examples "GET /api/analytics/:endpoint authorization examples" do |
   end
 
   context "when attempting to view organization analytics without belonging to the organization" do
-    it "raises the ActiveRecord::RecordNotFound error" do
-      expect { get "/api/analytics/#{endpoint}?api_token=#{pro_api_token.secret}&organization_id=#{org.id}#{extra_params}" }.
-        to raise_error ActiveRecord::RecordNotFound
+    before do
+      get "/api/analytics/#{endpoint}?organization_id=#{org.id}#{params}", headers: { "HTTP_API_KEY" => pro_api_token.secret }
+    end
+
+    it "renders an error message: 'Not authorized' in JSON" do
+      expect(JSON.parse(response.body)["error"]).to eq "Not authorized"
+    end
+
+    it "has a status 401" do
+      expect(response.status).to eq 401
     end
   end
 
   context "when attempting to view organization analytics and being a member of the organization" do
     before do
-      get "/api/analytics/#{endpoint}?api_token=#{org_member_token.secret}&organization_id=#{pro_org_member.organization_id}#{extra_params}"
+      get "/api/analytics/#{endpoint}?organization_id=#{pro_org_member.organization_id}#{params}", headers: { "HTTP_API_KEY" => org_member_token.secret }
     end
 
     it "renders JSON as the content type" do
@@ -40,10 +64,10 @@ RSpec.shared_examples "GET /api/analytics/:endpoint authorization examples" do |
   end
 
   context "when attempting to view another organization analytics and not belonging to that organization" do
-    it "raises the ActiveRecord::RecordNotFound error" do
+    it "responds with status 401 unauthorized" do
       org = create(:organization)
-      expect { get "/api/analytics/#{endpoint}?api_token=#{org_member_token.secret}&organization_id=#{org.id}#{extra_params}" }.
-        to raise_error ActiveRecord::RecordNotFound
+      get "/api/analytics/#{endpoint}?organization_id=#{org.id}#{params}", headers: { "HTTP_API_KEY" => org_member_token.secret }
+      expect(response.status).to eq 401
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
This adds analytics endpoints via API for stats! This is currently only available to pro members. Pro members who are also a part of an organization can view their respective organization's stats as well via API.

There are three endpoints currently:
- `/api/analytics/totals`, which gives you a summary of all your posts' stats,
- `/api/analytics/past_day` which gives you the past 24 hours worth of data, and
- `/api/analytics/historical`, which gives you a snapshot of data of each day based on a certain timeframe.

You'll need to generate an API token via https://dev.to/settings/account to authorize yourself. If you'd like view your organization's data, you can add the `organization_id` parameter. Here's an example endpoint: `https://dev.to/api/analytics/totals?api_token=blahblahblah&organization_id=9001`

For `/historical`, you must add at least a starting date parameter `start`. The ending date parameter `end` is optional, and leaving it out will give you all data up to the current date. Both date parameters must be in the format of `yyyy-mm-dd` (ex. 2019-03-29) Example endpoints:
```
https://dev.to/api/analytics/historical?api_token=blahblahblah&start=2019-03-26
https://dev.to/api/analytics/historical?api_token=blahblahblah&start=2019-03-01&end=2019-03-14
```

## Added to documentation?
Not yet, but will add to docs.dev.to soon!

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
