### PR TITLE
Added hover effect for `sidebar-profile-snapshot`

### DIFF
--- a/app/assets/stylesheets/articles.scss
+++ b/app/assets/stylesheets/articles.scss
@@ -884,6 +884,9 @@
           theme-container-box-shadow,
           $bold-shadow
         );
+        &:hover {
+          @include themeable(background, theme-container-background-hover, $light-gray);
+        }
         // background:red;
         .sidebar-profile-snapshot-inner {
           display: inline-block;


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Currently, when the user hovers over their profile snapshot in the sidebar of the home page, the opacity of the inner contents of the containing `div` is set to `0.9`.

https://github.com/thepracticaldev/dev.to/blob/957d1887b760102daa74b87363b39b4482420cb6/app/assets/stylesheets/articles.scss#L894-L896

I find that this is too subtle for user feedback. I believe that this does not fully communicate to the user that the `div` is indeed "clickable". This small pull request hopes to make this hover effect more obvious by changing the `background` of the containing `div` on hover. I took inspiration from the styles and fallbacks of the `sidebar-nav-link` buttons to avoid deviating from the site's theme.

https://github.com/thepracticaldev/dev.to/blob/957d1887b760102daa74b87363b39b4482420cb6/app/assets/stylesheets/articles.scss#L1010-L1016

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
**Hover state in default theme:**
![Default](https://user-images.githubusercontent.com/39114273/57061380-30030a80-6cef-11e9-9957-e25014e768c2.png)

**Hover state in night theme:**
![Night](https://user-images.githubusercontent.com/39114273/57061088-4066b580-6cee-11e9-8e71-852f4b274942.png)

**Hover state in pink theme:**
![Pink](https://user-images.githubusercontent.com/39114273/57061494-a0aa2700-6cef-11e9-9133-c7ccdbe20c41.png)


## Added to documentation?
- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?
Oh, boy, have I had some troubles with Git in this one. I had to delete my old fork of this repository just to fix my working tree. Welp, at least it's all good now. This GIF should suffice how I feel.
![Relief](https://media.giphy.com/media/l3q2T74mddn74nRhC/giphy.gif)