### PR TITLE
integrations github repos hover and text color

### DIFF
--- a/app/assets/stylesheets/settings.scss
+++ b/app/assets/stylesheets/settings.scss
@@ -390,12 +390,22 @@
     background: var(--theme-container-background, #fff);
     padding: 12px;
     margin:5px 0px;
+    transition:all .6s ease;
+    &:hover{
+      color: #0f0f0f;
+      background: $light-green;
+      button{
+        background:#a8f1e9;
+      }
+    }
     &.github-repo-row-selected {
       background: $light-green;
+      color: #0f0f0f;
     }
     .github-repo-row-name {
       font-weight:bold;
       button {
+        transition:all .6s ease;
         cursor:pointer;
         font-size:1.2em;
         font-weight: bold;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Documentation Update

## Description
  Fix. on settings/integrations page when you have selected GitHub repositories the selected by default will be white background and color, which makes it unreadable. This will make the color to black accent and will add a hover effect changing the background to white.

## Before 
![Before](https://user-images.githubusercontent.com/10896363/55511852-7f570c00-5659-11e9-9be8-7ae388536af6.png)
## After
![After](https://user-images.githubusercontent.com/10896363/55511872-8e3dbe80-5659-11e9-8de7-0dd270958620.png)
