### PR TITLE
Remove "How do I setup the repo with Windows/Linux/Ubuntu/not macOS?"

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -9,14 +9,3 @@ All documentation lives in the [docs folder](https://github.com/thepracticaldev/
 ## I'm getting an error [SOME-ERROR]. Where do I report it?
 
 You can [write a new issue](https://github.com/thepracticaldev/dev.to/issues/new) and let us know what exactly what went wrong. We'll be able to help you debug if we have specific information, the context of how the error happened, and any other information you think would help.
-
-## How do I setup the repo with Windows/Linux/Ubuntu/not macOS?
-
-Unfortunately, the core team develops only macOS right now. We don't have guidelines for other operating systems yet. If you want to get up and running on a different OS, you'll need to have the following installed:
-
-* Ruby
-* Ruby on Rails
-* [PostgresSQL](/additional-postgres-setup)
-* [Yarn](https://yarnpkg.com/en/docs/install)
-
-You can use a guide like [GoRails](https://gorails.com/setup/), but since we have not tried it ourselves we can't fully endorse it. Let us know how it goes, or if you have tips or experience setting all this up! We're open to including guides for other operating systems.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Documentation Update

## Description

This part of the documentation can be removed since we now have installation docs for Linux, Windows and Mac now. See https://docs.dev.to/installation/

![image](https://user-images.githubusercontent.com/833231/56334981-9ffa8800-6168-11e9-9539-19493ec4cfe9.png)


## Added to documentation?

- [x] docs.dev.to
- [ ] readme
- [ ] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![Dave Chapelle Show Delete GIF](https://media.giphy.com/media/wkKRo7N0T1ONO/giphy.gif)
