### PR TITLE
Enable random order for specs

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -52,6 +52,8 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
+  config.active_job.queue_adapter = :test
+
   # Install the Timber.io logger, but do not send logs.
   logger = Timber::Logger.new(nil)
   logger.level = config.log_level

--- a/spec/jobs/follows/create_chat_channel_job_spec.rb
+++ b/spec/jobs/follows/create_chat_channel_job_spec.rb
@@ -10,6 +10,12 @@ RSpec.describe Follows::CreateChatChannelJob, type: :job do
 
     it "creates a chat channel when mutual followers" do
       follow2 = create(:follow, follower: user2, followable: user)
+
+      # Follow has an after_create callback that creates a channel between the two users,
+      # so to make sure this test is correct, we delete all channels right after
+      ChatChannelMembership.delete_all
+      ChatChannel.delete_all
+
       expect do
         described_class.perform_now(follow2.id)
       end.to change(ChatChannel, :count).by(1)

--- a/spec/jobs/shared_examples/enqueues_job.rb
+++ b/spec/jobs/shared_examples/enqueues_job.rb
@@ -1,7 +1,6 @@
 RSpec.shared_examples "#enqueues_job" do |queue_name, args|
   describe "#perform_later" do
     it "enqueues the job" do
-      ActiveJob::Base.queue_adapter = :test
       expect do
         described_class.perform_later(*args)
       end.to have_enqueued_job.with(*args).on_queue(queue_name)

--- a/spec/jobs/users/touch_job_spec.rb
+++ b/spec/jobs/users/touch_job_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 RSpec.describe Users::TouchJob, type: :job do
   describe "#perform_later" do
     it "enqueues the job" do
-      ActiveJob::Base.queue_adapter = :test
       expect do
         described_class.perform_later(3)
       end.to have_enqueued_job.with(3).on_queue("touch_user")

--- a/spec/models/article_destroy_spec.rb
+++ b/spec/models/article_destroy_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe Article, type: :model do
-  before { ActiveJob::Base.queue_adapter = :test }
-
   context "when no organization" do
     let(:article) { create(:article) }
 

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -410,16 +410,16 @@ RSpec.describe Article, type: :model do
       it "updates the hotness score" do
         perform_enqueued_jobs do
           article.save
+          expect(article.reload.hotness_score.positive?).to eq(true)
         end
-        expect(article.reload.hotness_score.positive?).to eq(true)
       end
 
       it "updates the spaminess rating" do
         perform_enqueued_jobs do
           article.spaminess_rating = -1
           article.save
+          expect(article.reload.spaminess_rating).to eq(0)
         end
-        expect(article.reload.spaminess_rating).to eq(0)
       end
     end
 
@@ -429,16 +429,16 @@ RSpec.describe Article, type: :model do
       it "does not update the hotness score" do
         perform_enqueued_jobs do
           article.save
+          expect(article.reload.hotness_score).to eq(0)
         end
-        expect(article.reload.hotness_score).to eq(0)
       end
 
       it "does not update the spaminess rating" do
         perform_enqueued_jobs do
           article.spaminess_rating = -1
           article.save
+          expect(article.reload.spaminess_rating).to eq(-1)
         end
-        expect(article.reload.spaminess_rating).to eq(-1)
       end
     end
   end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -237,7 +237,7 @@ RSpec.describe Article, type: :model do
     end
   end
 
-  describe "queries" do
+  describe ".seo_boostable" do
     it "returns articles ordered by organic_page_views_count" do
       create(:article, score: 30)
       create(:article, score: 30)
@@ -245,17 +245,20 @@ RSpec.describe Article, type: :model do
       articles = Article.seo_boostable
       expect(articles.first[0]).to eq(top_article.path)
     end
+
     it "returns articles if within time frame" do
       top_article = create(:article, organic_page_views_past_month_count: 20, score: 30)
       articles = Article.seo_boostable(nil, 1.month.ago)
       expect(articles.first[0]).to eq(top_article.path)
     end
