### PR TITLE
Adjust badge streak copy for 16 week badge

### DIFF
--- a/app/labor/badge_rewarder.rb
+++ b/app/labor/badge_rewarder.rb
@@ -57,7 +57,11 @@ module BadgeRewarder
 
   def self.award_streak_badge(num_weeks)
     article_user_ids = Article.published.where("published_at > ? AND score > ?", 1.week.ago, -25).pluck(:user_id) # No cred for super low quality
-    message = "Congrats on achieving this streak! Consistent writing is hard. The next streak badge you can get is the #{num_weeks * 2} Week Badge. 😉"
+    message = if num_weeks == 16
+                "16 weeks! You've achieved the longest DEV writing streak possible. This makes you eligible for special quests in the future. Keep up the amazing contributions to our community!"
+              else
+                "Congrats on achieving this streak! Consistent writing is hard. The next streak badge you can get is the #{num_weeks * 2} Week Badge. 😉"
+              end
     users = User.where(id: article_user_ids).where("articles_count >= ?", num_weeks)
     usernames = []
     users.find_each do |user|


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
This makes it clear that the 16 week badge is the final streak badge, to eliminate the possibility to have folks toiling addictively or otherwise introduce negative side affects of gamification.