### PR TITLE
Add mailers specs for tracking

### DIFF
--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -61,22 +61,11 @@ class NotifyMailer < ApplicationMailer
     mail(to: params[:email_to], subject: params[:email_subject])
   end
 
-  def new_report_email(report)
-    @feedback_message = report
-    @user = report.reporter
-    mail(to: @user.email, subject: "Thank you for your report")
-  end
-
-  def new_message_email(message)
-    @message = message
-    @user = message.direct_receiver
-    subject = "#{message.user.name} just messaged you"
+  def new_message_email(direct_message)
+    @message = direct_message
+    @user = @message.direct_receiver
+    subject = "#{@message.user.name} just messaged you"
     mail(to: @user.email, subject: subject)
-  end
-
-  def reporter_resolution_email(report)
-    @feedback_message = report
-    @user = report.reporter
   end
 
   def account_deleted_email(user)

--- a/app/views/mailers/notify_mailer/account_deleted_email.html.erb
+++ b/app/views/mailers/notify_mailer/account_deleted_email.html.erb
@@ -7,7 +7,7 @@
 </p>
 
 <p>
-  Contact us at yo@dev.to if there is anything more we can help with. 😊
+  Contact us at <a href="mailto:yo@dev.to">yo@dev.to</a> if there is anything more we can help with. 😊
 </p>
 
 <p>

--- a/app/views/mailers/notify_mailer/new_message_email.html.erb
+++ b/app/views/mailers/notify_mailer/new_message_email.html.erb
@@ -6,7 +6,7 @@
   </tr>
   <tr>
     <td style='padding:20px;padding-bottom:30px;border-radius:3px;font-size:19px;background:#f4f4f4'>
-      <%= @message.message_html %>
+      <%= @message.message_html.html_safe %>
       <br /><br />
       <a style="background:#3c7dc1;color:white;padding:5px 14px;border-radius:3px;text-decoration:none;display:inline-block;margin-top:4px;" href='https://dev.to/connect/@<%= @message.user.username %>'>view on dev.to</a>
     </td>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,4 @@
