### PR TITLE
Fix seo_boostable for latest

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -383,6 +383,7 @@ class Article < ApplicationRecord
   end
 
   def self.seo_boostable(tag = nil, time_ago = 18.days.ago)
+    time_ago = 5.days.ago if time_ago == "latest" # Time ago sometimes returns this phrase instead of a date
     if tag
       Article.published.
         cached_tagged_with(tag).order("organic_page_views_past_month_count DESC").where("score > ?", 10).where("published_at > ?", time_ago).


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
The `Article.seo_boostable` breaks for a timeframe of "latest". This fixes it.