### PR TITLE
Refactor Comments::BustCacheJob to use a service

### DIFF
--- a/app/jobs/comments/bust_cache_job.rb
+++ b/app/jobs/comments/bust_cache_job.rb
@@ -2,10 +2,11 @@ module Comments
   class BustCacheJob < ApplicationJob
     queue_as :comments_bust_cache
 
-    def perform(comment_id, cache_buster = CacheBuster.new)
+    def perform(comment_id, service = EdgeCache::Commentable::Bust)
       comment = Comment.find_by(id: comment_id)
-      Comment.comment_async_bust(comment.commentable, comment.user.username) if comment
-      cache_buster.bust("#{comment.commentable.path}/comments") if comment&.commentable
+      return unless comment&.commentable
+
+      service.call(comment.commentable, comment.user.username)
     end
   end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -180,11 +180,6 @@ class Comment < ApplicationRecord
     end
   end
 
-  def self.comment_async_bust(commentable, username)
-    CacheBuster.new.bust_comment(commentable, username)
-    commentable.index!
-  end
-
   def remove_notifications
     Notification.remove_all_without_delay(notifiable_id: id, notifiable_type: "Comment")
     Notification.remove_all_without_delay(notifiable_id: id, notifiable_type: "Comment", action: "Moderation")

--- a/app/services/edge_cache/commentable/bust.rb
+++ b/app/services/edge_cache/commentable/bust.rb
@@ -1,0 +1,25 @@
+module EdgeCache
+  module Commentable
+    class Bust
+      def initialize(commentable, username, cache_buster = CacheBuster.new)
+        @commentable = commentable
+        @username = username
+        @cache_buster = cache_buster
+      end
+
+      def self.call(*args)
+        new(*args).call
+      end
+
+      def call
+        cache_buster.bust_comment(commentable, username)
+        cache_buster.bust("#{commentable.path}/comments")
+        commentable.index!
+      end
+
+      private
+
+      attr_reader :commentable, :username, :cache_buster
+    end
+  end
+end

--- a/spec/jobs/comments/bust_cache_job_spec.rb
+++ b/spec/jobs/comments/bust_cache_job_spec.rb
@@ -1,17 +1,31 @@
 require "rails_helper"
 
 RSpec.describe Comments::BustCacheJob, type: :job do
+  include_examples "#enqueues_job", "comments_bust_cache", 5
+
   describe "#perform_now" do
-    let(:article) { FactoryBot.create(:article) }
-    let(:comment) { FactoryBot.create(:comment, commentable: article) }
+    let(:edge_cache_commentable_bust_service) { double }
+    let(:comment) { create(:comment, commentable: create(:article)) }
 
-    it "busts cache" do
-      path = "#{comment.commentable.path}/comments"
-      cache_buster = double
-      allow(cache_buster).to receive(:bust)
+    before do
+      allow(edge_cache_commentable_bust_service).to receive(:call)
+    end
 
-      described_class.perform_now(comment.id, cache_buster)
-      expect(cache_buster).to have_received(:bust).with(path).once
+    it "calls the service" do
+      described_class.perform_now(comment.id, edge_cache_commentable_bust_service)
+      expect(edge_cache_commentable_bust_service).to have_received(:call).
+        with(comment.commentable, comment.user.username).once
+    end
+
+    it "doesn't call the service with a non existent comment" do
+      described_class.perform_now(9999, edge_cache_commentable_bust_service)
+      expect(edge_cache_commentable_bust_service).not_to have_received(:call)
+    end
+
+    it "doesn't call the service with a comment without a commentable" do
+      comment.update_columns(commentable_id: nil, commentable_type: nil)
+      described_class.perform_now(comment, edge_cache_commentable_bust_service)
+      expect(edge_cache_commentable_bust_service).not_to have_received(:call)
     end
   end
 end

--- a/spec/services/edge_cache/commentable/bust_spec.rb
+++ b/spec/services/edge_cache/commentable/bust_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe EdgeCache::Commentable::Bust, type: :service do
+  let(:commentable) { create(:article) }
+  let(:username) { create(:user).username }
+  let(:cache_buster) { double }
+
+  before do
+    allow(cache_buster).to receive(:bust_comment)
+    allow(cache_buster).to receive(:bust).with("#{commentable.path}/comments")
+  end
+
+  it "busts the cache" do
+    described_class.call(commentable, username, cache_buster)
+    expect(cache_buster).to have_received(:bust_comment).with(commentable, username).once
+    expect(cache_buster).to have_received(:bust).with("#{commentable.path}/comments").once
+  end
+
+  it "indexes the commentable" do
+    allow(commentable).to receive(:index!)
+    described_class.call(commentable, username, cache_buster)
+    expect(commentable).to have_received(:index!).once
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

This furthers the effort of separating jobs with their own inner business logic. Currently the busting logic is split between `Comments::BustCacheJob` and the Comment class.

With this refactor we move all the logic inside a service and make sure to test that both the cache buster and the index are triggered correctly.

It also creates an `EdgeCache` namespace.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
