### PR TITLE
Upgrade ahoy_email to 1.0.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem "acts-as-taggable-on", "~> 6.0" # A tagging plugin for Rails applications th
 gem "acts_as_follower", github: "thepracticaldev/acts_as_follower", branch: "master" # Allow any model to follow any other model
 gem "addressable", "~> 2.5", ">= 2.5.2" # A replacement for the URI implementation that is part of Ruby's standard library
 gem "administrate", "~> 0.11" # A Rails engine that helps you put together a super-flexible admin dashboard
-gem "ahoy_email", "~> 0.5" # Email analytics for Rails
+gem "ahoy_email", "~> 1.0" # Email analytics for Rails
 gem "airbrake", "~> 8.1" # Airbrake is an online tool that provides robust exception tracking in any of your Ruby applications
 gem "algoliasearch-rails", "~> 1.21" # Algolia Search is a hosted search engine capable of delivering real-time results from the first keystroke
 gem "algorithmia", "~> 1.0" # Ruby Client for Algorithmia Algorithms and Data API

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,12 +86,10 @@ GEM
     after_commit_action (1.1.0)
       activerecord (>= 3.0.0)
       activesupport (>= 3.0.0)
-    ahoy_email (0.5.2)
-      actionmailer
-      activerecord
+    ahoy_email (1.0.3)
+      actionmailer (>= 4.2)
       addressable (>= 2.3.2)
       nokogiri
-      railties
       safely_block (>= 0.1.1)
     airbrake (8.1.4)
       airbrake-ruby (~> 3.2)
@@ -300,7 +298,7 @@ GEM
       rainbow
       rubocop (~> 0.51)
       smart_properties
-    errbase (0.1.0)
+    errbase (0.1.1)
     erubi (1.8.0)
     et-orbi (1.1.6)
       tzinfo
@@ -965,7 +963,7 @@ DEPENDENCIES
   acts_as_follower!
   addressable (~> 2.5, >= 2.5.2)
   administrate (~> 0.11)
-  ahoy_email (~> 0.5)
+  ahoy_email (~> 1.0)
   airbrake (~> 8.1)
   algoliasearch-rails (~> 1.21)
   algorithmia (~> 1.0)

--- a/config/initializers/ahoy_email.rb
+++ b/config/initializers/ahoy_email.rb
@@ -1,0 +1,5 @@
+# enable tracking for open, click and UTM params
+AhoyEmail.api = true
+AhoyEmail.default_options[:open] = true
+AhoyEmail.default_options[:click] = true
+AhoyEmail.default_options[:utm_params] = true


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

Now that #2523 is in, we can confidently upgrade ahoy_email to 1.0.3, see [changelog](https://github.com/ankane/ahoy_email/blob/master/CHANGELOG.md) and [upgrading guide](https://github.com/ankane/ahoy_email#upgrading)
