### PR TITLE
Fix community name

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -207,4 +207,8 @@ module ApplicationHelper
            end
     logo
   end
+
+  def community_qualified_name
+    "The #{ApplicationConfig['COMMUNITY_NAME']} Community"
+  end
 end

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -11,20 +11,21 @@
 
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://dev.to<%= request.path %>" />
-  <meta property="og:title" content="<%= title_with_timeframe(page_title: "The #{ApplicationConfig['COMMUNITY_NAME']} Community", timeframe: params[:timeframe]) %>" />
+  <meta property="og:title" content="<%= title_with_timeframe(page_title: community_qualified_name, timeframe: params[:timeframe]) %>" />
   <meta property="og:image" content="https://thepracticaldev.s3.amazonaws.com/i/g355ol6qsrg0j2mhngz9.png">
   <meta property="og:description" content="Where programmers share ideas and help each other grow." />
-  <meta property="og:site_name" content="The #{ApplicationConfig['COMMUNITY_NAME']} Community" />
+  <meta property="og:site_name" content="<%= community_qualified_name %>" />
 
   <meta name="twitter:site" content="@ThePracticalDev">
-  <meta name="twitter:title" content="<%= title_with_timeframe(page_title: "The #{ApplicationConfig['COMMUNITY_NAME']} Community", timeframe: params[:timeframe]) %>">
+  <meta name="twitter:title" content="<%= title_with_timeframe(page_title: community_qualified_name, timeframe: params[:timeframe]) %>">
   <meta name="twitter:description" content="Where programmers share ideas, experiences, and help each other grow.">
   <meta name="twitter:image:src" content="https://thepracticaldev.s3.amazonaws.com/i/g355ol6qsrg0j2mhngz9.png">
   <meta name="twitter:card" content="summary_large_image">
   <%= auto_discovery_link_tag(:rss, "https://dev.to/feed", title: "#{ApplicationConfig['COMMUNITY_NAME']} RSS Feed") %>
 <% end %>
+
 <% params.delete(:i) %>
-<% cache("main-stories-index-#{params.to_s}-#{user_signed_in?}", expires_in: 4.minutes) do %>
+<% cache("main-stories-index-#{params}-#{user_signed_in?}", expires_in: 4.minutes) do %>
   <div class="home" id="index-container"
       data-params="<%= params.to_json(only: %i[tag username q]) %>" data-which="<%= @list_of %>"
       data-algolia-tag=""

--- a/app/views/layouts/_signup_modal.html.erb
+++ b/app/views/layouts/_signup_modal.html.erb
@@ -15,7 +15,7 @@
                                 sign_url: true), class: "sloan", alt: "sloth-mascot") %>
     <h1>Join our <%= ApplicationConfig["COMMUNITY_NAME"] %> Community :)</h1>
     <p>
-      We’re a place where coders share, stay up-to-date and grow their careers.
+      We're a place where coders share, stay up-to-date and grow their careers.
     </p>
     <a href="/users/auth/twitter?callback_url=<%= ApplicationConfig["APP_PROTOCOL"] %><%= ApplicationConfig["APP_DOMAIN"] %>/users/auth/twitter/callback" class="sign-up-link cta" data-no-instant>
       <img src="<%= asset_path("twitter-logo.svg") %>" class="icon-img" alt="Twitter" /> Auth With Twitter

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -73,7 +73,7 @@
       <%= csrf_meta_tags %>
     <% end %>
     <link rel="manifest" href="/manifest.json" />
-    <link rel="search" href="https://dev.to/search.xml" type="application/opensearchdescription+xml" title="The <%= ApplicationConfig["COMMUNITY_NAME"] %> Community" />
+    <link rel="search" href="https://dev.to/search.xml" type="application/opensearchdescription+xml" title="<%= community_qualified_name %>" />
   <% end %>
 </head>
 <body data-user-status="<%= user_logged_in_status %>" data-pusher-key="<%= ApplicationConfig["PUSHER_KEY"] %>">

