### PR TITLE
Move exporting into a job

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -27,7 +27,7 @@ class UsersController < ApplicationController
       notice = "Your profile was successfully updated."
       if @user.export_requested?
         notice += " The export will be emailed to you shortly."
-        Exporter::Service.new(@user).delay.export(send_email: true)
+        ExportContentJob.perform_later(@user.id)
       end
       cookies.permanent[:user_experience_level] = @user.experience_level.to_s if @user.experience_level.present?
       follow_hiring_tag(@user)

--- a/app/jobs/export_content_job.rb
+++ b/app/jobs/export_content_job.rb
@@ -1,0 +1,8 @@
+class ExportContentJob < ApplicationJob
+  queue_as :export_content
+
+  def perform(user_id, exporter = Exporter::Service)
+    user = User.find_by(id: user_id)
+    exporter.new(user).export(send_email: true) if user
+  end
+end

--- a/spec/jobs/export_content_job_spec.rb
+++ b/spec/jobs/export_content_job_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe ExportContentJob, type: :job do
+  describe "#perform_now" do
+    let(:exporter_service) { double }
+    let(:exporter) { double }
+    let(:user) { create(:user) }
+
+    before do
+      allow(exporter).to receive(:export)
+      allow(exporter_service).to receive(:new).and_return(exporter)
+    end
+
+    it "calls the service" do
+      described_class.perform_now(user.id, exporter_service)
+      expect(exporter).to have_received(:export).once
+    end
+
+    it "doesn't call the service if non existent user ID is given" do
+      described_class.perform_now(9999, exporter_service)
+      expect(exporter).not_to have_received(:export)
+    end
+  end
+end

--- a/spec/jobs/export_content_job_spec.rb
+++ b/spec/jobs/export_content_job_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe ExportContentJob, type: :job do
+  include_examples "#enqueues_job", "export_content", 1
+
   describe "#perform_now" do
     let(:exporter_service) { double }
     let(:exporter) { double }

--- a/spec/requests/user_settings_spec.rb
+++ b/spec/requests/user_settings_spec.rb
@@ -99,15 +99,13 @@ RSpec.describe "UserSettings", type: :request do
       end
 
       it "sends an email" do
-        run_background_jobs_immediately do
-          expect { send_request }.to change { ActionMailer::Base.deliveries.count }.by(1)
-        end
+        ActiveJob::Base.queue_adapter = :inline
+        expect { send_request }.to change { ActionMailer::Base.deliveries.count }.by(1)
       end
 
       it "does not send an email if there was no request" do
-        run_background_jobs_immediately do
-          expect { send_request(false) }.not_to(change { ActionMailer::Base.deliveries.count })
-        end
+        ActiveJob::Base.queue_adapter = :inline
+        expect { send_request(false) }.not_to(change { ActionMailer::Base.deliveries.count })
       end
     end
   end

--- a/spec/requests/user_settings_spec.rb
+++ b/spec/requests/user_settings_spec.rb
@@ -70,6 +70,10 @@ RSpec.describe "UserSettings", type: :request do
     end
 
     context "when requesting an export of the articles" do
+      before do
+        ActiveJob::Base.queue_adapter = :test
+      end
+
       def send_request(flag = true)
         put "/users/#{user.id}", params: {
           user: { tab: "misc", export_requested: flag }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

I've moved the exporter logic into a proper active job like @lightalloy is doing for the rest of the async logic.

This should also help understand/evade export requests. I've been currently waiting for more than a week for an export and I suspect it has something to do with the default queue delayed job uses for jobs created with `.delay`.

## Related Tickets & Documents

It possibly sheds some light for https://github.com/thepracticaldev/dev.to/issues/2031

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
