### PR TITLE
Convert underscores in article slugs properly

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -563,7 +563,7 @@ class Article < ApplicationRecord
   end
 
   def title_to_slug
-    title.to_s.downcase.parameterize + "-" + rand(100_000).to_s(26)
+    title.to_s.downcase.parameterize.tr("_", "") + "-" + rand(100_000).to_s(26)
   end
 
   def bust_cache

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -123,6 +123,11 @@ RSpec.describe Article, type: :model do
         article1.validate
         expect(article1.slug).not_to start_with(article0.slug)
       end
+
+      it "properly converts underscores and still has a valid slug" do
+        underscored_article = build(:article, title: "hey_hey_hey node_modules", published: false)
+        expect(underscored_article.valid?).to eq true
+      end
     end
 
     context "when published" do
@@ -135,6 +140,11 @@ RSpec.describe Article, type: :model do
       it "does not change slug if the article was edited" do
         article0.update(title: "New title.")
         expect(article0.slug).to start_with("hey-this-is-a-slug")
+      end
+
+      it "properly converts underscores and still has a valid slug" do
+        underscored_article = build(:article, title: "hey_hey_hey node_modules", published: true)
+        expect(underscored_article.valid?).to eq true
       end
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Resolves #2418

This converts article titles with underscores into valid slugs, since Rails' `parameterize` unfortunately does not handle underscores.