+
     it "does not return articles outside of timeframe" do
       top_article = create(:article, organic_page_views_past_month_count: 20, score: 30)
       top_article.update_column(:published_at, 3.months.ago)
       articles = Article.seo_boostable(nil, 1.month.ago)
       expect(articles.first).to eq(nil)
     end
+
     it "returns articles ordered by organic_page_views_count by tag" do
       create(:article, score: 30)
       create(:article, organic_page_views_count: 30, score: 30)
@@ -264,6 +267,7 @@ RSpec.describe Article, type: :model do
       articles = Article.seo_boostable("greatalicious")
       expect(articles.first[0]).to eq(top_article.path)
     end
+
     it "returns nothing if no tagged articles" do
       create(:article, score: 30)
       create(:article, organic_page_views_count: 30)
@@ -401,20 +405,21 @@ RSpec.describe Article, type: :model do
 
   describe "#async_score_calc" do
     context "when published" do
-      before { ActiveJob::Base.queue_adapter = :inline }
-
       let(:article) { build(:article) }
 
       it "updates the hotness score" do
-        article.save
-        article.reload
-        expect(article.hotness_score > 0).to eq(true)
+        perform_enqueued_jobs do
+          article.save
+          expect(article.reload.hotness_score.positive?).to eq(true)
+        end
       end
 
-      it "updates the spaminess score" do
-        article.spaminess_rating = -1
-        article.save
-        expect(article.spaminess_rating).to eq(0)
+      it "updates the spaminess rating" do
+        perform_enqueued_jobs do
+          article.spaminess_rating = -1
+          article.save
+          expect(article.reload.spaminess_rating).to eq(0)
+        end
       end
     end
 
@@ -422,14 +427,18 @@ RSpec.describe Article, type: :model do
       let(:article) { create(:article, published: false) }
 
       it "does not update the hotness score" do
-        article.save
-        expect(article.hotness_score).to eq(0)
+        perform_enqueued_jobs do
+          article.save
+          expect(article.reload.hotness_score).to eq(0)
+        end
       end
 
-      it "does not update the spaminess score" do
-        article.update_column(:spaminess_rating, -1)
-        article.save
-        expect(article.spaminess_rating).to eq(-1)
+      it "does not update the spaminess rating" do
+        perform_enqueued_jobs do
+          article.spaminess_rating = -1
+          article.save
+          expect(article.reload.spaminess_rating).to eq(-1)
+        end
       end
     end
   end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -410,16 +410,16 @@ RSpec.describe Article, type: :model do
       it "updates the hotness score" do
         perform_enqueued_jobs do
           article.save
-          expect(article.reload.hotness_score.positive?).to eq(true)
         end
+        expect(article.reload.hotness_score.positive?).to eq(true)
       end
 
       it "updates the spaminess rating" do
         perform_enqueued_jobs do
           article.spaminess_rating = -1
           article.save
-          expect(article.reload.spaminess_rating).to eq(0)
         end
+        expect(article.reload.spaminess_rating).to eq(0)
       end
     end
 
@@ -429,16 +429,16 @@ RSpec.describe Article, type: :model do
       it "does not update the hotness score" do
         perform_enqueued_jobs do
           article.save
-          expect(article.reload.hotness_score).to eq(0)
         end
+        expect(article.reload.hotness_score).to eq(0)
       end
 
       it "does not update the spaminess rating" do
         perform_enqueued_jobs do
           article.spaminess_rating = -1
           article.save
-          expect(article.reload.spaminess_rating).to eq(-1)
         end
+        expect(article.reload.spaminess_rating).to eq(-1)
       end
     end
   end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -13,17 +13,17 @@ RSpec.describe Notification, type: :model do
     let(:tag_follow) { user.follow(tag) }
 
     it "runs fine" do
-      perform_enqueued_jobs do
+      run_background_jobs_immediately do
         Notification.send_new_follower_notification(tag_follow)
       end
     end
 
     it "doesn't create a notification" do
