### PR TITLE
Fix non-english characters delete on tags

### DIFF
--- a/app/lib/acts_as_taggable_on/tag_parser.rb
+++ b/app/lib/acts_as_taggable_on/tag_parser.rb
@@ -13,7 +13,7 @@ module ActsAsTaggableOn
       return [] if string.blank?
 
       string.downcase.split(",").map do |t|
-        t.strip.delete(" ").gsub(/[^0-9a-z]/i, "")
+        t.strip.delete(" ").gsub(/[^[:alnum:]]/i, "")
       end
     end
 

--- a/spec/lib/acts_as_taggable_on/tag_parser_spec.rb
+++ b/spec/lib/acts_as_taggable_on/tag_parser_spec.rb
@@ -25,6 +25,10 @@ RSpec.describe ActsAsTaggableOn::TagParser do
       tags = ["w0rd", "app|3", "&!tes4@#$%^&*"]
       expect(create_tag_parser(tags)).to eq(%w[w0rd app3 tes4])
     end
+    it "allows non-english characters" do
+      tags = %w[Optimización Καλημέρα Français]
+      expect(create_tag_parser(tags)).to eq(%w[optimización καλημέρα français])
+    end
     it "returns nothing if nothing is recieved" do
       expect(create_tag_parser([])).to eq([])
     end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
Non-English characters are deleted when tags are parsed because the matching only allows alphanumeric ASCII characters. I switched the matching to use POSIX bracket expression which allows matching with non-ASCII characters.
I noticed this was an issue only the v1 editor.

## Related Tickets & Documents
Resolves #2226 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![non-english characters now allowed](https://user-images.githubusercontent.com/24629960/56809225-5f9ea800-6801-11e9-9c1b-49417de6ee0d.png)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed