### PR TITLE
Cleanup a bit the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -143,7 +143,6 @@ group :test do
   gem "selenium-webdriver", "~> 3.141" # WebDriver is a tool for writing automated tests of websites
   gem "shoulda-matchers", "4.0.1", require: false # Simple one-liner tests for common Rails functionality
   gem "simplecov", "~> 0.16", require: false # Code coverage with a powerful configuration library and automatic merging of coverage across test suites
-  gem "sinatra", "~> 2.0" # Sinatra is a DSL for quickly creating web applications in Ruby with minimal effort
   gem "stackprof", "~> 0.2", require: false, platforms: :ruby # stackprof is a fast sampling profiler for ruby code, with cpu, wallclock and object allocation samplers
   gem "stripe-ruby-mock", "~> 2.5", require: "stripe_mock" # A drop-in library to test stripe without hitting their servers
   gem "test-prof", "~> 0.7" # Ruby Tests Profiling Toolbox

--- a/Gemfile
+++ b/Gemfile
@@ -63,8 +63,6 @@ gem "omniauth", "~> 1.9" # A generalized Rack framework for multiple-provider au
 gem "omniauth-github", "~> 1.3" # OmniAuth strategy for GitHub
 gem "omniauth-twitter", "~> 1.4" # OmniAuth strategy for Twitter
 gem "pg", "~> 1.1" # Pg is the Ruby interface to the PostgreSQL RDBMS
-gem "pry", "~> 0.12" # An IRB alternative and runtime developer console
-gem "pry-rails", "~> 0.3" # Use Pry as your rails console
 gem "puma", "~> 3.12" # Puma is a simple, fast, threaded, and highly concurrent HTTP 1.1 server
 gem "pundit", "~> 2.0" # Object oriented authorization for Rails applications
 gem "pusher", "~> 1.3" # Ruby library for Pusher Channels HTTP API
@@ -125,7 +123,9 @@ group :development, :test do
   gem "fix-db-schema-conflicts", "~> 3.0" # Ensures consistent output of db/schema.rb despite local differences in the database
   gem "memory_profiler", "~> 0.9" # Memory profiling routines for Ruby 2.3+
   gem "parallel_tests", "~> 2.28" # Run Test::Unit / RSpec / Cucumber / Spinach in parallel
+  gem "pry", "~> 0.12" # An IRB alternative and runtime developer console
   gem "pry-byebug", "~> 3.7" # Combine 'pry' with 'byebug'. Adds 'step', 'next', 'finish', 'continue' and 'break' commands to control execution
+  gem "pry-rails", "~> 0.3" # Use Pry as your rails console
   gem "rspec-rails", "~> 3.8" # rspec-rails is a testing framework for Rails 3+
   gem "rubocop", "~> 0.67", require: false # Automatic Ruby code style checking tool
   gem "rubocop-performance", "~> 1.0", require: false # A collection of RuboCop cops to check for performance optimizations in Ruby code

--- a/Gemfile
+++ b/Gemfile
@@ -104,13 +104,14 @@ group :development do
   gem "brakeman", "~> 4.4", require: false # Brakeman detects security vulnerabilities in Ruby on Rails applications via static analysis
   gem "bullet", "~> 5.9" # help to kill N+1 queries and unused eager loading
   gem "bundler-audit", "~> 0.6" # bundler-audit provides patch-level verification for Bundled apps
-  gem "derailed_benchmarks", "~> 1.3" # A series of things you can use to benchmark a Rails or Ruby app
+  gem "derailed_benchmarks", "~> 1.3", require: false # A series of things you can use to benchmark a Rails or Ruby app
   gem "fix-db-schema-conflicts", "~> 3.0" # Ensures consistent output of db/schema.rb despite local differences in the database
   # switch foreman to stable release when thor dependency is updated to 0.20+
   gem "foreman", github: "thepracticaldev/foreman", ref: "b64e401", require: false # Process manager for applications with multiple components
   gem "guard", "~> 2.15", require: false # Guard is a command line tool to easily handle events on file system modifications
   gem "guard-livereload", "~> 2.5", require: false # Guard::LiveReload automatically reloads your browser when 'view' files are modified
   gem "guard-rspec", "~> 4.7", require: false # Guard::RSpec automatically run your specs
