### PR TITLE
[SMALL] UX: Fix comment preview loading in nightmode

### DIFF
--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -279,6 +279,8 @@ a.header-link {
       &.preview-loading {
         background: white url(image_path('loading-ellipsis.svg')) no-repeat
           center center;
+        background-color: var(--theme-container-background, white);
+        color: var(--theme-container-background, white);
         background-size: 50px;
       }
     }


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
This fixes the comment preview loading animation in nightmode

## Related Tickets & Documents
Closes #2359 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
### Before
![Screenshot from 2019-04-15 17-40-58](https://user-images.githubusercontent.com/13546486/56146416-75f96800-5fa6-11e9-9c68-62316efc6e48.png)

### After
![Screenshot from 2019-04-15 17-49-06](https://user-images.githubusercontent.com/13546486/56146744-0df75180-5fa7-11e9-9cd9-ef27f66007fe.png)
![Screenshot from 2019-04-15 17-43-54](https://user-images.githubusercontent.com/13546486/56146432-7bef4900-5fa6-11e9-82c3-2044808b9a62.png)


## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
