### PR TITLE
Add a blank href attribute if blank for GitHub readme tag

### DIFF
--- a/app/liquid_tags/github_tag/github_readme_tag.rb
+++ b/app/liquid_tags/github_tag/github_readme_tag.rb
@@ -48,6 +48,7 @@ class GithubTag
       readme = Nokogiri::HTML(readme_html)
       readme.css("img, a").each do |element|
         attribute = element.name == "img" ? "src" : "href"
+        element["href"] = "" if attribute == "href" && element.attributes[attribute].blank?
         path = element.attributes[attribute].value
         element.attributes[attribute].value = url.gsub(/\/README.md/, "") + "/" + path if path[0, 4] != "http"
       end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This resolves #2452 where some repositories' READMEs include `<a>` tags that don't have an `href` attribute. For example: `<a name="anchor-header"></a>`

The fix adds the `href` attribute and sets it to an empty string. We modify the link's value to link back to the original repository anyway with the following line, so I think this is a fairly safe fix.

https://github.com/thepracticaldev/dev.to/blob/e389757aa4ecf23f2b788f8c2a07150b43005a35/app/liquid_tags/github_tag/github_readme_tag.rb#L52
