### PR TITLE
Create serialized cached user and cached organization for articles

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -43,6 +43,7 @@ class Organization < ApplicationRecord
   before_save :remove_at_from_usernames
   after_save  :bust_cache
   before_save :generate_secret
+  before_save :update_articles
   before_validation :downcase_slug
   before_validation :check_for_slug_change
   before_validation :evaluate_markdown
@@ -99,6 +100,18 @@ class Organization < ApplicationRecord
 
   def downcase_slug
     self.slug = slug.downcase
+  end
+
+  def update_articles
+    return unless saved_change_to_slug || saved_change_to_name || saved_change_to_profile_image
+
+    cached_org_object = {
+      name: name,
+      username: username,
+      slug: slug,
+      profile_image_url: profile_image_url
+    }
+    articles.update(cached_organization: OpenStruct.new(cached_org_object))
   end
 
   def bust_cache

--- a/db/migrate/20190502165056_add_cached_user_to_articles.rb
+++ b/db/migrate/20190502165056_add_cached_user_to_articles.rb
@@ -1,0 +1,6 @@
+class AddCachedUserToArticles < ActiveRecord::Migration[5.2]
+  def change
+    add_column :articles, :cached_user, :text
+    add_column :articles, :cached_organization, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -591,21 +591,6 @@ ActiveRecord::Schema.define(version: 2019_05_02_165056) do
     t.index ["user_id"], name: "index_page_views_on_user_id"
   end
 
-  create_table "pages", force: :cascade do |t|
-    t.text "body_html"
-    t.text "body_markdown"
-    t.datetime "created_at", null: false
-    t.string "description"
-    t.string "group"
-    t.integer "group_order_number"
-    t.text "processed_html"
-    t.string "slug"
-    t.string "social_image"
-    t.string "template"
-    t.string "title"
-    t.datetime "updated_at", null: false
-  end
-
   create_table "podcast_episodes", id: :serial, force: :cascade do |t|
     t.text "body"
     t.integer "comments_count", default: 0, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_01_180125) do
+ActiveRecord::Schema.define(version: 2019_05_02_165056) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -56,7 +56,9 @@ ActiveRecord::Schema.define(version: 2019_05_01_180125) do
     t.text "body_html"
     t.text "body_markdown"
     t.jsonb "boost_states", default: {}, null: false
+    t.text "cached_organization"
     t.string "cached_tag_list"
+    t.text "cached_user"
     t.string "cached_user_name"
     t.string "cached_user_username"
     t.string "canonical_url"
@@ -587,6 +589,21 @@ ActiveRecord::Schema.define(version: 2019_05_01_180125) do
     t.bigint "user_id"
     t.index ["article_id"], name: "index_page_views_on_article_id"
     t.index ["user_id"], name: "index_page_views_on_user_id"
+  end
+
+  create_table "pages", force: :cascade do |t|
+    t.text "body_html"
+    t.text "body_markdown"
+    t.datetime "created_at", null: false
+    t.string "description"
+    t.string "group"
+    t.integer "group_order_number"
+    t.text "processed_html"
+    t.string "slug"
+    t.string "social_image"
+    t.string "template"
+    t.string "title"
+    t.datetime "updated_at", null: false
   end
 
   create_table "podcast_episodes", id: :serial, force: :cascade do |t|

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -388,6 +388,20 @@ RSpec.describe Article, type: :model do
       article = create(:article, user_id: user.id)
       expect(article.cached_user_username).to eq(article.user_username)
     end
+    it "assigns cached_user on save" do
+      article = create(:article, user_id: user.id)
+      expect(article.cached_user.username).to eq(article.user.username)
+      expect(article.cached_user.name).to eq(article.user.name)
+      expect(article.cached_user.profile_image_url).to eq(article.user.profile_image_url)
+    end
+    it "assigns cached_organization on save" do
+      organization = create(:organization)
+      article = create(:article, user_id: user.id, organization_id: organization.id)
+      expect(article.cached_organization.username).to eq(article.organization.username)
+      expect(article.cached_organization.name).to eq(article.organization.name)
+      expect(article.cached_organization.slug).to eq(article.organization.slug)
+      expect(article.cached_organization.profile_image_url).to eq(article.organization.profile_image_url)
+    end
   end
 
   describe "validations" do

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -125,5 +125,13 @@ RSpec.describe Organization, type: :model do
       article = Article.find_by(organization_id: organization.id)
       expect(article.path).to include new_slug
     end
+
+    it "updates article cached_organizations" do
+      create_article_for_organization
+      new_slug = "slug_#{rand(10_000)}"
+      organization.update(slug: new_slug)
+      article = Article.find_by(organization_id: organization.id)
+      expect(article.cached_organization.slug).to eq new_slug
+    end
   end
 end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
We query lists of articles _a lot_, and every time we do, we have to make one or more additional queries to pull in basic user/org profile info. This PR stores user and org info on articles so we can include them in more basic, optimized queries.

This PR only adds the data layer. Additional changes will adjust the queries to make use of the more optimized versions. We already do similar things with tags.