### PR TITLE
Prevent creating reaction notifications with empty json_data

### DIFF
--- a/app/services/notifications/reactions/send.rb
+++ b/app/services/notifications/reactions/send.rb
@@ -48,7 +48,7 @@ module Notifications
           json_data = reaction_json_data(recent_reaction, aggregated_reaction_siblings)
 
           previous_siblings_size = 0
-          notification = Notification.find_or_create_by(notification_params)
+          notification = Notification.find_or_initialize_by(notification_params)
           previous_siblings_size = notification.json_data["reaction"]["aggregated_siblings"].size if notification.json_data
           notification.json_data = json_data
           notification.notified_at = Time.current


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Bug Fix

## Description
A quick fix for the #2124 , since the #2213 takes a long time to merge
This pr should fix creating notifications with empty `json_data`, the change is:
- make 1 create query on creating reaction notification instead of 2 (create + update)

## Related Tickets & Documents
#2124 