### PR TITLE
Fix Save Changes text spill out of button

### DIFF
--- a/app/assets/stylesheets/preact/article-form.scss
+++ b/app/assets/stylesheets/preact/article-form.scss
@@ -396,7 +396,6 @@
     }
     @media screen and (min-width: 630px) {
       font-size: 16px;
-      width: 130px;
     }
   }
 }


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
I noticed the save changes text spills out of it's button when you edit a post using the v2 editor. I removed the fixed width so the button width adjusts based on the text length.
I checked on both Chrome and Firefox (the only browsers I can use to check) and things look consistent on both browsers. I also checked the publish new post view and everything looks consistent as well.

## Related Tickets & Documents
Resolved #2521

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
Before Change
![Before - Text Spill](https://user-images.githubusercontent.com/24629960/56772449-18c09c00-6788-11e9-8c6e-bbce3074ffe0.png)

Screenshot from Change on Chrome and Firefox respectively
![After Change - Chrome Ubuntu](https://user-images.githubusercontent.com/24629960/56772454-1d855000-6788-11e9-979b-a4429bbbd76c.png)

![after change - firefox Ubuntu](https://user-images.githubusercontent.com/24629960/56772465-2413c780-6788-11e9-9a43-49b195e1d10b.png)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed