### PR TITLE
Manage tag and community mod lists in Mailchimp

### DIFF
--- a/Envfile
+++ b/Envfile
@@ -109,6 +109,7 @@ variable :HONEYCOMB_API_KEY, :String, default: "Optional"
 variable :MAILCHIMP_API_KEY, :String, default: "Optional-valid"
 variable :MAILCHIMP_NEWSLETTER_ID, :String, default: "Optional"
 variable :MAILCHIMP_SUSTAINING_MEMBERS_ID, :String, default: "Optional"
+variable :MAILCHIMP_TAG_MODERATORS_ID, :String, default: "Optional"
 
 # Email digest frequency
 variable :PERIODIC_EMAIL_DIGEST_MAX, :Integer, default: 0

--- a/Envfile
+++ b/Envfile
@@ -110,6 +110,7 @@ variable :MAILCHIMP_API_KEY, :String, default: "Optional-valid"
 variable :MAILCHIMP_NEWSLETTER_ID, :String, default: "Optional"
 variable :MAILCHIMP_SUSTAINING_MEMBERS_ID, :String, default: "Optional"
 variable :MAILCHIMP_TAG_MODERATORS_ID, :String, default: "Optional"
+variable :MAILCHIMP_COMMUNITY_MODERATORS_ID, :String, default: "Optional"
 
 # Email digest frequency
 variable :PERIODIC_EMAIL_DIGEST_MAX, :Integer, default: 0

--- a/app/labor/assign_tag_moderator.rb
+++ b/app/labor/assign_tag_moderator.rb
@@ -1,4 +1,10 @@
 module AssignTagModerator
+  def self.add_trusted_role(user)
+    user.add_role :trusted
+    user.update(email_community_mod_newsletter: true)
+    MailchimpBot.new(user).manage_community_moderator_list
+  end
+
   def self.add_tag_moderators(user_ids, tag_ids)
     user_ids.each_with_index do |user_id, index|
       user = User.find(user_id)
@@ -6,16 +12,10 @@ module AssignTagModerator
       tag = Tag.find(tag_ids[index])
       user.add_role(:tag_moderator, tag)
       MailchimpBot.new(user).manage_tag_moderator_list
-      add_trusted_role
+      add_trusted_role(user)
       ChatChannel.find_by(slug: "tag-moderators").add_users(user) if user.chat_channels.find_by(slug: "tag-moderators").blank?
       NotifyMailer.tag_moderator_confirmation_email(user, tag.name).deliver unless tag.name == "go"
     end
-  end
-
-  def add_trusted_role
-    user.add_role :trusted
-    user.update(email_community_mod_newsletter: true)
-    MailchimpBot.new(user).manage_community_moderator_list
   end
 
   def self.remove_tag_moderator(user, tag)

--- a/app/labor/assign_tag_moderator.rb
+++ b/app/labor/assign_tag_moderator.rb
@@ -2,10 +2,18 @@ module AssignTagModerator
   def self.add_tag_moderators(user_ids, tag_ids)
     user_ids.each_with_index do |user_id, index|
       user = User.find(user_id)
+      user.update(email_tag_mod_newsletter: true) if user.email_tag_mod_newsletter == false
+      MailchimpBot.new(user).manage_tag_moderator_list
       tag = Tag.find(tag_ids[index])
       user.add_role(:tag_moderator, tag)
       ChatChannel.find_by(slug: "tag-moderators").add_users(user) if user.chat_channels.find_by(slug: "tag-moderators").blank?
       NotifyMailer.tag_moderator_confirmation_email(user, tag.name).deliver unless tag.name == "go"
     end
+  end
+
+  def self.remove_tag_moderator(user, tag)
+    user.remove_role(:tag_moderator, tag)
+    user.update(email_tag_mod_newsletter: false) if user.email_tag_mod_newsletter == true
+    MailchimpBot.new(user).manage_tag_moderator_list
   end
 end

