### PR TITLE
Add timestamp to comment and post notifications

### DIFF
--- a/app/views/notifications/_article.html.erb
+++ b/app/views/notifications/_article.html.erb
@@ -30,6 +30,9 @@
       <% if json_data["organization"] %>
         under <a href="<%= json_data["organization"]["path"] %>"><%= json_data["organization"]["name"] %></a>:
       <% end %>
+      <div>
+        <small><%= time_ago_in_words notification.created_at %></small>
+      </div>
       <a href="<%= json_data["article"]["path"] %>">
         <div class="notification-new-post">
           <div class="notification-new-post-title">

--- a/app/views/notifications/_comment.html.erb
+++ b/app/views/notifications/_comment.html.erb
@@ -16,6 +16,9 @@
       <a href="<%= json_data["comment"]["commentable"]["path"] %>">
         <%= sanitize(json_data["comment"]["commentable"]["title"]) %>
       </a>
+      <div>
+        <small><%= time_ago_in_words notification.created_at %> ago</small>
+      </div>
       <%= render "notifications/shared/comment_box", json_data: json_data, notification: notification, context: "default" %>
     <% elsif notification.action == "Moderation" %>
       Hey there! <%= image_tag "emoji/apple-hugging-face.png", class: "reaction-image" %> As a trusted member, could you react to this comment
@@ -34,6 +37,9 @@
       <a href="<%= json_data["comment"]["commentable"]["path"] %>">
         <%= sanitize(json_data["comment"]["commentable"]["title"]) %>
       </a>
+      <div>
+        <small><%= time_ago_in_words notification.created_at %> ago</small>
+      </div>
       <%= render "notifications/shared/comment_box", activity: activity, context: "moderation" %>
       Give them their first reply! 🎉
       <br>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
This commit adds timestamps to the comment and post notifications.
Instead of using `strftime` and ordinalizing the date I decided to use the
`time_ago_in_words` methods. I think that this looks better and is more
accurate when it comes to notifications recently received. The final say
is up to the main contributors though, if you would like me to change it
back let me know.

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/issues/2010

<img width="669" alt="Screen Shot 2019-04-25 at 10 26 19 PM" src="https://user-images.githubusercontent.com/25459752/56780096-f6407a00-67ab-11e9-9bee-8a92ae303f72.png">

