### PR TITLE
Embed Single File from Gist

### DIFF
--- a/app/views/pages/_editor_guide_text.html.erb
+++ b/app/views/pages/_editor_guide_text.html.erb
@@ -122,9 +122,16 @@
 
     <h3><strong>GitHub Gist Embed</strong></h3>
     <p>All you need is the gist link:</p>
-    <pre>
-    {% gist https://gist.github.com/QuincyLarson/4bb1682ce590dc42402b2edddbca7aaa %}
-    </pre>
+    <code>
+    {% gist https://gist.github.com/CristinaSolana/1885435 %}
+    </code>
+    <dl>
+      <dt><code>Single File Embed</code></dt>
+      <dd>
+        You can choose to embed a single gist file. <br>
+        <code>{% gist https://gist.github.com/CristinaSolana/1885435 file=gistfile1.md %}</code>
+      </dd>
+    </dl>
 
     <h3><strong>Video Embed</strong></h3>
     <p>All you need is the <code>id</code> from the URL.

--- a/spec/liquid_tags/gist_tag_spec.rb
+++ b/spec/liquid_tags/gist_tag_spec.rb
@@ -19,15 +19,19 @@ RSpec.describe GistTag, type: :liquid_template do
       ]
     end
 
+    let(:gist_link) { "https://gist.github.com/amochohan/8cb599ee5dc0af5f4246" }
+    let(:link_with_file_option) { "#{gist_link} file=01_Laravel 5 Simple ACL manager_Readme.md" }
+
     def generate_new_liquid(link)
       Liquid::Template.register_tag("gist", GistTag)
       Liquid::Template.parse("{% gist #{link} %}")
     end
 
-    def generate_script(link)
+    def generate_script(link, option = "")
+      uri = option.presence ? "#{link}.js?#{option}" : "#{link}.js"
       html = <<~HTML
         <div class="ltag_gist-liquid-tag">
-            <script id="gist-ltag" src="#{link}.js"></script>
+            <script id="gist-ltag" src="#{uri}"></script>
         </div>
       HTML
       html.tr("\n", " ").delete(" ")
@@ -38,6 +42,12 @@ RSpec.describe GistTag, type: :liquid_template do
         liquid = generate_new_liquid(link)
         expect(liquid.render.delete(" ")).to eq(generate_script(link))
       end
+    end
+
+    it "handles 'file' option" do
+      liquid = generate_new_liquid(link_with_file_option)
+      link, option = link_with_file_option.split(" ", 2)
+      expect(liquid.render.delete(" ")).to eq(generate_script(link, option))
     end
 
     it "rejects invalid gist url" do


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Add support to embed a single gist file in GitHub Gist embeds. I also made a change to the example used for the gist embed. I noticed a `pre` tag was used to keep the example on a single line so I changed the example to use a shorter link to avoid using the `pre` tag to keep it consistent with other examples.

## Related Tickets & Documents
Resolves #270

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
  - Gist without File option ![gist with no file option](https://user-images.githubusercontent.com/24629960/56920030-1f088e00-6a90-11e9-8655-72df6bf210ce.png)

  - Gist with File option ![gist with file option](https://user-images.githubusercontent.com/24629960/56920077-41021080-6a90-11e9-8567-12329d52bed8.png)

## Added to documentation?
- [x] editor guide