### PR TITLE
Move estimating user default language to ActiveJob

### DIFF
--- a/app/jobs/users/estimate_default_language_job.rb
+++ b/app/jobs/users/estimate_default_language_job.rb
@@ -1,0 +1,10 @@
+module Users
+  class EstimateDefaultLanguageJob < ApplicationJob
+    queue_as :users_estimate_language
+
+    def perform(user_id, service = Users::EstimateDefaultLanguage)
+      user = User.find_by(id: user_id)
+      service.call(user) if user
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -211,14 +211,7 @@ class User < ApplicationRecord
   end
 
   def estimate_default_language!
-    identity = identities.find_by(provider: "twitter")
-    if email.end_with?(".jp")
-      update(estimated_default_language: "ja", prefer_language_ja: true)
-    elsif identity
-      lang = identity.auth_data_dump["extra"]["raw_info"]["lang"]
-      update(:estimated_default_language => lang,
-             "prefer_language_#{lang}" => true)
-    end
+    Users::EstimateDefaultLanguage.call(self)
   end
   handle_asynchronously :estimate_default_language!
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -211,9 +211,12 @@ class User < ApplicationRecord
   end
 
   def estimate_default_language!
-    Users::EstimateDefaultLanguage.call(self)
+    Users::EstimateDefaultLanguageJob.perform_later(id)
   end
-  handle_asynchronously :estimate_default_language!
+
+  def estimate_default_language_without_delay!
+    Users::EstimateDefaultLanguageJob.perform_now(id)
+  end
 
   def calculate_score
     score = (articles.where(featured: true).size * 100) + comments.sum(:score)

--- a/app/services/users/estimate_default_language.rb
+++ b/app/services/users/estimate_default_language.rb
@@ -1,0 +1,26 @@
+module Users
+  class EstimateDefaultLanguage
+    def initialize(user)
+      @user = user
+    end
+
+    def self.call(*args)
+      new(*args).call
+    end
+
+    def call
+      identity = user.identities.find_by(provider: "twitter")
+      if user.email.end_with?(".jp")
+        user.update(estimated_default_language: "ja", prefer_language_ja: true)
+      elsif identity
+        lang = identity.auth_data_dump["extra"]["raw_info"]["lang"]
+        user.update(:estimated_default_language => lang,
+                    "prefer_language_#{lang}" => true)
+      end
+    end
+
+    private
+
+    attr_reader :user
+  end
+end

--- a/app/services/users/estimate_default_language.rb
+++ b/app/services/users/estimate_default_language.rb
@@ -10,7 +10,7 @@ module Users
 
     def call
       identity = user.identities.find_by(provider: "twitter")
-      if user.email.end_with?(".jp")
+      if user.email.to_s.end_with?(".jp")
         user.update(estimated_default_language: "ja", prefer_language_ja: true)
       elsif identity
         lang = identity.auth_data_dump["extra"]["raw_info"]["lang"]

--- a/spec/jobs/users/estimate_default_language_job_spec.rb
+++ b/spec/jobs/users/estimate_default_language_job_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe Users::EstimateDefaultLanguageJob, type: :job do
+  include_examples "#enqueues_job", "users_estimate_language", 2
+
+  describe "#perform_now" do
+    let(:user) { create(:user) }
+    let(:service) { double }
+
+    before { allow(service).to receive(:call) }
+
+    it "calls a service" do
+      described_class.perform_now(user.id, service)
+      expect(service).to have_received(:call).with(user).once
+    end
+
+    it "doesn't to anything for a non-existent user" do
+      described_class.perform_now(User.maximum(:id).to_i + 1, service)
+      expect(service).not_to have_received(:call)
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -379,28 +379,32 @@ RSpec.describe User, type: :model do
       expect(new_user.identities.size).to eq(2)
     end
 
-    it "estimates default language to be nil" do
-      user.estimate_default_language_without_delay!
-      expect(user.estimated_default_language).to eq(nil)
-    end
+    context "with active jobs" do
+      before { ActiveJob::Base.queue_adapter = :inline }
 
