### PR TITLE
Simplify AnalyticsService code

### DIFF
--- a/app/controllers/api/v0/analytics_controller.rb
+++ b/app/controllers/api/v0/analytics_controller.rb
@@ -38,14 +38,13 @@ module Api
       def past_day
         user = get_authenticated_user!
 
-        start_date = 1.day.ago.to_date.to_s(:iso)
         data = if params[:organization_id]
                  org = Organization.find_by(id: params[:organization_id])
                  raise UnauthorizedError unless org && belongs_to_org?(user, org)
 
-                 AnalyticsService.new(org, start_date: start_date).stats_grouped_by_day
+                 AnalyticsService.new(org, start_date: 1.day.ago).stats_grouped_by_day
                else
-                 AnalyticsService.new(user, start_date: start_date).stats_grouped_by_day
+                 AnalyticsService.new(user, start_date: 1.day.ago).stats_grouped_by_day
                end
         render json: data.to_json
       end

--- a/app/controllers/api/v0/analytics_controller.rb
+++ b/app/controllers/api/v0/analytics_controller.rb
@@ -53,10 +53,10 @@ module Api
       private
 
       def get_authenticated_user!
-        user = if request.headers["HTTP_API_KEY"].blank?
+        user = if request.headers["api-key"].blank?
                  current_user
                else
-                 api_secret = ApiSecret.find_by(secret: request.headers["HTTP_API_KEY"])
+                 api_secret = ApiSecret.find_by(secret: request.headers["api-key"])
                  raise UnauthorizedError if api_secret.blank?
 
                  api_secret.user

--- a/app/controllers/api/v0/analytics_controller.rb
+++ b/app/controllers/api/v0/analytics_controller.rb
@@ -11,9 +11,9 @@ module Api
                  org = Organization.find_by(id: params[:organization_id])
                  raise UnauthorizedError unless org && belongs_to_org?(user, org)
 
-                 AnalyticsService.new(organization: org).totals
+                 AnalyticsService.new(org).totals
                else
-                 AnalyticsService.new(user: user).totals
+                 AnalyticsService.new(user).totals
                end
         render json: data.to_json
       end
@@ -28,9 +28,9 @@ module Api
                  org = Organization.find_by(id: params[:organization_id])
                  raise UnauthorizedError unless org && belongs_to_org?(user, org)
 
-                 AnalyticsService.new(organization: org, start: params[:start], end: params[:end]).stats_grouped_by_day
+                 AnalyticsService.new(org, start_date: params[:start], end_date: params[:end]).stats_grouped_by_day
                else
-                 AnalyticsService.new(user: user, start: params[:start], end: params[:end]).stats_grouped_by_day
+                 AnalyticsService.new(user, start_date: params[:start], end_date: params[:end]).stats_grouped_by_day
                end
         render json: data.to_json
       end
@@ -38,13 +38,14 @@ module Api
       def past_day
         user = get_authenticated_user!
 
+        start_date = 1.day.ago.to_date.to_s(:iso)
         data = if params[:organization_id]
                  org = Organization.find_by(id: params[:organization_id])
                  raise UnauthorizedError unless org && belongs_to_org?(user, org)
 
-                 AnalyticsService.new(organization: org, start: DateTime.current - 1.day).stats_grouped_by_day
+                 AnalyticsService.new(org, start_date: start_date).stats_grouped_by_day
                else
-                 AnalyticsService.new(user: user, start: DateTime.current - 1.day).stats_grouped_by_day
+                 AnalyticsService.new(user, start_date: start_date).stats_grouped_by_day
                end
         render json: data.to_json
       end

--- a/app/services/analytics_service.rb
+++ b/app/services/analytics_service.rb
@@ -10,7 +10,7 @@ class AnalyticsService
   def totals
     total_views = article_data.sum(:page_views_count)
     logged_in_page_view_data = page_view_data.select { |pv| pv.user_id.present? }