+  gem "memory_profiler", "~> 0.9", require: false # Memory profiling routines for Ruby 2.3+
   gem "web-console", "~> 3.7" # Rails Console on the Browser
 end
 
@@ -118,7 +119,6 @@ group :development, :test do
   gem "capybara", "~> 3.13" # Capybara is an integration testing tool for rack based web applications
   gem "erb_lint", "~> 0.0", require: false # ERB Linter tool
   gem "faker", "~> 1.9" # A library for generating fake data such as names, addresses, and phone numbers
-  gem "memory_profiler", "~> 0.9" # Memory profiling routines for Ruby 2.3+
   gem "parallel_tests", "~> 2.28" # Run Test::Unit / RSpec / Cucumber / Spinach in parallel
   gem "pry", "~> 0.12" # An IRB alternative and runtime developer console
   gem "pry-byebug", "~> 3.7" # Combine 'pry' with 'byebug'. Adds 'step', 'next', 'finish', 'continue' and 'break' commands to control execution

--- a/Gemfile
+++ b/Gemfile
@@ -105,6 +105,7 @@ group :development do
   gem "bullet", "~> 5.9" # help to kill N+1 queries and unused eager loading
   gem "bundler-audit", "~> 0.6" # bundler-audit provides patch-level verification for Bundled apps
   gem "derailed_benchmarks", "~> 1.3" # A series of things you can use to benchmark a Rails or Ruby app
+  gem "fix-db-schema-conflicts", "~> 3.0" # Ensures consistent output of db/schema.rb despite local differences in the database
   # switch foreman to stable release when thor dependency is updated to 0.20+
   gem "foreman", github: "thepracticaldev/foreman", ref: "b64e401", require: false # Process manager for applications with multiple components
   gem "guard", "~> 2.15", require: false # Guard is a command line tool to easily handle events on file system modifications
@@ -117,7 +118,6 @@ group :development, :test do
   gem "capybara", "~> 3.13" # Capybara is an integration testing tool for rack based web applications
   gem "erb_lint", "~> 0.0", require: false # ERB Linter tool
   gem "faker", "~> 1.9" # A library for generating fake data such as names, addresses, and phone numbers
-  gem "fix-db-schema-conflicts", "~> 3.0" # Ensures consistent output of db/schema.rb despite local differences in the database
   gem "memory_profiler", "~> 0.9" # Memory profiling routines for Ruby 2.3+
   gem "parallel_tests", "~> 2.28" # Run Test::Unit / RSpec / Cucumber / Spinach in parallel
   gem "pry", "~> 0.12" # An IRB alternative and runtime developer console

--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,8 @@ gem "omniauth", "~> 1.9" # A generalized Rack framework for multiple-provider au
 gem "omniauth-github", "~> 1.3" # OmniAuth strategy for GitHub
 gem "omniauth-twitter", "~> 1.4" # OmniAuth strategy for Twitter
 gem "pg", "~> 1.1" # Pg is the Ruby interface to the PostgreSQL RDBMS
+gem "pry", "~> 0.12" # An IRB alternative and runtime developer console
+gem "pry-rails", "~> 0.3" # Use Pry as your rails console
 gem "puma", "~> 3.12" # Puma is a simple, fast, threaded, and highly concurrent HTTP 1.1 server
 gem "pundit", "~> 2.0" # Object oriented authorization for Rails applications
 gem "pusher", "~> 1.3" # Ruby library for Pusher Channels HTTP API
@@ -120,9 +122,7 @@ group :development, :test do
   gem "capybara", "~> 3.13" # Capybara is an integration testing tool for rack based web applications
   gem "faker", "~> 1.9" # A library for generating fake data such as names, addresses, and phone numbers
   gem "parallel_tests", "~> 2.28" # Run Test::Unit / RSpec / Cucumber / Spinach in parallel
