### PR TITLE
Add GA_FETCH_RATE ENV var to ease rate limiting

### DIFF
--- a/Envfile
+++ b/Envfile
@@ -101,6 +101,7 @@ variable :GA_SERVICE_ACCOUNT_JSON, :String, default: "Optional"
 variable :GA_TRACKING_ID, :String, default: "Optional"
 variable :GA_OPTIMIZE_ID, :String, default: "Optional"
 variable :GA_VIEW_ID, :String, default: "Optional"
+variable :GA_FETCH_RATE, :Integer, default: 25
 
 # Honeycomb
 variable :HONEYCOMB_API_KEY, :String, default: "Optional"

--- a/app/controllers/async_info_controller.rb
+++ b/app/controllers/async_info_controller.rb
@@ -69,6 +69,6 @@ class AsyncInfoController < ApplicationController
   private
 
   def occasionally_update_analytics
-    ArticleAnalyticsFetcher.new.delay.update_analytics(@user.id) if Rails.env.production? && rand(25) == 1
+    ArticleAnalyticsFetcher.new.delay.update_analytics(@user.id) if Rails.env.production? && rand(ApplicationConfig["GA_FETCH_RATE"]) == 1
   end
 end

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -10,7 +10,7 @@ class DashboardsController < ApplicationController
     target = @user.organization if @user&.organization && @user&.org_admin && params[:which] == "organization"
     @articles = target.articles.sorting(params[:sort]).decorate
     # Updates analytics in background if appropriate:
-    ArticleAnalyticsFetcher.new.delay.update_analytics(current_user.id) if @articles
+    ArticleAnalyticsFetcher.new.delay.update_analytics(current_user.id) if @articles && ApplicationConfig["GA_FETCH_RATE"] < 50 # Rate limit concerned, sometimes we throttle down.
   end
 
   def following


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
This allows us to set a rate at which we fetch from Google Analytics in order to insure we're handling rate limiting effectively. Maybe not long term solution, but fix for now.