--- a/app/labor/assign_tag_moderator.rb
+++ b/app/labor/assign_tag_moderator.rb
@@ -6,9 +6,16 @@ module AssignTagModerator
       tag = Tag.find(tag_ids[index])
       user.add_role(:tag_moderator, tag)
       MailchimpBot.new(user).manage_tag_moderator_list
+      add_trusted_role
       ChatChannel.find_by(slug: "tag-moderators").add_users(user) if user.chat_channels.find_by(slug: "tag-moderators").blank?
       NotifyMailer.tag_moderator_confirmation_email(user, tag.name).deliver unless tag.name == "go"
     end
+  end
+
+  def add_trusted_role
+    user.add_role :trusted
+    user.update(email_community_mod_newsletter: true)
+    MailchimpBot.new(user).manage_community_moderator_list
   end
 
   def self.remove_tag_moderator(user, tag)

--- a/app/labor/assign_tag_moderator.rb
+++ b/app/labor/assign_tag_moderator.rb
@@ -5,15 +5,23 @@ module AssignTagModerator
     MailchimpBot.new(user).manage_community_moderator_list
   end
 
+  def self.add_to_chat_channel(user)
+    ChatChannel.find_by(slug: "tag-moderators").add_users(user) if user.chat_channels.find_by(slug: "tag-moderators").blank?
+  end
+
+  def self.add_tag_mod_role(user, tag)
+    user.update(email_tag_mod_newsletter: true) if user.email_tag_mod_newsletter == false
+    user.add_role(:tag_moderator, tag)
+    MailchimpBot.new(user).manage_tag_moderator_list
+  end
+
   def self.add_tag_moderators(user_ids, tag_ids)
     user_ids.each_with_index do |user_id, index|
       user = User.find(user_id)
-      user.update(email_tag_mod_newsletter: true) if user.email_tag_mod_newsletter == false
       tag = Tag.find(tag_ids[index])
-      user.add_role(:tag_moderator, tag)
-      MailchimpBot.new(user).manage_tag_moderator_list
+      add_tag_mod_role(user, tag)
       add_trusted_role(user)
-      ChatChannel.find_by(slug: "tag-moderators").add_users(user) if user.chat_channels.find_by(slug: "tag-moderators").blank?
+      add_to_chat_channel(user)
       NotifyMailer.tag_moderator_confirmation_email(user, tag.name).deliver unless tag.name == "go"
     end
   end

--- a/app/labor/assign_tag_moderator.rb
+++ b/app/labor/assign_tag_moderator.rb
@@ -3,9 +3,9 @@ module AssignTagModerator
     user_ids.each_with_index do |user_id, index|
       user = User.find(user_id)
       user.update(email_tag_mod_newsletter: true) if user.email_tag_mod_newsletter == false
-      MailchimpBot.new(user).manage_tag_moderator_list
       tag = Tag.find(tag_ids[index])
       user.add_role(:tag_moderator, tag)
+      MailchimpBot.new(user).manage_tag_moderator_list
       ChatChannel.find_by(slug: "tag-moderators").add_users(user) if user.chat_channels.find_by(slug: "tag-moderators").blank?
       NotifyMailer.tag_moderator_confirmation_email(user, tag.name).deliver unless tag.name == "go"
     end

--- a/app/labor/mailchimp_bot.rb
+++ b/app/labor/mailchimp_bot.rb
@@ -12,6 +12,8 @@ class MailchimpBot
 
     upsert_to_membership_newsletter
     upsert_to_newsletter
+    manage_community_moderator_list
+    manage_tag_moderator_list
   end
 
   def upsert_to_newsletter
@@ -145,9 +147,15 @@ class MailchimpBot
           },
         )
       end
