### PR TITLE
Combining tags together in a search query (#2238)

### DIFF
--- a/app/views/articles/_algolia_search.html.erb
+++ b/app/views/articles/_algolia_search.html.erb
@@ -88,7 +88,7 @@
     if (filters === "MY_POSTS" && userData()) {
       searchObj["tagFilters"] = [['user_' + userData()['id']]]
     } else if (hashtags != null && hashtags.length > 0) {
-      for(i = 0; i < hashtags.length; i++){
+      for(var i = 0; i < hashtags.length; i++){
         hashtags[i] = hashtags[i].replace(/#/,'')
       }
       searchObj["tagFilters"] = hashtags

--- a/app/views/articles/_algolia_search.html.erb
+++ b/app/views/articles/_algolia_search.html.erb
@@ -63,6 +63,7 @@
   }
 
   function search(query, index, filters) {
+    var hashtags = query.match(/#\w+/g)
     var searchObj = {
       hitsPerPage: 60,
       page: "0",
@@ -83,8 +84,14 @@
       exactOnSingleWordQuery: "none",
       attributesToSnippet: ['body_text:19', 'comments_blob:8'],
     }
+
     if (filters === "MY_POSTS" && userData()) {
       searchObj["tagFilters"] = [['user_' + userData()['id']]]
+    } else if (hashtags != null && hashtags.length > 0) {
+      for(i = 0; i < hashtags.length; i++){
+        hashtags[i] = hashtags[i].replace(/#/,'')
+      }
+      searchObj["tagFilters"] = hashtags
     } else {
       searchObj["filters"] = filters
     }


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

```
Given I am a vistor
When I type in the search "#serverless #discuss"
And I press and enter
Then I should only see articles that are tagged  with both "serverless" and "go"
```

## Related Tickets & Documents

I have throughly documented my journey to implement this feature in the original ticket:
https://github.com/thepracticaldev/dev.to/issues/2238

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

I believe this is expected behaviour and check docs.dev.to and thought it not applicable to add documentation.

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![Come Dream WIth Me Tonight](https://media.giphy.com/media/ktnBE4jKnS9O0/giphy.gif)