--- a/app/views/videos/index.html.erb
+++ b/app/views/videos/index.html.erb
@@ -10,7 +10,7 @@
   <meta property="og:title" content="<% title "Videos" %>" />
   <meta property="og:image" content="https://thepracticaldev.s3.amazonaws.com/i/g355ol6qsrg0j2mhngz9.png">
   <meta property="og:description" content="All videos on DEV" />
-  <meta property="og:site_name" content="The #{ApplicationConfig['COMMUNITY_NAME']} Community" />
+  <meta property="og:site_name" content="<%= community_qualified_name %>" />
 
   <meta name="twitter:site" content="@ThePracticalDev">
   <meta name="twitter:title" content="<% title "Videos" %>">
@@ -18,7 +18,6 @@
   <meta name="twitter:image:src" content="https://thepracticaldev.s3.amazonaws.com/i/g355ol6qsrg0j2mhngz9.png">
   <meta name="twitter:card" content="summary_large_image">
 <% end %>
-
 
 <div class="home video-page-title" id="index-container" data-which="videos" data-params="<%= params.to_json(only: %i[tag username q]) %>">
   <header>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.describe ApplicationHelper, type: :helper do
+  describe "#community_qualified_name" do
+    it "equals to the full qualified community name" do
+      expected_name = "The #{ApplicationConfig['COMMUNITY_NAME']} Community"
+      expect(helper.community_qualified_name).to eq(expected_name)
+    end
+  end
+end

--- a/spec/system/homepage/user_visits_homepage_articles_spec.rb
+++ b/spec/system/homepage/user_visits_homepage_articles_spec.rb
@@ -43,5 +43,24 @@ RSpec.describe "User visits a homepage", type: :system do
 
       include_examples "no sign_in invitation"
     end
+
+    describe "meta tags" do
+      before { visit "/" }
+
+      it "contains the qualified community name in og:title" do
+        selector = "meta[property='og:title'][content='#{community_qualified_name}']"
+        expect(page).to have_selector(selector, visible: false)
+      end
+
+      it "contains the qualified community name in og:site_name" do
+        selector = "meta[property='og:site_name'][content='#{community_qualified_name}']"
+        expect(page).to have_selector(selector, visible: false)
+      end
+
+      it "contains the qualified community name in twitter:title" do
+        selector = "meta[name='twitter:title'][content='#{community_qualified_name}']"
+        expect(page).to have_selector(selector, visible: false)
+      end
+    end
   end
 end

--- a/spec/system/homepage/user_visits_homepage_spec.rb
+++ b/spec/system/homepage/user_visits_homepage_spec.rb
@@ -22,6 +22,13 @@ RSpec.describe "User visits a homepage", type: :system do
       end
       expect(page).to have_text("design your experience")
     end
+
+    describe "link tags" do
+      it "contains the qualified community name in the search link" do
+        selector = "link[rel='search'][title='#{community_qualified_name}']"
+        expect(page).to have_selector(selector, visible: false)
+      end
+    end
   end
 
   context "when logged in user" do

--- a/spec/system/videos/user_visits_videos_spec.rb
+++ b/spec/system/videos/user_visits_videos_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe "User visits the videos page", type: :system do
+  context "when user hasn't logged in" do
+    before { visit "/videos" }
+
+    describe "meta tags" do
+      it "contains the qualified community name in og:site_name" do
+        selector = "meta[property='og:site_name'][content='#{community_qualified_name}']"
+        expect(page).to have_selector(selector, visible: false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

This PR fixes a couple of instances where `The #{ApplicationConfig['COMMUNITY_NAME']} Community` was written verbatim instead of replaced with the actual text.

I've also introduced an application helper called `community_qualified_name` with the full text.

FYI: there are some instances in the code of `#{ApplicationConfig['COMMUNITY_NAME']} Community` without the `The` and other instances of `PracticalDev` or `DEV` or other variations.

## Related Tickets & Documents

Closes #2414 

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
