### PR TITLE
Conditional validations for user github_username and twitter_username #2061 

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -64,8 +64,8 @@ class User < ApplicationRecord
             length: { in: 2..30 },
             exclusion: { in: ReservedWords.all, message: "username is reserved" }
   validates :username, uniqueness: { case_sensitive: false }, if: :username_changed?
-  validates :twitter_username, uniqueness: { allow_blank: true }
-  validates :github_username, uniqueness: { allow_blank: true }
+  validates :twitter_username, uniqueness: { allow_blank: true }, if: :twitter_username_changed?
+  validates :github_username, uniqueness: { allow_blank: true }, if: :github_username_changed?
   validates :experience_level, numericality: { less_than_or_equal_to: 10 }, allow_blank: true
   validates :text_color_hex, format: /\A#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})\z/, allow_blank: true
   validates :bg_color_hex, format: /\A#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})\z/, allow_blank: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -64,8 +64,8 @@ class User < ApplicationRecord
             length: { in: 2..30 },
             exclusion: { in: ReservedWords.all, message: "username is reserved" }
   validates :username, uniqueness: { case_sensitive: false }, if: :username_changed?
-  validates :twitter_username, uniqueness: { allow_blank: true }, if: :twitter_username_changed?
-  validates :github_username, uniqueness: { allow_blank: true }, if: :github_username_changed?
+  validates :twitter_username, uniqueness: { allow_nil: true }, if: :twitter_username_changed?
+  validates :github_username, uniqueness: { allow_nil: true }, if: :github_username_changed?
   validates :experience_level, numericality: { less_than_or_equal_to: 10 }, allow_blank: true
   validates :text_color_hex, format: /\A#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})\z/, allow_blank: true
   validates :bg_color_hex, format: /\A#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})\z/, allow_blank: true

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe User, type: :model do
     it { is_expected.to have_many(:chat_channels).through(:chat_channel_memberships) }
     it { is_expected.to have_many(:push_notification_subscriptions).dependent(:destroy) }
     it { is_expected.to validate_uniqueness_of(:username).case_insensitive }
-    it { is_expected.to validate_uniqueness_of(:github_username).allow_blank }
-    it { is_expected.to validate_uniqueness_of(:twitter_username).allow_blank }
+    it { is_expected.to validate_uniqueness_of(:github_username).allow_nil }
+    it { is_expected.to validate_uniqueness_of(:twitter_username).allow_nil }
     it { is_expected.to validate_presence_of(:username) }
     it { is_expected.to validate_length_of(:username).is_at_most(30).is_at_least(2) }
     it { is_expected.to validate_length_of(:name).is_at_most(100) }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
- validate `github_username` and `twitter_username` uniqueness only if the corresponding field was changed to lower amount of requests when signing in and in other cases
- change `allow_blank` to `allow_nil` options in these fields' validations, since only `nil` is allowed to be written to the database.

## Related Tickets & Documents
#2061 
