### PR TITLE
Set users email to nil instead of blank 

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -52,11 +52,10 @@ class User < ApplicationRecord
   devise :omniauthable, :rememberable,
         :registerable, :database_authenticatable, :confirmable
   validates :email,
-            uniqueness: { allow_blank: true, case_sensitive: false },
             length: { maximum: 50 },
             email: true,
             allow_nil: true
-  validates :email, uniqueness: { case_sensitive: false }, if: :email_changed?
+  validates :email, uniqueness: { allow_nil: true, case_sensitive: false }, if: :email_changed?
   validates :name, length: { minimum: 1, maximum: 100 }
   validates :username,
             presence: true,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -55,7 +55,7 @@ class User < ApplicationRecord
             uniqueness: { allow_blank: true, case_sensitive: false },
             length: { maximum: 50 },
             email: true,
-            allow_blank: true
+            allow_nil: true
   validates :email, uniqueness: { case_sensitive: false }, if: :email_changed?
   validates :name, length: { minimum: 1, maximum: 100 }
   validates :username,
@@ -144,7 +144,7 @@ class User < ApplicationRecord
   before_update :mentorship_status_update
   before_validation :set_username
   # make sure usernames are not empty, to be able to use the database unique index
-  before_validation :verify_twitter_username, :verify_github_username
+  before_validation :verify_twitter_username, :verify_github_username, :verify_email
   before_validation :set_config_input
   before_validation :downcase_email
   before_validation :check_for_username_change
@@ -411,6 +411,10 @@ class User < ApplicationRecord
 
   def verify_github_username
     self.github_username = nil if github_username == ""
+  end
+
+  def verify_email
+    self.email = nil if email == ""
   end
 
   def set_username

--- a/db/migrate/20190404102732_allow_null_on_users_email.rb
+++ b/db/migrate/20190404102732_allow_null_on_users_email.rb
@@ -1,0 +1,5 @@
+class AllowNullOnUsersEmail < ActiveRecord::Migration[5.2]
+  def change
+    change_column :users, :email, :string, null: true, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_02_224426) do
+ActiveRecord::Schema.define(version: 2019_04_04_102732) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
 
   create_table "ahoy_messages", id: :serial, force: :cascade do |t|
@@ -777,7 +776,7 @@ ActiveRecord::Schema.define(version: 2019_04_02_224426) do
     t.string "dribbble_url"
     t.string "editor_version", default: "v1"
     t.string "education"
-    t.string "email", default: "", null: false
+    t.string "email"
     t.boolean "email_badge_notifications", default: true
     t.boolean "email_comment_notifications", default: true
     t.boolean "email_connect_messages", default: true

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe User, type: :model do
     service.get_user
   end
 
-  describe "makes sure usernames are not blank" do
+  describe "makes sure usernames and email are not blank" do
     it "sets twitter username to nil" do
       user = create(:user, twitter_username: "")
       user.reload
@@ -68,6 +68,18 @@ RSpec.describe User, type: :model do
       user.reload
       expect(user.github_username).to eq("hello")
       expect(user.twitter_username).to eq("world")
+    end
+
+    it "sets email to nil" do
+      user = create(:user, email: "")
+      user.reload
+      expect(user.email).to eq(nil)
+    end
+
+    it "sets correct email if it's not blank" do
+      user = create(:user, email: "anna@example.com")
+      user.reload
+      expect(user.email).to eq("anna@example.com")
     end
   end
 

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe "Dashboards", type: :request do
       end
 
       it "lists followed organizations" do
-        expect(response.body).to include organization.name
+        expect(response.body).to include CGI.escapeHTML(organization.name)
       end
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Since the unique key was added to the `users.email` blank values will be considered as duplicated.
Users don't always have emails specified, so we have to allow `null` values in the database and make sure there are no attempts to write blank emails into the database. 

## Related Tickets & Documents
#2061 