-      expect do
-        perform_enqueued_jobs do
+      run_background_jobs_immediately do
+        expect do
           Notification.send_new_follower_notification(tag_follow)
-        end
-      end.not_to change(Notification, :count)
+        end.not_to change(Notification, :count)
+      end
     end
   end
 

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -13,17 +13,17 @@ RSpec.describe Notification, type: :model do
     let(:tag_follow) { user.follow(tag) }
 
     it "runs fine" do
-      run_background_jobs_immediately do
+      perform_enqueued_jobs do
         Notification.send_new_follower_notification(tag_follow)
       end
     end
 
     it "doesn't create a notification" do
-      run_background_jobs_immediately do
-        expect do
+      expect do
+        perform_enqueued_jobs do
           Notification.send_new_follower_notification(tag_follow)
-        end.not_to change(Notification, :count)
-      end
+        end
+      end.not_to change(Notification, :count)
     end
   end
 

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -29,8 +29,9 @@ RSpec.describe Notification, type: :model do
 
   describe "#send_new_follower_notification" do
     before do
-      ActiveJob::Base.queue_adapter = :inline
-      Notification.send_new_follower_notification(follow_instance)
+      perform_enqueued_jobs do
+        Notification.send_new_follower_notification(follow_instance)
+      end
     end
 
     it "sets the notifiable_at column upon creation" do
@@ -70,8 +71,9 @@ RSpec.describe Notification, type: :model do
     context "when a user unfollows another user" do
       it "destroys the follow notification" do
         follow_instance = user.stop_following(user2)
-        ActiveJob::Base.queue_adapter = :inline
-        Notification.send_new_follower_notification(follow_instance)
+        perform_enqueued_jobs do
+          Notification.send_new_follower_notification(follow_instance)
+        end
         expect(Notification.count).to eq 0
       end
     end

--- a/spec/models/reaction_create_spec.rb
+++ b/spec/models/reaction_create_spec.rb
@@ -3,11 +3,8 @@ require "rails_helper"
 RSpec.describe Reaction, type: :model do
   let(:article) { create(:article, featured: true) }
   let(:user) { create(:user) }
-  # let!(:reaction) { build(:reaction, reactable: article) }
 
   context "when creating and enqueueing" do
-    before { ActiveJob::Base.queue_adapter = :test }
-
     it "enqueues the Users::TouchJob" do
       expect do
         create(:reaction, reactable: article, user: user)
@@ -33,21 +30,23 @@ RSpec.describe Reaction, type: :model do
     end
   end
 
-  context "when creating and inline" do
-    before { ActiveJob::Base.queue_adapter = :inline }
-
+  context "when creating and performing jobs" do
     it "updates the reactable Comment" do
-      updated_at = 1.day.ago
-      comment = create(:comment, commentable: article, updated_at: updated_at)
-      create(:reaction, reactable: comment, user: user)
-      expect(comment.reload.updated_at).to be > updated_at
+      perform_enqueued_jobs do
+        updated_at = 1.day.ago
+        comment = create(:comment, commentable: article, updated_at: updated_at)
+        create(:reaction, reactable: comment, user: user)
+        expect(comment.reload.updated_at).to be > updated_at
+      end
     end
 
     it "touches the user" do
-      updated_at = 1.day.ago
-      user.update_columns(updated_at: updated_at)
-      create(:reaction, reactable: article, user: user)
-      expect(user.reload.updated_at).to be > updated_at
+      perform_enqueued_jobs do
+        updated_at = 1.day.ago
+        user.update_columns(updated_at: updated_at)
+        create(:reaction, reactable: article, user: user)
+        expect(user.reload.updated_at).to be > updated_at
+      end
     end
   end
 end

--- a/spec/models/reaction_create_spec.rb
+++ b/spec/models/reaction_create_spec.rb
@@ -32,22 +32,21 @@ RSpec.describe Reaction, type: :model do
 
   context "when creating and performing jobs" do
     it "updates the reactable Comment" do
