### PR TITLE
Automated DEV setup using Gitpod

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -1,0 +1,6 @@
+FROM gitpod/workspace-postgres
+
+# Install Ruby
+COPY .ruby-version /tmp
+RUN bash -lc "rvm install ruby-$(cat /tmp/.ruby-version)" \
+ && rm -f /tmp/*

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,24 @@
+image:
+  file: .gitpod.dockerfile
+ports:
+  - port: 3000
+    onOpen: open-preview
+  - port: 3035
+    onOpen: ignore
+  - port: 5432
+    onOpen: ignore
+tasks:
+  - init: >
+      cp config/sample_application.yml config/application.yml &&
+      bin/setup 2>/dev/null
+    command: >
+      while [ -z "${ALGOLIASEARCH_APPLICATION_ID:=$(cat config/application.yml | grep ALGOLIASEARCH_APPLICATION_ID | sed 's/.*:\s*//')}" ] ||
+            [ -z "${ALGOLIASEARCH_SEARCH_ONLY_KEY:=$(cat config/application.yml | grep ALGOLIASEARCH_SEARCH_ONLY_KEY | sed 's/.*:\s*//')}" ] ||
+            [ -z "${ALGOLIASEARCH_API_KEY:=$(cat config/application.yml | grep ALGOLIASEARCH_API_KEY | sed 's/.*:\s*//')}" ] ; do
+        gp open config/application.yml 2>/dev/null &&
+        printf "\n❗ Dev.to requires free Algolia credentials.\n" &&
+        printf "❗ To get them, please follow https://docs.dev.to/get-api-keys-dev-env/#algolia\n\n" &&
+        read -p "Add them to config/application.yml, save the file, and press any key to continue... " -n 1 -r
+      done ;
+      bin/setup &&
+      bin/startup

--- a/README.md
+++ b/README.md
@@ -187,6 +187,12 @@ Our docker implementation is incomplete and may not work smoothly. Please kindly
 1. run `docker-compose up`
 1. That's it! Navigate to `localhost:3000`
 
+### Gitpod Installation
+
+Simply open dev.to in Gitpod, a free online dev environment for GitHub:
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/thepracticaldev/dev.to)
+
 #### Starting the application
 
 We're mostly a Rails app, with a bit of Webpack sprinkled in. **For most cases, simply running `bin/rails server` will do.** If you're working with Webpack though, you'll need to run the following:


### PR DESCRIPTION
👋 Hello!

I work on gitpod.io, a one-click online IDE for GitHub, and I'd like to contribute an almost fully-automated dev setup for DEV. ⚡️

Please let me know what you think.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [x] Documentation Update

## Description

In this PR, I've configured Gitpod to:
- pre-install PostgreSQL and the correct Ruby version (via `.gitpod.dockerfile`)
- initialize DEV workspaces with a `config/application.yml` and run `bin/setup`
- automatically start `bin/startup` and open the app in a preview

Here is what it looks like:

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/jankeromnes/dev.to)
<img width="1552" alt="Screenshot 2019-04-07 at 15 00 01" src="https://user-images.githubusercontent.com/599268/55684989-ae1efc00-5951-11e9-9087-4a32d694e3c6.png">

## Related Tickets & Documents

(none)

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

The only non-automated part are the Algolia credentials, which Gitpod will ask for on startup like so:

<img width="1552" alt="Screenshot 2019-04-07 at 14 55 54" src="https://user-images.githubusercontent.com/599268/55684982-a19aa380-5951-11e9-8a09-cfcd1318b21e.png">

## Added to documentation?

- [ ] docs.dev.to
- [x] readme
- [ ] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![frictionless coding](https://i.giphy.com/media/lJNoBCvQYp7nq/giphy.webp)