-Rails.logger.info "1/9 Creating Organizations"
+Rails.logger.info "1. Creating Organizations"
 
 3.times do
   Organization.create!(
@@ -17,7 +17,7 @@ end
 
 ##############################################################################
 
-Rails.logger.info "2/9 Creating Users"
+Rails.logger.info "2. Creating Users"
 
 roles = %i[level_1_member level_2_member level_3_member level_4_member
            workshop_pass]
@@ -50,7 +50,7 @@ end
 
 ##############################################################################
 
-Rails.logger.info "3/9 Creating Tags"
+Rails.logger.info "3. Creating Tags"
 
 tags = %w[beginners career computerscience git go
           java javascript linux productivity python security webdev]
@@ -66,7 +66,7 @@ end
 
 ##############################################################################
 
-Rails.logger.info "4/9 Creating Articles"
+Rails.logger.info "4. Creating Articles"
 
 Article.clear_index!
 25.times do |i|
@@ -97,7 +97,7 @@ end
 
 ##############################################################################
 
-Rails.logger.info "5/9 Creating Comments"
+Rails.logger.info "5. Creating Comments"
 
 Comment.clear_index!
 30.times do
@@ -112,7 +112,7 @@ end
 
 ##############################################################################
 
-Rails.logger.info "6/9 Creating Podcasts"
+Rails.logger.info "6. Creating Podcasts"
 
 image_file = Rails.root.join("spec", "support", "fixtures", "images", "image1.jpeg")
 
@@ -175,7 +175,7 @@ end
 
 ##############################################################################
 
-Rails.logger.info "7/9 Creating Broadcasts"
+Rails.logger.info "7. Creating Broadcasts"
 
 Broadcast.create!(
   title: "Welcome Notification",
@@ -186,7 +186,7 @@ Broadcast.create!(
 
 ##############################################################################
 
-Rails.logger.info "8/9 Creating chat_channel"
+Rails.logger.info "8. Creating Chat Channels and Messages"
 
 ChatChannel.clear_index!
 ChatChannel.without_auto_index do
@@ -197,12 +197,19 @@ ChatChannel.without_auto_index do
       slug: chan,
     )
   end
+
+  direct_channel = ChatChannel.create_with_users(User.last(2), "direct")
+  Message.create!(
+    chat_channel: direct_channel,
+    user: User.last,
+    message_markdown: "This is **awesome**",
+  )
 end
 ChatChannel.reindex!
 
-Rails.logger.info "9/9 Creating html_variant"
+Rails.logger.info "9. Creating HTML Variants"
 
-HtmlVariant.create(
+HtmlVariant.create!(
   name: rand(100).to_s,
   group: "badge_landing_page",
   html: rand(1000).to_s,
@@ -210,6 +217,24 @@ HtmlVariant.create(
   published: true,
   approved: true,
   user_id: User.first.id,
+)
+
+Rails.logger.info "10. Creating Badges"
+
+Badge.create!(
+  title: Faker::Lorem.word,
+  description: Faker::Lorem.sentence,
+  badge_image: File.open(Rails.root.join("app", "assets", "images", "#{rand(1..40)}.png")),
+)
+
+Rails.logger.info "10. Creating FeedbackMessages"
+
+FeedbackMessage.create!(
+  reporter: User.last,
+  feedback_type: "spam",
+  message: Faker::Lorem.sentence,
+  category: "spam",
+  status: "Open",
 )
 ##############################################################################
 

--- a/spec/mailers/digest_mailer_spec.rb
+++ b/spec/mailers/digest_mailer_spec.rb
@@ -1,16 +1,32 @@
 require "rails_helper"
 
 RSpec.describe DigestMailer, type: :mailer do
+  let(:user) { build_stubbed(:user) }
+  let(:article) { build_stubbed(:article) }
+
   describe "#digest_email" do
-    it "works correctly" do
-      user = build_stubbed(:user)
-      article = build_stubbed(:article)
+    before do
       allow(article).to receive(:title).and_return("test title")
+    end
+
+    it "works correctly" do
       email = described_class.digest_email(user, [article])
 
       expect(email.subject).not_to be_nil
       expect(email.to).to eq([user.email])
       expect(email.from).to eq(["yo@dev.to"])
+    end
+
+    it "includes the tracking pixel" do
+      email = described_class.digest_email(user, [article])
+      expect(email.body).to include("open.gif")
+    end
+
+    it "includes UTM params" do
+      email = described_class.digest_email(user, [article])
+      expect(email.body).to include(CGI.escape("utm_medium=email"))
+      expect(email.body).to include(CGI.escape("utm_source=digest_mailer"))
+      expect(email.body).to include(CGI.escape("utm_campaign=digest_email"))
     end
   end
 end

--- a/spec/mailers/membership_mailer_spec.rb
+++ b/spec/mailers/membership_mailer_spec.rb
@@ -5,32 +5,73 @@ RSpec.describe MembershipMailer, type: :mailer do
 
   describe "#new_membership_subscription_email" do
     it "renders proper subject" do
-      user = create(:user)
-      new_membership_subscription_email = described_class.new_membership_subscription_email(
-        user, "level_1_member"
-      )
-      expect(new_membership_subscription_email.subject).to include("Thanks for subscribing")
+      email = described_class.new_membership_subscription_email(user, "level_1_member")
+      expect(email.subject).to include("Thanks for subscribing")
     end
 
     it "renders proper receiver" do
-      user = create(:user)
-      new_membership_subscription_email = described_class.new_membership_subscription_email(
-        user, "level_1_member"
-      )
-      expect(new_membership_subscription_email.to).to eq([user.email])
+      email = described_class.new_membership_subscription_email(user, "level_1_member")
+      expect(email.to).to eq([user.email])
+    end
+
+    it "includes the tracking pixel" do
+      email = described_class.new_membership_subscription_email(user, "level_1_member")
+      expect(email.html_part.body).to include("open.gif")
+    end
+
+    it "includes UTM params" do
+      email = described_class.new_membership_subscription_email(user, "level_1_member")
+      expect(email.html_part.body).to include(CGI.escape("utm_medium=email"))
+      expect(email.html_part.body).to include(CGI.escape("utm_source=membership_mailer"))
+      expect(email.html_part.body).to include(CGI.escape("utm_campaign=new_membership_subscription_email"))
+    end
+  end
+
+  describe "#subscription_update_confirm_email" do
+    it "renders proper subject" do
+      email = described_class.subscription_update_confirm_email(user)
+      expect(email.subject).to include("Your subscription has been updated.")
+    end
+
+    it "renders proper receiver" do
+      email = described_class.subscription_update_confirm_email(user)
+      expect(email.to).to eq([user.email])
+    end
+
+    it "includes the tracking pixel" do
+      email = described_class.subscription_update_confirm_email(user)
+      expect(email.html_part.body).to include("open.gif")
+    end
+
+    it "includes UTM params" do
+      email = described_class.subscription_update_confirm_email(user)
+      expect(email.html_part.body).to include(CGI.escape("utm_medium=email"))
+      expect(email.html_part.body).to include(CGI.escape("utm_source=membership_mailer"))
+      expect(email.html_part.body).to include(CGI.escape("utm_campaign=subscription_update_confirm_email"))
     end
   end
 
   describe "#subscription_cancellation_email" do
     it "renders proper subject" do
-      user = create(:user)
-      subscription_cancellation_email = described_class.subscription_cancellation_email(user)
-      expect(subscription_cancellation_email.subject).to include("Sorry to lose you")
+      email = described_class.subscription_cancellation_email(user)
+      expect(email.subject).to include("Sorry to lose you")
     end
+
     it "renders proper receiver" do
-      user = create(:user)
-      subscription_cancellation_email = described_class.subscription_cancellation_email(user)
-      expect(subscription_cancellation_email.to).to eq([user.email])
+      email = described_class.subscription_cancellation_email(user)
+      expect(email.to).to eq([user.email])
+    end
+
+    it "includes the tracking pixel" do
+      email = described_class.subscription_cancellation_email(user)
+      expect(email.html_part.body).to include("open.gif")
+    end
+
+    it "includes UTM params" do
+      email = described_class.subscription_cancellation_email(user)
+      expect(email.html_part.body).to include(CGI.escape("utm_medium=email"))
+      expect(email.html_part.body).to include(CGI.escape("utm_source=membership_mailer"))
+      expect(email.html_part.body).to include(CGI.escape("utm_campaign=subscription_cancellation_email"))
     end
   end
 end

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -1,178 +1,398 @@
 require "rails_helper"
 
 RSpec.describe NotifyMailer, type: :mailer do
-  describe "notify" do
-    let(:user)      { create(:user) }
-    let(:user2)     { create(:user) }
-    let(:article)   { create(:article, user_id: user.id) }
-    let(:comment)   { create(:comment, user_id: user.id, commentable_id: article.id) }
+  let(:user)      { create(:user) }
+  let(:user2)     { create(:user) }
+  let(:article)   { create(:article, user_id: user.id) }
+  let(:comment)   { create(:comment, user_id: user.id, commentable_id: article.id) }
 
-    describe "#new_reply_email" do
-      it "renders proper subject" do
-        new_reply_email = described_class.new_reply_email(comment)
-        expect(new_reply_email.subject).to include("replied to your")
-      end
-
-      it "renders proper receiver" do
-        new_reply_email = described_class.new_reply_email(comment)
-        expect(new_reply_email.to).to eq([comment.user.email])
-      end
+  describe "#new_reply_email" do
+    it "renders proper subject" do
+      email = described_class.new_reply_email(comment)
+      expected_subject = "#{comment.user.name} replied to your #{comment.parent_type}"
+      expect(email.subject).to eq(expected_subject)
     end
 
-    describe "#new_follower_email" do
-      it "renders proper subject" do
-        user2.follow(user)
-        new_follower_email = described_class.new_follower_email(Follow.last)
-        expect(new_follower_email.subject).to eq("#{user2.name} just followed you on dev.to")
-      end
-
-      it "renders proper receiver" do
-        user2.follow(user)
-        new_follower_email = described_class.new_follower_email(Follow.last)
-        expect(new_follower_email.to).to eq([user.email])
-      end
+    it "renders proper receiver" do
+      email = described_class.new_reply_email(comment)
+      expect(email.to).to eq([comment.user.email])
     end
 
-    describe "#new_mention_email" do
-      it "renders proper subject" do
-        mention = create(:mention, user_id: user2.id, mentionable_id: comment.id)
-        new_mention_email = described_class.new_mention_email(mention)
-        expect(new_mention_email.subject).to include("#{comment.user.name} just mentioned you")
-      end
-
-      it "renders proper receiver" do
-        mention = create(:mention, user_id: user2.id, mentionable_id: comment.id)
-        new_mention_email = described_class.new_mention_email(mention)
-        expect(new_mention_email.to).to eq([user2.email])
-      end
+    it "includes the tracking pixel" do
+      email = described_class.new_reply_email(comment)
+      expect(email.html_part.body).to include("open.gif")
     end
 
-    describe "#new_badge_email" do
-      let(:badge) { create(:badge) }
+    it "includes UTM params" do
+      email = described_class.new_reply_email(comment)
+      expect(email.html_part.body).to include(CGI.escape("utm_medium=email"))
+      expect(email.html_part.body).to include(CGI.escape("utm_source=notify_mailer"))
+      expect(email.html_part.body).to include(CGI.escape("utm_campaign=new_reply_email"))
+    end
+  end
 
-      def create_badge_achievement(user, badge, rewarder)
-        BadgeAchievement.create(
-          user_id: user.id,
-          badge_id: badge.id,
-          rewarder_id: rewarder.id,
-          rewarding_context_message_markdown: "Hello [Yoho](/hey)",
-        )
-      end
+  describe "#new_follower_email" do
+    before { user2.follow(user) }
 
-      it "renders proper subject" do
-        badge_achievement = create_badge_achievement(user, badge, user2)
-        new_badge_email = described_class.new_badge_email(badge_achievement)
-        expect(new_badge_email.subject).to eq("You just got a badge")
-      end
-
-      it "renders proper receiver" do
-        badge_achievement = create_badge_achievement(user, badge, user2)
-        new_badge_email = described_class.new_badge_email(badge_achievement)
-        expect(new_badge_email.to).to eq([user.email])
-      end
+    it "renders proper subject" do
+      email = described_class.new_follower_email(user2.follows.last)
+      expect(email.subject).to eq("#{user2.name} just followed you on dev.to")
     end
 
-    describe "#new_feedback_message_resolution_email" do
-      def params(user_email, feedback_message_id)
-        {
-          email_to: user_email,
-          email_subject: "DEV Report Status Update",
-          email_body: "You've violated our code of conduct",
-          email_type: "Reporter",
-          feedback_message_id: feedback_message_id
-        }
-      end
-
-      it "renders proper subject" do
-        feedback_message = create(:feedback_message, :abuse_report, reporter_id: user.id)
-        feedback_message_resolution_email = described_class.
-          feedback_message_resolution_email(params(user.email, feedback_message.id))
-        expect(feedback_message_resolution_email.subject).to eq "DEV Report Status Update"
-      end
-
-      it "renders proper receiver" do
-        feedback_message = create(:feedback_message, :abuse_report, reporter_id: user.id)
-        feedback_message_resolution_email = described_class.
-          feedback_message_resolution_email(params(user.email, feedback_message.id))
-        expect(feedback_message_resolution_email.to).to eq [user.email]
-      end
+    it "renders proper receiver" do
+      email = described_class.new_follower_email(user2.follows.last)
+      expect(email.to).to eq([user.email])
     end
 
-    describe "#account_deleted_email" do
-      let(:user) { create(:user) }
-
-      it "renders proper subject" do
-        account_deleted_email = described_class.account_deleted_email(user)
-        expect(account_deleted_email.subject).to eq "dev.to - Account Deletion Confirmation"
-      end
-
-      it "renders proper receiver" do
-        account_deleted_email = described_class.account_deleted_email(user)
-        expect(account_deleted_email.to).to eq [user.email]
-      end
+    it "includes the tracking pixel" do
+      email = described_class.new_follower_email(user2.follows.last)
+      expect(email.html_part.body).to include("open.gif")
     end
 
-    describe "#mentee_email" do
-      let(:mentee) { create(:user) }
-      let(:mentor) { create(:user) }
+    it "includes UTM params" do
+      email = described_class.new_follower_email(user2.follows.last)
+      expect(email.html_part.body).to include(CGI.escape("utm_medium=email"))
+      expect(email.html_part.body).to include(CGI.escape("utm_source=notify_mailer"))
+      expect(email.html_part.body).to include(CGI.escape("utm_campaign=new_follower_email"))
+    end
+  end
 
-      it "renders proper subject" do
-        mentee_email = described_class.mentee_email(mentee, mentor)
-        expect(mentee_email.subject).to eq "You have been matched with a DEV mentor!"
-      end
+  describe "#new_mention_email" do
+    let(:mention) { create(:mention, user_id: user2.id, mentionable_id: comment.id) }
 
-      it "renders proper from" do
-        mentee_email = described_class.mentee_email(mentee, mentor)
-        expect(mentee_email.from).to include "liana@dev.to"
-      end
+    it "renders proper subject" do
+      email = described_class.new_mention_email(mention)
+      expect(email.subject).to eq("#{comment.user.name} just mentioned you!")
     end
 
-    describe "#mentor_email" do
-      let(:mentee) { create(:user) }
-      let(:mentor) { create(:user) }
-
-      it "renders proper subject" do
-        mentor_email = described_class.mentor_email(mentor, mentee)
-        expect(mentor_email.subject).to eq "You have been matched with a new DEV mentee!"
-      end
-
-      it "renders proper from" do
-        mentor_email = described_class.mentor_email(mentor, mentee)
-        expect(mentor_email.from).to include "liana@dev.to"
-      end
+    it "renders proper receiver" do
+      email = described_class.new_mention_email(mention)
+      expect(email.to).to eq([user2.email])
     end
 
-    describe "#tag_moderator_confirmation_email" do
-      let(:user) { create(:user) }
-      let(:tag) { create(:tag) }
-
-      it "renders proper subject" do
-        moderator_email = described_class.tag_moderator_confirmation_email(user, tag.name)
-        expect(moderator_email.subject).to eq "Congrats! You're the moderator for ##{tag.name}"
-      end
+    it "includes the tracking pixel" do
+      email = described_class.new_mention_email(mention)
+      expect(email.html_part.body).to include("open.gif")
     end
 
-    describe "#export_email" do
-      it "renders proper subject" do
-        export_email = described_class.export_email(user, "attachment")
-        expect(export_email.subject).to include("export of your content is ready")
+    it "includes UTM params" do
+      email = described_class.new_mention_email(mention)
+      expect(email.html_part.body).to include(CGI.escape("utm_medium=email"))
+      expect(email.html_part.body).to include(CGI.escape("utm_source=notify_mailer"))
+      expect(email.html_part.body).to include(CGI.escape("utm_campaign=new_mention_email"))
+    end
+  end
+
+  describe "#unread_notifications_email" do
+    it "renders proper subject" do
+      email = described_class.unread_notifications_email(user)
+      expect(email.subject).to eq("🔥 You have 0 unread notifications on dev.to")
+    end
+
+    it "renders proper receiver" do
+      email = described_class.unread_notifications_email(user)
+      expect(email.to).to eq([user.email])
+    end
+
+    it "includes the tracking pixel" do
+      email = described_class.unread_notifications_email(user)
+      expect(email.html_part.body).to include("open.gif")
+    end
+
+    it "includes UTM params" do
+      email = described_class.unread_notifications_email(user)
+      expect(email.html_part.body).to include(CGI.escape("utm_medium=email"))
+      expect(email.html_part.body).to include(CGI.escape("utm_source=notify_mailer"))
+      expect(email.html_part.body).to include(CGI.escape("utm_campaign=unread_notifications_email"))
+    end
+  end
+
+  describe "#video_upload_complete_email" do
+    it "renders proper subject" do
+      email = described_class.video_upload_complete_email(article)
+      expect(email.subject).to eq("Your video upload is complete")
+    end
+
+    it "renders proper receiver" do
+      email = described_class.video_upload_complete_email(article)
+      expect(email.to).to eq([article.user.email])
+    end
+
+    it "includes the tracking pixel" do
+      email = described_class.video_upload_complete_email(article)
+      expect(email.html_part.body).to include("open.gif")
+    end
+
+    it "includes UTM params" do
+      email = described_class.video_upload_complete_email(article)
+      expect(email.html_part.body).to include(CGI.escape("utm_medium=email"))
+      expect(email.html_part.body).to include(CGI.escape("utm_source=notify_mailer"))
+      expect(email.html_part.body).to include(CGI.escape("utm_campaign=video_upload_complete_email"))
+    end
+  end
+
+  describe "#new_badge_email" do
+    let(:badge) { create(:badge) }
+    let(:badge_achievement) { create_badge_achievement(user, badge, user2) }
+
+    def create_badge_achievement(user, badge, rewarder)
+      BadgeAchievement.create(
+        user_id: user.id,
+        badge_id: badge.id,
+        rewarder_id: rewarder.id,
+        rewarding_context_message_markdown: "Hello [Yoho](/hey)",
+      )
+    end
+
+    it "renders proper subject" do
+      email = described_class.new_badge_email(badge_achievement)
+      expect(email.subject).to eq("You just got a badge")
+    end
+
+    it "renders proper receiver" do
+      email = described_class.new_badge_email(badge_achievement)
+      expect(email.to).to eq([user.email])
+    end
+
+    it "includes the tracking pixel" do
+      email = described_class.new_badge_email(badge_achievement)
+      expect(email.html_part.body).to include("open.gif")
+    end
+
+    it "includes UTM params" do
+      email = described_class.new_badge_email(badge_achievement)
+      expect(email.html_part.body).to include(CGI.escape("utm_medium=email"))
+      expect(email.html_part.body).to include(CGI.escape("utm_source=notify_mailer"))
+      expect(email.html_part.body).to include(CGI.escape("utm_campaign=new_badge_email"))
+    end
+  end
+
+  describe "#feedback_message_resolution_email" do
+    let(:feedback_message) { create(:feedback_message, :abuse_report, reporter_id: user.id) }
+
+    def params(user_email, feedback_message_id)
+      {
+        email_to: user_email,
+        email_subject: "DEV Report Status Update",
+        email_body: "You've violated our code of conduct",
+        email_type: "Reporter",
+        feedback_message_id: feedback_message_id
+      }
+    end
+
+    it "renders proper subject" do
+      email_params = params(user.email, feedback_message.id)
+      email = described_class.feedback_message_resolution_email(email_params)
+      expect(email.subject).to eq("DEV Report Status Update")
+    end
+
+    it "renders proper receiver" do
+      email_params = params(user.email, feedback_message.id)
+      email = described_class.feedback_message_resolution_email(email_params)
+      expect(email.to).to eq([user.email])
+    end
+
+    it "includes the tracking pixel" do
+      email_params = params(user.email, feedback_message.id)
+      email = described_class.feedback_message_resolution_email(email_params)
+      expect(email.html_part.body).to include("open.gif")
+    end
+
+    it "includes UTM params" do
+      email_params = params(user.email, feedback_message.id)
+      email = described_class.feedback_message_resolution_email(email_params)
+      expect(email.html_part.body).to include(CGI.escape("utm_medium=email"))
+      expect(email.html_part.body).to include(CGI.escape("utm_source=notify_mailer"))
+      expect(email.html_part.body).to include(
+        CGI.escape("utm_campaign=#{email_params[:email_type]}"),
+      )
+    end
+
+    it "tracks the feedback message ID after delivery" do
+      email_params = params(user.email, feedback_message.id)
+      email = described_class.feedback_message_resolution_email(email_params)
+
+      assert_emails 1 do
+        email.deliver_now
       end
 
-      it "renders proper receiver" do
-        export_email = described_class.export_email(user, "attachment")
-        expect(export_email.to).to eq([user.email])
-      end
+      expect(user.email_messages.last.feedback_message_id).to eq(feedback_message.id)
+    end
+  end
 
-      it "attaches a zip file" do
-        export_email = described_class.export_email(user, "attachment")
-        expect(export_email.attachments[0].content_type).to include("application/zip")
-      end
+  describe "#new_message_email" do
+    let(:direct_channel) { ChatChannel.create_with_users([user, user2], "direct") }
+    let(:direct_message) { create(:message, user: user, chat_channel: direct_channel) }
 
-      it "adds the correct filename" do
-        export_email = described_class.export_email(user, "attachment")
-        expected_filename = "devto-export-#{Date.current.iso8601}.zip"
-        expect(export_email.attachments[0].filename).to eq(expected_filename)
-      end
+    it "renders proper subject" do
+      email = described_class.new_message_email(direct_message)
+      expect(email.subject).to eq("#{user.name} just messaged you")
+    end
+
+    it "renders proper receiver" do
+      email = described_class.new_message_email(direct_message)
+      expect(email.to).to eq([direct_message.direct_receiver.email])
+    end
+
+    it "includes the tracking pixel" do
+      email = described_class.new_message_email(direct_message)
+      expect(email.html_part.body).to include("open.gif")
+    end
+
+    it "includes UTM params" do
+      email = described_class.new_message_email(direct_message)
+      expect(email.html_part.body).to include(CGI.escape("utm_medium=email"))
+      expect(email.html_part.body).to include(CGI.escape("utm_source=notify_mailer"))
+      expect(email.html_part.body).to include(CGI.escape("utm_campaign=new_message_email"))
+    end
+  end
+
+  describe "#account_deleted_email" do
+    it "renders proper subject" do
+      email = described_class.account_deleted_email(user)
+      expect(email.subject).to eq("dev.to - Account Deletion Confirmation")
+    end
+
+    it "renders proper receiver" do
+      email = described_class.account_deleted_email(user)
+      expect(email.to).to eq([user.email])
+    end
+
+    it "includes the tracking pixel" do
+      email = described_class.account_deleted_email(user)
+      expect(email.html_part.body).to include("open.gif")
+    end
+
+    it "does not include UTM params" do
+      email = described_class.account_deleted_email(user)
+      expect(email.html_part.body).not_to include(CGI.escape("utm_medium=email"))
+      expect(email.html_part.body).not_to include(CGI.escape("utm_source=notify_mailer"))
+      expect(email.html_part.body).not_to include(CGI.escape("utm_campaign=account_deleted_email"))
+    end
+  end
+
+  describe "#mentee_email" do
+    let(:mentee) { user }
+    let(:mentor) { user2 }
+
+    it "renders proper subject" do
+      email = described_class.mentee_email(mentee, mentor)
+      expect(email.subject).to eq("You have been matched with a DEV mentor!")
+    end
+
+    it "renders proper from" do
+      email = described_class.mentee_email(mentee, mentor)
+      expect(email.from).to eq(["liana@dev.to"])
+    end
+
+    it "renders proper receiver" do
+      email = described_class.mentee_email(mentee, mentor)
+      expect(email.to).to eq([mentee.email])
+    end
+
+    it "includes the tracking pixel" do
+      email = described_class.mentee_email(mentee, mentor)
+      expect(email.html_part.body).to include("open.gif")
+    end
+
+    it "includes UTM params" do
+      email = described_class.mentee_email(mentee, mentor)
+      expect(email.html_part.body).to include(CGI.escape("utm_medium=email"))
+      expect(email.html_part.body).to include(CGI.escape("utm_source=notify_mailer"))
+      expect(email.html_part.body).to include(CGI.escape("utm_campaign=mentee_email"))
+    end
+  end
+
+  describe "#mentor_email" do
+    let(:mentee) { user }
+    let(:mentor) { user2 }
+
+    it "renders proper subject" do
+      email = described_class.mentor_email(mentor, mentee)
+      expect(email.subject).to eq("You have been matched with a new DEV mentee!")
+    end
+
+    it "renders proper from" do
+      email = described_class.mentor_email(mentor, mentee)
+      expect(email.from).to eq(["liana@dev.to"])
+    end
+
+    it "renders proper receiver" do
+      email = described_class.mentor_email(mentor, mentee)
+      expect(email.to).to eq([mentor.email])
+    end
+
+    it "includes the tracking pixel" do
+      email = described_class.mentor_email(mentor, mentee)
+      expect(email.html_part.body).to include("open.gif")
+    end
+
+    it "includes UTM params" do
+      email = described_class.mentor_email(mentor, mentee)
+      expect(email.html_part.body).to include(CGI.escape("utm_medium=email"))
+      expect(email.html_part.body).to include(CGI.escape("utm_source=notify_mailer"))
+      expect(email.html_part.body).to include(CGI.escape("utm_campaign=mentor_email"))
+    end
+  end
+
+  describe "#export_email" do
+    it "renders proper subject" do
+      email = described_class.export_email(user, "attachment")
+      expect(email.subject).to include("export of your content is ready")
+    end
+
+    it "renders proper receiver" do
+      email = described_class.export_email(user, "attachment")
+      expect(email.to).to eq([user.email])
+    end
+
+    it "attaches a zip file" do
+      email = described_class.export_email(user, "attachment")
+      expect(email.attachments[0].content_type).to include("application/zip")
+    end
+
+    it "adds the correct filename" do
+      email = described_class.export_email(user, "attachment")
+      expected_filename = "devto-export-#{Date.current.iso8601}.zip"
+      expect(email.attachments[0].filename).to eq(expected_filename)
+    end
+
+    it "includes the tracking pixel" do
+      email = described_class.export_email(user, "attachment")
+      expect(email.html_part.body).to include("open.gif")
+    end
+
+    it "includes UTM params" do
+      email = described_class.export_email(user, "attachment")
+      expect(email.html_part.body).to include(CGI.escape("utm_medium=email"))
+      expect(email.html_part.body).to include(CGI.escape("utm_source=notify_mailer"))
+      expect(email.html_part.body).to include(CGI.escape("utm_campaign=export_email"))
+    end
+  end
+
+  describe "#tag_moderator_confirmation_email" do
+    let(:tag) { create(:tag) }
+
+    it "renders proper subject" do
+      email = described_class.tag_moderator_confirmation_email(user, tag.name)
+      expect(email.subject).to eq("Congrats! You're the moderator for ##{tag.name}")
+    end
+
+    it "renders proper receiver" do
+      email = described_class.tag_moderator_confirmation_email(user, tag.name)
+      expect(email.to).to eq([user.email])
+    end
+
+    it "includes the tracking pixel" do
+      email = described_class.tag_moderator_confirmation_email(user, tag.name)
+      expect(email.html_part.body).to include("open.gif")
+    end
+
+    it "includes UTM params" do
+      email = described_class.tag_moderator_confirmation_email(user, tag.name)
+      expect(email.html_part.body).to include(CGI.escape("utm_medium=email"))
+      expect(email.html_part.body).to include(CGI.escape("utm_source=notify_mailer"))
+      expect(email.html_part.body).to include(CGI.escape("utm_campaign=tag_moderator_confirmation_email"))
     end
   end
 end

--- a/spec/mailers/previews/notify_mailer_preview.rb
+++ b/spec/mailers/previews/notify_mailer_preview.rb
@@ -13,7 +13,8 @@ class NotifyMailerPreview < ActionMailer::Preview
   end
 
   def new_mention_email
-    NotifyMailer.new_mention_email(Mention.last)
+    mention = Mention.find_or_create_by(user: User.find(1), mentionable: Comment.find(1))
+    NotifyMailer.new_mention_email(mention)
   end
 
   def video_upload_complete_email
@@ -21,11 +22,13 @@ class NotifyMailerPreview < ActionMailer::Preview
   end
 
   def new_badge_email
-    NotifyMailer.new_badge_email(BadgeAchievement.first)
-  end
-
-  def new_report_email
-    NotifyMailer.new_report_email(FeedbackMessage.first)
+    badge_achievement = BadgeAchievement.find_or_create_by(
+      user: User.find(1),
+      badge: Badge.find(1),
+      rewarder: User.find(2),
+      rewarding_context_message: "You made it!",
+    )
+    NotifyMailer.new_badge_email(badge_achievement)
   end
 
   def mentee_email
@@ -57,7 +60,9 @@ class NotifyMailerPreview < ActionMailer::Preview
     params = {
       email_to: @user.email,
       email_subject: "Courtesy notice from dev.to",
-      email_body: email_body
+      email_body: email_body,
+      email_type: "Reporter",
+      feedback_message_id: rand(100)
     }
     NotifyMailer.feedback_message_resolution_email(params)
   end
@@ -68,5 +73,9 @@ class NotifyMailerPreview < ActionMailer::Preview
 
   def account_deleted_email
     NotifyMailer.account_deleted_email(User.last)
+  end
+
+  def export_email
+    NotifyMailer.export_email(User.last, "attachment")
   end
 end

--- a/spec/mailers/scholarship_mailer_spec.rb
+++ b/spec/mailers/scholarship_mailer_spec.rb
@@ -5,15 +5,30 @@ RSpec.describe ScholarshipMailer, type: :mailer do
 
   describe "#scholarship_awarded_email" do
     it "renders proper subject" do
-      user = create(:user)
-      scholarship_awarded_email = described_class.scholarship_awarded_email(user)
-      expect(scholarship_awarded_email.subject).to eq("Congrats on your DEV Scholarship!")
+      email = described_class.scholarship_awarded_email(user)
+      expect(email.subject).to eq("Congrats on your DEV Scholarship!")
+    end
+
+    it "renders proper from" do
+      email = described_class.scholarship_awarded_email(user)
+      expect(email.from).to eq(["members@dev.to"])
     end
 
     it "renders proper receiver" do
-      user = create(:user)
-      scholarship_awarded_email = described_class.scholarship_awarded_email(user)
-      expect(scholarship_awarded_email.to).to eq([user.email])
+      email = described_class.scholarship_awarded_email(user)
+      expect(email.to).to eq([user.email])
+    end
+
+    it "includes the tracking pixel" do
+      email = described_class.scholarship_awarded_email(user)
+      expect(email.html_part.body).to include("open.gif")
+    end
+
+    it "includes UTM params" do
+      email = described_class.scholarship_awarded_email(user)
+      expect(email.html_part.body).to include(CGI.escape("utm_medium=email"))
+      expect(email.html_part.body).to include(CGI.escape("utm_source=scholarship_mailer"))
+      expect(email.html_part.body).to include(CGI.escape("utm_campaign=scholarship_awarded_email"))
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -62,6 +62,7 @@ RSpec.configure do |config|
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
   config.include ApplicationHelper
+  config.include ActionMailer::TestHelper
   config.include ActiveJob::TestHelper
   config.include Devise::Test::ControllerHelpers, type: :view
   config.include Devise::Test::IntegrationHelpers, type: :system


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

I was planning to upgrade `ahoy_email` to its latest version, which contains breaking changes, so I thought it would be better to make sure there were tests in place for mailer tracking before attempting to do so.

In the process I removed `new_report_email` and `reporter_resolution_email` because they have no templates associated and weren't used anywhere.

I also added `.html_safe` in the direct message email to display the actual HTML, not the tags.

The additions to the `seeds.rb` are so that the preview mailers don't fail on local, because the requirements for them to render were not present.

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