-
-      if a_tag_moderator?
+      if user.tag_moderator?
         gibbon.lists(ApplicationConfig["MAILCHIMP_TAG_MODERATORS_ID"]).members(target_md5_email).update(
+          body: {
+            status: "unsubscribed"
+          },
+        )
+      end
+      if user.has_role?(:trusted)
+        gibbon.lists(ApplicationConfig["MAILCHIMP_COMMUNITY_MODERATORS_ID"]).members(target_md5_email).update(
           body: {
             status: "unsubscribed"
           },
@@ -167,10 +175,6 @@ class MailchimpBot
     # Is that mailchimp should be updated if a user decides to
     # unsubscribes
     user.monthly_dues.positive? || saved_changes["monthly_dues"]
-  end
-
-  def a_tag_moderator?
-    !user.roles.where(name: "tag_moderator").empty?
   end
 
   def md5_email(email)

--- a/app/labor/mailchimp_bot.rb
+++ b/app/labor/mailchimp_bot.rb
@@ -11,9 +11,9 @@ class MailchimpBot
     return true unless Rails.env.production? || Rails.env.test?
 
     upsert_to_membership_newsletter
-    upsert_to_newsletter
     manage_community_moderator_list
     manage_tag_moderator_list
+    upsert_to_newsletter
   end
 
   def upsert_to_newsletter

--- a/app/labor/mailchimp_bot.rb
+++ b/app/labor/mailchimp_bot.rb
@@ -48,6 +48,8 @@ class MailchimpBot
   end
 
   def manage_community_moderator_list
+    return false unless user.has_role?(:trusted)
+
     success = false
     status = user.email_community_mod_newsletter ? "subscribed" : "unsubscribed"
     begin
@@ -72,6 +74,8 @@ class MailchimpBot
   end
 
   def manage_tag_moderator_list
+    return false unless user.tag_moderator?
+
     success = false
     tags = user.roles.where(name: "tag_moderator").map { |t| Tag.find(t.resource_id).name }
     status = user.email_tag_mod_newsletter ? "subscribed" : "unsubscribed"

--- a/app/labor/mailchimp_bot.rb
+++ b/app/labor/mailchimp_bot.rb
@@ -45,6 +45,30 @@ class MailchimpBot
     success
   end
 
+  def manage_community_moderator_list
+    success = false
+    status = user.email_community_mod_newsletter ? "subscribed" : "unsubscribed"
+    begin
+      gibbon.lists(ApplicationConfig["MAILCHIMP_COMMUNITY_MODERATORS_ID"]).members(target_md5_email).upsert(
+        body: {
+          email_address: user.email,
+          status: status,
+          merge_fields: {
+            NAME: user.name.to_s,
+            USERNAME: user.username.to_s,
+            TWITTER: user.twitter_username.to_s,
+            GITHUB: user.github_username.to_s,
+            IMAGE_URL: user.profile_image_url.to_s
+          }
+        },
+      )
+      success = true
+    rescue Gibbon::MailChimpError => e
+      report_error(e)
+    end
+    success
+  end
+
   def manage_tag_moderator_list
     success = false
     tags = user.roles.where(name: "tag_moderator").map { |t| Tag.find(t.resource_id).name }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -406,6 +406,10 @@ class User < ApplicationRecord
     MailchimpBot.new(self).unsubscribe_all_newsletters
   end
 
+  def tag_moderator?
+    roles.where(name: "tag_moderator").any?
+  end
+
   private
 
   def send_welcome_notification

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -69,6 +69,8 @@ class UserPolicy < ApplicationPolicy
        email_digest_periodic
        email_follower_notifications
        email_membership_newsletter
+       email_tag_mod_newsletter
+       email_community_mod_newsletter
        email_mention_notifications
        email_connect_messages
        email_newsletter

--- a/app/services/moderator/manage_activity_and_roles.rb
+++ b/app/services/moderator/manage_activity_and_roles.rb
@@ -96,9 +96,13 @@ module Moderator
       when "Regular Member"
         regular_member
       when "Trusted"
-        trusted
+        remove_negative_roles
+        user.remove_role :pro
+        add_trusted_role
       when "Pro"
-        pro
+        remove_negative_roles
+        add_trusted_role
+        user.add_role :pro
       end
       create_note(role, note)
     end
@@ -119,18 +123,6 @@ module Moderator
       user.add_role :warned
       user.remove_role :banned
       remove_privileges
-    end
-
-    def pro
-      remove_negative_roles
-      add_trusted_role
-      user.add_role :pro
-    end
-
-    def trusted
-      remove_negative_roles
-      user.remove_role :pro
-      add_trusted_role
     end
 
     def add_trusted_role

--- a/app/services/moderator/manage_activity_and_roles.rb
+++ b/app/services/moderator/manage_activity_and_roles.rb
@@ -53,11 +53,22 @@ module Moderator
     end
 
     def remove_privileges
-      @user.remove_role :trusted
       @user.remove_role :video_permission
-      @user.remove_role :tag_moderator
       @user.remove_role :workshop_pass
       @user.remove_role :pro
+      remove_trusted_role
+      remove_tag_moderator_role
+    end
+
+    def remove_trusted_role
+      @user.remove_role :trusted
+      @user.update(email_community_mod_newsletter: false)
+      MailchimpBot.new(user).manage_community_moderator_list
+    end
+
+    def remove_tag_moderator_role
+      @user.remove_role :tag_moderator
+      MailchimpBot.new(user).manage_tag_moderator_list
     end
 
     def create_note(reason, content)
@@ -89,13 +100,19 @@ module Moderator
       when "Trusted"
         remove_negative_roles
         user.remove_role :pro
-        user.add_role :trusted
+        add_trusted_role
       when "Pro"
         remove_negative_roles
-        user.add_role :trusted
+        add_trusted_role
         user.add_role :pro
       end
       create_note(role, note)
+    end
+
+    def add_trusted_role
+      user.add_role :trusted
+      user.update(email_community_mod_newsletter: true)
+      MailchimpBot.new(user).manage_community_moderator_list
     end
 
     def remove_negative_roles

--- a/app/services/moderator/manage_activity_and_roles.rb
+++ b/app/services/moderator/manage_activity_and_roles.rb
@@ -56,11 +56,11 @@ module Moderator
       @user.remove_role :video_permission
       @user.remove_role :workshop_pass
       @user.remove_role :pro
-      remove_trusted_role
+      remove_mod_roles
       remove_tag_moderator_role
     end
 
-    def remove_trusted_role
+    def remove_mod_roles
       @user.remove_role :trusted
       @user.remove_role :tag_moderator
       @user.update(email_tag_mod_newsletter: false)
@@ -90,27 +90,47 @@ module Moderator
         user.add_role :banned
         remove_privileges
       when "Warn"
-        user.add_role :warned
-        user.remove_role :banned
-        remove_privileges
+        warned
       when "Comment Ban"
-        user.add_role :comment_banned
-        user.remove_role :banned
-        remove_privileges
+        comment_banned
       when "Regular Member"
-        remove_negative_roles
-        user.remove_role :pro
-        remove_trusted_role
+        regular_member
       when "Trusted"
-        remove_negative_roles
-        user.remove_role :pro
-        add_trusted_role
+        trusted
       when "Pro"
-        remove_negative_roles
-        add_trusted_role
-        user.add_role :pro
+        pro
       end
       create_note(role, note)
+    end
+
+    def comment_banned
+      user.add_role :comment_banned
+      user.remove_role :banned
+      remove_privileges
+    end
+
+    def regular_member
+      remove_negative_roles
+      user.remove_role :pro
+      remove_mod_roles
+    end
+
+    def warned
+      user.add_role :warned
+      user.remove_role :banned
+      remove_privileges
+    end
+
+    def pro
+      remove_negative_roles
+      add_trusted_role
+      user.add_role :pro
+    end
+
+    def trusted
+      remove_negative_roles
+      user.remove_role :pro
+      add_trusted_role
     end
 
     def add_trusted_role

--- a/app/services/moderator/manage_activity_and_roles.rb
+++ b/app/services/moderator/manage_activity_and_roles.rb
@@ -62,6 +62,9 @@ module Moderator
 
     def remove_trusted_role
       @user.remove_role :trusted
+      @user.remove_role :tag_moderator
+      @user.update(email_tag_mod_newsletter: false)
+      MailchimpBot.new(user).manage_tag_moderator_list
       @user.update(email_community_mod_newsletter: false)
       MailchimpBot.new(user).manage_community_moderator_list
     end

--- a/app/services/moderator/manage_activity_and_roles.rb
+++ b/app/services/moderator/manage_activity_and_roles.rb
@@ -97,6 +97,7 @@ module Moderator
       when "Regular Member"
         remove_negative_roles
         user.remove_role :pro
+        remove_trusted_role
       when "Trusted"
         remove_negative_roles
         user.remove_role :pro

--- a/app/views/users/_notifications.html.erb
+++ b/app/views/users/_notifications.html.erb
@@ -15,13 +15,13 @@
         <%= f.label :email_membership_newsletter, "Send me sustaining membership newsletter emails" %>
       </div>
     <% end %>
-    <% if current_user.has_role?(:trusted) %>
+    <% if current_user.tag_moderator? %>
       <div class="sub-field">
-        <%= f.check_box :email_community_mod_newsletter %>
-        <%= f.label :email_community_mod_newsletter, "Send me community moderator newsletter emails" %>
+        <%= f.check_box :email_tag_mod_newsletter %>
+        <%= f.label :email_tag_mod_newsletter, "Send me tag moderator newsletter emails" %>
       </div>
     <% end %>
-    <% if current_user.has_role?(:tag_moderator) %>
+    <% if current_user.has_role?(:trusted) %>
       <div class="sub-field">
         <%= f.check_box :email_community_mod_newsletter %>
         <%= f.label :email_community_mod_newsletter, "Send me community moderator newsletter emails" %>

--- a/app/views/users/_notifications.html.erb
+++ b/app/views/users/_notifications.html.erb
@@ -15,6 +15,18 @@
         <%= f.label :email_membership_newsletter, "Send me sustaining membership newsletter emails" %>
       </div>
     <% end %>
+    <% if current_user.has_role?(:trusted) %>
+      <div class="sub-field">
+        <%= f.check_box :email_community_mod_newsletter %>
+        <%= f.label :email_community_mod_newsletter, "Send me community moderator newsletter emails" %>
+      </div>
+    <% end %>
+    <% if current_user.has_role?(:tag_moderator) %>
+      <div class="sub-field">
+        <%= f.check_box :email_community_mod_newsletter %>
+        <%= f.label :email_community_mod_newsletter, "Send me community moderator newsletter emails" %>
+      </div>
+    <% end %>
     <div class="sub-field">
       <%= f.check_box :email_comment_notifications %>
       <%= f.label :email_comment_notifications, "Send me an email when someone replies to me in a comment thread" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -139,7 +139,6 @@ Rails.application.routes.draw do
   resources :rating_votes, only: [:create]
   resources :page_views, only: %i[create update]
   resources :buffer_updates, only: [:create]
-
   get "/notifications/:filter" => "notifications#index"
   get "/notifications/:filter/:org_id" => "notifications#index"
   patch "/onboarding_update" => "users#onboarding_update"

--- a/db/migrate/20190405190915_add_mailchimp_lists_to_users.rb
+++ b/db/migrate/20190405190915_add_mailchimp_lists_to_users.rb
@@ -1,0 +1,6 @@
+class AddMailchimpListsToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :email_tag_mod_newsletter, :boolean, default: false
+    add_column :users, :email_community_mod_newsletter, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_04_102732) do
+ActiveRecord::Schema.define(version: 2019_04_05_190915) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -779,6 +779,7 @@ ActiveRecord::Schema.define(version: 2019_04_04_102732) do
     t.string "email"
     t.boolean "email_badge_notifications", default: true
     t.boolean "email_comment_notifications", default: true
