### PR TITLE
Fix estimating default language when the user email is nil

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -212,7 +212,7 @@ class User < ApplicationRecord
 
   def estimate_default_language!
     identity = identities.find_by(provider: "twitter")
-    if email.end_with?(".jp")
+    if email.to_s.end_with?(".jp")
       update(estimated_default_language: "ja", prefer_language_ja: true)
     elsif identity
       lang = identity.auth_data_dump["extra"]["raw_info"]["lang"]

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -379,7 +379,7 @@ RSpec.describe User, type: :model do
       expect(new_user.identities.size).to eq(2)
     end
 
-    it "estimages default language when the email is nil" do
+    it "estimates default language when the email is nil" do
       no_email_user = create(:user, email: nil)
       no_email_user.estimate_default_language_without_delay!
       no_email_user.reload

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -379,6 +379,13 @@ RSpec.describe User, type: :model do
       expect(new_user.identities.size).to eq(2)
     end
 
+    it "estimages default language when the email is nil" do
+      no_email_user = create(:user, email: nil)
+      no_email_user.estimate_default_language_without_delay!
+      no_email_user.reload
+      expect(no_email_user.estimated_default_language).to eq(nil)
+    end
+
     it "estimates default language to be nil" do
       user.estimate_default_language_without_delay!
       expect(user.estimated_default_language).to eq(nil)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Fix estimating default language when the user email is `nil`

## Related Tickets & Documents
#1621 
