### PR TITLE
remove Product Roadmap link from TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ Welcome to the [dev.to](https://dev.to) codebase. We are so excited to have you.
   - [Starting the application](#starting-the-application)
   - [Suggested Workflow](#suggested-workflow)
 - [Additional docs](#additional-docs)
-- [Product Roadmap](#product-roadmap)
 - [Core Team Members](#core-team)
 - [License](#license)
 


### PR DESCRIPTION
it looks like the Product Roadmap section of the Read Me was removed at https://github.com/thepracticaldev/dev.to/commit/65bdaa86f3c598ab95e557a92365642f34037be4#diff-04c6e90faac2675aa89e2176d2eec7d8, so that anchor was broken. this removes the link from the Table Of Contents.

<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [X] Documentation Update

## Description
Removed a broken link from the table of contents

## Related Tickets & Documents
Product Roadmap removed from README at https://github.com/thepracticaldev/dev.to/commit/65bdaa86f3c598ab95e557a92365642f34037be4#diff-04c6e90faac2675aa89e2176d2eec7d8

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [X] readme
- [ ] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![wrestler Big E doing a lil' dance in a wrestling ring](https://media.giphy.com/media/ONG94CcPgBOuKKRwVn/giphy.gif)
