### PR TITLE
settings.scss: Fix color contrast in text colors

### DIFF
--- a/app/assets/stylesheets/settings.scss
+++ b/app/assets/stylesheets/settings.scss
@@ -3,7 +3,7 @@
   font-family: $helvetica;
   #notice{
     background:$green;
-    color:white;
+    color:black;
     padding:40px 0px 40px;
     text-align:center;
     position:relative;
@@ -12,6 +12,7 @@
     right:0px;
     &.error-notice{
       background: rgba(255, 80, 80, 0.7);
+      color:white;
     }
   }
   .user-settings-page {


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
This PR fixes the text colour of the alert messages which was failing the accessible colour contrast requirement of 4.5:1 ratio.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Before:
![Screenshot 2019-04-11 16 28 47](https://user-images.githubusercontent.com/379918/55952332-fbafa780-5c76-11e9-8814-c50bd2494c4f.png)

After:
![Screenshot 2019-04-11 16 29 03](https://user-images.githubusercontent.com/379918/55952322-f5b9c680-5c76-11e9-9dc0-8178d92c91ad.png)


## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [ ] no documentation needed

CC @benhalpern 