-      comment = nil
-      updated_at = 1.day.ago
       perform_enqueued_jobs do
+        updated_at = 1.day.ago
         comment = create(:comment, commentable: article, updated_at: updated_at)
         create(:reaction, reactable: comment, user: user)
+        expect(comment.reload.updated_at).to be > updated_at
       end
-      expect(comment.reload.updated_at).to be > updated_at
     end
 
     it "touches the user" do
-      updated_at = 1.day.ago
-      user.update_columns(updated_at: updated_at)
       perform_enqueued_jobs do
+        updated_at = 1.day.ago
+        user.update_columns(updated_at: updated_at)
         create(:reaction, reactable: article, user: user)
+        expect(user.reload.updated_at).to be > updated_at
       end
-      expect(user.reload.updated_at).to be > updated_at
     end
   end
 end

--- a/spec/models/reaction_create_spec.rb
+++ b/spec/models/reaction_create_spec.rb
@@ -32,21 +32,22 @@ RSpec.describe Reaction, type: :model do
 
   context "when creating and performing jobs" do
     it "updates the reactable Comment" do
+      comment = nil
+      updated_at = 1.day.ago
       perform_enqueued_jobs do
-        updated_at = 1.day.ago
         comment = create(:comment, commentable: article, updated_at: updated_at)
         create(:reaction, reactable: comment, user: user)
-        expect(comment.reload.updated_at).to be > updated_at
       end
+      expect(comment.reload.updated_at).to be > updated_at
     end
 
     it "touches the user" do
+      updated_at = 1.day.ago
+      user.update_columns(updated_at: updated_at)
       perform_enqueued_jobs do
-        updated_at = 1.day.ago
-        user.update_columns(updated_at: updated_at)
         create(:reaction, reactable: article, user: user)
-        expect(user.reload.updated_at).to be > updated_at
       end
+      expect(user.reload.updated_at).to be > updated_at
     end
   end
 end

--- a/spec/models/reaction_destroy_spec.rb
+++ b/spec/models/reaction_destroy_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe Reaction, type: :model do
   let!(:reaction) { create(:reaction, reactable: article) }
 
   it "creates a ScoreCalcJob on article reaction destroy" do
-    ActiveJob::Base.queue_adapter = :test
     expect { reaction.destroy }.to have_enqueued_job(Articles::ScoreCalcJob).exactly(:once)
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -379,31 +379,35 @@ RSpec.describe User, type: :model do
       expect(new_user.identities.size).to eq(2)
     end
 
-    context "with active jobs" do
-      before { ActiveJob::Base.queue_adapter = :inline }
-
+    context "when estimating the default language" do
       it "estimates default language to be nil" do
-        user.estimate_default_language!
-        expect(user.estimated_default_language).to eq(nil)
+        perform_enqueued_jobs do
+          user.estimate_default_language!
+        end
+        expect(user.reload.estimated_default_language).to eq(nil)
       end
 
       it "estimates default language to be japan with jp email" do
-        user.update_column(:email, "ben@hello.jp")
-        user.estimate_default_language!
-        user.reload
-        expect(user.estimated_default_language).to eq("ja")
+        perform_enqueued_jobs do
+          user.update_column(:email, "ben@hello.jp")
+          user.estimate_default_language!
+        end
+        expect(user.reload.estimated_default_language).to eq("ja")
       end
 
       it "estimates default language based on ID dump" do
-        new_user = user_from_authorization_service(:twitter, nil, "navbar_basic")
-        new_user.estimate_default_language!
+        perform_enqueued_jobs do
+          new_user = user_from_authorization_service(:twitter, nil, "navbar_basic")
+          new_user.estimate_default_language!
+        end
       end
 
       it "returns proper preferred_languages_array" do
-        user.update_column(:email, "ben@hello.jp")
-        user.estimate_default_language!
-        user.reload
-        expect(user.decorate.preferred_languages_array).to include("ja")
+        perform_enqueued_jobs do
+          user.update_column(:email, "ben@hello.jp")
+          user.estimate_default_language!
+        end
+        expect(user.reload.decorate.preferred_languages_array).to include("ja")
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -388,23 +388,23 @@ RSpec.describe User, type: :model do
       end
 
       it "estimates default language to be japan with jp email" do
