### PR TITLE
Use nil instead of empty string for banishing to account for new DB constraints

### DIFF
--- a/app/services/moderator/banish_user.rb
+++ b/app/services/moderator/banish_user.rb
@@ -46,7 +46,7 @@ module Moderator
 
     def remove_profile_info
       user.update_columns(
-        twitter_username: "", github_username: "", website_url: "", summary: "",
+        twitter_username: nil, github_username: nil, website_url: "", summary: "",
         location: "", education: "", employer_name: "", employer_url: "", employment_title: "",
         mostly_work_with: "", currently_learning: "", currently_hacking_on: "", available_for: "",
         email_public: false, facebook_url: nil, dribbble_url: nil, medium_url: nil, stackoverflow_url: nil,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This resolves an issue with the banisher. Banishing currently isn't working because we use empty string, which is no longer compatible with our unique indices on `github_username` and `twitter_username`.

This changes it from empty string `""` to `nil`.