### PR TITLE
Add hover to article save button

### DIFF
--- a/app/assets/javascripts/utilities/buildArticleHTML.js.erb
+++ b/app/assets/javascripts/utilities/buildArticleHTML.js.erb
@@ -78,8 +78,8 @@ function buildArticleHTML(article) {
     var saveButton = '';
     if (article.class_name === "Article") {
       var saveButton = '<button class="article-engagement-count bookmark-engage" data-reactable-id="'+article.id+'">\
-                        <span class="bm-success">SAVED</span>\
-                        <span class="bm-initial">SAVE</span>\
+                        <span class="bm-success"></span>\
+                        <span class="bm-initial"></span>\
                       </button>'
     } else if (article.class_name === "User") {
       var saveButton = '<button style="width: 122px" class="article-engagement-count bookmark-engage follow-action-button"\

--- a/app/assets/stylesheets/articles.scss
+++ b/app/assets/stylesheets/articles.scss
@@ -689,6 +689,11 @@
         .bm-success {
           display: none;
         }
+        .bm-initial {
+          &:after{
+            content: "SAVE";
+          }
+        }
         &.selected {
           color: darken($purple, 33%);
           background: transparent;
@@ -697,7 +702,14 @@
             display: none;
           }
           .bm-success {
-            display: block;
+            display: inline-block;
+
+            &:before{
+              content: "SAVED";
+            }
+            &:hover:before{
+              content: "UNSAVE";
+            }
           }
         }
         &.following-butt {

--- a/app/assets/stylesheets/more-articles.scss
+++ b/app/assets/stylesheets/more-articles.scss
@@ -135,7 +135,7 @@
       }
     }
     .content-author{
-      
+
       img{
         border-radius: 100%;
         width: 28px;

--- a/app/views/articles/_single_story.html.erb
+++ b/app/views/articles/_single_story.html.erb
@@ -64,7 +64,7 @@
     data-reactable-id="<%= story.id %>"
     aria-label="Save to reading list"
     title="Save to reading list">
-    <span class="bm-success">SAVED</span>
-    <span class="bm-initial">SAVE</span>
+    <span class="bm-success"></span>
+    <span class="bm-initial"></span>
   </button>
 </div>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -130,8 +130,8 @@
               data-reactable-id="<%= @featured_story.id %>"
               aria-label="Add to reading list"
               title="Add to reading list">
-              <span class="bm-success">SAVED</span>
-              <span class="bm-initial">SAVE</span>
+              <span class="bm-success"></span>
+              <span class="bm-initial"></span>
             </button>
           </div>
         </a>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
This commit changes the implementation of the bookmark article button so
that it is clear that clicking on the button, when the article is saved, will unsave the article.

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/issues/2594

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![unsave_on_hover](https://user-images.githubusercontent.com/25459752/56876317-8123ad80-6a14-11e9-8f61-54e6f04e7bf8.gif)
## 

What gif best describes this PR or how it makes you feel?

![SAVE](https://media.giphy.com/media/xULW8DlWhDskBqHgcM/giphy.gif)
