### PR TITLE
Added rbenv troubleshooting section.

### DIFF
--- a/docs/installation/mac-os.md
+++ b/docs/installation/mac-os.md
@@ -45,6 +45,17 @@ For additional configuration, [click here](/additional-postgres-setup)
 
 **_Solution:_** Run the command `rbenv install <version number>`
 
+**Error:** `ruby-build: definition not found: <version number>` when `rbenv` was installed via `brew`.
+
+```bash
+ruby-build: definition not found: <version number>
+
+See all available versions with `rbenv install --list'.                       If the version you need is missing, try upgrading ruby-build:
+```
+
+**_Solution:_**
+Run the following to update `ruby-build`, `brew update && brew upgrade ruby-build`. After that, rerun `rbenv install <version number>` and that version will get installed.
+
 **Error:**
 
 ```bash


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [X] Documentation Update

## Description
Added a section on troubleshooting rbenv failing to install v. 2.6.1 of ruby. I haven't had the application running locally since Christmas (v. 2.5.1), so I ran `rbenv install 2.6.1` only to get the following error:

```bash
ruby-build: definition not found: 2.6.1
See all available versions with `rbenv install --list'.                       If the version you need is missing, try upgrading ruby-build:
```

The update to the docs explains how to fix this. Feel free to change the wording as you see fit.

## Added to documentation?

- [x] docs.dev.to
- [ ] readme
- [ ] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![](https://media.giphy.com/media/syCa5ird7wp0c/giphy.gif)
