### PR TITLE
Add report abuse link to listings

### DIFF
--- a/app/javascript/listings/singleListing.jsx
+++ b/app/javascript/listings/singleListing.jsx
@@ -5,7 +5,7 @@ export const SingleListing = ({listing, onAddTag, currentUserId, onChangeCategor
   const tagLinks = listing.tag_list.map(tag => (
     <a href={`/listings?t=${tag}`} onClick={e => onAddTag(e, tag)} data-no-instant>{tag}</a>
   ));
-  const editButton = currentUserId === listing.user_id ? <a href={`/listings/${listing.id}/edit`} className="classified-listing-edit-button">edit</a> : '';
+  const editButton = currentUserId === listing.user_id ? <a href={`/listings/${listing.id}/edit`} className="classified-listing-edit-button">・edit</a> : <a href={`/report-abuse?url=https://dev.to/listings/${listing.category}/${listing.slug}`}>・report abuse</a>;
   return (
     <div className="single-classified-listing">
       <div className="listing-content">

--- a/app/models/feedback_message.rb
+++ b/app/models/feedback_message.rb
@@ -9,7 +9,7 @@ class FeedbackMessage < ApplicationRecord
   validates :reported_url, :category, presence: { if: :abuse_report? }
   validates :category,
             inclusion: {
-              in: ["spam", "other", "rude or vulgar", "harassment", "bug"]
+              in: ["spam", "other", "rude or vulgar", "harassment", "bug", "listings"]
             }
   validates :status,
             inclusion: {

--- a/app/views/classified_listings/index.html.erb
+++ b/app/views/classified_listings/index.html.erb
@@ -23,7 +23,7 @@
 <div class="home">
   <div class="classifieds-container" id="classifieds-index-container"
     data-category="<%= params[:category] %>" data-listings="<%= @classified_listings.to_json(
-            only: %i[title processed_html tag_list category id user_id],
+            only: %i[title processed_html tag_list category id user_id slug],
             include: {
               author: { only: %i[username name], methods: %i[username profile_image_90] },
             },

--- a/app/views/feedback_messages/_form.html.erb
+++ b/app/views/feedback_messages/_form.html.erb
@@ -34,6 +34,10 @@
         <%= label_tag(:category_spam, "Spam or copyright issue") %>
       </li>
       <li>
+        <%= f.radio_button :category, "listings" %>
+        <%= label_tag(:category_spam, "Inappropriate listings message/category") %>
+      </li>
+      <li>
         <%= f.radio_button :category, "other" %>
         <%= label_tag(:category_other, "Other") %>
       </li>

--- a/app/views/feedback_messages/_form.html.erb
+++ b/app/views/feedback_messages/_form.html.erb
@@ -35,7 +35,7 @@
       </li>
       <li>
         <%= f.radio_button :category, "listings" %>
-        <%= label_tag(:category_spam, "Inappropriate listings message/category") %>
+        <%= label_tag(:category_listing, "Inappropriate listings message/category") %>
       </li>
       <li>
         <%= f.radio_button :category, "other" %>


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Not the ideal UI but now there's a way to report abuse on listings. 

- Adds link to each listing card (pulls in the listing slug as a pram), does not appear on your own listings
- Adds a category on the report abuse form

## Screenshots

![](https://cl.ly/9a0aa6fad9ba/download/Image%202019-05-03%20at%204.04.33%20PM.png)

![](https://cl.ly/afc63f595b15/download/Image%202019-05-03%20at%204.05.25%20PM.png)
