### PR TITLE
Add listings to /internal pages

### DIFF
--- a/app/controllers/internal/classified_listings_controller.rb
+++ b/app/controllers/internal/classified_listings_controller.rb
@@ -1,0 +1,29 @@
+class Internal::ClassifiedListingsController < Internal::ApplicationController
+  layout "internal"
+
+  def index
+    @classified_listings = ClassifiedListing.all
+  end
+
+  def edit
+    @classified_listing = ClassifiedListing.find(params[:id])
+  end
+
+  def update
+    @classified_listing = ClassifiedListing.find(params[:id])
+    @classified_listing.update!(listing_params)
+    flash[:success] = "Listing updated successfully"
+    redirect_to "/internal/listings/#{@classified_listing.id}/edit"
+  end
+
+  def destroy
+    @classified_listing = ClassifiedListing.find(params[:id])
+    @classified_listing.destroy
+    flash[:warning] = "'#{@classified_listing.title}' was destroyed successfully"
+    redirect_to "/internal/listings"
+  end
+
+  def listing_params
+    params.require(:classified_listing).permit(:published, :body_markdown, :title, :category, :tag_list)
+  end
+end

--- a/app/views/internal/classified_listings/edit.html.erb
+++ b/app/views/internal/classified_listings/edit.html.erb
@@ -1,0 +1,34 @@
+<a href="/internal/listings">Back to All Listings</a>
+
+<h1>Edit <a href="/listings/<%= @classified_listing.category %>/<%= @classified_listing.slug %>" target="_blank"><%= @classified_listing.title %></a></h1>
+
+<%= form_for [:internal, @classified_listing] do |form| %>
+  <%= form.label :title %>
+  <br>
+  <%= form.text_field :title, size: 100, maxlength: 128 %>
+  <hr>
+  <%= form.label :body_markdown %>
+  <br>
+  <%= form.text_area :body_markdown, cols: 40, rows: 15, maxlength: 400 %>
+  <hr>
+  <%= form.label :tag_list %>
+  <br>
+  <i style="font-size: 15px;">Comma separated, one space, 8 tags max</i>
+  <br>
+  <%= form.text_field :tag_list, value: @classified_listing.cached_tag_list, size: 100 %>
+  <hr>
+  <%= form.label :category %>
+  <br>
+  <%= form.select :category, options_for_select(ClassifiedListing.select_options_for_categories.map(&:last), @classified_listing.category) %>
+  <hr>
+  <%= form.label :published %>
+  <br>
+  <%= form.check_box :published %>
+  <hr>
+  <%= form.submit "Update Listing", class: "btn btn-lg btn-primary" %>
+
+  <hr>
+<% end %>
+
+<%= link_to "Destroy Listing", url_for(action: :destroy, id: @classified_listing.id), method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-danger" %>
+<br><br><br>

--- a/app/views/internal/classified_listings/index.html.erb
+++ b/app/views/internal/classified_listings/index.html.erb
@@ -1,0 +1,32 @@
+<a href="/listings">Visit /listings</a>
+
+<div class="wrapper">
+  <div class="grid-item">Title (direct link)</div>
+  <div class="grid-item">Category</div>
+  <div class="grid-item">Tags (cached_tag_list)</div>
+  <div class="grid-item">Published?</div>
+  <div class="grid-item">Last Bumped</div>
+</div>
+<% @classified_listings.each do |listing| %>
+  <div class="wrapper">
+    <div class="grid-item">
+      <a href="/listings/<%= listing.category %>/<%= listing.slug %>" target="_blank">
+        <%= listing.title %>
+      </a>
+    </div>
+    <div class="grid-item"><%= listing.category %></div>
+    <div class="grid-item"><%= listing.cached_tag_list %></div>
+    <div class="grid-item"><%= listing.published ? "Yes" : "No" %></div>
+    <div class="grid-item"><%= time_ago_in_words(listing.bumped_at) %> ago</div>
+    <div class="grid-item">
+      <a class="btn btn-success" href="/internal/listings/<%= listing.id %>/edit">Edit</a>
+    </div>
+  </div>
+<% end %>
+
+<style>
+.wrapper {
+  border-bottom: 1px solid grey;
+  padding: 10px;
+}
+</style>

--- a/app/views/layouts/internal.html.erb
+++ b/app/views/layouts/internal.html.erb
@@ -112,7 +112,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
       <ul class="nav navbar-nav">
-        <% controller_names = %w(comments articles users members dogfood tags welcome broadcasts reports pages) %>
+        <% controller_names = %w(comments articles users members dogfood tags welcome broadcasts reports pages classified_listings) %>
         <% controller_names.each do |name| %>
           <li class="<%= "active" if controller_name == name %>"><a href="/internal/<%= name %>"><%= name %></a></li>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,8 @@ Rails.application.routes.draw do
         post "merge"
       end
     end
+    resources :classified_listings
+    resources :listings, controller: "classified_listings"
     resources :events
     resources :dogfood, only: [:index]
     resources :buffer_updates, only: %i[create update]


### PR DESCRIPTION
This adds listings to /internal. You can view it from `/internal/listings` or `/internal/classified_listings`.

## Index view:
![Screen Shot 2019-05-06 at 5 27 38 PM](https://user-images.githubusercontent.com/17884966/57256358-770d3a80-7024-11e9-8b2d-47f3dde65c01.png)

## Edit view:
![Screen Shot 2019-05-06 at 5 27 54 PM](https://user-images.githubusercontent.com/17884966/57256359-770d3a80-7024-11e9-9f65-3a8363587fc2.png)
