### PR TITLE
Add tech admin role and allow tech admins to view /delayed_job

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -13,6 +13,7 @@ class Role < ApplicationRecord
               in: %w[
                 super_admin
                 admin
+                tech_support
                 tag_moderator
                 trusted
                 banned

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -13,7 +13,7 @@ class Role < ApplicationRecord
               in: %w[
                 super_admin
                 admin
-                tech_support
+                tech_admin
                 tag_moderator
                 trusted
                 banned

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -311,7 +311,7 @@ class User < ApplicationRecord
   end
 
   def tech_support?
-    has_role?(:tech_support) || has_role?(:super_admin?)
+    has_role?(:tech_support) || has_role?(:super_admin)
   end
 
   def trusted

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -310,8 +310,8 @@ class User < ApplicationRecord
     has_role?(:super_admin) || has_role?(:admin)
   end
 
-  def tech_support?
-    has_role?(:tech_support) || has_role?(:super_admin)
+  def tech_admin?
+    has_role?(:tech_admin) || has_role?(:super_admin)
   end
 
   def trusted

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -310,6 +310,10 @@ class User < ApplicationRecord
     has_role?(:super_admin) || has_role?(:admin)
   end
 
+  def tech_support?
+    has_role?(:tech_support) || has_role(:super_admin?)
+  end
+
   def trusted
     Rails.cache.fetch("user-#{id}/has_trusted_role", expires_in: 200.hours) do
       has_role? :trusted

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -311,7 +311,7 @@ class User < ApplicationRecord
   end
 
   def tech_support?
-    has_role?(:tech_support) || has_role(:super_admin?)
+    has_role?(:tech_support) || has_role?(:super_admin?)
   end
 
   def trusted

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
     registrations: "registrations"
   }
 
-  authenticated :user, ->(user) { user.admin? } do
+  authenticated :user, ->(user) { user.tech_support? } do
     mount DelayedJobWeb, at: "/delayed_job"
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
     registrations: "registrations"
   }
 
-  authenticated :user, ->(user) { user.tech_support? } do
+  authenticated :user, ->(user) { user.tech_admin? } do
     mount DelayedJobWeb, at: "/delayed_job"
   end
 

--- a/spec/requests/delayed_job_spec.rb
+++ b/spec/requests/delayed_job_spec.rb
@@ -4,6 +4,11 @@ RSpec.describe "Delayed Job web interface", type: :request do
   let(:user)          { create(:user) }
   let(:super_admin)   { create(:user, :super_admin) }
   let(:article)       { create(:article, user_id: user.id) }
+  let(:tech_support) do
+    user = create(:user)
+    user.add_role :tech_support
+    user
+  end
 
   describe "GET /delayed_job" do
     context "when not logged in" do
@@ -25,6 +30,20 @@ RSpec.describe "Delayed Job web interface", type: :request do
 
     context "when logged in as a super admin" do
       before { login_as super_admin }
+
+      it "redirects to overview" do
+        get "/delayed_job"
+        expect(response).to redirect_to("/delayed_job/overview")
+      end
+
+      it "renders overview" do
+        get "/delayed_job/overview"
+        expect(response.body).to include "Overview"
+      end
+    end
+
+    context "when logged in as a tech support member" do
+      before { login_as tech_support }
 
       it "redirects to overview" do
         get "/delayed_job"

--- a/spec/requests/delayed_job_spec.rb
+++ b/spec/requests/delayed_job_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe "Delayed Job web interface", type: :request do
   let(:user)          { create(:user) }
   let(:super_admin)   { create(:user, :super_admin) }
   let(:article)       { create(:article, user_id: user.id) }
-  let(:tech_support) do
+  let(:tech_admin) do
     user = create(:user)
-    user.add_role :tech_support
+    user.add_role :tech_admin
     user
   end
 
@@ -43,7 +43,7 @@ RSpec.describe "Delayed Job web interface", type: :request do
     end
 
     context "when logged in as a tech support member" do
-      before { login_as tech_support }
+      before { login_as tech_admin }
 
       it "redirects to overview" do
         get "/delayed_job"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
This PR adds the `tech_admin` role to allow particular people to view specific tech related data (like `/delayed_job`).