### PR TITLE
Use published scope for articles

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -19,6 +19,8 @@ linters:
     rubocop_config:
       inherit_from:
         - .rubocop.yml
+      Layout/InitialIndentation:
+        Enabled: false
       Layout/TrailingBlankLines:
         Enabled: false
       Lint/UselessAssignment:

--- a/app/controllers/api/v0/articles_controller.rb
+++ b/app/controllers/api/v0/articles_controller.rb
@@ -26,7 +26,7 @@ module Api
       end
 
       def show
-        relation = Article.includes(:user).where(published: true)
+        relation = Article.published.includes(:user)
         @article = if params[:id] == "by_path"
                      relation.find_by!(path: params[:url]).decorate
                    else

--- a/app/controllers/api/v0/videos_controller.rb
+++ b/app/controllers/api/v0/videos_controller.rb
@@ -11,9 +11,9 @@ module Api
 
       def index
         @page = params[:page]
-        @video_articles = Article.where.not(video: [nil, ""], video_thumbnail_url: [nil, ""]).
+        @video_articles = Article.published.
+          where.not(video: [nil, ""], video_thumbnail_url: [nil, ""]).
           where("score > ?", -4).
-          where(published: true).
           order("hotness_score DESC").
           page(params[:page].to_i).per(24)
       end

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -9,7 +9,7 @@ class ArticlesController < ApplicationController
   def feed
     skip_authorization
 
-    @articles = Article.where(published: true).
+    @articles = Article.published.
       select(:published_at, :processed_html, :user_id, :organization_id, :title, :path).
       order(published_at: :desc).
       page(params[:page].to_i).per(12)

--- a/app/controllers/internal/articles_controller.rb
+++ b/app/controllers/internal/articles_controller.rb
@@ -3,70 +3,57 @@ class Internal::ArticlesController < Internal::ApplicationController
 
   def index
     @pending_buffer_updates = BufferUpdate.where(status: "pending").includes(:article)
-    case params[:state]
 
+    case params[:state]
     when /not\-buffered/
       days_ago = params[:state].split("-")[2].to_f
-      @articles = Article.
-        where(last_buffered: nil, published: true).
-        includes(:user).
-        includes(:buffer_updates).
+      @articles = Article.published.where(last_buffered: nil).
+        where("published_at > ? OR crossposted_at > ?", days_ago.days.ago, days_ago.days.ago).
+        includes(:user, :buffer_updates).
+        limited_columns_internal_select.
         order("positive_reactions_count DESC").
         page(params[:page]).
-        where("published_at > ? OR crossposted_at > ?", days_ago.days.ago, days_ago.days.ago).
-        limited_columns_internal_select.
         per(50)
     when /top\-/
-      @articles = Article.
-        where(published: true).
+      @articles = Article.published.
         where("published_at > ?", params[:state].split("-")[1].to_i.months.ago).
-        includes(:user).
-        includes(:buffer_updates).
+        includes(:user, :buffer_updates).
+        limited_columns_internal_select.
         order("positive_reactions_count DESC").
         page(params[:page]).
-        limited_columns_internal_select.
         per(50)
     when "satellite"
-      @articles = Article.
-        where(last_buffered: nil, published: true).
-        includes(:user).
-        includes(:buffer_updates).
-        order("hotness_score DESC").
+      @articles = Article.published.where(last_buffered: nil).
+        includes(:user, :buffer_updates).
         tagged_with(Tag.bufferized_tags, any: true).
-        page(params[:page]).
         limited_columns_internal_select.
+        order("hotness_score DESC").
+        page(params[:page]).
         per(60)
     when "boosted-additional-articles"
-      @articles = Article.
-        includes(:user).
-        order("published_at DESC").
-        includes(:buffer_updates).
-        boosted_via_additional_articles.
-        page(params[:page]).
-        per(100).
-        limited_columns_internal_select
-    when "chronological"
-      @articles = Article.
-        where(published: true).
-        order("published_at DESC").
-        page(params[:page]).
+      @articles = Article.boosted_via_additional_articles.
+        includes(:user, :buffer_updates).
         limited_columns_internal_select.
+        order("published_at DESC").
+        page(params[:page]).
+        per(100)
+    when "chronological"
+      @articles = Article.published.
+        limited_columns_internal_select.
+        order("published_at DESC").
+        page(params[:page]).
         per(50)
     else # MIX
-      @articles = Article.
-        where(published: true).
+      @articles = Article.published.
+        limited_columns_internal_select.
         order("hotness_score DESC").
         page(params[:page]).
