### PR TITLE
Move async user methods to ActiveJob

### DIFF
--- a/app/jobs/users/bust_cache_job.rb
+++ b/app/jobs/users/bust_cache_job.rb
@@ -1,0 +1,15 @@
+module Users
+  class BustCacheJob < ApplicationJob
+    queue_as :users_bust_cache
+
+    def perform(user_id, cache_buster = CacheBuster.new)
+      user = User.find_by(id: user_id)
+
+      cache_buster.bust("/#{user.username}") if user
+      cache_buster.bust("/#{user.username}?i=i") if user
+      cache_buster.bust("/live/#{user.username}") if user
+      cache_buster.bust("/live/#{user.username}?i=i") if user
+      cache_buster.bust("/feed/#{user.username}") if user
+    end
+  end
+end

--- a/app/jobs/users/subscribe_to_mailchimp_newsletter_job.rb
+++ b/app/jobs/users/subscribe_to_mailchimp_newsletter_job.rb
@@ -1,0 +1,11 @@
+module Users
+  class SubscribeToMailchimpNewsletterJob < ApplicationJob
+    queue_as :users_subscribe_to_mailchimp_newsletter
+
+    def perform(user_id)
+      user = User.find_by(id: user_id)
+
+      MailchimpBot.new(user).upsert if user
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -363,11 +363,8 @@ class User < ApplicationRecord
 
     return if saved_changes["unconfirmed_email"] && saved_changes["confirmation_sent_at"]
 
-    # This is when user is updating their email. There
-    # is no need to update mailchimp until email is confirmed.
-    MailchimpBot.new(self).upsert
+    Users::SubscribeToMailchimpNewsletterJob.perform_later(id)
   end
-  handle_asynchronously :subscribe_to_mailchimp_newsletter
 
   def a_sustaining_member?
     monthly_dues.positive?
@@ -501,13 +498,8 @@ class User < ApplicationRecord
   end
 
   def bust_cache
-    CacheBuster.new.bust("/#{username}")
-    CacheBuster.new.bust("/#{username}?i=i")
-    CacheBuster.new.bust("/live/#{username}")
-    CacheBuster.new.bust("/live/#{username}?i=i")
-    CacheBuster.new.bust("/feed/#{username}")
+    Users::BustCacheJob.perform_later(id)
   end
-  handle_asynchronously :bust_cache
 
   def core_profile_details_changed?
     saved_change_to_username? ||

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -358,6 +358,14 @@ class User < ApplicationRecord
     errors.add(:username, "is taken.") if Organization.find_by(slug: username)
   end
 
+  def subscribe_to_mailchimp_newsletter_without_delay
+    return unless email.present? && email.include?("@")
+
+    return if saved_changes["unconfirmed_email"] && saved_changes["confirmation_sent_at"]
+
+    Users::SubscribeToMailchimpNewsletterJob.perform_now(id)
+  end
+
   def subscribe_to_mailchimp_newsletter
     return unless email.present? && email.include?("@")
 

--- a/spec/jobs/users/bust_cache_job_spec.rb
+++ b/spec/jobs/users/bust_cache_job_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe Users::BustCacheJob, type: :job do
+  include_examples "#enqueues_job", "users_bust_cache", [1, 2]
+
+  describe "#perform_now" do
+    let(:user) { FactoryBot.create(:user) }
+
+    it "busts cache" do
+      path = user.path
+
+      cache_buster = double
+      allow(cache_buster).to receive(:bust)
+
+      described_class.perform_now(user.id, cache_buster) do
+        expect(cache_buster).to have_received(:bust).with(path)
+        expect(cache_buster).to have_received(:bust).with("/feed#{path}")
+      end
+    end
+  end
+end

--- a/spec/jobs/users/subscribe_to_mailchimp_newsletter_job_spec.rb
+++ b/spec/jobs/users/subscribe_to_mailchimp_newsletter_job_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe Users::SubscribeToMailchimpNewsletterJob, type: :job do
+  include_examples "#enqueues_job", "users_subscribe_to_mailchimp_newsletter", [1, 2]
+
+  describe "#perform_now" do
+    let(:user) { FactoryBot.create(:user) }
+
+    it "subscribes user to mailchimp newsletter" do
+      mailchimp_bot = MailchimpBot.new(user)
+
+      allow(mailchimp_bot).to receive(:upsert)
+
+      described_class.perform_now(user.id) do
+        expect(mailchimp_bot).to have_received(:upsert)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
This commit moves async user methods to ActiveJobs

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/issues/2497
