### PR TITLE
Added validation to classified_listings user and organization

### DIFF
--- a/app/models/classified_listing.rb
+++ b/app/models/classified_listing.rb
@@ -10,6 +10,9 @@ class ClassifiedListing < ApplicationRecord
   before_validation :modify_inputs
   acts_as_taggable_on :tags
 
+  validates :user_id, presence: true, unless: :organization_id?
+  validates :organization_id, presence: true, unless: :user_id?
+
   validates :title, presence: true,
                     length: { maximum: 128 }
   validates :body_markdown, presence: true,

--- a/spec/models/classified_listing_spec.rb
+++ b/spec/models/classified_listing_spec.rb
@@ -7,6 +7,25 @@ RSpec.describe ClassifiedListing, type: :model do
   it { is_expected.to validate_presence_of(:title) }
   it { is_expected.to validate_presence_of(:body_markdown) }
 
+  describe "valid associations" do
+    it "is not valid w/o user and org" do
+      cl = build(:classified_listing, user_id: nil, organization_id: nil)
+      expect(cl).not_to be_valid
+      expect(cl.errors[:user_id]).to be_truthy
+      expect(cl.errors[:organization_id]).to be_truthy
+    end
+
+    it "is valid with user_id" do
+      cl = build(:classified_listing, user_id: user.id, organization_id: nil)
+      expect(cl).to be_valid
+    end
+
+    it "is valid with organization_id" do
+      cl = build(:classified_listing, user_id: nil, organization_id: create(:organization).id)
+      expect(cl).to be_valid
+    end
+  end
+
   describe "body html" do
     it "converts markdown to html" do
       expect(classified_listing.processed_html).to include("<p>")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Fix possible bug: when `user_id` and `organization_id` are `nil`, `author` is also nil, so getting attribute `:author` for algolia will fail.