### PR TITLE
allow codesandbox to accept runonclick

### DIFF
--- a/app/liquid_tags/codesandbox_tag.rb
+++ b/app/liquid_tags/codesandbox_tag.rb
@@ -43,7 +43,7 @@ class CodesandboxTag < LiquidTagBase
   # composed of letters, numbers, dashes, underscores, forward slashes, @ signs, periods/dots,
   # and % symbols.  Invalid options will raise an exception
   def valid_option(option)
-    raise StandardError, "CodeSandbox Error: Invalid options" unless (option =~ /\A(initialpath=([a-zA-Z0-9\-\_\/\.\@\%])+)\Z|\A(module=([a-zA-Z0-9\-\_\/\.\@\%])+)\Z/)&.zero?
+    raise StandardError, "CodeSandbox Error: Invalid options" unless (option =~ /\A(initialpath=([a-zA-Z0-9\-\_\/\.\@\%])+)\Z|\A(module=([a-zA-Z0-9\-\_\/\.\@\%])+)\Z|\A(runonclick=((0|1){1}))\Z/)&.zero?
 
     option
   end

--- a/app/views/pages/_editor_guide_text.html.erb
+++ b/app/views/pages/_editor_guide_text.html.erb
@@ -180,6 +180,11 @@
         Which module to open by default.<br>
         <code>{% codesandbox ppxnl191zx module=/path/to/module %}</code>
       </dd>
+      <dt><code>runonclick</code></dt>
+      <dd>
+        Delays when code is ran if <code>1</code> <br>
+        <code>{% codesandbox ppxnl191zx runonclick=1 %}</code>
+      </dd>
     </dl>
 
     <h3><strong>JSFiddle Embed</strong></h3>

--- a/spec/liquid_tags/codesandbox_tag_spec.rb
+++ b/spec/liquid_tags/codesandbox_tag_spec.rb
@@ -5,13 +5,19 @@ RSpec.describe CodesandboxTag, type: :liquid_template do
     let(:valid_id) { "22qaa1wcxr" }
     let(:valid_id_with_initialpath) { "68jkdlsaie initialpath=/initial/path/file.js" }
     let(:valid_id_with_module) { "28qvv1wvxr module=/path/to/module.html" }
+    let(:valid_id_with_runonclick) { "28qvv1wvxr runonclick=1" }
     let(:valid_id_with_initialpath_and_module) { "43lkjfdauf initialpath=/initial-path/file.js module=/path/to/module.html" }
+    let(:valid_id_with_runonclick_and_module) { "43lkjfdauf runonclick=1 module=/path/to/module.html" }
+    let(:valid_id_with_initialpath_and_runonclick) { "43lkjfdauf initialpath=/initial-path/file.js runonclick=1" }
+    let(:valid_id_with_initialpath_and_module_and_runonclick) { "43lkjfdauf initialpath=/initial-path/file.js module=/path/to/module.html runonclick=1" }
     let(:valid_id_with_special_characters) { "68jkfdsasa initialpath=/.@%_- module=-/%@._" }
 
     let(:bad_ids) do
       [
         "28qvv1wvxr initialpath=((",
         "22qaa1wcxr module=",
+        "22qaa1wcxr runonclick=",
+        "22qaa1wcxr runonclick=42836",
         "68jkdlsaie initialpath=uses-a-(",
         "68jkfdsasa initialpath=/uses-a-semi-colon-;",
         "43lkjfdauf module= initialpath=",
@@ -43,8 +49,28 @@ RSpec.describe CodesandboxTag, type: :liquid_template do
       expect(liquid.render).to include("<iframe")
     end
 
+    it "accepts a vaild id with runonclick" do
+      liquid = generate_tag(valid_id_with_runonclick)
+      expect(liquid.render).to include("<iframe")
+    end
+
     it "accepts a vaild id with initialpath and module" do
       liquid = generate_tag(valid_id_with_initialpath_and_module)
+      expect(liquid.render).to include("<iframe")
+    end
+
+    it "accepts a vaild id with initialpath and runonclick" do
+      liquid = generate_tag(valid_id_with_initialpath_and_runonclick)
+      expect(liquid.render).to include("<iframe")
+    end
+
+    it "accepts a vaild id with runonclick and module" do
+      liquid = generate_tag(valid_id_with_runonclick_and_module)
+      expect(liquid.render).to include("<iframe")
+    end
+
+    it "accepts a vaild id with initialpath and module and runonclick" do
+      liquid = generate_tag(valid_id_with_initialpath_and_module_and_runonclick)
       expect(liquid.render).to include("<iframe")
     end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
Added `runonclick` as an option for the codesandbox liquid tag. Adding `runonclick=1` allows users to let the viewer determine when the codesandbox runs. 

## Related Tickets & Documents
workaround for #2290

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![Screen Shot 2019-04-11 at 12 12 23](https://user-images.githubusercontent.com/13403332/55973232-1e2fc980-5c53-11e9-9d1d-c7b88c07610e.png)

## Added to documentation?
- [x] `p/editor_guide`