### PR TITLE
Apply theme color to sidebar widget links

### DIFF
--- a/app/assets/stylesheets/preact/sidebar-widget.scss
+++ b/app/assets/stylesheets/preact/sidebar-widget.scss
@@ -23,6 +23,7 @@
               display: block;
               padding: 5px 0px;
               font-size: 18px;
+              color: $black;
               color: var(--theme-color, $black);
               &:hover {
                 text-decoration: underline;

--- a/app/assets/stylesheets/preact/sidebar-widget.scss
+++ b/app/assets/stylesheets/preact/sidebar-widget.scss
@@ -23,7 +23,7 @@
               display: block;
               padding: 5px 0px;
               font-size: 18px;
-              color: $black;
+              color: var(--theme-color, $black);
               &:hover {
                 text-decoration: underline;
               }


### PR DESCRIPTION
# What type of PR is this?

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
This commit updates the sidebar widget links to apply the appropriate
theme color. This will prevent the links from being hard to read due to low contrast in night theme.

<img width="307" alt="Screen Shot 2019-04-23 at 7 57 26 PM" src="https://user-images.githubusercontent.com/25459752/56623392-09afe180-6602-11e9-988e-feefdc5db67b.png">

<img width="306" alt="Screen Shot 2019-04-23 at 7 32 09 PM" src="https://user-images.githubusercontent.com/25459752/56623382-fef54c80-6601-11e9-86d5-e3c35c9db2de.png">
