### PR TITLE
FIxes #2286

### DIFF
--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -296,6 +296,7 @@ a.header-link {
       width: calc(100% - 80px);
       margin: 19px auto 8px;
       border: 2px solid $yellow;
+      color: #0f0f0f;
       p.loading-message {
         opacity: 0.6;
       }


### PR DESCRIPTION
Will fix the comment preview box text color not visible

<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Documentation Update

## Description
When you preview you comment markdown the background is a yellow accent and the color is white, which makes it not visible. Changed the color of the preview comment div to *#0f0f0f*

## Before
![Screenshot 2019-04-03 at 22 21 41](https://user-images.githubusercontent.com/10896363/55514112-30ac7080-565f-11e9-84a8-f0c15fb3b102.png)
## After
![Screenshot 2019-04-03 at 22 21 47](https://user-images.githubusercontent.com/10896363/55514121-3609bb00-565f-11e9-9d87-d16bbeaf4ba2.png)