+        user.update_column(:email, "ben@hello.jp")
         perform_enqueued_jobs do
-          user.update_column(:email, "ben@hello.jp")
           user.estimate_default_language!
         end
         expect(user.reload.estimated_default_language).to eq("ja")
       end
 
       it "estimates default language based on ID dump" do
+        new_user = user_from_authorization_service(:twitter, nil, "navbar_basic")
         perform_enqueued_jobs do
-          new_user = user_from_authorization_service(:twitter, nil, "navbar_basic")
           new_user.estimate_default_language!
         end
       end
 
       it "returns proper preferred_languages_array" do
+        user.update_column(:email, "ben@hello.jp")
         perform_enqueued_jobs do
-          user.update_column(:email, "ben@hello.jp")
           user.estimate_default_language!
         end
         expect(user.reload.decorate.preferred_languages_array).to include("ja")

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -388,23 +388,23 @@ RSpec.describe User, type: :model do
       end
 
       it "estimates default language to be japan with jp email" do
-        user.update_column(:email, "ben@hello.jp")
         perform_enqueued_jobs do
+          user.update_column(:email, "ben@hello.jp")
           user.estimate_default_language!
         end
         expect(user.reload.estimated_default_language).to eq("ja")
       end
 
       it "estimates default language based on ID dump" do
-        new_user = user_from_authorization_service(:twitter, nil, "navbar_basic")
         perform_enqueued_jobs do
+          new_user = user_from_authorization_service(:twitter, nil, "navbar_basic")
           new_user.estimate_default_language!
         end
       end
 
       it "returns proper preferred_languages_array" do
-        user.update_column(:email, "ben@hello.jp")
         perform_enqueued_jobs do
+          user.update_column(:email, "ben@hello.jp")
           user.estimate_default_language!
         end
         expect(user.reload.decorate.preferred_languages_array).to include("ja")

--- a/spec/observers/comment_observer_spec.rb
+++ b/spec/observers/comment_observer_spec.rb
@@ -9,11 +9,12 @@ RSpec.describe CommentObserver, type: :observer do
   end
 
   it "pings slack if user with warned role creates a comment" do
-    ActiveJob::Base.queue_adapter = :inline
-    user.add_role :warned
-    Comment.observers.enable :comment_observer do
-      run_background_jobs_immediately do
-        create(:comment, user: user, commentable: article)
+    perform_enqueued_jobs do
+      user.add_role :warned
+      Comment.observers.enable :comment_observer do
+        run_background_jobs_immediately do
+          create(:comment, user: user, commentable: article)
+        end
       end
     end
     expect(SlackBot).to have_received(:ping).twice

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -62,6 +62,7 @@ RSpec.configure do |config|
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
   config.include ApplicationHelper
+  config.include ActiveJob::TestHelper
   config.include Devise::Test::ControllerHelpers, type: :view
   config.include Devise::Test::IntegrationHelpers, type: :system
   config.include Devise::Test::IntegrationHelpers, type: :request

--- a/spec/requests/follows_api_spec.rb
+++ b/spec/requests/follows_api_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "FollowsApi", type: :request do
     let(:user3) { create(:user) }
     let(:user4) { create(:user) }
     let(:user5) { create(:user) }
-    let!(:users_hash) do
+    let(:users_hash) do
       [{ id: user2.id }, { id: user3.id }, { id: user4.id }, { id: user5.id }].to_json
     end
 

--- a/spec/requests/follows_api_spec.rb
+++ b/spec/requests/follows_api_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "FollowsApi", type: :request do
     let(:user3) { create(:user) }
     let(:user4) { create(:user) }
     let(:user5) { create(:user) }
