### PR TITLE
Allow seo_boostable to better handle nil

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -384,6 +384,7 @@ class Article < ApplicationRecord
 
   def self.seo_boostable(tag = nil, time_ago = 18.days.ago)
     time_ago = 5.days.ago if time_ago == "latest" # Time ago sometimes returns this phrase instead of a date
+    time_ago = 18.days.ago if time_ago.nil? # Time ago sometimes is given as nil and should then be the default. I know, sloppy.
     if tag
       Article.published.
         cached_tagged_with(tag).order("organic_page_views_past_month_count DESC").where("score > ?", 8).where("published_at > ?", time_ago).

--- a/app/views/articles/_sidebar_additional.html.erb
+++ b/app/views/articles/_sidebar_additional.html.erb
@@ -145,7 +145,7 @@
         </div>
       <% end %>
     <% else %>
-      <% cache("seo-boostable-posts-homepage-#{params[:timeframe]}", expires_in: 18.hours) do %>
+      <% cache("seo-boostable-posts-homepage-#{params[:timeframe]}-xoxo", expires_in: 18.hours) do %>
         <% @boostable_posts = Article.seo_boostable(nil, Timeframer.new(params[:timeframe]).datetime) %>
         <% if @boostable_posts.any? %>
           <div class="widget">

--- a/app/views/articles/tags/_sidebar_additional.html.erb
+++ b/app/views/articles/tags/_sidebar_additional.html.erb
@@ -20,7 +20,7 @@
       <div id="sidebarWidget__pack" data-tag-info="<%= @tag_model.attributes.slice("id", "text_color_hex", "bg_color_hex", "name").to_json %>">
       </div>
     <% else %>
-      <% cache("seo-boostable-posts-for-tag-#{@tag}-#{params[:timeframe]}", expires_in: 18.hours) do %>
+      <% cache("seo-boostable-posts-for-tag-#{@tag}-#{params[:timeframe]}-xoxo", expires_in: 18.hours) do %>
         <% @boostable_posts = Article.seo_boostable(@tag, Timeframer.new(params[:timeframe]).datetime) %>
         <% if @boostable_posts.any? %>
           <div class="widget">


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
Currently a nil value in the second arg for this method will result in an empty array when it should result in the default value.