-  gem "pry", "~> 0.12" # An IRB alternative and runtime developer console
   gem "pry-byebug", "~> 3.7" # Combine 'pry' with 'byebug'. Adds 'step', 'next', 'finish', 'continue' and 'break' commands to control execution
-  gem "pry-rails", "~> 0.3" # Use Pry as your rails console
   gem "rspec-rails", "~> 3.8" # rspec-rails is a testing framework for Rails 3+
   gem "rubocop", "~> 0.67", require: false # Automatic Ruby code style checking tool
   gem "rubocop-performance", "~> 1.0", require: false # A collection of RuboCop cops to check for performance optimizations in Ruby code

--- a/Gemfile
+++ b/Gemfile
@@ -115,7 +115,6 @@ end
 
 group :development, :test do
   gem "capybara", "~> 3.13" # Capybara is an integration testing tool for rack based web applications
-  gem "derailed", "~> 0.1" # A shortcut for "derailed_benchmarks"
   gem "erb_lint", "~> 0.0", require: false # ERB Linter tool
   gem "faker", "~> 1.9" # A library for generating fake data such as names, addresses, and phone numbers
   gem "fix-db-schema-conflicts", "~> 3.0" # Ensures consistent output of db/schema.rb despite local differences in the database

--- a/Gemfile
+++ b/Gemfile
@@ -129,7 +129,6 @@ group :development, :test do
   gem "rubocop-rspec", "~> 1.32", require: false # Code style checking for RSpec files
   gem "spring", "~> 2.0" # Preloads your application so things like console, rake and tests run faster
   gem "spring-commands-rspec", "~> 1.0" # rspec command for spring
-  gem "vcr", "~> 4.0" # Record your test suite's HTTP interactions and replay them during future test runs for fast, deterministic, accurate tests
 end
 
 group :test do
@@ -149,6 +148,7 @@ group :test do
   gem "stripe-ruby-mock", "~> 2.5", require: "stripe_mock" # A drop-in library to test stripe without hitting their servers
   gem "test-prof", "~> 0.7" # Ruby Tests Profiling Toolbox
   gem "timecop", "~> 0.9" # A gem providing "time travel" and "time freezing" capabilities, making it dead simple to test time-dependent code
+  gem "vcr", "~> 4.0" # Record your test suite's HTTP interactions and replay them during future test runs for fast, deterministic, accurate tests
   gem "webmock", "~> 3.5" # WebMock allows stubbing HTTP requests and setting expectations on HTTP requests
   gem "zonebie", "~> 0.6.1" # Runs your tests in a random timezone
 end

--- a/Gemfile
+++ b/Gemfile
@@ -82,7 +82,6 @@ gem "s3_direct_upload", "~> 0.1" # Direct Upload to Amazon S3
 gem "sail", "~> 1.5" # Sail is a lightweight Rails engine that brings an admin panel for managing configuration settings on a live Rails app
 gem "sass-rails", "~> 5.0" # Sass adapter for the Rails asset pipeline
 gem "scout_apm", "~> 2.4" # Monitors Ruby apps and reports detailed metrics on performance to Scout
-gem "sdoc", "~> 1.0", group: :doc # rdoc generator html with javascript search index
 gem "serviceworker-rails", "~> 0.5" # Integrates ServiceWorker into the Rails asset pipeline
 gem "sitemap_generator", "~> 6.0" # SitemapGenerator is a framework-agnostic XML Sitemap generator
 gem "skylight", "~> 3.1" # Skylight is a smart profiler for Rails, Sinatra, and other Ruby apps
@@ -154,4 +153,8 @@ group :test do
   gem "timecop", "~> 0.9" # A gem providing "time travel" and "time freezing" capabilities, making it dead simple to test time-dependent code
   gem "webmock", "~> 3.5" # WebMock allows stubbing HTTP requests and setting expectations on HTTP requests
   gem "zonebie", "~> 0.6.1" # Runs your tests in a random timezone