-    let(:users_hash) do
+    let!(:users_hash) do
       [{ id: user2.id }, { id: user3.id }, { id: user4.id }, { id: user5.id }].to_json
     end
 

--- a/spec/requests/user_settings_spec.rb
+++ b/spec/requests/user_settings_spec.rb
@@ -70,10 +70,6 @@ RSpec.describe "UserSettings", type: :request do
     end
 
     context "when requesting an export of the articles" do
-      before do
-        ActiveJob::Base.queue_adapter = :test
-      end
-
       def send_request(flag = true)
         put "/users/#{user.id}", params: {
           user: { tab: "misc", export_requested: flag }
@@ -103,13 +99,15 @@ RSpec.describe "UserSettings", type: :request do
       end
 
       it "sends an email" do
-        ActiveJob::Base.queue_adapter = :inline
-        expect { send_request }.to change { ActionMailer::Base.deliveries.count }.by(1)
+        perform_enqueued_jobs do
+          expect { send_request }.to change { ActionMailer::Base.deliveries.count }.by(1)
+        end
       end
 
       it "does not send an email if there was no request" do
-        ActiveJob::Base.queue_adapter = :inline
-        expect { send_request(false) }.not_to(change { ActionMailer::Base.deliveries.count })
+        perform_enqueued_jobs do
+          expect { send_request(false) }.not_to(change { ActionMailer::Base.deliveries.count })
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -93,15 +93,15 @@ RSpec.configure do |config|
   #   # particularly slow.
   #   config.profile_examples = 10
   #
-  #   # Run specs in random order to surface order dependencies. If you find an
-  #   # order dependency and want to debug it, you can fix the order by providing
-  #   # the seed, which is printed after each run.
-  #   #     --seed 1234
-  #   config.order = :random
-  #
-  #   # Seed global randomization in this process using the `--seed` CLI option.
-  #   # Setting this allows you to use `--seed` to deterministically reproduce
-  #   # test failures related to randomization by passing the same `--seed` value
-  #   # as the one that triggered the failure.
-  #   Kernel.srand config.seed
+  # Run specs in random order to surface order dependencies. If you find an
+  # order dependency and want to debug it, you can fix the order by providing
+  # the seed, which is printed after each run.
+  #     --seed 1234
+  config.order = :random
+
+  # Seed global randomization in this process using the `--seed` CLI option.
+  # Setting this allows you to use `--seed` to deterministically reproduce
+  # test failures related to randomization by passing the same `--seed` value
+  # as the one that triggered the failure.
+  Kernel.srand config.seed
 end

--- a/spec/system/comments/user_fills_out_comment_spec.rb
+++ b/spec/system/comments/user_fills_out_comment_spec.rb
@@ -3,9 +3,8 @@ require "rails_helper"
 RSpec.describe "Creating Comment", type: :system, js: true do
   let(:user) { create(:user) }
   let(:raw_comment) { Faker::Lorem.paragraph }
-  let(:article) do
-    create(:article, user_id: user.id, show_comments: true)
-  end
+  # the article should be created before signing in
+  let!(:article) { create(:article, user_id: user.id, show_comments: true) }
 
   before do
     sign_in user

--- a/spec/system/dashboards/user_sorts_dashboard_articles_spec.rb
+++ b/spec/system/dashboards/user_sorts_dashboard_articles_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe "Sorting Dashboard Articles", type: :system, js: true do
   let(:article3) { create(:article, user_id: user.id, published_at: 5.minutes.ago, created_at: 3.days.ago, positive_reactions_count: 0, page_views_count: 1000, comments_count: 50) }
 
   before do
-    sign_in user
     article1
     article2
     article3
+    sign_in user
   end
 
   it "shows articles sorted by default in created_at DESC" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

Running specs in a random order it's a great way to see if there are dependency problems among tests or weird race conditions. 

The great thing about this is that by providing the seed with the failing test in a subsequent run it's possible to reproduce the conditions that lead to the tests failing.

I had to make some modifications to some tests to increase robustness (and get rid of the weird behaviors on sequencing and active job related tests)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
