### PR TITLE
Allow users to follow podcasts

### DIFF
--- a/app/assets/javascripts/initializers/initializeFetchFollowedArticles.js.erb
+++ b/app/assets/javascripts/initializers/initializeFetchFollowedArticles.js.erb
@@ -1,4 +1,5 @@
 function initializeFetchFollowedArticles() {
+  insertPodcasts();
   if ( document.getElementById("featured-story-marker") && checkUserLoggedIn() ) {
     algoliaFollowedArticles();
   }
@@ -174,6 +175,30 @@ function algoliaFollowedArticles(){
         if (el){el.outerHTML = ''}
       });
     }
+}
+
+function insertPodcasts() {
+  var el = document.getElementById('followed-podcasts');
+  var insertPlace = document.getElementById('article-index-podcast-div');
+  if (el && insertPlace){
+    var user = userData();
+    if (user.followed_podcast_ids && user.followed_podcast_ids.length > 0) {
+      var data = JSON.parse(el.dataset.episodes);
+      var podcastHTML = '';
+      var episodeCount = 0;
+      data.forEach(function(ep) {
+        if (user.followed_podcast_ids.indexOf(ep.podcast.id)) {
+          episodeCount += 1;
+          podcastHTML = podcastHTML + '<a class="individual-podcast-link" href="/' + ep.podcast.slug + '/' + ep.slug + '"><strong>' + ep.podcast.title + '</strong> ' + ep.title + '</a>'
+        }
+      });
+      if (episodeCount > 0) {
+        insertPlace.innerHTML = '<div class="single-article single-article-podcast-div"><h3><a href="/pod">Today\'s Podcasts</a></h3>' + podcastHTML + '</div>';
+      } else {
+        insertPlace.innerHTML = '<div class="single-article single-article-podcast-div"><h3><a href="/pod">Today\'s Podcasts</a></h3><p>Nothing in your feed today</p></a></div>';
+      }
+    }
+  }
 }
 
 function findOne(haystack, arr) {

--- a/app/assets/javascripts/initializers/initializeFetchFollowedArticles.js.erb
+++ b/app/assets/javascripts/initializers/initializeFetchFollowedArticles.js.erb
@@ -187,7 +187,7 @@ function insertPodcasts() {
       var podcastHTML = '';
       var episodeCount = 0;
       data.forEach(function(ep) {
-        if (user.followed_podcast_ids.indexOf(ep.podcast.id)) {
+        if (user.followed_podcast_ids.indexOf(ep.podcast.id) > -1) {
           episodeCount += 1;
           podcastHTML = podcastHTML + '<a class="individual-podcast-link" href="/' + ep.podcast.slug + '/' + ep.slug + '"><strong>' + ep.podcast.title + '</strong> ' + ep.title + '</a>'
         }
@@ -195,7 +195,7 @@ function insertPodcasts() {
       if (episodeCount > 0) {
         insertPlace.innerHTML = '<div class="single-article single-article-podcast-div"><h3><a href="/pod">Today\'s Podcasts</a></h3>' + podcastHTML + '</div>';
       } else {
-        insertPlace.innerHTML = '<div class="single-article single-article-podcast-div"><h3><a href="/pod">Today\'s Podcasts</a></h3><p>Nothing in your feed today</p></a></div>';
+        insertPlace.innerHTML = '<div class="single-article single-article-podcast-div"><h3><a href="/pod">Today\'s Podcasts</a></h3><p>Nothing in your feed today</p></div>';
       }
     }
   }

--- a/app/assets/javascripts/initializers/initializePodcastPlayback.js
+++ b/app/assets/javascripts/initializers/initializePodcastPlayback.js
@@ -14,7 +14,6 @@ function initializePodcastPlayback() {
     return document.getElementById(name);
   }
 
-
   function getByClass(name) {
     return document.getElementsByClassName(name);
   }

--- a/app/assets/javascripts/utilities/buildArticleHTML.js.erb
+++ b/app/assets/javascripts/utilities/buildArticleHTML.js.erb
@@ -1,6 +1,6 @@
 function buildArticleHTML(article) {
   if (article && article.type_of == "podcast_episodes") {
-    return '<div class="single-article single-article-small-pic">\
+    return '<div class="single-article single-article-small-pic single-article-single-podcast">\
       <div class="small-pic">\
        <a href="/'+article.podcast.slug+'" class="small-pic-link-wrapper">\
          <img src="'+article.podcast.image_url+'" alt="'+article.podcast.title+' image">\

--- a/app/assets/stylesheets/articles.scss
+++ b/app/assets/stylesheets/articles.scss
@@ -1129,9 +1129,11 @@
       }
       &.podcast-pic-widget {
         a {
-          &:hover {
-            text-decoration: none;
-          }
+          @include themeable(
+            color, 
+            theme-color, 
+            $black
+          );
         }
         .widget-body {
           padding-bottom: 10px;
@@ -1154,6 +1156,7 @@
             width: calc(100% - 55px);
             display: inline-block;
             padding-left: 4px;
+            font-weight: bold;
             .podcast-name-inner {
               font-size: 14px;
               line-height: 15px;

--- a/app/assets/stylesheets/articles.scss
+++ b/app/assets/stylesheets/articles.scss
@@ -257,6 +257,47 @@
           margin-top: 12px;
         }
       }
+      &.single-article-single-podcast {
+        h4 {
+          bottom: 10px;
+        }
+        .content {
+          padding-bottom: 40px;
+        }
+      }
+      &.single-article-podcast-div {
+        margin-top: 8px;
+        padding: 8px 0px 15px;
+        font-size: 0.8em;
+        h3 {
+          font-size: 1.5em;
+          margin-left: 13px;
+          font-weight: 800;
+        }
+        a.individual-podcast-link {
+          strong {
+            display: block;
+            margin-bottom: 4px;
+          }
+          display: block;
+          padding: 4px 14px 7px;
+          &:hover {
+            @include themeable(background, theme-container-background-hover, $light-gray);
+          }
+        }
+        p {
+          margin-left: 14px;
+        }
+        @media screen and (min-width: 430px) {
+          margin-top: 12px;
+          a.individual-podcast-link {
+            strong {
+              margin-bottom: 5px;
+            }
+            padding: 5px 14px 9px;
+          }
+        }
+      }
       h4 {
         white-space: nowrap;
         overflow: hidden;
@@ -844,7 +885,7 @@
     width: 280px;
     margin: auto;
     text-align: left;
-    font-size: 0.9em;
+    font-size: 0.92em;
     line-height: 1.35em;
     margin-left: 0.786vw;
     min-height: 5px;
@@ -1012,7 +1053,8 @@
             display: inline-block;
             width: calc(100% - 10px);
             font-weight: 500;
-            padding: 3px 8px;
+            padding: 4px 9px;
+            font-size: 1em;
             &:hover {
               @include themeable(
                 background,
@@ -1092,38 +1134,38 @@
           }
         }
         .widget-body {
-          text-align: center;
           padding-bottom: 10px;
         }
         .podcast-pic {
           position: relative;
-          display: inline-block;
+          padding: 5px 0px;
+          border-top-left-radius: 100px;
+          border-bottom-left-radius: 100px;
+          border-top-right-radius: 5px;
+          border-bottom-right-radius: 5px;
           img {
-            width: 100px;
-            height: 100px;
+            width: 23px;
+            height: 23px;
+            border-radius: 100px;
+            vertical-align: -7px;
+            margin-left: 3px;
           }
           .podcast-name {
-            bottom: 12px;
-            display: none;
-            position: absolute;
-            width: 90%;
-            left: 5%;
-            z-index: 15;
-            text-align: left;
-            height: 54px;
+            width: calc(100% - 55px);
+            display: inline-block;
+            padding-left: 4px;
             .podcast-name-inner {
-              font-size: 12px;
+              font-size: 14px;
               line-height: 15px;
-              padding: 2px;
-              color: white;
-              background: rgba(0, 0, 0, 0.89);
               display: block;
             }
           }
           &:hover {
-            .podcast-name {
-              display: block;
-            }
+            @include themeable(
+              background, 
+              theme-container-background-hover, 
+              $light-gray
+            );
           }
         }
       }

--- a/app/assets/stylesheets/podcast-episodes-show.scss
+++ b/app/assets/stylesheets/podcast-episodes-show.scss
@@ -8,7 +8,7 @@
     text-align:center;
     .title{
       padding-top:40px;
-      background:rgb(6, 32, 48) url(https://i.imgur.com/fKYKgo4.png);
+      background:$black;
       height:300px;
       margin-bottom:-120px;
       @media screen and ( min-width: 600px ){
@@ -25,6 +25,8 @@
         color:rgb(235, 243, 245);
         a{
           color:white;
+          display: inline-block;
+          margin-right: 4px;
         }
         img{
           height:28px;
@@ -35,6 +37,13 @@
           vertical-align:-4px;
           margin-right:8px;
           border-radius:30px;
+        }
+        .follow-action-button {
+          width: 120px;
+          border-radius: 3px;
+          border: 0px;
+          font-size:16px;
+          vertical-align:2px;
         }
         @media screen and ( min-width: 600px ){
           font-size:22px;

--- a/app/controllers/async_info_controller.rb
+++ b/app/controllers/async_info_controller.rb
@@ -41,6 +41,7 @@ class AsyncInfoController < ApplicationController
         followed_tags: @user.cached_followed_tags.to_json(only: %i[id name bg_color_hex text_color_hex hotness_score], methods: [:points]),
         followed_user_ids: @user.cached_following_users_ids,
         followed_organization_ids: @user.cached_following_organizations_ids,
+        followed_podcast_ids: @user.cached_following_podcasts_ids,
         reading_list_ids: ReadingList.new(@user).cached_ids_of_articles,
         saw_onboarding: @user.saw_onboarding,
         checked_code_of_conduct: @user.checked_code_of_conduct,
@@ -57,6 +58,7 @@ class AsyncInfoController < ApplicationController
   def user_cache_key
     "#{current_user&.id}__
     #{current_user&.last_sign_in_at}__
+    #{current_user&.last_followed_at}__
     #{current_user&.updated_at}__
     #{current_user&.reactions_count}__
     #{current_user&.comments_count}__

--- a/app/controllers/follows_controller.rb
+++ b/app/controllers/follows_controller.rb
@@ -25,6 +25,8 @@ class FollowsController < ApplicationController
                    Organization.find(params[:followable_id])
                  elsif params[:followable_type] == "Tag"
                    Tag.find(params[:followable_id])
+                 elsif params[:followable_type] == "Podcast"
+                   Podcast.find(params[:followable_id])
                  else
                    User.find(params[:followable_id])
                  end

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -243,10 +243,12 @@ class StoriesController < ApplicationController
   def assign_podcasts
     return unless user_signed_in?
 
+    num_hours = Rails.env.production? ? 24 : 800
     @podcast_episodes = PodcastEpisode.
       includes(:podcast).
       order("published_at desc").
-      select(:slug, :title, :podcast_id).limit(5)
+      where("published_at > ?", num_hours.hours.ago).
+      select(:slug, :title, :podcast_id)
   end
 
   def article_finder(num_articles)

--- a/app/labor/follow_checker.rb
+++ b/app/labor/follow_checker.rb
@@ -13,6 +13,8 @@ class FollowChecker
                      Tag.find(followable_id)
                    elsif followable_type == "Organization"
                      Organization.find(followable_id)
+                   elsif followable_type == "Podcast"
+                     Podcast.find(followable_id)
                    else
                      User.find(followable_id)
                    end

--- a/app/models/podcast.rb
+++ b/app/models/podcast.rb
@@ -4,6 +4,8 @@ class Podcast < ApplicationRecord
   mount_uploader :image, ProfileImageUploader
   mount_uploader :pattern_image, ProfileImageUploader
 
+  validates :main_color_hex, presence: true
+
   after_save :bust_cache
   after_create :pull_all_episodes
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -250,6 +250,15 @@ class User < ApplicationRecord
     end
   end
 
+  def cached_following_podcasts_ids
+    Rails.cache.fetch(
+      "user-#{id}-#{updated_at}-#{last_followed_at}/following_podcasts_ids",
+      expires_in: 120.hours,
+    ) do
+      Follow.where(follower_id: id, followable_type: "Podcast").pluck(:followable_id)
+    end
+  end
+
   def cached_preferred_langs
     Rails.cache.fetch("user-#{id}-#{updated_at}/cached_preferred_langs", expires_in: 24.hours) do
       preferred_languages_array

--- a/app/views/articles/_podcast_episodes_feed.html.erb
+++ b/app/views/articles/_podcast_episodes_feed.html.erb
@@ -1,6 +1,6 @@
 <% @podcast_episodes.each_with_index do |episode, i| %>
   <a href="<%= episode.path %>" class="small-pic-link-wrapper" id="article-link-<%= episode.id %>">
-    <div class="single-article single-article-small-pic">
+    <div class="single-article single-article-small-pic single-article-single-podcast">
       <div class="small-pic">
         <%= cl_image_tag(episode.image_url || episode.podcast.image_url,
                          type: "fetch",

--- a/app/views/articles/_sidebar_additional.html.erb
+++ b/app/views/articles/_sidebar_additional.html.erb
@@ -125,26 +125,7 @@
         </div>
       </div>
     <% end %>
-    <% if user_signed_in? %>
-      <% cache("featured-homepage-podcasts", expires_in: 15.minutes) do %>
-        <div class="widget" id="podcast-widget">
-          <header>
-            <a href="/pod"><h4>latest podcasts</h4></a>
-          </header>
-          <div class="widget-body">
-            <% @podcast_episodes.each do |ep| %>
-              <div class="widget-podcast-ep">
-                <a href="<%= ep.path %>"><%= ep.title %></a>
-                <div class="widget-podcast-title">
-                  <a href="<%= ep.podcast.path %>"><%= ep.podcast.title %></a>
-                </div>
-              </div>
-            <% end %>
-            <a class="cta cta-button" href="/pod">VIEW ALL</a>
-          </div>
-        </div>
-      <% end %>
-    <% else %>
+    <% unless user_signed_in? %>
       <% cache("seo-boostable-posts-homepage-#{params[:timeframe]}-xoxo", expires_in: 18.hours) do %>
         <% @boostable_posts = Article.seo_boostable(nil, Timeframer.new(params[:timeframe]).datetime) %>
         <% if @boostable_posts.any? %>

--- a/app/views/articles/_sidebar_nav.html.erb
+++ b/app/views/articles/_sidebar_nav.html.erb
@@ -25,7 +25,9 @@
         </a>
         <a class="sidebar-nav-link" href="/videos">
           videos
-          <span id="reading-list-count"></span>
+        </a>
+        <a class="sidebar-nav-link" href="/pod">
+          podcasts
         </a>
         <% if 1==2 #not for display yet %>
           <a class="sidebar-nav-link" href="/listings">

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -136,6 +136,7 @@
           </div>
         </a>
       <% end %>
+      <div id="article-index-podcast-div"></div>
       <div class="substories" id="substories">
         <% if @stories.any? %>
           <%= render "stories/main_stories_feed" %>

--- a/app/views/podcast_episodes/_episodes_feed.html.erb
+++ b/app/views/podcast_episodes/_episodes_feed.html.erb
@@ -1,6 +1,6 @@
 <% @podcast_episodes.each_with_index do |episode, i| %>
   <a href="<%= episode.path %>" class="small-pic-link-wrapper" id="article-link-<%= episode.id %>">
-    <div class="single-article single-article-small-pic">
+    <div class="single-article single-article-small-pic single-article-single-podcast">
       <div class="small-pic">
         <%= cl_image_tag(episode.image_url || episode.podcast.image_url,
                          type: "fetch",

--- a/app/views/podcast_episodes/_sidebar.html.erb
+++ b/app/views/podcast_episodes/_sidebar.html.erb
@@ -3,6 +3,9 @@
   <div class="side-bar">
     <% if @podcast_index && @podcasts %>
       <div class="widget podcast-pic-widget">
+        <header>
+          <a href="/pod"><h4>podcasts</h4></a>
+        </header>
         <div class="widget-body">
           <% @podcasts.each do |podcast| %>
             <a href="/<%= podcast.slug %>">

--- a/app/views/podcast_episodes/_sidebar.html.erb
+++ b/app/views/podcast_episodes/_sidebar.html.erb
@@ -3,9 +3,6 @@
   <div class="side-bar">
     <% if @podcast_index && @podcasts %>
       <div class="widget podcast-pic-widget">
-        <header>
-          <h4>&lt;ALL SHOWS&gt;</h4>
-        </header>
         <div class="widget-body">
           <% @podcasts.each do |podcast| %>
             <a href="/<%= podcast.slug %>">
@@ -28,6 +25,7 @@
               </div>
             </a>
           <% end %>
+          <p>If you know of a great dev podcast that should be added to this list, contact <a href="mailto:yo@dev.to">yo@dev.to</a></p>
         </div>
       </div>
     <% elsif @podcast %>

--- a/app/views/podcast_episodes/index.html.erb
+++ b/app/views/podcast_episodes/index.html.erb
@@ -3,11 +3,12 @@
 <% end %>
 <% if @podcast %>
   <div class="user-profile-header tag-header podcast-header" style="background:#<%= @podcast.main_color_hex %> url(<%= cl_image_path(@podcast.pattern_image_url || "https://i.imgur.com/fKYKgo4.png",
-                                                                       type: "fetch",
-                                                                       quality: "auto",
-                                                                       sign_url: true,
-                                                                       flags: "progressive",
-                                                                       fetch_format: "jpg") %>);color:white;">
+                                                                                                                    type: "fetch",
+                                                                                                                    quality: "auto",
+                                                                                                                    sign_url: true,
+                                                                                                                    flags: "progressive",
+                                                                                                                    fetch_format: "jpg")
+                                                                                                                  %>);">
     <div class="tag-or-query-header-container">
       <h1><img class="record" src="<%= cl_image_path(@podcast.image_url,
                                                      type: "fetch",
@@ -19,15 +20,11 @@
                                                      flags: "progressive",
                                                      fetch_format: "auto",
                                                      class: "main-image") %>"
-               alt="<%= @podcast.title %>" /> <%= @podcast.title %></h1>
+               alt="<%= @podcast.title %>" /> <%= @podcast.title %>
+               <button id="user-follow-butt" class="cta follow-action-button user-profile-follow-button" data-info='{"id":<%= @podcast.id %>,"className":"<%= @podcast.class.name %>"}'>&nbsp;</button>
+</h1>
     </div>
     <%= render "podcast_episodes/subscribe_buttons" %>
-  </div>
-<% else %>
-  <div class="user-profile-header tag-header">
-    <div class="tag-or-query-header-container">
-      <h1>Podcasts</h1>
-    </div>
   </div>
 <% end %>
 

--- a/app/views/podcast_episodes/show.html.erb
+++ b/app/views/podcast_episodes/show.html.erb
@@ -32,16 +32,19 @@
 
 <div class="podcast-episode-container">
   <div class="hero">
-    <div class="title" style="background:#<%= @podcast.main_color_hex %> url(<%= cl_image_path(@podcast.pattern_image_url || "https://i.imgur.com/fKYKgo4.png",
-                                                                         type: "fetch",
-                                                                         quality: "auto",
-                                                                         sign_url: true,
-                                                                         flags: "progressive",
-                                                                         fetch_format: "jpg") %>)">
+    <div class="title" style="background:#<%= @podcast.main_color_hex %> url(<%= cl_image_path(
+                                                                                @podcast.pattern_image_url || "https://i.imgur.com/fKYKgo4.png",
+                                                                                type: "fetch",
+                                                                                quality: "auto",
+                                                                                sign_url: true,
+                                                                                flags: "progressive",
+                                                                                fetch_format: "jpg")
+                                                                             %>)">
       <h2>
         <a href="/<%= @podcast.slug %>">
           <img alt="<%= @podcast.title %>" src="<%= cloudinary(@podcast.image_url, 60, 80) %>" /><%= @podcast.title %>
         </a>
+        <button id="user-follow-butt" class="cta follow-action-button" data-info='{"id":<%= @podcast.id %>,"className":"<%= @podcast.class.name %>"}'>&nbsp;</button>
       </h2>
       <% if @episode.title.size > 60 %>
         <h1 class="smaller"><%= @episode.title %></h1>
@@ -86,8 +89,8 @@
         <%= simple_format((@episode.processed_html || @episode.body).html_safe, sanitize: true) %>
       <% else %>
         <%= sanitize (@episode.processed_html || "").html_safe,
-                     tags: %w(strong em a table tbody thead tfoot th tr td col colgroup del p h1 h2 h3 h4 h5 h6 blockquote time div span i em u b ul ol li dd dl dt q code pre img sup cite center small),
-                     attributes: %w(href strong em class ref rel src title alt colspan height width size rowspan span value start data-conversation data-lang id) %>
+                     tags: %w[strong em a table tbody thead tfoot th tr td col colgroup del p h1 h2 h3 h4 h5 h6 blockquote time div span i em u b ul ol li dd dl dt q code pre img sup cite center small],
+                     attributes: %w[href strong em class ref rel src title alt colspan height width size rowspan span value start data-conversation data-lang id] %>
       <% end %>
       <p style="font-size:16px;">
         <a href="<%= @episode.website_url %>">Episode source</a>

--- a/app/views/stories/_main_stories_feed.html.erb
+++ b/app/views/stories/_main_stories_feed.html.erb
@@ -6,6 +6,8 @@
          order("published_at DESC").
          limit(rand(15..60)).
          decorate %>
+    <div id="followed-podcasts" data-episodes="<%= @podcast_episodes.to_json(include: { podcast: { only: %i[slug title id] } }) %>">
+    </div>
     <div id="new-articles-object" data-articles="
       <%= @new_stories.to_json(
             only: %i[title path id user_id comments_count positive_reactions_count organization_id

--- a/spec/factories/podcasts.rb
+++ b/spec/factories/podcasts.rb
@@ -5,11 +5,12 @@ FactoryBot.define do
   )
 
   factory :podcast do
-    title         { Faker::Beer.name }
-    image         { image }
-    description   { Faker::Hipster.paragraph(1) }
-    slug          { "slug-#{rand(10_000)}" }
-    feed_url      { Faker::Internet.url }
-    after(:build) { |pod| pod.define_singleton_method(:pull_all_episodes) {} }
+    title           { Faker::Beer.name }
+    image           { image }
+    description     { Faker::Hipster.paragraph(1) }
+    slug            { "slug-#{rand(10_000)}" }
+    feed_url        { Faker::Internet.url }
+    main_color_hex  { "ffffff" }
+    after(:build)   { |pod| pod.define_singleton_method(:pull_all_episodes) {} }
   end
 end

--- a/spec/requests/follows_create_spec.rb
+++ b/spec/requests/follows_create_spec.rb
@@ -68,6 +68,27 @@ RSpec.describe "Following/Unfollowing", type: :request do
       end
     end
 
+    context "when followable_type is a Podcast" do
+      let(:podcast) { create(:podcast) }
+
+      before do
+        post "/follows", params: {
+          followable_type: "Podcast", followable_id: podcast.id
+        }
+      end
+
+      it "follows" do
+        expect(JSON.parse(response.body)["outcome"]).to eq("followed")
+      end
+
+      it "unfollows if already followed" do
+        post "/follows", params: {
+          followable_type: "Podcast", followable_id: podcast.id, verb: "unfollow"
+        }
+        expect(JSON.parse(response.body)["outcome"]).to eq("unfollowed")
+      end
+    end
+
     it "returns articles of tag the user follows" do
       article = create(:article)
       user.follow(Tag.find_by(name: article.tag_list.first))

--- a/spec/requests/follows_show_spec.rb
+++ b/spec/requests/follows_show_spec.rb
@@ -5,11 +5,12 @@ RSpec.describe "Follows #show", type: :request do
   let(:user) { create(:user) }
   let(:tag) { create(:tag) }
   let(:organization) { create(:organization) }
+  let(:podcast) { create(:podcast) }
 
   before { login_as current_user }
 
   def get_following_status
-    %w[User Organization Tag].map do |type|
+    %w[User Organization Tag Podcast].map do |type|
       get "/follows/#{send(type.downcase).id}", params: { followable_type: type }
       response.body
     end

--- a/spec/requests/podcast_episodes_index_spec.rb
+++ b/spec/requests/podcast_episodes_index_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "PodcastEpisodesSpec", type: :request do
   describe "GET podcast episodes index" do
     it "renders page with proper sidebar" do
       get "/pod"
-      expect(response.body).to include("<h1>Podcasts</h1>")
+      expect(response.body).to include("If you know of a great dev podcast")
     end
   end
 end

--- a/spec/system/podcasts/user_visits_podcasts_root_page_spec.rb
+++ b/spec/system/podcasts/user_visits_podcasts_root_page_spec.rb
@@ -6,12 +6,6 @@ RSpec.describe "User visits /pod page", type: :system do
 
   before { visit "/pod" }
 
-  it "displays the header" do
-    within "h4" do
-      expect(page).to have_text("podcasts")
-    end
-  end
-
   it "displays the podcasts" do
     within "#articles-list" do
       expect(page).to have_link(nil, href: podcast_episode.path)

--- a/spec/system/podcasts/user_visits_podcasts_root_page_spec.rb
+++ b/spec/system/podcasts/user_visits_podcasts_root_page_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe "User visits /pod page", type: :system do
   before { visit "/pod" }
 
   it "displays the header" do
-    within "h1" do
-      expect(page).to have_text("Podcasts")
+    within "h4" do
+      expect(page).to have_text("podcasts")
     end
   end
 


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

If user follows any podcasts, that day's podcasts will show up in their feed like this:

![](https://cl.ly/8b5bd0aa885b/Image%202019-05-04%20at%201.24.44%20PM.png)

Users can follow podcasts like they follow users/orgs/tags:

![](https://cl.ly/e93ac5a9f814/Image%202019-05-04%20at%201.26.05%20PM.png)

If a user follows no podcasts, very little about their overall experience changes.