### PR TITLE
Podcast main_color_hex is required

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -149,7 +149,7 @@ podcast_objects = [
     slug: "developeronfire",
     twitter_username: "raelyard",
     website_url: "http://developeronfire.com",
-    main_color_hex: "",
+    main_color_hex: Faker::Color.hex_color,
     overcast_url: "https://overcast.fm/itunes1006105326/developer-on-fire",
     android_url: "http://subscribeonandroid.com/developeronfire.com/rss.xml",
     image: Rack::Test::UploadedFile.new(image_file, "image/jpeg")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

The `rails db:reset` command failed because `main_color_hex` wasn't specified in the `seeds.rb`

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
