### PR TITLE
Remove unused gem fake_stripe

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -134,7 +134,6 @@ end
 group :test do
   gem "approvals", "~> 0.0" # A library to make it easier to do golden-master style testing in Ruby
   gem "factory_bot_rails", "~> 4.11" # factory_bot is a fixtures replacement with a straightforward definition syntax, support for multiple build strategies
-  gem "fake_stripe", "~> 0.2" # An implementation of the Stripe credit card processing service to run during your integration tests
   gem "launchy", "~> 2.4" # Launchy is helper class for launching cross-platform applications in a fire and forget manner.
   gem "pundit-matchers", "~> 1.6" # A set of RSpec matchers for testing Pundit authorisation policies
   gem "rspec-retry", "~> 0.6" # retry intermittently failing rspec examples

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -312,10 +312,6 @@ GEM
     factory_bot_rails (4.11.1)
       factory_bot (~> 4.11.1)
       railties (>= 3.0.0)
-    fake_stripe (0.2.0)
-      capybara
-      sinatra
-      webmock
     faker (1.9.3)
       i18n (>= 0.7)
     faraday (0.15.4)
@@ -1002,7 +998,6 @@ DEPENDENCIES
   envied (~> 0.9)
   erb_lint (~> 0.0)
   factory_bot_rails (~> 4.11)
-  fake_stripe (~> 0.2)
   faker (~> 1.9)
   fastly (~> 1.15)
   fastly-rails (~> 0.8)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

I can't find a place where the gem [fake_stripe](https://rubygems.org/gems/fake_stripe) is used, it has likely been completely replaced by [stripe-ruby-mock](https://rubygems.org/gems/stripe-ruby-mock) but left behind.

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
