### PR TITLE
override styling for inline code when in night-theme (#2210)

### DIFF
--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -21,6 +21,7 @@ $yellow: #fefa87;
 $tan: #fdf9f3;
 $off-white: #fffffe;
 $bold-blue: #0045ff;
+$night-theme-markdown-inline-code: #ffffff;
 
 $helvetica: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 $monospace: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
@@ -39,6 +40,9 @@ body.night-theme {
   .on-page-nav-butt img, .icon-img, .dropdown-icon, .reaction-button:not(.reacted) img, .image-upload-button button, .icon-image {
     -webkit-filter: invert(95%);
     filter: invert(95%);
+  }
+  .inner-comment code {
+    color: $night-theme-markdown-inline-code;
   }
 }
 


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
Fixed the night-theme mode color contrast for inline code comments

## Related Tickets & Documents
#2210 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
<img width="846" alt="Screen Shot 2019-04-12 at 12 46 46 PM" src="https://user-images.githubusercontent.com/33923739/56053484-33275e00-5d22-11e9-8200-7696ba256dc9.png">

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [ ] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://i.giphy.com/media/l41Ye6Oq2BffmtJLi/giphy.webp)