-    average_read_time_in_seconds = logged_in_page_view_data.size.positive? ? logged_in_page_view_data.sum(&:time_tracked_in_seconds) / logged_in_page_view_data.size : 0
+    average_read_time_in_seconds = logged_in_page_view_data.size.positive? ? logged_in_page_view_data.sum(:time_tracked_in_seconds) / logged_in_page_view_data.size : 0
 
     {
       comments: {
@@ -40,7 +40,7 @@ class AnalyticsService
       string_date = date.strftime("%a, %m/%d") # this is locale dependent!
       reaction_data_of_date = reaction_data.where("date(created_at) = ?", date)
       logged_in_page_view_data = page_view_data.where("date(created_at) = ?", date).where.not(user_id: nil)
-      average_read_time_in_seconds = logged_in_page_view_data.size.positive? ? logged_in_page_view_data.sum(&:time_tracked_in_seconds) / logged_in_page_view_data.size : 0
+      average_read_time_in_seconds = logged_in_page_view_data.size.positive? ? logged_in_page_view_data.sum(:time_tracked_in_seconds) / logged_in_page_view_data.size : 0
       total_views = page_view_data.where("date(created_at) = ?", date).sum(:counts_for_number_of_views)
 
       final_hash[string_date] = {

--- a/app/services/analytics_service.rb
+++ b/app/services/analytics_service.rb
@@ -1,7 +1,8 @@
 class AnalyticsService
-  def initialize(options)
+  def initialize(user_or_org, options = {})
     @options = options
-    @user_or_org = options[:user] || options[:organization]
+    @user_or_org = user_or_org
+
     @article_data ||= Article.where("#{user_or_org.class.name.downcase}_id" => user_or_org.id, published: true)
     @article_ids ||= @article_data.pluck(:id)
     if options[:start]

--- a/app/services/analytics_service.rb
+++ b/app/services/analytics_service.rb
@@ -34,16 +34,15 @@ class AnalyticsService
   end
 
   def stats_grouped_by_day
-    final_hash = {}
+    result = {}
 
     (start_date.to_date..end_date.to_date).each do |date|
-      string_date = date.strftime("%a, %m/%d") # this is locale dependent!
       reaction_data_of_date = reaction_data.where("date(created_at) = ?", date)
       logged_in_page_view_data = page_view_data.where("date(created_at) = ?", date).where.not(user_id: nil)
       average_read_time_in_seconds = average_read_time(logged_in_page_view_data)
       total_views = page_view_data.where("date(created_at) = ?", date).sum(:counts_for_number_of_views)
 
-      final_hash[string_date] = {
+      result[date.to_s(:iso)] = {
         comments: {
           total: comment_data.where("date(created_at) = ?", date).size
         },
@@ -64,7 +63,7 @@ class AnalyticsService
       }
     end
 
-    final_hash
+    result
   end
 
   private

--- a/app/services/analytics_service.rb
+++ b/app/services/analytics_service.rb
@@ -41,7 +41,7 @@ class AnalyticsService
       reaction_data_of_date = reaction_data.where("date(created_at) = ?", date)
       logged_in_page_view_data = page_view_data.where("date(created_at) = ?", date).where.not(user_id: nil)
       average_read_time_in_seconds = logged_in_page_view_data.size.positive? ? logged_in_page_view_data.sum(&:time_tracked_in_seconds) / logged_in_page_view_data.size : 0
-      total_views = page_view_data.where("date(created_at) = ?", date).sum(&:counts_for_number_of_views)
+      total_views = page_view_data.where("date(created_at) = ?", date).sum(:counts_for_number_of_views)
 
       final_hash[string_date] = {
         comments: {

--- a/app/services/analytics_service.rb
+++ b/app/services/analytics_service.rb
@@ -1,21 +1,10 @@
 class AnalyticsService
-  def initialize(user_or_org, options = {})
-    @options = options
+  def initialize(user_or_org, start_date: "", end_date: "")
     @user_or_org = user_or_org
+    @start_date = Time.zone.parse(start_date)&.beginning_of_day
+    @end_date = Time.zone.parse(end_date)&.end_of_day || Time.current.end_of_day
 
-    @article_data ||= Article.where("#{user_or_org.class.name.downcase}_id" => user_or_org.id, published: true)
-    @article_ids ||= @article_data.pluck(:id)
-    if options[:start]
-      @reaction_data ||= Reaction.where(reactable_id: article_ids, reactable_type: "Article").where("created_at >= ? AND created_at <= ? AND points > 0", start_date.in_time_zone, end_date.in_time_zone)
-      @comment_data ||= Comment.where(commentable_id: article_ids, commentable_type: "Article").where("created_at >= ? AND created_at <= ? AND score > 0", start_date.in_time_zone, end_date.in_time_zone)
-      @follow_data ||= Follow.where(followable_type: user_or_org.class.name, followable_id: user_or_org.id)
-      @page_view_data ||= PageView.where(article_id: article_ids).where("created_at > ? AND created_at < ?", start_date.in_time_zone, end_date.in_time_zone)
-    else
-      @reaction_data ||= Reaction.where(reactable_id: article_ids, reactable_type: "Article").where("points > 0")
-      @comment_data ||= Comment.where(commentable_id: article_ids, commentable_type: "Article").where("score > 0")
-      @follow_data ||= Follow.where(followable_type: user_or_org.class.name, followable_id: user_or_org.id)
-      @page_view_data ||= PageView.where(article_id: article_ids)
-    end
+    load_data
   end
 
   def totals
@@ -47,22 +36,22 @@ class AnalyticsService
   def stats_grouped_by_day
     final_hash = {}
 
-    dates.each do |date|
-      string_date = date.strftime("%a, %m/%d")
-      reaction_data_of_date = reaction_data.select { |rxn| rxn.created_at.beginning_of_day.to_i == date.to_i }
-      logged_in_page_view_data = page_view_data.select { |pv| pv.created_at.beginning_of_day.to_i == date.to_i && pv.user_id.present? }
+    (start_date.to_date..end_date.to_date).each do |date|
+      string_date = date.strftime("%a, %m/%d") # this is locale dependent!
+      reaction_data_of_date = reaction_data.where("date(created_at) = ?", date)
+      logged_in_page_view_data = page_view_data.where("date(created_at) = ?", date).where.not(user_id: nil)
       average_read_time_in_seconds = logged_in_page_view_data.size.positive? ? logged_in_page_view_data.sum(&:time_tracked_in_seconds) / logged_in_page_view_data.size : 0
-      total_views = page_view_data.select { |pv| pv.created_at.beginning_of_day.to_i == date.to_i }.sum(&:counts_for_number_of_views)
+      total_views = page_view_data.where("date(created_at) = ?", date).sum(&:counts_for_number_of_views)
 
       final_hash[string_date] = {
         comments: {
-          total: comment_data.count { |c| c.created_at.beginning_of_day.to_i == date.to_i }
+          total: comment_data.where("date(created_at) = ?", date).size
         },
         reactions: {
-          total: reaction_data_of_date.count,
-          like: reaction_data_of_date.count { |rxn| rxn.category == "like" },
-          readinglist: reaction_data_of_date.count { |rxn| rxn.category == "readinglist" },
-          unicorn: reaction_data_of_date.count { |rxn| rxn.category == "unicorn" }
+          total: reaction_data_of_date.size,
+          like: reaction_data_of_date.where("category = ?", "like").size,
+          readinglist: reaction_data_of_date.where("category = ?", "readinglist").size,
+          unicorn: reaction_data_of_date.where("category = ?", "unicorn").size
         },
         page_views: {
           total: total_views,
@@ -70,7 +59,7 @@ class AnalyticsService
           average_read_time_in_seconds: average_read_time_in_seconds
         },
         follows: {
-          total: follow_data.count { |f| f.created_at.beginning_of_day.to_i == date.to_i }
+          total: follow_data.where("date(created_at) = ?", date).size
         }
       }
     end
@@ -80,26 +69,26 @@ class AnalyticsService
 
   private
 
-  attr_reader :options, :user_or_org, :article_data, :article_ids, :reaction_data, :comment_data, :follow_data, :page_view_data
+  attr_reader :user_or_org, :start_date, :end_date, :article_data, :reaction_data, :comment_data, :follow_data, :page_view_data
 
-  def start_date
-    options[:start].to_datetime.beginning_of_day
-  end
+  def load_data
+    @article_data = Article.where("#{user_or_org.class.name.downcase}_id" => user_or_org.id, published: true)
+    article_ids = @article_data.pluck(:id)
 
-  def end_date
-    if options[:end].present?
-      options[:end].to_datetime.end_of_day
+    if @start_date && @end_date
+      @reaction_data ||= Reaction.where(reactable_id: article_ids, reactable_type: "Article").
+        where(created_at: @start_date..@end_date).
+        where("points > 0")
+      @comment_data = Comment.where(commentable_id: article_ids, commentable_type: "Article").
+        where(created_at: @start_date..@end_date).
+        where("score > 0")
+      @page_view_data = PageView.where(article_id: article_ids).where(created_at: @start_date..@end_date)
     else
-      DateTime.current.end_of_day
+      @reaction_data = Reaction.where(reactable_id: article_ids, reactable_type: "Article").where("points > 0")
+      @comment_data = Comment.where(commentable_id: article_ids, commentable_type: "Article").where("score > 0")
+      @page_view_data = PageView.where(article_id: article_ids)
     end
-  end
 
-  def dates
-    date_range = (end_date - start_date.beginning_of_day).to_i
-    dates_array = []
-    date_range.times do |index|
-      dates_array.push(start_date + index.days)
-    end
-    dates_array.push(end_date)
+    @follow_data = Follow.where(followable_type: user_or_org.class.name, followable_id: user_or_org.id)
   end
 end

--- a/app/services/analytics_service.rb
+++ b/app/services/analytics_service.rb
@@ -1,8 +1,8 @@
 class AnalyticsService
   def initialize(user_or_org, start_date: "", end_date: "")
     @user_or_org = user_or_org
-    @start_date = Time.zone.parse(start_date)&.beginning_of_day
-    @end_date = Time.zone.parse(end_date)&.end_of_day || Time.current.end_of_day
+    @start_date = Time.zone.parse(start_date.to_s)&.beginning_of_day
+    @end_date = Time.zone.parse(end_date.to_s)&.end_of_day || Time.current.end_of_day
 
     load_data
   end
@@ -76,7 +76,7 @@ class AnalyticsService
     article_ids = @article_data.pluck(:id)
 
     if @start_date && @end_date
-      @reaction_data ||= Reaction.where(reactable_id: article_ids, reactable_type: "Article").
+      @reaction_data = Reaction.where(reactable_id: article_ids, reactable_type: "Article").
         where(created_at: @start_date..@end_date).
         where("points > 0")
       @comment_data = Comment.where(commentable_id: article_ids, commentable_type: "Article").

--- a/app/services/analytics_service.rb
+++ b/app/services/analytics_service.rb
@@ -9,7 +9,7 @@ class AnalyticsService
 
   def totals
     total_views = article_data.sum(:page_views_count)
-    logged_in_page_view_data = page_view_data.select { |pv| pv.user_id.present? }
+    logged_in_page_view_data = page_view_data.where.not(user_id: nil)
     average_read_time_in_seconds = average_read_time(logged_in_page_view_data)
 
     {

--- a/app/services/analytics_service.rb
+++ b/app/services/analytics_service.rb
@@ -10,7 +10,7 @@ class AnalyticsService
   def totals
     total_views = article_data.sum(:page_views_count)
     logged_in_page_view_data = page_view_data.select { |pv| pv.user_id.present? }
-    average_read_time_in_seconds = logged_in_page_view_data.size.positive? ? logged_in_page_view_data.sum(:time_tracked_in_seconds) / logged_in_page_view_data.size : 0
+    average_read_time_in_seconds = average_read_time(logged_in_page_view_data)
 
     {
       comments: {
@@ -40,7 +40,7 @@ class AnalyticsService
       string_date = date.strftime("%a, %m/%d") # this is locale dependent!
       reaction_data_of_date = reaction_data.where("date(created_at) = ?", date)
       logged_in_page_view_data = page_view_data.where("date(created_at) = ?", date).where.not(user_id: nil)
-      average_read_time_in_seconds = logged_in_page_view_data.size.positive? ? logged_in_page_view_data.sum(:time_tracked_in_seconds) / logged_in_page_view_data.size : 0
+      average_read_time_in_seconds = average_read_time(logged_in_page_view_data)
       total_views = page_view_data.where("date(created_at) = ?", date).sum(:counts_for_number_of_views)
 
       final_hash[string_date] = {
@@ -90,5 +90,9 @@ class AnalyticsService
     end
 
     @follow_data = Follow.where(followable_type: user_or_org.class.name, followable_id: user_or_org.id)
+  end
+
+  def average_read_time(page_view_data)
+    page_view_data.size.positive? ? page_view_data.sum(:time_tracked_in_seconds) / page_view_data.size : 0
   end
 end

--- a/spec/factories/page_views.rb
+++ b/spec/factories/page_views.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :page_view do
+    user
+    article
+  end
+end

--- a/spec/services/analytics/analytics_service_spec.rb
+++ b/spec/services/analytics/analytics_service_spec.rb
@@ -57,12 +57,12 @@ RSpec.describe AnalyticsService, type: :service do
 
     it "returns stats grouped by day" do
       stats = described_class.new(user, start_date: "2019-04-01", end_date: "2019-04-04").stats_grouped_by_day
-      expect(stats.keys).to eq(["Mon, 04/01", "Tue, 04/02", "Wed, 04/03", "Thu, 04/04"])
+      expect(stats.keys).to eq(["2019-04-01", "2019-04-02", "2019-04-03", "2019-04-04"])
     end
 
     it "returns stats for a specific day" do
       stats = described_class.new(user, start_date: "2019-04-01", end_date: "2019-04-04").stats_grouped_by_day
-      expect(stats["Mon, 04/01"].keys).to eq(%i[comments reactions page_views follows])
+      expect(stats["2019-04-01"].keys).to eq(%i[comments reactions page_views follows])
     end
   end
 end

--- a/spec/services/analytics/analytics_service_spec.rb
+++ b/spec/services/analytics/analytics_service_spec.rb
@@ -6,44 +6,44 @@ RSpec.describe AnalyticsService, type: :service do
 
   describe "#totals" do
     it "returns totals stats for a user" do
-      totals = described_class.new(user: user).totals
+      totals = described_class.new(user).totals
       expect(totals.keys).to eq(%i[comments reactions follows page_views])
     end
 
     it "returns stats for comments for a user" do
-      totals = described_class.new(user: user).totals
+      totals = described_class.new(user).totals
       expect(totals[:comments].keys).to eq([:total])
     end
 
     it "returns stats for reactions for a user" do
-      totals = described_class.new(user: user).totals
+      totals = described_class.new(user).totals
       expect(totals[:reactions].keys).to eq(%i[total like readinglist unicorn])
     end
 
     it "returns stats for follows for a user" do
-      totals = described_class.new(user: user).totals
+      totals = described_class.new(user).totals
       expect(totals[:follows].keys).to eq([:total])
     end
 
     it "returns stats for page views for a user" do
-      totals = described_class.new(user: user).totals
+      totals = described_class.new(user).totals
       expect(totals[:page_views].keys).to eq(%i[total average_read_time_in_seconds total_read_time_in_seconds])
     end
 
     it "returns totals stats for an org" do
-      totals = described_class.new(organization: organization).totals
+      totals = described_class.new(organization).totals
       expect(totals.keys).to eq(%i[comments reactions follows page_views])
     end
   end
 
   describe "#stats_grouped_by_day" do
     it "returns stats grouped by day" do
-      stats = described_class.new(user: user, start: "2019-04-01", end: "2019-04-04").stats_grouped_by_day
+      stats = described_class.new(user, start: "2019-04-01", end: "2019-04-04").stats_grouped_by_day
       expect(stats.keys).to eq(["Mon, 04/01", "Tue, 04/02", "Wed, 04/03", "Thu, 04/04"])
     end
 
     it "returns stats for a specific day" do
-      stats = described_class.new(user: user, start: "2019-04-01", end: "2019-04-04").stats_grouped_by_day
+      stats = described_class.new(user, start: "2019-04-01", end: "2019-04-04").stats_grouped_by_day
       expect(stats["Mon, 04/01"].keys).to eq(%i[comments reactions page_views follows])
     end
   end

--- a/spec/services/analytics/analytics_service_spec.rb
+++ b/spec/services/analytics/analytics_service_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe AnalyticsService, type: :service do
+  let(:user) { create(:user) }
+  let(:organization) { create(:organization) }
+
+  describe "#totals" do
+    it "returns totals stats for a user" do
+      totals = described_class.new(user: user).totals
+      expect(totals.keys).to eq(%i[comments reactions follows page_views])
+    end
+
+    it "returns stats for comments for a user" do
+      totals = described_class.new(user: user).totals
+      expect(totals[:comments].keys).to eq([:total])
+    end
+
+    it "returns stats for reactions for a user" do
+      totals = described_class.new(user: user).totals
+      expect(totals[:reactions].keys).to eq(%i[total like readinglist unicorn])
+    end
+
+    it "returns stats for follows for a user" do
+      totals = described_class.new(user: user).totals
+      expect(totals[:follows].keys).to eq([:total])
+    end
+
+    it "returns stats for page views for a user" do
+      totals = described_class.new(user: user).totals
+      expect(totals[:page_views].keys).to eq(%i[total average_read_time_in_seconds total_read_time_in_seconds])
+    end
+
+    it "returns totals stats for an org" do
+      totals = described_class.new(organization: organization).totals
+      expect(totals.keys).to eq(%i[comments reactions follows page_views])
+    end
+  end
+
+  describe "#stats_grouped_by_day" do
+    it "returns stats grouped by day" do
+      stats = described_class.new(user: user, start: "2019-04-01", end: "2019-04-04").stats_grouped_by_day
+      expect(stats.keys).to eq(["Mon, 04/01", "Tue, 04/02", "Wed, 04/03", "Thu, 04/04"])
+    end
+
+    it "returns stats for a specific day" do
+      stats = described_class.new(user: user, start: "2019-04-01", end: "2019-04-04").stats_grouped_by_day
+      expect(stats["Mon, 04/01"].keys).to eq(%i[comments reactions page_views follows])
+    end
+  end
+end

--- a/spec/services/analytics/analytics_service_spec.rb
+++ b/spec/services/analytics/analytics_service_spec.rb
@@ -37,6 +37,14 @@ RSpec.describe AnalyticsService, type: :service do
   end
 
   describe "#stats_grouped_by_day" do
+    before do
+      article = create(:article, user: user, published: true)
+      create(:reaction, reactable: article)
+      create(:reading_reaction, reactable: article)
+      create(:page_view, user: user, article: article)
+      create(:follow)
+    end
+
     it "returns stats grouped by day" do
       stats = described_class.new(user, start: "2019-04-01", end: "2019-04-04").stats_grouped_by_day
       expect(stats.keys).to eq(["Mon, 04/01", "Tue, 04/02", "Wed, 04/03", "Thu, 04/04"])

--- a/spec/services/analytics/analytics_service_spec.rb
+++ b/spec/services/analytics/analytics_service_spec.rb
@@ -4,6 +4,16 @@ RSpec.describe AnalyticsService, type: :service do
   let(:user) { create(:user) }
   let(:organization) { create(:organization) }
 
+  describe "initialization" do
+    it "raises an error if start date is invalid" do
+      expect(-> { described_class.new(user, start_date: "2000-") }).to raise_error(ArgumentError)
+    end
+
+    it "raises an error if end date is invalid" do
+      expect(-> { described_class.new(user, end_date: "2000-") }).to raise_error(ArgumentError)
+    end
+  end
+
   describe "#totals" do
     it "returns totals stats for a user" do
       totals = described_class.new(user).totals
@@ -46,12 +56,12 @@ RSpec.describe AnalyticsService, type: :service do
     end
 
     it "returns stats grouped by day" do
-      stats = described_class.new(user, start: "2019-04-01", end: "2019-04-04").stats_grouped_by_day
+      stats = described_class.new(user, start_date: "2019-04-01", end_date: "2019-04-04").stats_grouped_by_day
       expect(stats.keys).to eq(["Mon, 04/01", "Tue, 04/02", "Wed, 04/03", "Thu, 04/04"])
     end
 
     it "returns stats for a specific day" do
-      stats = described_class.new(user, start: "2019-04-01", end: "2019-04-04").stats_grouped_by_day
+      stats = described_class.new(user, start_date: "2019-04-01", end_date: "2019-04-04").stats_grouped_by_day
       expect(stats["Mon, 04/01"].keys).to eq(%i[comments reactions page_views follows])
     end
   end

--- a/spec/support/api_analytics_shared_examples.rb
+++ b/spec/support/api_analytics_shared_examples.rb
@@ -8,7 +8,7 @@ RSpec.shared_examples "GET /api/analytics/:endpoint authorization examples" do |
   let(:org_member_token)  { create(:api_secret, user: pro_org_member) }
 
   context "when an invalid token is given" do
-    before { get "/api/analytics/#{endpoint}?#{params}", headers: { "HTTP_API_KEY" => "abadskajdlsak" } }
+    before { get "/api/analytics/#{endpoint}?#{params}", headers: { "api-key" => "abadskajdlsak" } }
 
     it "renders an error message: 'Not authorized' in JSON" do
       expect(JSON.parse(response.body)["error"]).to eq "Not authorized"
@@ -20,7 +20,7 @@ RSpec.shared_examples "GET /api/analytics/:endpoint authorization examples" do |
   end
 
   context "when a valid token is given but the user is not a pro" do
-    before { get "/api/analytics/#{endpoint}?#{params}", headers: { "HTTP_API_KEY" => "abadskajdlsak" } }
+    before { get "/api/analytics/#{endpoint}?#{params}", headers: { "api-key" => "abadskajdlsak" } }
 
     it "renders an error message: 'Not authorized' in JSON" do
       expect(JSON.parse(response.body)["error"]).to eq "Not authorized"
@@ -32,7 +32,7 @@ RSpec.shared_examples "GET /api/analytics/:endpoint authorization examples" do |
   end
 
   context "when a valid token is given and the user is a pro" do
-    before { get "/api/analytics/#{endpoint}?#{params}", headers: { "HTTP_API_KEY" => pro_api_token.secret } }
+    before { get "/api/analytics/#{endpoint}?#{params}", headers: { "api-key" => pro_api_token.secret } }
 
     it "renders JSON as the content type" do
       expect(response.content_type).to eq "application/json"
@@ -41,7 +41,7 @@ RSpec.shared_examples "GET /api/analytics/:endpoint authorization examples" do |
 
   context "when attempting to view organization analytics without belonging to the organization" do
     before do
-      get "/api/analytics/#{endpoint}?organization_id=#{org.id}#{params}", headers: { "HTTP_API_KEY" => pro_api_token.secret }
+      get "/api/analytics/#{endpoint}?organization_id=#{org.id}#{params}", headers: { "api-key" => pro_api_token.secret }
     end
 
     it "renders an error message: 'Not authorized' in JSON" do
@@ -55,7 +55,7 @@ RSpec.shared_examples "GET /api/analytics/:endpoint authorization examples" do |
 
   context "when attempting to view organization analytics and being a member of the organization" do
     before do
-      get "/api/analytics/#{endpoint}?organization_id=#{pro_org_member.organization_id}#{params}", headers: { "HTTP_API_KEY" => org_member_token.secret }
+      get "/api/analytics/#{endpoint}?organization_id=#{pro_org_member.organization_id}#{params}", headers: { "api-key" => org_member_token.secret }
     end
 
     it "renders JSON as the content type" do
@@ -66,7 +66,7 @@ RSpec.shared_examples "GET /api/analytics/:endpoint authorization examples" do |
   context "when attempting to view another organization analytics and not belonging to that organization" do
     it "responds with status 401 unauthorized" do
       org = create(:organization)
-      get "/api/analytics/#{endpoint}?organization_id=#{org.id}#{params}", headers: { "HTTP_API_KEY" => org_member_token.secret }
+      get "/api/analytics/#{endpoint}?organization_id=#{org.id}#{params}", headers: { "api-key" => org_member_token.secret }
       expect(response.status).to eq 401
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

This refactoring does mainly three things:

* simplifies `AnalyticsService` interface
* uses SQL queries instead of in memory calculations to retrieve counts
* uses date objects for ranges

A few things I've left out that should be discussed/decided:

* `AnalyticsService` should probably be renamed to `Analytics::Pro` as suggested by @lightalloy 
* `date.strftime("%a, %m/%d")` is locale dependent and potentially repeats itself (if start_date and end_date go past a year there could be dates with the same string version). Also, users outside the US could misinterpret dates as "03/04" (3rd of march or 4th of april?). I suggest using the ISO "2019-04-01" as key for the hash. 
* I think the date validation using regexps, now that dates are parsed, is unnecessary:

```ruby
      def valid_date_params?
        date_regex = /\A\d{4}-\d{1,2}-\d{1,2}\Z/ # for example, 2019-03-22 or 2019-2-1
        if params[:end]
          (params[:start] =~ date_regex)&.zero? && (params[:end] =~ date_regex)&.zero?
        else
          (params[:start] =~ date_regex)&.zero?
        end
      end
```

## Related Tickets & Documents

Closes #2307

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