+    t.boolean "email_community_mod_newsletter", default: false
     t.boolean "email_connect_messages", default: true
     t.boolean "email_digest_periodic", default: true, null: false
     t.boolean "email_follower_notifications", default: true
@@ -786,6 +787,7 @@ ActiveRecord::Schema.define(version: 2019_04_04_102732) do
     t.boolean "email_mention_notifications", default: true
     t.boolean "email_newsletter", default: true
     t.boolean "email_public", default: false
+    t.boolean "email_tag_mod_newsletter", default: false
     t.boolean "email_unread_notifications", default: true
     t.string "employer_name"
     t.string "employer_url"

--- a/spec/labor/mailchimp_bot_spec.rb
+++ b/spec/labor/mailchimp_bot_spec.rb
@@ -82,6 +82,19 @@ RSpec.describe MailchimpBot do
     end
   end
 
+  describe "manage community moderator list" do
+    it "sends proper information" do
+      user.update(email_community_mod_newsletter: true)
+      described_class.new(user).manage_community_moderator_list
+      expect(my_gibbon_client).to have_received(:upsert).
+        with(hash_including(
+               body: hash_including(
+                 status: "subscribed",
+               ),
+             ))
+    end
+  end
+
   describe "#upsert_to_membership_newsletter" do
     it "returns false if user isn't a sustaining member" do
       expect(described_class.new(user).upsert_to_membership_newsletter).to be(false)

