### PR TITLE
Correctly align saved/unsave

### DIFF
--- a/app/assets/stylesheets/articles.scss
+++ b/app/assets/stylesheets/articles.scss
@@ -638,7 +638,7 @@
     }
     .article-reading-time {
       position: absolute;
-      right: 75px;
+      right: 82px;
       bottom: 12px;
       font-size: 13px;
       padding: 6px 0px;
@@ -698,10 +698,12 @@
         }
         .bm-success {
           display: none;
+          position: relative;
+          top: 1px;
         }
         .bm-initial {
-          &:after{
-            content: "SAVE";
+          &:after {
+            content: 'SAVE';
           }
         }
         &.selected {
@@ -714,11 +716,12 @@
           .bm-success {
             display: inline-block;
 
-            &:before{
-              content: "SAVED";
+            &:before {
+              content: 'SAVED';
             }
-            &:hover:before{
-              content: "UNSAVE";
+
+            &:hover:before {
+              content: 'UNSAVE';
             }
           }
         }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

After https://github.com/thepracticaldev/dev.to/pull/2597 I noticed two quirks on the SAVE/SAVED/UNSAVE button

The first one is how the "unsave" text overlaps with the reading time:

![Screenshot 2019-05-02 at 1 40 55 PM](https://user-images.githubusercontent.com/146201/57073079-3e95f580-6ce0-11e9-9ad8-9022f01244bc.png)

The second one is due to the instantaneous nature of `hover`. When the user clicks "SAVE", the text turns to "SAVED" but then it quickly turns to "UNSAVE" because of the CSS `:hover` definition.

The transition can bee seen in this recording:

![before](https://user-images.githubusercontent.com/146201/57073187-9e8c9c00-6ce0-11e9-9a6f-46ed87eadae5.gif)

This PR addresses only the alignment.

The delay can be probably inserted using JS but I'm not sure it's the right approach. I've found [an example using transition](https://codepen.io/ironion/pen/WQbjPR) but I couldn't reproduce it with the website.

I should probably create a separate issue so that maybe someone can work on that aspect

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Before

![Screenshot 2019-05-02 at 1 40 55 PM](https://user-images.githubusercontent.com/146201/57073433-5c178f00-6ce1-11e9-802d-43d31f24ad16.png)

After

![Screenshot 2019-05-02 at 1 41 06 PM](https://user-images.githubusercontent.com/146201/57073440-5f127f80-6ce1-11e9-9465-2603af9dd59b.png)


## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
