### PR TITLE
Release Open Inbox

### DIFF
--- a/app/assets/stylesheets/chat.scss
+++ b/app/assets/stylesheets/chat.scss
@@ -512,7 +512,7 @@
   }
 }
 
-.userdetails__reportabuse {
+.userdetails__reportabuse, .userdetails__blockmsg {
   a {
     background-color: rgb(255, 0, 0);
     color: rgb(255, 255, 254);
@@ -796,7 +796,7 @@
       background: transparent;
       background: var(--theme-container-background-hover, transparent);
     }
-    
+
   }
 }
 

--- a/app/javascript/chat/__tests__/__snapshots__/userDetails.test.jsx.snap
+++ b/app/javascript/chat/__tests__/__snapshots__/userDetails.test.jsx.snap
@@ -145,21 +145,68 @@ exports[`<UserDetails /> for user1 should render and test snapshot 1`] = `
           close this chat and prevent this user from re-opening chat with you
         </li>
         <li>
-          give the DEV team your consent to read messages in this chat to understand your report
+          give the DEV team your consent to read messages in this chat to understand your report and take appropriate action
         </li>
       </ul>
+      <p>
+        Blocking is only on Connect right now and has not been implemented across DEV yet.
+      </p>
       <h5>
         Are you sure?
       </h5>
       <a
         href="/report-abuse"
         onClick={[Function]}
+        tabIndex="0"
       >
-        Yes
+        Yes, Report
       </a>
       <a
         class="no"
         onClick={[Function]}
+        onKeyUp={[Function]}
+        tabIndex="0"
+      >
+        No
+      </a>
+    </div>
+  </div>
+  <div
+    id="userdetails__blockmsg"
+    style="display:none"
+  >
+    <div
+      class="userdetails__blockmsg"
+    >
+      <p>
+        Blocking on connect will: 
+      </p>
+      <ul>
+        <li>
+          close this chat and prevent this user from re-opening chat with you
+        </li>
+        <li>
+          NOT notify the user you will block--this channel will become inaccessible for both users
+        </li>
+      </ul>
+      <p>
+        Blocking is only on Connect right now and has not been implemented across DEV yet. Consider reporting abuse to the DEV team if this user is spamming or harassing elsewhere on dev.to, so we can take further action.
+      </p>
+      <h5>
+        Are you sure?
+      </h5>
+      <a
+        onClick={[Function]}
+        onKeyUp={[Function]}
+        tabIndex="0"
+      >
+        Yes, Block
+      </a>
+      <a
+        class="no"
+        onClick={[Function]}
+        onKeyUp={[Function]}
+        tabIndex="0"
       >
         No
       </a>
@@ -313,21 +360,68 @@ exports[`<UserDetails /> for user2 should render and test snapshot 1`] = `
           close this chat and prevent this user from re-opening chat with you
         </li>
         <li>
-          give the DEV team your consent to read messages in this chat to understand your report
+          give the DEV team your consent to read messages in this chat to understand your report and take appropriate action
         </li>
       </ul>
+      <p>
+        Blocking is only on Connect right now and has not been implemented across DEV yet.
+      </p>
       <h5>
         Are you sure?
       </h5>
       <a
         href="/report-abuse"
         onClick={[Function]}
+        tabIndex="0"
       >
-        Yes
+        Yes, Report
       </a>
       <a
         class="no"
         onClick={[Function]}
+        onKeyUp={[Function]}
+        tabIndex="0"
+      >
+        No
+      </a>
+    </div>
+  </div>
+  <div
+    id="userdetails__blockmsg"
+    style="display:none"
+  >
+    <div
+      class="userdetails__blockmsg"
+    >
+      <p>
+        Blocking on connect will: 
+      </p>
+      <ul>
+        <li>
+          close this chat and prevent this user from re-opening chat with you
+        </li>
+        <li>
+          NOT notify the user you will block--this channel will become inaccessible for both users
+        </li>
+      </ul>
+      <p>
+        Blocking is only on Connect right now and has not been implemented across DEV yet. Consider reporting abuse to the DEV team if this user is spamming or harassing elsewhere on dev.to, so we can take further action.
+      </p>
+      <h5>
+        Are you sure?
+      </h5>
+      <a
+        onClick={[Function]}
+        onKeyUp={[Function]}
+        tabIndex="0"
+      >
+        Yes, Block
+      </a>
+      <a
+        class="no"
+        onClick={[Function]}
+        onKeyUp={[Function]}
+        tabIndex="0"
       >
         No
       </a>

