### PR TITLE
WIP Add proper error handling when creating a listing

### DIFF
--- a/app/assets/stylesheets/classified_listings.scss
+++ b/app/assets/stylesheets/classified_listings.scss
@@ -181,9 +181,12 @@
     }
     .classified-errors {
       background: $red;
-      color: white;
+      color: $black;
       padding: 20px;
       border-radius: 3px;
+      h2 {
+        color: $black;
+      }
     }
     label {
       display: inline-block;

--- a/app/assets/stylesheets/classified_listings_form.scss
+++ b/app/assets/stylesheets/classified_listings_form.scss
@@ -1,1 +1,0 @@
-@import 'variables';

--- a/app/controllers/classified_listings_controller.rb
+++ b/app/controllers/classified_listings_controller.rb
@@ -46,12 +46,15 @@ class ClassifiedListingsController < ApplicationController
     @classified_listing.bumped_at = Time.current
     @classified_listing.published = true
     @classified_listing.organization_id = current_user.organization_id if @org
-    return unless @classified_listing.save
-
-    clear_listings_cache
-    credits.limit(@number_of_credits_needed).update_all(spent: true)
-    @classified_listing.index!
-    redirect_to "/listings"
+    if @classified_listing.save
+      clear_listings_cache
+      credits.limit(@number_of_credits_needed).update_all(spent: true)
+      @classified_listing.index!
+      redirect_to "/listings"
+    else
+      @credits = current_user.credits.where(spent: false)
+      render :new
+    end
   end
 
   def update

--- a/app/controllers/classified_listings_controller.rb
+++ b/app/controllers/classified_listings_controller.rb
@@ -53,6 +53,7 @@ class ClassifiedListingsController < ApplicationController
       redirect_to "/listings"
     else
       @credits = current_user.credits.where(spent: false)
+      @classified_listing.cached_tag_list = classified_listing_params[:tag_list]
       render :new
     end
   end

--- a/app/javascript/listings/elements/categories.jsx
+++ b/app/javascript/listings/elements/categories.jsx
@@ -3,8 +3,14 @@ import { h, Component } from 'preact';
 
 class Categories extends Component {
   options = () => {
-    const { categoriesForSelect } = this.props
+    const { categoriesForSelect, category } = this.props
     return categoriesForSelect.map(array => {
+      // array example: ["Education/Courses (1 Credit)", "education"]
+      if(category === array[1]) {
+        return(
+          <option value={array[1]} selected>{array[0]}</option>
+        )
+      }
       return(
         <option value={array[1]}>{array[0]}</option>
       )
@@ -51,6 +57,7 @@ class Categories extends Component {
 Categories.propTypes = {
   categoriesForSelect: PropTypes.array.isRequired,
   categoriesForDetails: PropTypes.array.isRequired,
+  category: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
 }
 

--- a/app/javascript/listings/listingForm.jsx
+++ b/app/javascript/listings/listingForm.jsx
@@ -47,7 +47,7 @@ export default class ListingForm extends Component {
         <div>
           <Title defaultValue={title} onChange={linkState(this, 'title')} />
           <BodyMarkdown defaultValue={bodyMarkdown} onChange={linkState(this, 'bodyMarkdown')} />
-          <Categories categoriesForSelect={categoriesForSelect} categoriesForDetails={categoriesForDetails} onChange={linkState(this, 'category')} />
+          <Categories categoriesForSelect={categoriesForSelect} categoriesForDetails={categoriesForDetails} onChange={linkState(this, 'category')} category={category} />
           <Tags defaultValue={tagList} category={category} onInput={linkState(this, 'tagList')} />
           {/* add contact via connect checkbox later */}
         </div>

--- a/app/models/classified_listing.rb
+++ b/app/models/classified_listing.rb
@@ -89,7 +89,7 @@ class ClassifiedListing < ApplicationRecord
   end
 
   def restrict_markdown_input
-    errors.add(:body_markdown, "has too many linebreaks. No no more than 12 allowed.") if body_markdown.to_s.scan(/(?=\n)/).count > 12
+    errors.add(:body_markdown, "has too many linebreaks. No more than 12 allowed.") if body_markdown.to_s.scan(/(?=\n)/).count > 12
     errors.add(:body_markdown, "is not allowed to include images.") if body_markdown.to_s.include?("![")
     errors.add(:body_markdown, "is not allowed to include liquid tags.") if body_markdown.to_s.include?("{% ")
   end

--- a/app/views/classified_listings/_form.html.erb
+++ b/app/views/classified_listings/_form.html.erb
@@ -6,7 +6,7 @@
   <div class="classified-form-inner">
     <% if classified_listing.errors.any? %>
       <div class="classified-errors">
-        <h2><%= pluralize(classified_listing.errors.count, "error") %> prohibited this classified_listing from being saved:</h2>
+        <h2 style="color: white;"><%= pluralize(classified_listing.errors.count, "error") %> prohibited this listing from being saved:</h2>
 
         <ul>
         <% classified_listing.errors.full_messages.each do |message| %>

--- a/app/views/classified_listings/_form.html.erb
+++ b/app/views/classified_listings/_form.html.erb
@@ -16,7 +16,7 @@
       </div>
     <% end %>
     <div id="listingform-data"
-        data-listing="<%= classified_listing.to_json(only: %i[id title slug cached_tag_list]) %>"
+        data-listing="<%= classified_listing.to_json(only: %i[id title body_markdown category cached_tag_list]) %>"
         data-organizations="<%= @organizations.to_json %>"
         data-categories-for-select="<%= ClassifiedListing.select_options_for_categories.to_json %>"
         data-categories-for-details="<%= ClassifiedListing.categories_available.transform_values{ |value_hash| value_hash.except(:cost) }.values.to_json %>"

--- a/app/views/classified_listings/_form.html.erb
+++ b/app/views/classified_listings/_form.html.erb
@@ -6,7 +6,7 @@
   <div class="classified-form-inner">
     <% if classified_listing.errors.any? %>
       <div class="classified-errors">
-        <h2 style="color: white;"><%= pluralize(classified_listing.errors.count, "error") %> prohibited this listing from being saved:</h2>
+        <h2><%= pluralize(classified_listing.errors.count, "error") %> prohibited this listing from being saved:</h2>
 
         <ul>
         <% classified_listing.errors.full_messages.each do |message| %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This adds proper error handling when submitting a listing. It'll show the error messages if a submitted listing is invalid.

Also:
- makes the error text `$black`.
- removes an accidentally committed stylesheet.

![Screen Shot 2019-05-07 at 4 59 11 PM](https://user-images.githubusercontent.com/17884966/57332897-ae91ea80-70e9-11e9-8aee-58c8338e6457.png)

