### PR TITLE
Add the word "ago" after timestamp on articles

### DIFF
--- a/app/views/notifications/_article.html.erb
+++ b/app/views/notifications/_article.html.erb
@@ -31,7 +31,7 @@
         under <a href="<%= json_data["organization"]["path"] %>"><%= json_data["organization"]["name"] %></a>:
       <% end %>
       <div>
-        <small><%= time_ago_in_words notification.created_at %></small>
+        <small><%= time_ago_in_words notification.created_at %> ago</small>
       </div>
       <a href="<%= json_data["article"]["path"] %>">
         <div class="notification-new-post">


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
It looks like the word "ago" was left off for article notifications in @ KDRaypole's awesome PR here: https://github.com/thepracticaldev/dev.to/pull/2565 .  This PR adds it.

## Related Tickets & Documents
Related to https://github.com/thepracticaldev/dev.to/pull/2565

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
