### PR TITLE
Add nightmode version of sponsorship images

### DIFF
--- a/app/assets/stylesheets/articles.scss
+++ b/app/assets/stylesheets/articles.scss
@@ -1178,9 +1178,13 @@
           img {
             border: 0;
             margin: auto;
+            margin-bottom: 8px;
             width: 98%;
             min-height: 35px;
             border-radius: 8px;
+            &.partner-image-dark-mode {
+              display: none;
+            }
           }
           .sponsor-tagline {
             margin: 10px auto;

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -45,6 +45,12 @@ body.night-theme {
     border-color: white !important;
     box-shadow: 3px 3px 0px #fff !important;
   }
+  .partner-image-dark-mode {
+    display: block !important;
+  }
+  .partner-image-light-mode {
+    display: none !important;
+  }
 }
 
 body.sans-serif-article-body {

--- a/app/dashboards/organization_dashboard.rb
+++ b/app/dashboards/organization_dashboard.rb
@@ -15,6 +15,7 @@ class OrganizationDashboard < Administrate::BaseDashboard
     tag_line: Field::String,
     profile_image: CarrierwaveField,
     nav_image: CarrierwaveField,
+    dark_nav_image: CarrierwaveField,
     url: Field::String,
     twitter_username: Field::String,
     github_username: Field::String,
@@ -36,7 +37,9 @@ class OrganizationDashboard < Administrate::BaseDashboard
     cta_body_markdown: Field::Text,
     sponsorship_url: Field::Text,
     sponsorship_tagline: Field::Text,
-    is_gold_sponsor: Field::Boolean
+    is_gold_sponsor: Field::Boolean,
+    sponsorship_blurb_html: Field::Text,
+    sponsorship_featured_number: Field::Number
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -66,6 +69,7 @@ class OrganizationDashboard < Administrate::BaseDashboard
     tag_line
     profile_image
     nav_image
+    dark_nav_image
     url
     bg_color_hex
     text_color_hex
@@ -84,7 +88,9 @@ class OrganizationDashboard < Administrate::BaseDashboard
     cta_body_markdown
     sponsorship_url
     sponsorship_tagline
+    sponsorship_blurb_html
     is_gold_sponsor
+    sponsorship_featured_number
   ].freeze
 
   def display_resource(organization)

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -51,6 +51,7 @@ class Organization < ApplicationRecord
 
   mount_uploader :profile_image, ProfileImageUploader
   mount_uploader :nav_image, ProfileImageUploader
+  mount_uploader :dark_nav_image, ProfileImageUploader
 
   alias_attribute :username, :slug
   alias_attribute :old_username, :old_slug

--- a/app/views/articles/_sidebar.html.erb
+++ b/app/views/articles/_sidebar.html.erb
@@ -16,7 +16,8 @@
             <% @sponsors.each do |organization| %>
               <div class="sidebar-sponsor">
                 <a class="partner-link" href="<%= organization.sponsorship_url %>" target="_blank" data-details="<%= organization.slug %>__image">
-                  <img src="<%= cloudinary(organization.nav_image_url) %>" style="margin-bottom:8px;" alt="Digital Ocean logo" />
+                  <img src="<%= cloudinary(organization.nav_image_url) %>" style="margin-bottom:8px;" alt="<%= organization.name %> logo" class="partner-image-light-mode" />
+                  <img src="<%= cloudinary(organization.dark_nav_image_url || organization.nav_image_url) %>" style="margin-bottom:8px;" alt="<%= organization.name %> logo" class="partner-image-dark-mode" />
                 </a>
                 <div class="sponsor-tagline" style="display:inline;">
                   <%= organization.sponsorship_tagline %>

--- a/db/migrate/20190501180125_add_dark_nav_image_to_organizations.rb
+++ b/db/migrate/20190501180125_add_dark_nav_image_to_organizations.rb
@@ -1,0 +1,5 @@
+class AddDarkNavImageToOrganizations < ActiveRecord::Migration[5.2]
+  def change
+    add_column :organizations, :dark_nav_image, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_30_123156) do
+ActiveRecord::Schema.define(version: 2019_05_01_180125) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -241,6 +241,7 @@ ActiveRecord::Schema.define(version: 2019_04_30_123156) do
     t.bigint "organization_id"
     t.text "processed_html"
     t.boolean "published"
+    t.string "slug"
     t.string "title"
     t.datetime "updated_at", null: false
     t.bigint "user_id"
@@ -541,6 +542,7 @@ ActiveRecord::Schema.define(version: 2019_04_30_123156) do
     t.string "cta_button_text"
     t.string "cta_button_url"
     t.text "cta_processed_html"
+    t.string "dark_nav_image"
     t.string "email"
     t.string "github_username"
     t.boolean "is_gold_sponsor", default: false


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
This allows us to set a dark version for sponsor logos in addition to the one that looks good on light colors.