-        limited_columns_internal_select.
         per(30)
 
-      @featured_articles = Article.
-        where(published: true).
-        or(Article.where(published_from_feed: true)).
+      @featured_articles = Article.published.or(Article.where(published_from_feed: true)).
         where(featured: true).
         where("featured_number > ?", Time.current.to_i).
-        includes(:user).
-        includes(:buffer_updates).
+        includes(:user, :buffer_updates).
         limited_columns_internal_select.
         order("featured_number DESC")
     end

--- a/app/controllers/moderations_controller.rb
+++ b/app/controllers/moderations_controller.rb
@@ -5,15 +5,14 @@ class ModerationsController < ApplicationController
     skip_authorization
     return unless current_user&.trusted
 
-    @articles = Article.where(published: true).
+    @articles = Article.published.
       includes(:rating_votes).
       where("rating_votes_count < 3").
       where("score > -5").
       order("hotness_score DESC").limit(100)
-    if params[:tag].present?
-      @articles = @articles.
-        cached_tagged_with(params[:tag])
-    end
+
+    @articles = @articles.cached_tagged_with(params[:tag]) if params[:tag].present?
+
     @articles = @articles.decorate
   end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -61,12 +61,12 @@ class PagesController < ApplicationController
   end
 
   def shecoded
-    @top_articles = Article.tagged_with(%w[shecoded shecodedally theycoded], any: true).
-      where(published: true, approved: true).where("published_at > ? AND score > ?", 3.weeks.ago, 28).
+    @top_articles = Article.published.tagged_with(%w[shecoded shecodedally theycoded], any: true).
+      where(approved: true).where("published_at > ? AND score > ?", 3.weeks.ago, 28).
       order(Arel.sql("RANDOM()")).
       includes(:user).decorate
-    @articles = Article.tagged_with(%w[shecoded shecodedally theycoded], any: true).
-      where(published: true, approved: true).where("published_at > ? AND score > ?", 3.weeks.ago, -8).
+    @articles = Article.published.tagged_with(%w[shecoded shecodedally theycoded], any: true).
+      where(approved: true).where("published_at > ? AND score > ?", 3.weeks.ago, -8).
       order(Arel.sql("RANDOM()")).
       where.not(id: @top_articles.pluck(:id)).
       includes(:user).decorate
@@ -77,8 +77,7 @@ class PagesController < ApplicationController
   private # helpers
 
   def latest_published_welcome_thread
-    Article.where(user_id: ApplicationConfig["DEVTO_USER_ID"], published: true).
-      tagged_with("welcome").last
+    Article.published.where(user_id: ApplicationConfig["DEVTO_USER_ID"]).tagged_with("welcome").last
   end
 
   def members_for_display

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -145,8 +145,7 @@ class StoriesController < ApplicationController
 
   def handle_organization_index
     @user = @organization
