### PR TITLE
Improve Gist Link Regex

### DIFF
--- a/app/liquid_tags/gist_tag.rb
+++ b/app/liquid_tags/gist_tag.rb
@@ -38,7 +38,7 @@ class GistTag < LiquidTagBase
   end
 
   def valid_link?(link)
-    (link =~ /\Ahttps\:\/\/gist\.github\.com\/([a-zA-Z0-9\-]){1,39}\/([a-zA-Z0-9]){32}\Z/)&.
+    (link =~ /\Ahttps\:\/\/gist\.github\.com\/([a-zA-Z0-9](-?[a-zA-Z0-9]){0,38})\/([a-zA-Z0-9]){1,32}\Z/)&.
       zero?
   end
 end

--- a/spec/liquid_tags/gist_tag_spec.rb
+++ b/spec/liquid_tags/gist_tag_spec.rb
@@ -2,7 +2,14 @@ require "rails_helper"
 
 RSpec.describe GistTag, type: :liquid_template do
   describe "#link" do
-    let(:gist_link) { "https://gist.github.com/vaidehijoshi/6536e03b81e93a78c56537117791c3f1" }
+    let(:gist_link) do
+      [
+        "https://gist.github.com/amochohan/8cb599ee5dc0af5f4246",
+        "https://gist.github.com/vaidehijoshi/6536e03b81e93a78c56537117791c3f1",
+        "https://gist.github.com/CristinaSolana/1885435",
+      ]
+    end
+
     let(:bad_links) do
       [
         "//pastebin.com/raw/b77FrXUA#gist.github.com",
@@ -27,8 +34,10 @@ RSpec.describe GistTag, type: :liquid_template do
     end
 
     it "accepts proper gist url" do
-      liquid = generate_new_liquid(gist_link)
-      expect(liquid.render.delete(" ")).to eq(generate_script(gist_link))
+      gist_link.each do |link|
+        liquid = generate_new_liquid(link)
+        expect(liquid.render.delete(" ")).to eq(generate_script(link))
+      end
     end
 
     it "rejects invalid gist url" do

--- a/spec/liquid_tags/gist_tag_spec.rb
+++ b/spec/liquid_tags/gist_tag_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe GistTag, type: :liquid_template do
   describe "#link" do
-    let(:gist_link) do
+    let(:gist_links) do
       [
         "https://gist.github.com/amochohan/8cb599ee5dc0af5f4246",
         "https://gist.github.com/vaidehijoshi/6536e03b81e93a78c56537117791c3f1",
@@ -34,7 +34,7 @@ RSpec.describe GistTag, type: :liquid_template do
     end
 
     it "accepts proper gist url" do
-      gist_link.each do |link|
+      gist_links.each do |link|
         liquid = generate_new_liquid(link)
         expect(liquid.render.delete(" ")).to eq(generate_script(link))
       end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
While working with the gist liquid tag, I noticed that valid gist links were resulting in errors. After looking at `gist_tag.rb`, I noticed that for a link to be considered valid the gist-id had to be exactly 32
characters which is not always true.

Both `https://gist.github.com/amochohan/8cb599ee5dc0af5f4246` and `https://gist.github.com/CristinaSolana/1885435` are valid gist links that would not match with the previous regex.

I changed the regex so links with a gist-id of at least one character and at most 32 characters is considered valid. I decided to continue with the 32 characters that had previously been used as the upper bound. I also made a change so links with a github username that starts or ends with hypens or contains consecutive hypens are considered invalid. The aforementioned change was based on the validation message from the create new GitHub account form.

## Related Tickets & Documents
None

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
