### PR TITLE
Fix Blogcast styling issues

### DIFF
--- a/app/liquid_tags/blogcast_tag.rb
+++ b/app/liquid_tags/blogcast_tag.rb
@@ -12,7 +12,7 @@ class BlogcastTag < LiquidTagBase
           id="blogcast_#{@id}"
           mozallowfullscreen="true"
           src="https://blogcast.host/embed/#{@id}"
-          style="width:100%;height:132px;overflow:hidden;"
+          style="width:100%;min-height:132px;overflow:hidden;margin:0;"
           webkitallowfullscreen="true"></iframe>
       </div>
     HTML


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

I noticed the Blogcast embed wasn't displaying nicely on mobile devices, and it was also creating some weird spacing around it. This PR should fix both of those problems.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Before: 
<img width="353" alt="Image 2019-04-03 at 6 12 31 PM" src="https://user-images.githubusercontent.com/23558090/55507467-03a88f80-5658-11e9-8f97-70417afbab45.png">


After: 
<img width="343" alt="Image 2019-04-03 at 6 12 53 PM" src="https://user-images.githubusercontent.com/23558090/55507491-10c57e80-5658-11e9-94aa-77e3f4c7aef0.png">


## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