--- a/app/javascript/chat/userDetails.jsx
+++ b/app/javascript/chat/userDetails.jsx
@@ -88,8 +88,18 @@ export default class UserDetails extends Component {
         <div className="userdetails__blockreport">
           <button
             onClick={() => {
-              blockChat(channelId);
-              window.location.href = `/connect`;
+              const modal = document.getElementById('userdetails__blockmsg');
+              const otherModal = document.getElementById(
+                'userdetails__reportabuse',
+              );
+              otherModal.style.display = 'none';
+              if (modal.style.display === 'none') {
+                modal.style.display = 'block';
+                window.location.href = `#userdetails__blockmsg`;
+              } else {
+                modal.style.display = 'none';
+                window.location.href = `#`;
+              }
             }}
           >
             Block User
@@ -98,6 +108,10 @@ export default class UserDetails extends Component {
           <button
             onClick={() => {
               const modal = document.getElementById('userdetails__reportabuse');
+              const otherModal = document.getElementById(
+                'userdetails__blockmsg',
+              );
+              otherModal.style.display = 'none';
               if (modal.style.display === 'none') {
                 modal.style.display = 'block';
                 window.location.href = `#userdetails__reportabuse`;
@@ -120,25 +134,95 @@ export default class UserDetails extends Component {
               </li>
               <li>
                 give the DEV team your consent to read messages in this chat to
-                understand your report
+                understand your report and take appropriate action
               </li>
             </ul>
+            <p>
+              Blocking is only on Connect right now and has not been implemented
+              across DEV yet.
+            </p>
             <h5>Are you sure?</h5>
             <a
+              tabIndex="0"
               href="/report-abuse"
               onClick={() => {
                 blockChat(channelId);
               }}
             >
-              Yes
+              Yes, Report
             </a>
             <a
+              tabIndex="0"
               className="no"
               onClick={() => {
                 document.getElementById(
                   'userdetails__reportabuse',
                 ).style.display = 'none';
                 window.location.href = `#`;
+              }}
+              onKeyUp={e => {
+                if (e.keyCode === 13) {
+                  document.getElementById(
+                    'userdetails__reportabuse',
+                  ).style.display = 'none';
+                  window.location.href = `#`;
+                }
+              }}
+            >
+              No
+            </a>
+          </div>
+        </div>
+        <div id="userdetails__blockmsg" style="display:none">
+          <div className="userdetails__blockmsg">
+            <p>Blocking on connect will: </p>
+            <ul>
+              <li>
+                close this chat and prevent this user from re-opening chat with
+                you
+              </li>
+              <li>
+                NOT notify the user you will block--this channel will become
+                inaccessible for both users
+              </li>
+            </ul>
+            <p>
+              Blocking is only on Connect right now and has not been implemented
+              across DEV yet. Consider reporting abuse to the DEV team if this
+              user is spamming or harassing elsewhere on dev.to, so we can take
+              further action.
+            </p>
+            <h5>Are you sure?</h5>
+            <a
+              tabIndex="0"
+              onClick={() => {
+                blockChat(channelId);
+                window.location.href = `/connect`;
+              }}
+              onKeyUp={e => {
+                if (e.keyCode === 13) {
+                  blockChat(channelId);
+                  window.location.href = `/connect`;
+                }
+              }}
+            >
+              Yes, Block
+            </a>
+            <a
+              tabIndex="0"
+              className="no"
+              onClick={() => {
+                document.getElementById('userdetails__blockmsg').style.display =
+                  'none';
+                window.location.href = `#`;
+              }}
+              onKeyUp={e => {
+                if (e.keyCode === 13) {
+                  document.getElementById(
+                    'userdetails__blockmsg',
+                  ).style.display = 'none';
+                  window.location.href = `#`;
+                }
               }}
             >
               No

--- a/app/views/users/_misc.html.erb
+++ b/app/views/users/_misc.html.erb
@@ -149,18 +149,16 @@
   <% end %>
 <% end %>
 
-<% if false %>
-  <h2> Connect </h2>
+<h2> Connect </h2>
 
-  <h3> Inbox Type </h3>
+<h3> Inbox Type </h3>
 
-  <%= form_for(@user) do |f| %>
-    <div class="field checkbox-label-first">
-      <%= f.label :inbox_type, "Open your inbox to messages from people you don't follow or keep your inbox private to mutual follows." %>
-      <div class="sub-field">
-        <%= f.select :inbox_type, [["Open", "open"], ["Private", "private"]] %>
-      </div>
-      <%= f.submit "SUBMIT", class: "cta" %>
+<%= form_for(@user) do |f| %>
+  <div class="field checkbox-label-first">
+    <%= f.label :inbox_type, "Open your inbox to messages from people you don't follow or keep your inbox private to mutual follows." %>
+    <div class="sub-field">
+      <%= f.select :inbox_type, [["Open", "open"], ["Private", "private"]] %>
     </div>
-  <% end %>
+    <%= f.submit "SUBMIT", class: "cta" %>
+  </div>
 <% end %>


### PR DESCRIPTION
## What type of PR is this?

- [x] Refactor

## Description
- Gives users the ability to change your inbox type between `private` and `open` in `/settings/misc`. 
- Added message when clicking on Block in Connect that explains that block is only implemented in connect and not all throughout DEV. 

## Related Tickets & Documents
continues off #1563 and #2074 
resolves #1567 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
### `/settings/misc`
<img width="1280" alt="Screen Shot 2019-04-16 at 15 48 56" src="https://user-images.githubusercontent.com/13403332/56239944-31ca9e00-6060-11e9-88ca-31626aef5748.png">

### New Message Modal
<img width="1280" alt="Screen Shot 2019-04-16 at 15 47 39" src="https://user-images.githubusercontent.com/13403332/56239964-3bec9c80-6060-11e9-92c1-b827699783ed.png">

### `/connect`
<img width="1280" alt="Screen Shot 2019-04-16 at 15 47 54" src="https://user-images.githubusercontent.com/13403332/56239991-4dce3f80-6060-11e9-8042-d0d78ab91404.png">

### Additional Clarification
<img width="465" alt="Screen Shot 2019-04-16 at 15 48 22" src="https://user-images.githubusercontent.com/13403332/56240004-5757a780-6060-11e9-9c22-b4645f5fb094.png">

## Added to documentation?

- [x] no documentation needed