-    @stories = ArticleDecorator.decorate_collection(@organization.articles.
-      where(published: true).
+    @stories = ArticleDecorator.decorate_collection(@organization.articles.published.
       limited_column_select.
       includes(:user).
       order("published_at DESC").page(@page).per(8))
@@ -163,8 +162,7 @@ class StoriesController < ApplicationController
       return
     end
     assign_user_comments
-    @stories = ArticleDecorator.decorate_collection(@user.
-      articles.where(published: true).
+    @stories = ArticleDecorator.decorate_collection(@user.articles.published.
       limited_column_select.
       order("published_at DESC").page(@page).per(user_signed_in? ? 2 : 5))
     @article_index = true
@@ -261,11 +259,7 @@ class StoriesController < ApplicationController
 
   def article_finder(num_articles)
     tag = params[:tag]
-    articles = Article.where(published: true).
-      includes(:user).
-      limited_column_select.
-      page(@page).
-      per(num_articles)
+    articles = Article.published.includes(:user).limited_column_select.page(@page).per(num_articles)
     articles = articles.cached_tagged_with(tag) if tag.present? # More efficient than tagged_with
     articles
   end

--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -7,9 +7,9 @@ class VideosController < ApplicationController
   end
 
   def index
-    @video_articles = Article.where.not(video: [nil, ""], video_thumbnail_url: [nil, ""]).
+    @video_articles = Article.published.
+      where.not(video: [nil, ""], video_thumbnail_url: [nil, ""]).
       where("score > ?", -4).
-      where(published: true).
       order("hotness_score DESC").
       page(params[:page].to_i).per(24)
     set_surrogate_key_header "videos_landing_page"

--- a/app/facades/dashboard/pro.rb
+++ b/app/facades/dashboard/pro.rb
@@ -8,7 +8,8 @@ module Dashboard
 
     def user_or_org_article_ids
       @user_or_org_article_ids ||=
-        Article.where("#{user_or_org.class.name.downcase}_id" => user_or_org.id, published: true).pluck(:id)
+        Article.published.where("#{user_or_org.class.name.downcase}_id" => user_or_org.id).
+          pluck(:id)
     end
 
     def this_week_reactions

--- a/app/labor/article_analytics_fetcher.rb
+++ b/app/labor/article_analytics_fetcher.rb
@@ -4,7 +4,7 @@ class ArticleAnalyticsFetcher
   end
 
   def update_analytics(user_id)
-    articles_to_check = Article.published.where(user_id: user_id)
+    articles_to_check = Article.where(published: true, user_id: user_id)
     qualified_articles = get_articles_that_qualify(articles_to_check)
     return if qualified_articles.none?
 

--- a/app/labor/article_analytics_fetcher.rb
+++ b/app/labor/article_analytics_fetcher.rb
@@ -4,7 +4,7 @@ class ArticleAnalyticsFetcher
   end
 
   def update_analytics(user_id)
-    articles_to_check = Article.where(user_id: user_id, published: true)
+    articles_to_check = Article.published.where(user_id: user_id)
     qualified_articles = get_articles_that_qualify(articles_to_check)
     return if qualified_articles.none?
 

--- a/app/labor/article_analytics_fetcher.rb
+++ b/app/labor/article_analytics_fetcher.rb
@@ -4,7 +4,7 @@ class ArticleAnalyticsFetcher
   end
 
   def update_analytics(user_id)
-    articles_to_check = Article.where(published: true, user_id: user_id)
+    articles_to_check = Article.where(user_id: user_id, published: true)
     qualified_articles = get_articles_that_qualify(articles_to_check)
     return if qualified_articles.none?
 

--- a/app/labor/article_suggester.rb
+++ b/app/labor/article_suggester.rb
@@ -13,7 +13,7 @@ class ArticleSuggester
   end
 
   def other_suggestions(num = 4)
-    Article.where(featured: true, published: true).
+    Article.published.where(featured: true).
       where.not(id: article.id).
       order("hotness_score DESC").
       includes(:user).
@@ -22,8 +22,7 @@ class ArticleSuggester
   end
 
   def suggestions_by_tag
-    Article.tagged_with(article.tag_list, any: true).
-      where(published: true).
+    Article.published.tagged_with(article.tag_list, any: true).
       where.not(id: article.id).
       order("hotness_score DESC").
       includes(:user).

--- a/app/labor/badge_rewarder.rb
+++ b/app/labor/badge_rewarder.rb
@@ -56,7 +56,7 @@ module BadgeRewarder
   end
 
   def self.award_streak_badge(num_weeks)
-    article_user_ids = Article.where(published: true).where("published_at > ? AND score > ?", 1.week.ago, -25).pluck(:user_id) # No cred for super low quality
+    article_user_ids = Article.published.where("published_at > ? AND score > ?", 1.week.ago, -25).pluck(:user_id) # No cred for super low quality
     message = "Congrats on achieving this streak! Consistent writing is hard. The next streak badge you can get is the #{num_weeks * 2} Week Badge. 😉"
     users = User.where(id: article_user_ids).where("articles_count >= ?", num_weeks)
     usernames = []

--- a/app/labor/cache_buster.rb
+++ b/app/labor/cache_buster.rb
@@ -13,7 +13,7 @@ class CacheBuster
   end
 
   def bust_comment(commentable, username)
-    bust("/") if Article.where(published: true).order("hotness_score DESC").limit(3).pluck(:id).include?(commentable.id)
+    bust("/") if Article.published.order("hotness_score DESC").limit(3).pluck(:id).include?(commentable.id)
     if commentable.decorate.cached_tag_list_array.include?("discuss") &&
         commentable.featured_number.to_i > 35.hours.ago.to_i
       bust("/")
@@ -63,7 +63,7 @@ class CacheBuster
       CacheBuster.new.bust "/videos?i=i"
     end
     TIMEFRAMES.each do |timeframe|
-      if Article.where(published: true).where("published_at > ?", timeframe[0]).
+      if Article.published.where("published_at > ?", timeframe[0]).
           order("positive_reactions_count DESC").limit(3).pluck(:id).include?(article.id)
         bust("/top/#{timeframe[1]}")
         bust("/top/#{timeframe[1]}?i=i")
@@ -74,7 +74,7 @@ class CacheBuster
       bust("/latest")
       bust("/latest?i=i")
     end
-    bust("/") if Article.where(published: true).order("hotness_score DESC").limit(4).pluck(:id).include?(article.id)
+    bust("/") if Article.published.order("hotness_score DESC").limit(4).pluck(:id).include?(article.id)
   end
 
   def bust_tag_pages(article)
@@ -86,7 +86,7 @@ class CacheBuster
         bust("/t/#{tag}/latest?i=i")
       end
       TIMEFRAMES.each do |timeframe|
-        if Article.where(published: true).where("published_at > ?", timeframe[0]).tagged_with(tag).
+        if Article.published.where("published_at > ?", timeframe[0]).tagged_with(tag).
             order("positive_reactions_count DESC").limit(3).pluck(:id).include?(article.id)
           bust("/top/#{timeframe[1]}")
           bust("/top/#{timeframe[1]}?i=i")
@@ -97,7 +97,7 @@ class CacheBuster
         end
       end
       if rand(2) == 1 &&
-          Article.where(published: true).tagged_with(tag).
+          Article.published.tagged_with(tag).
               order("hotness_score DESC").limit(2).pluck(:id).include?(article.id)
         bust("/t/#{tag}")
         bust("/t/#{tag}?i=i")

--- a/app/labor/email_logic.rb
+++ b/app/labor/email_logic.rb
@@ -31,16 +31,16 @@ class EmailLogic
     articles = if user_has_followings?
                  @user.followed_articles.
                    where("published_at > ?", fresh_date).
-                   where(published: true, email_digest_eligible: true).
+                   where(email_digest_eligible: true).
                    where.not(user_id: @user.id).
                    where("score > ?", 12).
                    where("experience_level_rating > ? AND experience_level_rating < ?", (@user.experience_level || 5) - 3.6, (@user.experience_level || 5) + 3.6).
                    order("score DESC").
                    limit(8)
                else
-                 Article.
+                 Article.published.
                    where("published_at > ?", fresh_date).
-                   where(published: true, featured: true, email_digest_eligible: true).
+                   where(featured: true, email_digest_eligible: true).
                    where.not(user_id: @user.id).
                    where("score > ?", 25).
                    order("score DESC").

--- a/app/labor/email_logic.rb
+++ b/app/labor/email_logic.rb
@@ -31,7 +31,7 @@ class EmailLogic
     articles = if user_has_followings?
                  @user.followed_articles.
                    where("published_at > ?", fresh_date).
-                   where(email_digest_eligible: true).
+                   where(published: true, email_digest_eligible: true).
                    where.not(user_id: @user.id).
                    where("score > ?", 12).
                    where("experience_level_rating > ? AND experience_level_rating < ?", (@user.experience_level || 5) - 3.6, (@user.experience_level || 5) + 3.6).

--- a/app/labor/rate_limit_checker.rb
+++ b/app/labor/rate_limit_checker.rb
@@ -9,9 +9,7 @@ class RateLimitChecker
              when "comment_creation"
                user.comments.where("created_at > ?", 30.seconds.ago).size > 9
              when "published_article_creation"
-               user.articles.
-                 where(published: true).
-                 where("created_at > ?", 30.seconds.ago).size > 9
+               user.articles.published.where("created_at > ?", 30.seconds.ago).size > 9
              else
                false
              end

--- a/app/labor/sticky_article_collection.rb
+++ b/app/labor/sticky_article_collection.rb
@@ -8,8 +8,7 @@ class StickyArticleCollection
   end
 
   def user_stickies
-    author.articles.
-      where(published: true).
+    author.articles.published.
       limited_column_select.
       tagged_with(article_tags, any: true).
       where.not(id: article.id).order("published_at DESC").
@@ -21,10 +20,9 @@ class StickyArticleCollection
   end
 
   def tag_articles
-    @tag_articles ||= Article.tagged_with(article_tags, any: true).
+    @tag_articles ||= Article.published.tagged_with(article_tags, any: true).
       includes(:user).
       where("positive_reactions_count > ? OR comments_count > ?", reaction_count_num, comment_count_num).
-      where(published: true).
       where.not(id: article.id, user_id: article.user_id).
       where("featured_number > ?", 5.days.ago.to_i).
       order(Arel.sql("RANDOM()")).
@@ -34,10 +32,9 @@ class StickyArticleCollection
   def more_articles
     return [] if tag_articles.size > 6
 
-    Article.tagged_with(%w[career productivity discuss explainlikeimfive], any: true).
+    Article.published.tagged_with(%w[career productivity discuss explainlikeimfive], any: true).
       includes(:user).
       where("comments_count > ?", comment_count_num).
-      where(published: true).
       where.not(id: article.id, user_id: article.user_id).
       where("featured_number > ?", 5.days.ago.to_i).
       order(Arel.sql("RANDOM()")).

--- a/app/labor/user_states.rb
+++ b/app/labor/user_states.rb
@@ -19,7 +19,7 @@ class UserStates
   end
 
   def made_first_article
-    user.articles.where(published: true).any?
+    user.articles.published.any?
   end
 
   def follows_a_tag

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -232,10 +232,9 @@ class User < ApplicationRecord
   end
 
   def followed_articles
-    Article.published.
-      tagged_with(cached_followed_tag_names, any: true).
+    Article.tagged_with(cached_followed_tag_names, any: true).
       union(Article.where(user_id: cached_following_users_ids)).
-      where(language: cached_preferred_langs)
+      where(language: cached_preferred_langs, published: true)
   end
 
   def cached_following_users_ids

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -232,11 +232,10 @@ class User < ApplicationRecord
   end
 
   def followed_articles
-    Article.tagged_with(cached_followed_tag_names, any: true).union(
-      Article.where(
-        user_id: cached_following_users_ids,
-      ),
-    ).where(language: cached_preferred_langs, published: true)
+    Article.published.
+      tagged_with(cached_followed_tag_names, any: true).
+      union(Article.where(user_id: cached_following_users_ids)).
+      where(language: cached_preferred_langs)
   end
 
   def cached_following_users_ids

--- a/app/services/analytics_service.rb
+++ b/app/services/analytics_service.rb
@@ -74,7 +74,7 @@ class AnalyticsService
   def load_data
     @article_data = Article.published.where("#{user_or_org.class.name.downcase}_id" => user_or_org.id)
     if @article_id
-      @article_data = articles.where(id: @article_id)
+      @article_data = @article_data.where(id: @article_id)
       raise UnauthorizedError if @article_data.blank?
 
       article_ids = @article_id

--- a/app/services/analytics_service.rb
+++ b/app/services/analytics_service.rb
@@ -72,13 +72,13 @@ class AnalyticsService
   attr_reader :user_or_org, :start_date, :end_date, :article_data, :reaction_data, :comment_data, :follow_data, :page_view_data
 
   def load_data
+    @article_data = Article.published.where("#{user_or_org.class.name.downcase}_id" => user_or_org.id)
     if @article_id
-      @article_data = Article.where(id: @article_id, published: true, "#{user_or_org.class.name.downcase}_id" => user_or_org.id)
+      @article_data = articles.where(id: @article_id)
       raise UnauthorizedError if @article_data.blank?
 
       article_ids = @article_id
     else
-      @article_data = Article.where("#{user_or_org.class.name.downcase}_id" => user_or_org.id, published: true)
       article_ids = @article_data.pluck(:id)
     end
 

--- a/app/services/article_api_index_service.rb
+++ b/app/services/article_api_index_service.rb
@@ -33,15 +33,13 @@ class ArticleApiIndexService
           end
 
     if (user = User.find_by(username: username))
-      user.articles.
-        where(published: true).
+      user.articles.published.
         includes(:user).
         order("published_at DESC").
         page(page).
         per(num)
     elsif (organization = Organization.find_by(slug: username))
-      organization.articles.
-        where(published: true).
+      organization.articles.published.
         includes(:user).
         order("published_at DESC").
         page(page).
@@ -52,53 +50,35 @@ class ArticleApiIndexService
   end
 
   def tag_articles
-    if Tag.find_by(name: tag)&.requires_approval
-      Article.
-        where(published: true, approved: true).
-        order("featured_number DESC").
-        includes(:user).
-        includes(:organization).
-        page(page).
-        per(30).
-        cached_tagged_with(tag)
-    elsif top.present?
-      Article.
-        where(published: true).
-        order("positive_reactions_count DESC").
-        where("published_at > ?", top.to_i.days.ago).
-        includes(:user).
-        includes(:organization).
-        page(page).
-        per(30).
-        cached_tagged_with(tag)
-    else
-      Article.
-        where(published: true).
-        order("hotness_score DESC").
-        includes(:user).
-        includes(:organization).
-        page(page).
-        per(30).
-        cached_tagged_with(tag)
-    end
+    articles = Article.published.cached_tagged_with(tag).includes(:user, :organization)
+
+    articles = if Tag.find_by(name: tag)&.requires_approval
+                 articles.where(approved: true).order("featured_number DESC")
+               elsif top.present?
+                 articles.where("published_at > ?", top.to_i.days.ago).
+                   order("positive_reactions_count DESC")
+               else
+                 articles.order("hotness_score DESC")
+               end
+
+    articles.page(page).per(30)
   end
 
   def state_articles(state)
     if state == "fresh"
-      Article.where(published: true).
+      Article.published.
         where("positive_reactions_count < ? AND featured_number > ? AND score > ?", 2, 7.hours.ago.to_i, -2)
     elsif state == "rising"
-      Article.where(published: true).
+      Article.published.
         where("positive_reactions_count > ? AND positive_reactions_count < ? AND featured_number > ?", 19, 33, 3.days.ago.to_i)
     end
   end
 
   def base_articles
-    Article.
-      where(published: true, featured: true).
+    Article.published.
+      where(featured: true).
+      includes(:user, :organization).
       order("hotness_score DESC").
-      includes(:user).
-      includes(:organization).
       page(page).
       per(30)
   end

--- a/app/services/suggester/articles/classic.rb
+++ b/app/services/suggester/articles/classic.rb
@@ -21,12 +21,11 @@ module Suggester
 
       def qualifying_articles(tag_names)
         tag_name = tag_names.sample
-        Rails.cache.
-          fetch("classic-article-for-tag-#{tag_name}}", expires_in: 90.minutes) do
-          Article.cached_tagged_with(tag_name).
+        Rails.cache.fetch("classic-article-for-tag-#{tag_name}}", expires_in: 90.minutes) do
+          Article.published.cached_tagged_with(tag_name).
             includes(:user).
             limited_column_select.
-            where(published: true, featured: true).
+            where(featured: true).
             where("positive_reactions_count > ?", MIN_REACTION_COUNT).
             where("published_at > ?", 10.months.ago).
             order(Arel.sql("RANDOM()"))

--- a/app/services/suggester/articles/high_quality.rb
+++ b/app/services/suggester/articles/high_quality.rb
@@ -8,12 +8,12 @@ module Suggester
       end
 
       def suggest(num)
-        Article.where(published: true, featured: true).
+        Article.published.where(featured: true).
           includes(:user).
-          where("positive_reactions_count > ?", MIN_HQ_REACTION_COUNT).
-          order(Arel.sql("RANDOM()")).
           limited_column_select.
+          where("positive_reactions_count > ?", MIN_HQ_REACTION_COUNT).
           where.not(id: @not_ids).
+          order(Arel.sql("RANDOM()")).
           limit(num)
       end
     end

--- a/app/services/suggester/users/recent.rb
+++ b/app/services/suggester/users/recent.rb
@@ -20,11 +20,9 @@ module Suggester
       private
 
       def tagged_article_user_ids(num_weeks = 1)
-        Article.
+        Article.published.
           tagged_with(user.decorate.cached_followed_tag_names, any: true).
-          where(published: true).
-          where("score > ? AND published_at > ?",
-                article_reaction_count, num_weeks.weeks.ago).
+          where("score > ? AND published_at > ?", article_reaction_count, num_weeks.weeks.ago).
           pluck(:user_id).
           each_with_object(Hash.new(0)) { |value, counts| counts[value] += 1 }.
           sort_by { |_key, value| value }.

--- a/app/services/suggester/users/sidebar.rb
+++ b/app/services/suggester/users/sidebar.rb
@@ -10,16 +10,17 @@ module Suggester
       def suggest
         Rails.cache.fetch(generate_cache_name, expires_in: 120.hours) do
           reaction_count = Rails.env.production? ? 25 : 0
-          user_ids = Article.tagged_with([given_tag], any: true).
-            where(published: true).
+          user_ids = Article.published.tagged_with([given_tag], any: true).
             where("positive_reactions_count > ?", reaction_count).
             where("published_at > ?", 4.months.ago).
             where("user_id != ?", user.id).
-            where.not(user_id: user.following_by_type("User").
-            pluck(:id)).pluck(:user_id)
-          group_one = User.select(:id, :name, :username, :profile_image, :summary).where(id: user_ids).
+            where.not(user_id: user.following_by_type("User").pluck(:id)).
+            pluck(:user_id)
+          group_one = User.select(:id, :name, :username, :profile_image, :summary).
+            where(id: user_ids).
             order("reputation_modifier DESC").limit(20).to_a
-          group_two = User.select(:id, :name, :username, :profile_image, :summary).where(id: user_ids).
+          group_two = User.select(:id, :name, :username, :profile_image, :summary).
+            where(id: user_ids).
             order(Arel.sql("RANDOM()")).limit(20).to_a
           (group_one + group_two).uniq
         end

--- a/app/views/articles/_collection.html.erb
+++ b/app/views/articles/_collection.html.erb
@@ -1,5 +1,5 @@
 <% @collection = @article.collection %>
-<% if @collection.present? && @collection.articles.where(published: true).size > 1 %>
+<% if @collection.present? && @collection.articles.published.size > 1 %>
   <div class="article-collection-wrapper article-collection-wrapper-<%= position %>">
     <% if @collection.slug.present? %>
       <p>Part of "<%= @collection.slug %>" series</p>
@@ -7,7 +7,7 @@
       <p>Part of a series</p>
     <% end %>
     <div class="article-collection">
-      <% @collection.articles.where(published: true).order("published_at ASC").each_with_index do |article, i| %>
+      <% @collection.articles.published.order("published_at ASC").each_with_index do |article, i| %>
         <a
           href="<%= article.path if article.published %>"
           class="<%= collection_link_class(@article, article) %>"

--- a/app/views/articles/_special_sidebar.html.erb
+++ b/app/views/articles/_special_sidebar.html.erb
@@ -4,7 +4,7 @@
   </a>
   <center style="padding:10px;font-weight:600;font-size:22px;">Latest Posts</center>
 </div>
-<% Article.tagged_with("shecoded").where(approved: true, published: true).order("created_at DESC").limit(8).each do |article| %>
+<% Article.published.tagged_with("shecoded").where(approved: true).order("created_at DESC").limit(8).each do |article| %>
   <a href="<%= article.path %>" style="display:block;color:#0e0e0e">
     <div class="widget">
       <header>
@@ -19,7 +19,7 @@
     <a href="/t/shecoded">
       <img src="<%= asset_path("she-coded-rectangle.png") %>" style="cursor:pointer;min-height:136px;background:#0e0e0e" alt="she coded" />
       <center style="padding:10px;font-weight:600;font-size:22px;text-decoration:underline;color:#0e0e0e">View
-        All <%= Article.tagged_with("shecoded").where(approved: true, published: true).size %> Submissions
+        All <%= Article.published.tagged_with("shecoded").where(approved: true).size %> Submissions
       </center>
     </a>
   </div>

--- a/app/views/articles/tags/_sidebar.html.erb
+++ b/app/views/articles/tags/_sidebar.html.erb
@@ -1,4 +1,4 @@
-<% cache "tag-sidebar-#{@tag}-#{@tag_model&.updated_at}-#{@tag_model&.taggings_count}", expires_in: 5.hour do %>
+<% cache "tag-sidebar-#{@tag}-#{@tag_model&.updated_at}-#{@tag_model&.taggings_count}", expires_in: 5.hours do %>
   <div id="sidebar-wrapper-left" class="sidebar-wrapper sidebar-wrapper-left">
     <div class="sidebar-bg" id="sidebar-bg-left"></div>
     <div class="side-bar">
@@ -53,7 +53,7 @@
       <% end %>
       <div class="sidebar-data">
         <div>
-          <%= pluralize Article.cached_tagged_with(@tag).where(published: true).size, "Post" %> Published
+          <%= pluralize Article.published.cached_tagged_with(@tag).size, "Post" %> Published
         </div>
       </div>
     </div>

--- a/app/views/mailers/digest_mailer/digest_email.html.erb
+++ b/app/views/mailers/digest_mailer/digest_email.html.erb
@@ -39,7 +39,7 @@
       <% elsif tip_rand == 3 %>
         You're a better dev today than you were yesterday.
       <% elsif tip_rand == 4 %>
-        <% if @user.articles.where(published: true).any? %>
+        <% if @user.articles.published.any? %>
           Can't wait to see <b>your</b> next DEV post!
         <% else %>
           Can't wait to see <b>your</b> first DEV post!

--- a/app/views/stories/_main_stories_feed.html.erb
+++ b/app/views/stories/_main_stories_feed.html.erb
@@ -1,11 +1,11 @@
 <% if @default_home_feed && user_signed_in? %>
   <% cache("fetched-home-articles-object", expires_in: 3.minutes) do %>
-    <% @new_stories = Article.where("published_at > ? AND score > ?", rand(2..6).hours.ago, -30).
-         where(published: true).
+    <% @new_stories = Article.published.
+         where("published_at > ? AND score > ?", rand(2..6).hours.ago, -30).
          includes(:user).
-         limit(rand(15..60)).
-         order("published_at DESC").
          limited_column_select.
+         order("published_at DESC").
+         limit(rand(15..60)).
          decorate %>
     <div id="new-articles-object" data-articles="
       <%= @new_stories.to_json(

--- a/app/views/users/_sidebar.html.erb
+++ b/app/views/users/_sidebar.html.erb
@@ -47,7 +47,7 @@
       <% cache "user-profile-sidebar-stats-#{@user.id}-#{@user.last_article_at}-#{@user.last_comment_at}-#{@user.last_followed_at}", expires_in: 10.days do %>
         <div class="sidebar-data">
           <div>
-            <%= pluralize @user.articles.where(published: true).size, "Post" %> Published
+            <%= pluralize @user.articles.published.size, "Post" %> Published
           </div>
           <div>
             <%= pluralize @user.comments.where(deleted: false).size, "Comment" %> Written

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -15,9 +15,8 @@ end
 SitemapGenerator::Sitemap.default_host = "#{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}"
 
 SitemapGenerator::Sitemap.create do
-  Article.where(published: true).
-    where("score > ? OR featured = ?", 12, true).
-    where(published: true).limit(38_000).find_each do |article|
+  Article.published.where("score > ? OR featured = ?", 12, true).
+    limit(38_000).find_each do |article|
     add article.path, lastmod: article.last_comment_at, changefreq: "daily"
   end
 

--- a/lib/tasks/fetch.rake
+++ b/lib/tasks/fetch.rake
@@ -28,10 +28,9 @@ task resave_supported_tags: :environment do
 end
 
 task renew_hired_articles: :environment do
-  Article.
-    tagged_with("hiring").
+  Article.published.tagged_with("hiring").
     where("featured_number < ?", 7.days.ago.to_i + 11.minutes.to_i).
-    where(approved: true, published: true, automatically_renew: true).
+    where(approved: true, automatically_renew: true).
     each do |article|
 
     if article.automatically_renew
@@ -52,7 +51,7 @@ task clear_memory_if_too_high: :environment do
 end
 
 task save_nil_hotness_scores: :environment do
-  Article.where(hotness_score: nil, published: true).find_each(&:save)
+  Article.published.where(hotness_score: nil).find_each(&:save)
 end
 
 task github_repo_fetch_all: :environment do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -414,7 +414,6 @@ RSpec.describe User, type: :model do
 
     before do
       create_list(:article, 3, user_id: user2.id)
-      create(:article, user_id: user2.id, published: false)
       user.follow(user2)
     end
 
@@ -424,10 +423,6 @@ RSpec.describe User, type: :model do
 
     it "returns segment of articles if limit is passed" do
       expect(user.followed_articles.limit(2).size).to eq(2)
-    end
-
-    it "includes only published articles" do
-      expect(user.followed_articles.all?(&:published?)).to be(true)
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -414,6 +414,7 @@ RSpec.describe User, type: :model do
 
     before do
       create_list(:article, 3, user_id: user2.id)
+      create(:article, user_id: user2.id, published: false)
       user.follow(user2)
     end
 
@@ -423,6 +424,10 @@ RSpec.describe User, type: :model do
 
     it "returns segment of articles if limit is passed" do
       expect(user.followed_articles.limit(2).size).to eq(2)
+    end
+
+    it "includes only published articles" do
+      expect(user.followed_articles.all?(&:published?)).to be(true)
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -419,7 +419,7 @@ RSpec.describe User, type: :model do
     end
 
     it "returns all articles following" do
-      expect(user.followed_articles.size).to eq(3)
+      expect(user.followed_articles.size).to eq(4)
     end
 
     it "returns segment of articles if limit is passed" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -419,7 +419,7 @@ RSpec.describe User, type: :model do
     end
 
     it "returns all articles following" do
-      expect(user.followed_articles.size).to eq(4)
+      expect(user.followed_articles.size).to eq(3)
     end
 
     it "returns segment of articles if limit is passed" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

`where(published: true)` is an omnipresent condition in selecting all kinds of articles in the code.
A dedicated scope makes it shorter to type and as self explanatory.

Some specifiers have been re-ordered to follow a similar structure of `WHERE` queries (I haven't been too methodical about it, the order in the end doesn't matter for Rails)

I've also disabled erblint's rubocop `Layout/InitialIndentation` because it raises a lot of false positives

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
