### PR TITLE
Escape range separator in article slug regexp

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -24,7 +24,7 @@ class Article < ApplicationRecord
   has_many :rating_votes
   has_many :page_views
 
-  validates :slug, presence: { if: :published? }, format: /\A[0-9a-z-_]*\z/,
+  validates :slug, presence: { if: :published? }, format: /\A[0-9a-z\-_]*\z/,
                    uniqueness: { scope: :user_id }
   validates :title, presence: true,
                     length: { maximum: 128 }

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Article, type: :model do
     let(:article1) { build(:article, title: title, published: false) }
 
     before do
-      article0.validate
+      article0.validate!
     end
 
     context "when unpublished" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

The char "-" in regexp defaults a a separator for a range of character, for example: "a-z", Ruby is smart enough to understand "-_" is no range but it does emit a warning:

```text
warning: character class has '-' without escape: /\A[0-9a-z-_]*\z/
```

By properly escaping the char "-" we ensure that no warning or issues can arise in the future.

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
