### PR TITLE
Move Welcome Notification to Active Jobs

### DIFF
--- a/app/jobs/notifications/welcome_notification_job.rb
+++ b/app/jobs/notifications/welcome_notification_job.rb
@@ -1,0 +1,11 @@
+module Notifications
+  class WelcomeNotificationJob < ApplicationJob
+    queue_as :send_welcome_notification
+
+    def perform(receiver_id, service = WelcomeNotification::Send)
+      welcome_broadcast = Broadcast.find_by(title: "Welcome Notification")
+
+      service.call(receiver_id, welcome_broadcast) if welcome_broadcast
+    end
+  end
+end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -112,25 +112,12 @@ class Notification < ApplicationRecord
     handle_asynchronously :send_mention_notification
 
     def send_welcome_notification(receiver_id)
-      welcome_broadcast = Broadcast.find_by(title: "Welcome Notification")
-      return if welcome_broadcast.nil?
-
-      dev_account = User.dev_account
-      json_data = {
-        user: user_data(dev_account),
-        broadcast: {
-          processed_html: welcome_broadcast.processed_html
-        }
-      }
-      Notification.create(
-        user_id: receiver_id,
-        notifiable_id: welcome_broadcast.id,
-        notifiable_type: "Broadcast",
-        action: welcome_broadcast.type_of,
-        json_data: json_data,
-      )
+      Notifications::WelcomeNotificationJob.perform_later(receiver_id)
     end
-    handle_asynchronously :send_welcome_notification
+
+    def send_welcome_notification_without_delay(receiver_id)
+      Notifications::WelcomeNotificationJob.perform_now(receiver_id)
+    end
 
     def send_moderation_notification(notifiable)
       # notifiable is currently only comment

--- a/app/services/notifications/welcome_notification/send.rb
+++ b/app/services/notifications/welcome_notification/send.rb
@@ -1,0 +1,38 @@
+# send welcome notification
+module Notifications
+  module WelcomeNotification
+    class Send
+      def initialize(receiver_id, welcome_broadcast)
+        @receiver_id = receiver_id
+        @welcome_broadcast = welcome_broadcast
+      end
+
+      delegate :user_data, to: Notifications
+
+      def self.call(*args)
+        new(*args).call
+      end
+
+      def call
+        dev_account = User.dev_account
+        json_data = {
+          user: user_data(dev_account),
+          broadcast: {
+            processed_html: welcome_broadcast.processed_html
+          }
+        }
+        Notification.create(
+          user_id: receiver_id,
+          notifiable_id: welcome_broadcast.id,
+          notifiable_type: "Broadcast",
+          action: welcome_broadcast.type_of,
+          json_data: json_data,
+        )
+      end
+
+      private
+
+      attr_reader :receiver_id, :welcome_broadcast
+    end
+  end
+end

--- a/spec/jobs/notifications/welcome_notification_job_spec.rb
+++ b/spec/jobs/notifications/welcome_notification_job_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe Notifications::WelcomeNotificationJob, type: :job do
+  include_examples "#enqueues_job", "send_welcome_notification"
+
+  describe "::perform_now" do
+    let(:welcome_notification_service) { double }
+
+    before do
+      create(:broadcast, :onboarding)
+      allow(welcome_notification_service).to receive(:call)
+      allow(User).to receive(:dev_account).and_return(create(:user))
+    end
+
+    it "calls the service" do
+      user = create(:user)
+
+      described_class.perform_now(user.id, welcome_notification_service)
+      expect(welcome_notification_service).to have_received(:call).once
+    end
+  end
+end

--- a/spec/services/notifications/welcome_notification/send_spec.rb
+++ b/spec/services/notifications/welcome_notification/send_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe Notifications::WelcomeNotification::Send, type: :service do
+  describe "::call" do
+    before do
+      allow(User).to receive(:dev_account).and_return(create(:user))
+    end
+
+    it "checks a newly created welcome notification", :aggregate_failures do
+      welcome_broadcast = create(:broadcast, :onboarding)
+      welcome_notification = described_class.call(create(:user).id, welcome_broadcast)
+
+      expect(welcome_notification).to be_kind_of(Notification)
+      expect(welcome_notification.notifiable_type).to eq "Broadcast"
+      expect(welcome_notification.action).to eq "Onboarding"
+      expect(welcome_notification.json_data["broadcast"]["processed_html"]).to eq welcome_broadcast.processed_html
+    end
+  end
+end


### PR DESCRIPTION
 - creation of welcome notification is in own service
 - which is called by an active job

Resolves: #1996

<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Move Welcome Notification to Active Jobs
## Related Tickets & Documents
Issue #1996 
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
