### PR TITLE
Fix double AWS_LAMBDA initialization

### DIFF
--- a/config/initializers/aws_sdk.rb
+++ b/config/initializers/aws_sdk.rb
@@ -5,5 +5,5 @@ AWS_LAMBDA = if Rails.env.production?
                  secret_access_key: ApplicationConfig["AWS_SDK_SECRET"],
                )
              else
-               AWS_LAMBDA = Aws::FakeClient.new
+               Aws::FakeClient.new
              end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

The Rails server complains with a warning that there's a double initialization for the constant `AWS_LAMBDA`:

```shell
./config/initializers/aws_sdk.rb:1: warning: already initialized constant AWS_LAMBDA
./config/initializers/aws_sdk.rb:8: warning: previous definition of AWS_LAMBDA was here
```

This fixes it

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
