### PR TITLE
Clear cache on sidebars on user merge

### DIFF
--- a/app/services/moderator/merge_user.rb
+++ b/app/services/moderator/merge_user.rb
@@ -45,8 +45,7 @@ module Moderator
         @delete_user.update_columns(twitter_username: nil, github_username: nil)
         @keep_user.update_columns(twitter_username: @old_tu) if @keep_user.twitter_username.nil?
         @keep_user.update_columns(github_username: @old_gu) if @keep_user.github_username.nil?
-        @keep_user.touch(:profile_updated_at)
-        @keep_user.touch(:last_followed_at) # clears cache on sidebar
+        @keep_user.touch(:profile_updated_at, :last_followed_at) # clears cache on sidebar
       end
     end
 
@@ -70,7 +69,7 @@ module Moderator
 
     def merge_profile
       if @delete_user.github_repos.any?
-        @delete_user.github_repos&.update_all(user_id: @keep_user.id)
+        @delete_user.github_repos.update_all(user_id: @keep_user.id)
         @keep_user.touch(:github_repos_updated_at)
       end
       if @delete_user.badge_achievements.any?

--- a/app/services/moderator/merge_user.rb
+++ b/app/services/moderator/merge_user.rb
@@ -45,6 +45,8 @@ module Moderator
         @delete_user.update_columns(twitter_username: nil, github_username: nil)
         @keep_user.update_columns(twitter_username: @old_tu) if @keep_user.twitter_username.nil?
         @keep_user.update_columns(github_username: @old_gu) if @keep_user.github_username.nil?
+        @keep_user.touch(:profile_updated_at)
+        @keep_user.touch(:last_followed_at) # clears cache on sidebar
       end
     end
 
@@ -67,7 +69,10 @@ module Moderator
     end
 
     def merge_profile
-      @delete_user.github_repos&.update_all(user_id: @keep_user.id) if @delete_user.github_repos.any?
+      if @delete_user.github_repos.any?
+        @delete_user.github_repos&.update_all(user_id: @keep_user.id)
+        @keep_user.touch(:github_repos_updated_at)
+      end
       if @delete_user.badge_achievements.any?
         @delete_user.badge_achievements.update_all(user_id: @keep_user.id)
         @keep_user.badge_achievements_count = @keep_user.badge_achievements.size


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
Sidebars don't update when users are merged. This should update the rails cache in these areas. 