### PR TITLE
Fix Listings body_markdown from being too long because of linebreaks

### DIFF
--- a/app/javascript/listings/listingForm.jsx
+++ b/app/javascript/listings/listingForm.jsx
@@ -42,8 +42,6 @@ export default class ListingForm extends Component {
       categoriesForDetails,
       categoriesForSelect,
     } = this.state;
-    console.log(category)
-    console.log(this.state)
     if (id === null) {
       return(
         <div>

--- a/app/models/classified_listing.rb
+++ b/app/models/classified_listing.rb
@@ -85,7 +85,7 @@ class ClassifiedListing < ApplicationRecord
     ActsAsTaggableOn::Taggable::Cache.included(ClassifiedListing)
     ActsAsTaggableOn.default_parser = ActsAsTaggableOn::TagParser
     self.category = category.to_s.downcase
-    self.body_markdown = body_markdown.gsub(/\r\n/, "\n")
+    self.body_markdown = body_markdown.to_s.gsub(/\r\n/, "\n")
   end
 
   def restrict_markdown_input

--- a/app/models/classified_listing.rb
+++ b/app/models/classified_listing.rb
@@ -85,6 +85,7 @@ class ClassifiedListing < ApplicationRecord
     ActsAsTaggableOn::Taggable::Cache.included(ClassifiedListing)
     ActsAsTaggableOn.default_parser = ActsAsTaggableOn::TagParser
     self.category = category.to_s.downcase
+    self.body_markdown = body_markdown.gsub(/\r\n/, "\n")
   end
 
   def restrict_markdown_input


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This fixes a weird issue where the front end value has a different character limit than the backend value. There's probably some other edge cases but this should solve one of the more common cases for now.

We'll also want to add proper error handling, since right now we have a simple guard clause that `returns` nothing:
https://github.com/thepracticaldev/dev.to/blob/97040ab60316b3a6bbd0d7fe489e1f953e863a7f/app/controllers/classified_listings_controller.rb#L49