### PR TITLE
Minor adjustments to listings

### DIFF
--- a/app/models/classified_listing.rb
+++ b/app/models/classified_listing.rb
@@ -67,7 +67,7 @@ class ClassifiedListing < ApplicationRecord
       "education" => { cost: 1, name: "Education/Courses", rules: "Educational material and/or schools/bootcamps." },
       "jobs" => { cost: 25, name: "Job Listings", rules: "Companies offering employment right now." },
       "mentors" => { cost: 1, name: "Offering Mentorship", rules: "You are available to mentor someone." },
-      "products" => { cost: 10, name: "Products/Tools", rules: "Must be available right now." },
+      "products" => { cost: 5, name: "Products/Tools", rules: "Must be available right now." },
       "mentees" => { cost: 1, name: "Seeking a Mentor", rules: "You are looking for a mentor." },
       "forsale" => { cost: 1, name: "Stuff for Sale", rules: "Personally owned physical items for sale." },
       "events" => { cost: 1, name: "Upcoming Events", rules: "In-person or online events with date included." },

--- a/app/models/classified_listing.rb
+++ b/app/models/classified_listing.rb
@@ -69,8 +69,8 @@ class ClassifiedListing < ApplicationRecord
       "mentors" => { cost: 1, name: "Offering Mentorship", rules: "You are available to mentor someone." },
       "products" => { cost: 10, name: "Products/Tools", rules: "Must be available right now." },
       "mentees" => { cost: 1, name: "Seeking a Mentor", rules: "You are looking for a mentor." },
-      "forsale" => { cost: 1, name: "Stuff for Sale", rules: "Personally owned physical items for sale" },
-      "events" => { cost: 1, name: "Upcoming Events", rules: "In-person or online events with date included" },
+      "forsale" => { cost: 1, name: "Stuff for Sale", rules: "Personally owned physical items for sale." },
+      "events" => { cost: 1, name: "Upcoming Events", rules: "In-person or online events with date included." },
       "misc" => { cost: 1, name: "Miscellaneous", rules: "Must not fit in any other category." }
     }
   end

--- a/app/views/credits/new.html.erb
+++ b/app/views/credits/new.html.erb
@@ -32,7 +32,7 @@
       </div>
       $2.50/per credit
     </div>
-      <br/> 
+      <br />
     </div>
     <p class="bulk-description"><em>Contact <a href="mailto:biz@dev.to">biz@dev.to</a> to for custom bulk pricing and partnerships.</em></p>
     <details>
@@ -45,7 +45,7 @@
         </p>
         <ul>
           <li>
-            <strong>products/tools: 5 credits</strong>
+            <strong>products/tools: 10 credits</strong>
           </li>
           <li>
             <strong>job listings: 25 credits</strong>

--- a/app/views/credits/new.html.erb
+++ b/app/views/credits/new.html.erb
@@ -61,11 +61,11 @@
     </details>
     <details>
       <summary>
-        How many credits <%= params[:purchaser] == "organization" ? "does #{@purchaser.username}" : "do I currently" %> have?
+        How many credits <%= params[:purchaser] == "organization" ? "does #{@purchaser.name}" : "do I currently" %> have?
       </summary>
       <div>
         <p>
-          <%= params[:purchaser] == "organization" ? "#{@purchaser.username} has" : "You have" %> <%= @purchaser.credits.where(spent: false).size %> credits.
+          <%= params[:purchaser] == "organization" ? "#{@purchaser.name} has" : "You have" %> <%= @purchaser.credits.where(spent: false).size %> credits.
         </p>
       </div>
     </details>

--- a/app/views/credits/new.html.erb
+++ b/app/views/credits/new.html.erb
@@ -61,11 +61,11 @@
     </details>
     <details>
       <summary>
-        How many credits do I currently have?
+        How many credits <%= params[:purchaser] == "organization" ? "does #{@purchaser.username}" : "do I currently" %> have?
       </summary>
       <div>
         <p>
-          You have <%= current_user.credits.where(spent: false).size %> credits
+          <%= params[:purchaser] == "organization" ? "#{@purchaser.username} has" : "You have" %> <%= @purchaser.credits.where(spent: false).size %> credits.
         </p>
       </div>
     </details>


### PR DESCRIPTION
## Description
- Displays the correct amount of listings in `/credits/new`, depending on whether it's a user purchasing or an org.
    - User text: "How many credits do I have?" "You have `x` credits." 
    - Org text: "How many credits does `org_name` have?" "`org_name` has `y` credits." 
- Add periods to all the category rules.
- Fix an inconsistency for product cost with the rule/back-end cost vs the cost in `/credits/new`. See code suggestions below to resolve.