### PR TITLE
Fix colon emoji in codeblock (#2216)

### DIFF
--- a/app/labor/markdown_parser.rb
+++ b/app/labor/markdown_parser.rb
@@ -24,7 +24,7 @@ class MarkdownParser
     html = wrap_all_images_in_links(html)
     html = wrap_all_tables(html)
     html = remove_empty_paragraphs(html)
-    html = EmojiConverter.call(html)
+    html = escape_colon_emojis_in_codeblock(html)
     wrap_mentions_with_links!(html)
   end
 
@@ -88,6 +88,21 @@ class MarkdownParser
   end
 
   private
+
+  def escape_colon_emojis_in_codeblock(html)
+    html_doc = Nokogiri::HTML.fragment(html)
+
+    html_doc.children.each do |el|
+      next if el.name == "code"
+
+      if el.search("code").empty?
+        el.swap(EmojiConverter.call(el.to_html))
+      else
+        el.children = escape_colon_emojis_in_codeblock(el.children.to_html)
+      end
+    end
+    html_doc.to_html
+  end
 
   def catch_xss_attempts(markdown)
     bad_xss = ['src="data', "src='data", "src='&", 'src="&', "data:text/html"]

--- a/spec/labor/markdown_parser_spec.rb
+++ b/spec/labor/markdown_parser_spec.rb
@@ -126,6 +126,13 @@ RSpec.describe MarkdownParser do
     end
   end
 
+  context "when a colon emoji is used" do
+    it "doesn't change text in codeblock" do
+      result = generate_and_parse_markdown("<span>:o:<code>:o:</code>:o:<code>:o:</code>:o:<span>:o:</span>:o:</span>")
+      expect(result).to include("<span>⭕️<code>:o:</code>⭕️<code>:o:</code>⭕️<span>⭕️</span>⭕️</span>")
+    end
+  end
+
   context "when using Liquid variables" do
     it "prevents Liquid variables" do
       expect { generate_and_parse_markdown("{{ 'something' }}") }.to raise_error(StandardError)


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Documentation Update

## Description
This bug is fixed by excluding `code` tags and their content from being processed by `EmojiConverter`

### Snippet used

```
:o:
```

```python
':o:'
```

```ruby
':o:'
":o:"
```
`:o:` 

### Before
![Screen Shot 2019-04-10 at 16 24 26](https://user-images.githubusercontent.com/8961745/55882436-377e3a80-5bad-11e9-9f2c-cf2b7b74c76a.png)

### After
![Screen Shot 2019-04-10 at 16 23 52](https://user-images.githubusercontent.com/8961745/55882432-34834a00-5bad-11e9-8333-e2cecc088b74.png)

## Related Tickets & Documents
Fixes #2216 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
No UI changes

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed
