### PR TITLE
Add caching for historical data

### DIFF
--- a/app/services/analytics_service.rb
+++ b/app/services/analytics_service.rb
@@ -38,7 +38,7 @@ class AnalyticsService
     result = {}
 
     (start_date.to_date..end_date.to_date).each do |date|
-      result[date.to_s(:iso)] = data_for_date(date)
+      result[date.to_s(:iso)] = cached_data_for_date(date)
     end
 
     result
@@ -80,7 +80,7 @@ class AnalyticsService
     page_view_data.size.positive? ? page_view_data.sum(:time_tracked_in_seconds) / page_view_data.size : 0
   end
 
-  def data_for_date(date)
+  def cached_data_for_date(date)
     expiration_date = if date == Time.current.to_date
                         30.minutes
                       else


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
This adds caching for any historical data for analytics. Since most of the data is static, we'll cache it for 7 days. Data for the current day will be cached for 30 minutes. This should help improve the query speed, but we'll want to explore using SQL `GROUP` or other methods detailed in #2311 for a longer term solution.

I wasn't sure what other tests to add, but I tested this in development and it was hitting the cache. A two week query only used two SQL queries and took 21ms to load.