### PR TITLE
Ensure Gitpod init always succeeds

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -10,7 +10,7 @@ ports:
 tasks:
   - init: >
       cp config/sample_application.yml config/application.yml &&
-      bin/setup 2>/dev/null
+      bin/setup 2>/dev/null || true
     command: >
       while [ -z "${ALGOLIASEARCH_APPLICATION_ID:=$(cat config/application.yml | grep ALGOLIASEARCH_APPLICATION_ID | sed 's/.*:\s*//')}" ] ||
             [ -z "${ALGOLIASEARCH_SEARCH_ONLY_KEY:=$(cat config/application.yml | grep ALGOLIASEARCH_SEARCH_ONLY_KEY | sed 's/.*:\s*//')}" ] ||


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

PR #2321 added an automated DEV setup using Gitpod.

It works mostly great, but there is a minor problem in the `init` task:

```yaml
tasks:
  - init: >
      cp config/sample_application.yml config/application.yml &&
      bin/setup 2>/dev/null
```

Here we run `bin/setup` during the `init` phase, in order to pre-install as many dependencies as possible, but we don't really care about errors at this stage. (Errors like missing credentials are handled during the later `command` phase.)

So we silence error output with `2>/dev/null`. But in some cases this isn't enough to ignore all errors, e.g. a non-zero exit code in `init` can prevent the `command` phase from running.

The proper way to ignore all errors is `bin/setup 2>/dev/null || true`.

## Related Tickets & Documents

(none)

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

(none)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![rapid unscheduled disassembly](https://i.giphy.com/media/MBSgT1Jvwm9Mc/giphy.webp)