-    it "estimates default language to be japan with jp email" do
-      user.update_column(:email, "ben@hello.jp")
-      user.estimate_default_language_without_delay!
-      user.reload
-      expect(user.estimated_default_language).to eq("ja")
-    end
+      it "estimates default language to be nil" do
+        user.estimate_default_language!
+        expect(user.estimated_default_language).to eq(nil)
+      end
 
-    it "estimates default language based on ID dump" do
-      new_user = user_from_authorization_service(:twitter, nil, "navbar_basic")
-      new_user.estimate_default_language_without_delay!
-    end
+      it "estimates default language to be japan with jp email" do
+        user.update_column(:email, "ben@hello.jp")
+        user.estimate_default_language!
+        user.reload
+        expect(user.estimated_default_language).to eq("ja")
+      end
 
-    it "returns proper preferred_languages_array" do
-      user.update_column(:email, "ben@hello.jp")
-      user.estimate_default_language_without_delay!
-      user.reload
-      expect(user.decorate.preferred_languages_array).to include("ja")
+      it "estimates default language based on ID dump" do
+        new_user = user_from_authorization_service(:twitter, nil, "navbar_basic")
+        new_user.estimate_default_language!
+      end
+
+      it "returns proper preferred_languages_array" do
+        user.update_column(:email, "ben@hello.jp")
+        user.estimate_default_language!
+        user.reload
+        expect(user.decorate.preferred_languages_array).to include("ja")
+      end
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -383,19 +383,23 @@ RSpec.describe User, type: :model do
       user.estimate_default_language_without_delay!
       expect(user.estimated_default_language).to eq(nil)
     end
+
     it "estimates default language to be japan with jp email" do
-      user.email = "ben@hello.jp"
+      user.update_column(:email, "ben@hello.jp")
       user.estimate_default_language_without_delay!
+      user.reload
       expect(user.estimated_default_language).to eq("ja")
     end
+
     it "estimates default language based on ID dump" do
       new_user = user_from_authorization_service(:twitter, nil, "navbar_basic")
       new_user.estimate_default_language_without_delay!
     end
 
     it "returns proper preferred_languages_array" do
-      user.email = "ben@hello.jp"
+      user.update_column(:email, "ben@hello.jp")
       user.estimate_default_language_without_delay!
+      user.reload
       expect(user.decorate.preferred_languages_array).to include("ja")
     end
   end

--- a/spec/services/users/estimate_default_language_spec.rb
+++ b/spec/services/users/estimate_default_language_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Users::EstimateDefaultLanguage, type: :service do
-  xit "estimates default language when the email is nil" do
+  it "estimates default language when the email is nil" do
     no_email_user = create(:user, email: nil)
     described_class.call(no_email_user)
     no_email_user.reload

--- a/spec/services/users/estimate_default_language_spec.rb
+++ b/spec/services/users/estimate_default_language_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe Users::EstimateDefaultLanguage, type: :service do
+  xit "estimates default language when the email is nil" do
+    no_email_user = create(:user, email: nil)
+    described_class.call(no_email_user)
+    no_email_user.reload
+    expect(no_email_user.estimated_default_language).to eq(nil)
+  end
+
+  it "estimates default language to be nil" do
+    user = create(:user)
+    described_class.call(user)
+    expect(user.estimated_default_language).to eq(nil)
+  end
+
+  it "estimates default language to be japan with jp email" do
+    user = create(:user, email: "anna@example.jp")
+    described_class.call(user)
+    expect(user.estimated_default_language).to eq("ja")
+  end
+
+  it "estimates default language based on identity data dump" do
+    user = create(:user)
+    create(:identity, provider: :twitter, user: user, auth_data_dump: { "extra" => { "raw_info" => { "lang" => "it" } } })
+    described_class.call(user)
+    user.reload
+    expect(user.estimated_default_language).to eq("it")
+  end
+
+  it "sets preferred_languages_array" do
+    user = create(:user, email: "annaboo@example.jp")
+    described_class.call(user)
+    user.reload
+    expect(user.decorate.preferred_languages_array).to include("ja")
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
- moved logic to a separate class
- create a separate job
- kept the old `estimate_default_language_without_delay!` method in case there will be existing jobs using it

## Related Tickets & Documents
Prepare to fix #2368 