### PR TITLE
Touch profile_updated_at when updating social usernames

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -65,6 +65,7 @@ class UsersController < ApplicationController
       identity.destroy
       identity_username = "#{provider}_username".to_sym
       @user.update(identity_username => nil)
+      @user.touch(:profile_updated_at)
       redirect_to "/settings/#{@tab}",
                   notice: "Your #{provider.capitalize} account was successfully removed."
     else

--- a/app/services/authorization_service.rb
+++ b/app/services/authorization_service.rb
@@ -72,6 +72,7 @@ class AuthorizationService
     user.github_username = auth.info.nickname if auth.provider == "github" && auth.info.nickname != user.github_username
     user.twitter_username = auth.info.nickname if auth.provider == "twitter" && auth.info.nickname != user.twitter_username
     add_social_identity_data(user)
+    user.touch(:profile_updated_at) if user.twitter_username_changed? || user.github_username_changed?
     user.save
     user
   end

--- a/spec/requests/user_settings_spec.rb
+++ b/spec/requests/user_settings_spec.rb
@@ -133,6 +133,12 @@ RSpec.describe "UserSettings", type: :request do
         expect(user.twitter_username).to eq nil
       end
 
+      it "touches the profile_updated_at timestamp" do
+        original_profile_updated_at = user.profile_updated_at
+        delete "/users/remove_association", params: { provider: "twitter" }
+        expect(user.profile_updated_at).to be > original_profile_updated_at
+      end
+
       it "redirects successfully to /settings/account" do
         delete "/users/remove_association", params: { provider: "twitter" }
         expect(response).to redirect_to "/settings/account"

--- a/spec/requests/user_settings_spec.rb
+++ b/spec/requests/user_settings_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe "UserSettings", type: :request do
 
       before { login_as user }
 
-      it "allows the user to remove an identity" do
+      it "brings the identity count to 1" do
         delete "/users/remove_association", params: { provider: "twitter" }
         expect(user.identities.count).to eq 1
       end

--- a/spec/services/authorization_service_spec.rb
+++ b/spec/services/authorization_service_spec.rb
@@ -44,5 +44,26 @@ RSpec.describe AuthorizationService do
       expect(user.remember_token).to be_truthy
       expect(user.remember_created_at).to be_truthy
     end
+
+    context "when the user has a new Twitter username" do
+      it "updates their username properly" do
+        new_username = "new_username#{rand(1000)}"
+        auth.info.nickname = new_username
+        service = described_class.new(auth)
+        service.get_user
+        user.reload
+        expect(user.twitter_username).to eq new_username
+      end
+
+      it "touches the profile_updated_at timestamp" do
+        original_profile_updated_at = user.profile_updated_at
+        new_username = "new_username#{rand(1000)}"
+        auth.info.nickname = new_username
+        service = described_class.new(auth)
+        service.get_user
+        user.reload
+        expect(user.profile_updated_at).to be > original_profile_updated_at
+      end
+    end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This fixes a bug where removing your Twitter/GitHub account does not remove the URL from your profile page. It also fixes a bug where your Twitter/GitHub URL does not update properly if you have a new username and sign in again.