### PR TITLE
Add index to ahoy_messages to

### DIFF
--- a/db/migrate/20190410124957_add_index_to_ahoy_messages_to.rb
+++ b/db/migrate/20190410124957_add_index_to_ahoy_messages_to.rb
@@ -1,0 +1,5 @@
+class AddIndexToAhoyMessagesTo < ActiveRecord::Migration[5.2]
+  def change
+    add_index :ahoy_messages, :to
+  end
+end

--- a/db/migrate/20190410124957_add_index_to_ahoy_messages_to.rb
+++ b/db/migrate/20190410124957_add_index_to_ahoy_messages_to.rb
@@ -1,5 +1,7 @@
 class AddIndexToAhoyMessagesTo < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
   def change
-    add_index :ahoy_messages, :to
+    add_index :ahoy_messages, :to, algorithm: :concurrently
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -33,6 +33,7 @@ ActiveRecord::Schema.define(version: 2019_06_07_110030) do
     t.string "utm_medium"
     t.string "utm_source"
     t.string "utm_term"
+    t.index ["to"], name: "index_ahoy_messages_on_to"
     t.index ["token"], name: "index_ahoy_messages_on_token"
     t.index ["user_id", "user_type"], name: "index_ahoy_messages_on_user_id_and_user_type"
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
Sometimes delayed jobs fail with the timeout error on this request:
```sql
SELECT COUNT(*) FROM "ahoy_messages" WHERE "ahoy_messages"."to" = $1 AND (sent_at > '2019-04-10 08:44:40.736979')
```
I added index to optimize it. It would also be useful to remove old rows from the table from time to time if that's acceptable.
Adding an index can take a long time if the table is large, which I suppose to be true (same as with `notifications`)

## Related Tickets & Documents
#1621 