### PR TITLE
UX: Liquid Tags Nightmode

### DIFF
--- a/app/assets/stylesheets/ltags/TagTag.scss
+++ b/app/assets/stylesheets/ltags/TagTag.scss
@@ -18,6 +18,7 @@
   .ltag__tag__content {
     a {
       color: $black !important;
+      color: var(--theme-container-color, $black) !important;
     }
     width: 90%;
     width: calc(100% - 36px);

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -41,6 +41,10 @@ body.night-theme {
     -webkit-filter: invert(95%);
     filter: invert(95%);
   }
+  .ltag__tag {
+    border-color: white !important;
+    box-shadow: 3px 3px 0px #fff !important;
+  }
 }
 
 body.sans-serif-article-body {


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
This fixes the liquid tags in nightmode.

Some issues I encountered:

* I was unable to repro the issue regarding the javascript tag @mariocsee reported ( see image below ). At first I thought it would be the `html_sanitizer` stripping the `script` part away from `javascript` and thus creating a non closing tag but that isn't the issue.

* The border colors of the tags are generated by the following code in `app/liquid_tags/tag_tag.rb`
```
def dark_color
  HexComparer.new([@tag.bg_color_hex || "#0000000", @tag.text_color_hex || "#ffffff"]).brightness(0.88)
end
```
There seems to be no way for the lib to get the current user and what theme he uses, so I can not modify the values accordingly. Thats why I had to change it in `variables.scss`. If someone knows a better to handle this, I am more than welcome to hear it.

## Related Tickets & Documents
#2397 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
### Before
<img width="720" alt="55996122-7b903e80-5c84-11e9-8694-70421035366c" src="https://user-images.githubusercontent.com/13546486/56152021-ead29f00-5fb2-11e9-86fe-932b19516b00.png">

### After
![Screenshot from 2019-04-15 19-11-03](https://user-images.githubusercontent.com/13546486/56152034-f0c88000-5fb2-11e9-8f4a-7e48b4066867.png)


## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
