### PR TITLE
Added organizations to total following count

### DIFF
--- a/app/views/dashboards/_actions.html.erb
+++ b/app/views/dashboards/_actions.html.erb
@@ -9,6 +9,6 @@
   </a>
   <a class="action <%= "active" if params[:action] == "following" %>" href="/dashboard/following">
     <span>FOLLOWING</span>
-    <span>(<%= @user.following_users_count + @user.following_tags_count %>)</span>
+    <span>(<%= @user.following_users_count + @user.following_tags_count + @followed_organizations.count %>)</span>
   </a>
 </div>

--- a/app/views/dashboards/_actions.html.erb
+++ b/app/views/dashboards/_actions.html.erb
@@ -9,6 +9,6 @@
   </a>
   <a class="action <%= "active" if params[:action] == "following" %>" href="/dashboard/following">
     <span>FOLLOWING</span>
-    <span>(<%= @user.following_users_count + @user.following_tags_count + @followed_organizations.count %>)</span>
+    <span>(<%= @user.following_users_count + @user.following_tags_count + @user.following_organizations_count %>)</span>
   </a>
 </div>

--- a/app/views/dashboards/following.html.erb
+++ b/app/views/dashboards/following.html.erb
@@ -45,7 +45,7 @@
     <% end %>
   <% end %>
 
-  <h2>Followed organizations (<%= @followed_organizations.count %>)</h2>
+  <h2>Followed organizations (<%= @user.following_organizations_count %>)</h2>
   <% @followed_organizations.each do |follow| %>
     <% organization = follow.followable %>
     <div class="single-article">


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
In #2157 followed organizations was added as a separate category to the following page but the count wasn't added to the total following count.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
Before:
<img width="845" alt="Screenshot at Apr 24 19-56-57" src="https://user-images.githubusercontent.com/11406433/56682617-3af4e400-66cc-11e9-921d-ee14047afd74.png">

After:
<img width="856" alt="Screenshot at Apr 24 20-00-35" src="https://user-images.githubusercontent.com/11406433/56682636-447e4c00-66cc-11e9-8a2b-dc852491bd37.png">

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
