### PR TITLE
Only set cache control header on videos index page

### DIFF
--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -1,6 +1,6 @@
 class VideosController < ApplicationController
   after_action :verify_authorized, except: %i[index]
-  before_action :set_cache_control_headers
+  before_action :set_cache_control_headers, only: %i[index]
 
   def new
     authorize :video


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
We erroneously added cache control headers to `/videos/new` which breaks some of the functionality of a page expected to be rendered from the origin.