--- a/spec/labor/mailchimp_bot_spec.rb
+++ b/spec/labor/mailchimp_bot_spec.rb
@@ -8,16 +8,27 @@ class FakeGibbonRequest < Gibbon::Request
   def members(*args)
     super
   end
+
+  def tag_mods(*args)
+    super
+  end
+
+  def community_mods(*args)
+    super
+  end
 end
 
 RSpec.describe MailchimpBot do
   let(:user) { create(:user, :ignore_after_callback) }
   let(:article) { create(:article, user_id: user.id) }
   let(:my_gibbon_client) { instance_double(FakeGibbonRequest) }
+  let(:tag) { create(:tag, name: "tag name", bg_color_hex: Faker::Color.hex_color, text_color_hex: Faker::Color.hex_color, supported: true) }
 
   before do
     allow(Gibbon::Request).to receive(:new) { my_gibbon_client }
     allow(my_gibbon_client).to receive(:lists) { my_gibbon_client }
+    allow(my_gibbon_client).to receive(:tag_mods) { my_gibbon_client }
+    allow(my_gibbon_client).to receive(:community_mods) { my_gibbon_client }
     allow(my_gibbon_client).to receive(:members) { my_gibbon_client }
     allow(my_gibbon_client).to receive(:upsert).and_return(true)
   end
@@ -83,9 +94,32 @@ RSpec.describe MailchimpBot do
   end
 
   describe "manage community moderator list" do
+    it "returns false if user isn't a community moderator" do
+      expect(described_class.new(user).manage_community_moderator_list).to be(false)
+    end
+
     it "sends proper information" do
       user.update(email_community_mod_newsletter: true)
+      user.add_role :trusted
       described_class.new(user).manage_community_moderator_list
+      expect(my_gibbon_client).to have_received(:upsert).
+        with(hash_including(
+               body: hash_including(
+                 status: "subscribed",
+               ),
+             ))
+    end
+  end
+
+  describe "manage tag moderator list" do
+    it "returns false if user isn't a tag moderator" do
+      expect(described_class.new(user).manage_community_moderator_list).to be(false)
+    end
+
+    it "sends proper information" do
+      user.update(email_tag_mod_newsletter: true)
+      user.add_role(:tag_moderator, tag)
+      described_class.new(user).manage_tag_moderator_list
       expect(my_gibbon_client).to have_received(:upsert).
         with(hash_including(
                body: hash_including(


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
- Tag mods automatically get community mod priviledgs
- Tag mods and community mods get added/removed from mailchimp lists as the role is toggled.
- User can unsubscribe from either list in settings/notifications