### PR TITLE
Upgrade emoji_regex to 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem "devise", "~> 4.6" # Flexible authentication solution for Rails
 gem "draper", "~> 3.0" # Draper adds an object-oriented layer of presentation logic to your Rails apps
 gem "dry-struct", "~> 0.6" # Typed structs and value objects
 gem "email_validator", "~> 2.0" # Email validator for Rails and ActiveModel
-gem "emoji_regex", "~> 1.0" # A pair of Ruby regular expressions for matching Unicode Emoji symbols
+gem "emoji_regex", "~> 2.0" # A pair of Ruby regular expressions for matching Unicode Emoji symbols
 gem "envied", "~> 0.9" # Ensure presence and type of your app's ENV-variables
 gem "fastly", "~> 1.15" # Client library for the Fastly acceleration system
 gem "fastly-rails", "~> 0.8" # Fastly dynamic caching integration for Rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -287,7 +287,7 @@ GEM
       http_parser.rb (~> 0.6.0)
     email_validator (2.0.1)
       activemodel
-    emoji_regex (1.0.1)
+    emoji_regex (2.0.0)
     envied (0.9.1)
       coercible (~> 1.0)
       thor (~> 0.15)
@@ -994,7 +994,7 @@ DEPENDENCIES
   draper (~> 3.0)
   dry-struct (~> 0.6)
   email_validator (~> 2.0)
-  emoji_regex (~> 1.0)
+  emoji_regex (~> 2.0)
   envied (~> 0.9)
   erb_lint (~> 0.0)
   factory_bot_rails (~> 4.11)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

Upgraded [emoji_regex](https://github.com/ticky/ruby-emoji-regex) to 2.0 which adds support for Unicode 12 and 230 new emojis, see [changelog](https://github.com/ticky/ruby-emoji-regex/releases/tag/v2.0.0)
