### PR TITLE
Add param to bust crappy old caches

### DIFF
--- a/app/views/articles/_sidebar_nav.html.erb
+++ b/app/views/articles/_sidebar_nav.html.erb
@@ -19,7 +19,7 @@
         navigation
       </div>
       <div class="sidebar-nav-element">
-        <a class="sidebar-nav-link" href="/readinglist">
+        <a class="sidebar-nav-link" href="/readinglist?we-hope-you-like-the-new-and-improved-reading-list---more-positive-changes-coming=woohoo">
           <img class="nav-emoji" src="<%= asset_path("emoji/emoji-one-bookmark.png") %>" /> Reading List
           <span id="reading-list-count"></span>
         </a>


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
The reading list had been cached at the serviceworker layer, which was a nice idea, but there are cache invalidation problems.

I believe tacking on a param should solve the problem.