### PR TITLE
[SMALL] UX: Rename "Start an ask me anything" to "Start an AMA"

### DIFF
--- a/app/views/articles/_sidebar_additional.html.erb
+++ b/app/views/articles/_sidebar_additional.html.erb
@@ -53,7 +53,7 @@
                 <%= render "articles/widget_list_item", plucked_article: plucked_article, show_comment_count: true %>
               <% end %>
             </div>
-            <a class="cta cta-button" href="/new/ama">START AN "ASK ME ANYTHING"</a>
+            <a class="cta cta-button" href="/new/ama">START AN "AMA"</a>
           </div>
         </div>
       <% end %>


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
I randomly noticed the "Start an ask me anything" button and found that it looked very squished. I increased its width.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
### Before
![Screenshot from 2019-04-13 22-17-10](https://user-images.githubusercontent.com/13546486/56084884-6f4de200-5e3a-11e9-9994-06b25b4eccd7.png)

### After
![Screenshot from 2019-04-13 22-19-55](https://user-images.githubusercontent.com/13546486/56084885-72e16900-5e3a-11e9-9da8-c790974b4ea9.png)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
