### PR TITLE
Match timeframe link style with tag colors

### DIFF
--- a/app/views/articles/tag_index.html.erb
+++ b/app/views/articles/tag_index.html.erb
@@ -35,7 +35,7 @@
     <div class="articles-list" id="articles-list">
       <% if @tag_model && @tag_model.supported %>
         <style>
-          .nav-chronofiter-link.selected {
+          .nav-chronofiter-link.selected, .nav-chronofiter-link:hover {
             background: <%= @tag_model.bg_color_hex %> !important;
             color: <%= @tag_model.text_color_hex %> !important;
             box-shadow: 3px 4px 0px <%= HexComparer.new([@tag_model.bg_color_hex || "#ffffff"], 4).accent %> !important;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
This commit changes the timeframe links to match the tag colors when
hovered.

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/issues/2666

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![add_themed_hover](https://user-images.githubusercontent.com/25459752/57335752-97ef9180-70f1-11e9-9ad0-8521b281ec67.gif)

