### PR TITLE
Remove last remnants of Flipflop

### DIFF
--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -74,59 +74,10 @@ RSpec.describe "Pages", type: :request do
   end
 
   describe "GET /live" do
-    let(:user) { create(:user) }
-
     context "when nothing is live" do
       it "shows the correct message" do
         get "/live"
         expect(response.body).to include("Nothing is live right now")
-      end
-    end
-
-    context "when live is starting soon" do
-      before do
-        test_strategy = Flipflop::FeatureSet.current.test!
-        test_strategy.switch!(:live_starting_soon, true)
-        get "/live"
-      end
-
-      after do
-        test_strategy = Flipflop::FeatureSet.current.test!
-        test_strategy.switch!(:live_starting_soon, false)
-      end
-
-      xit "shows the correct message" do
-        expect(response.body).to include("Our event is starting soon")
-      end
-    end
-
-    context "when live is live" do
-      before do
-        test_strategy = Flipflop::FeatureSet.current.test!
-        test_strategy.switch!(:live_is_live, true)
-        create(:chat_channel, :workshop)
-      end
-
-      after do
-        test_strategy = Flipflop::FeatureSet.current.test!
-        test_strategy.switch!(:live_is_live, false)
-      end
-
-      xit "shows a sign in page for logged out users" do
-        get "/live"
-        expect(response.body).to include("Great to have you")
-      end
-
-      xit "shows the video for logged in users" do
-        login_as user
-        get "/live"
-        expect(response.body).to include("<iframe class=\"live-video\"")
-      end
-
-      xit "shows the chat for logged in users" do
-        login_as user
-        get "/live"
-        expect(response.body).to include("<div id=\"chat\"")
       end
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

As discussed in #2573 about with @jessleenyc I'm sending a small PR to remove some (already ignored) tests that were using Flipflop which has been since removed in https://github.com/thepracticaldev/dev.to/pull/1358 by @Zhao-Andy 

## Related Tickets & Documents

References #2573 

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
