### PR TITLE
Tweak to pink theme

### DIFF
--- a/app/assets/stylesheets/top-bar.scss
+++ b/app/assets/stylesheets/top-bar.scss
@@ -1,4 +1,6 @@
 @import 'variables';
+@import 'mixins';
+
 .stories-index,
 .comments-index,
 .users-index,
@@ -191,10 +193,10 @@
         border-radius: 100%;
         margin-top: -1px;
         margin-left: -1px;
-        -ms-user-select:none;
-        -moz-user-select:none;
-        -webkit-user-select:none;
-        user-select:none;
+        -ms-user-select: none;
+        -moz-user-select: none;
+        -webkit-user-select: none;
+        user-select: none;
       }
     }
     .bars {
@@ -213,7 +215,9 @@
         }
       }
       &.desktop {
-        &:hover,&:active,&:focus {
+        &:hover,
+        &:active,
+        &:focus {
           .menu {
             display: block;
           }
@@ -283,7 +287,12 @@
           padding: 6px 10px;
         }
         &.prime-option {
-          border-bottom: 3px solid #7a7e81;
+          border-bottom: 3px solid;
+          @include themeable(
+            border-color,
+            theme-prime-option-border-color,
+            #7a7e81
+          );
           margin-bottom: 5px;
           font-size: 1.22em;
           font-weight: 500;
@@ -301,7 +310,7 @@
       }
     }
   }
-  
+
   .skip-content-link {
     position: absolute;
     top: 0;
@@ -316,7 +325,7 @@
     opacity: 0;
     transition: opacity 0.3s $ease-in-cubic, transform 0.3s $ease-in-cubic;
 
-    &:focus {      
+    &:focus {
       pointer-events: auto;
       opacity: 1;
       transform: translate(-50%, 22px);

--- a/app/views/layouts/_user_config.html.erb
+++ b/app/views/layouts/_user_config.html.erb
@@ -49,7 +49,8 @@
       --theme-container-color: #333;\
       --theme-container-box-shadow: none;\
       --theme-container-border: 1px solid #ff4983;\
-      --theme-social-icon-invert: invert(0)</style>'
+      --theme-social-icon-invert: invert(0);\
+      --theme-prime-option-border-color: rgba(255, 255, 255, 0.55)</style>'
     }
   } catch(e) {
       console.log(e)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

Just a suggestion for the pink theme. I find the greyish border with the pink background hard on the eyes when the user menu is open.  

![image](https://user-images.githubusercontent.com/833231/57184937-34672900-6e91-11e9-8ab6-6bd1db2e8295.png)

A white border with about 55% transparency looks good and isn't hard on the eyeballs.

![image](https://user-images.githubusercontent.com/833231/57184972-c1aa7d80-6e91-11e9-8ea0-b348ce1e1aa9.png)

Side note, but looking at the screenshots, I wonder if white for the menu items would look better. Thoughts?

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![Visine](https://media.giphy.com/media/LPRxnliEiUz4s/giphy.gif)