+end
+
+group :doc do
+  gem "sdoc", "~> 1.0" # rdoc generator html with javascript search index
 end

--- a/Gemfile
+++ b/Gemfile
@@ -105,6 +105,7 @@ group :development do
   gem "bullet", "~> 5.9" # help to kill N+1 queries and unused eager loading
   gem "bundler-audit", "~> 0.6" # bundler-audit provides patch-level verification for Bundled apps
   gem "derailed_benchmarks", "~> 1.3", require: false # A series of things you can use to benchmark a Rails or Ruby app
+  gem "erb_lint", "~> 0.0", require: false # ERB Linter tool
   gem "fix-db-schema-conflicts", "~> 3.0" # Ensures consistent output of db/schema.rb despite local differences in the database
   # switch foreman to stable release when thor dependency is updated to 0.20+
   gem "foreman", github: "thepracticaldev/foreman", ref: "b64e401", require: false # Process manager for applications with multiple components
@@ -117,7 +118,6 @@ end
 
 group :development, :test do
   gem "capybara", "~> 3.13" # Capybara is an integration testing tool for rack based web applications
-  gem "erb_lint", "~> 0.0", require: false # ERB Linter tool
   gem "faker", "~> 1.9" # A library for generating fake data such as names, addresses, and phone numbers
   gem "parallel_tests", "~> 2.28" # Run Test::Unit / RSpec / Cucumber / Spinach in parallel
   gem "pry", "~> 0.12" # An IRB alternative and runtime developer console

--- a/Gemfile
+++ b/Gemfile
@@ -110,7 +110,6 @@ group :development do
   gem "guard", "~> 2.15", require: false # Guard is a command line tool to easily handle events on file system modifications
   gem "guard-livereload", "~> 2.5", require: false # Guard::LiveReload automatically reloads your browser when 'view' files are modified
   gem "guard-rspec", "~> 4.7", require: false # Guard::RSpec automatically run your specs
-  gem "rb-fsevent", "~> 0.10", require: false #  FSEvents API with signals handled
   gem "web-console", "~> 3.7" # Rails Console on the Browser
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1070,7 +1070,6 @@ DEPENDENCIES
   serviceworker-rails (~> 0.5)
   shoulda-matchers (= 4.0.1)
   simplecov (~> 0.16)
-  sinatra (~> 2.0)
   sitemap_generator (~> 6.0)
   skylight (~> 3.1)
   slack-notifier (~> 2.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -235,8 +235,6 @@ GEM
       delayed_job (> 2.0.3)
       rack-protection (>= 1.5.5)
       sinatra (>= 1.4.4)
-    derailed (0.1.0)
-      derailed_benchmarks
     derailed_benchmarks (1.3.5)
       benchmark-ips (~> 2)
       get_process_mem (~> 0)
@@ -996,7 +994,6 @@ DEPENDENCIES
   dalli (~> 2.7)
   delayed_job_active_record (~> 4.1)
   delayed_job_web (~> 1.4)
-  derailed (~> 0.1)
   derailed_benchmarks (~> 1.3)
   devise (~> 4.6)
   draper (~> 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1052,7 +1052,6 @@ DEPENDENCIES
   rails (~> 5.2, >= 5.2.3)
   rails-assets-airbrake-js-client (~> 1.6)!
   rails-observers (~> 0.1)
-  rb-fsevent (~> 0.10)
   recaptcha (~> 4.13)
   redcarpet (~> 3.4)
   reverse_markdown (~> 1.1)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

I've applied the following changes:

* pry was previously enabled in production, now it's only available in development and test
* removed gems that were not explicitly used (rb-fsevent and sinatra)
* moved some gems in the proper groups (fix-db-schema-conflicts, erb_lint and memory_profile will be available only in development, vcr is only needed during testing)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
