### PR TITLE
Make reading list button hover effect compatible with a11y

### DIFF
--- a/app/assets/javascripts/initializers/initializeReadingListIcons.js
+++ b/app/assets/javascripts/initializers/initializeReadingListIcons.js
@@ -132,15 +132,24 @@ function addHoverEffectToReadingListButtons() {
   });
 }
 
+/*
+  Determines if the element is the target of the reading list button hover.
+*/
+function isReadingListButtonHoverTarrget(element) {
+  var classList = element.classList;
+
+  return (
+    (element.tagName === 'BUTTON' &&
+      classList.contains('bookmark-engage') &&
+      classList.contains('selected')) ||
+    (element.tagName === 'SPAN' && classList.contains('bm-success'))
+  );
+}
+
 function readingListButtonMouseHandler(event) {
   var target = event.target;
-  var performTheSwap =
-    (target.tagName === 'BUTTON' &&
-      target.classList.contains('bookmark-engage') &&
-      target.classList.contains('selected')) ||
-    (target.tagName === 'SPAN' && target.classList.contains('bm-success'));
 
-  if (performTheSwap) {
+  if (isReadingListButtonHoverTarrget(target)) {
     event.preventDefault();
 
     var textReplacement = this; // see .bind below, this becomes the bound text

--- a/app/assets/javascripts/initializers/initializeReadingListIcons.js
+++ b/app/assets/javascripts/initializers/initializeReadingListIcons.js
@@ -127,15 +127,23 @@ function properButtonFromEvent(event) {
 function addHoverEffectToReadingListButtons() {
   var articlesList = document.getElementsByClassName('articles-list');
   Array.from(articlesList).forEach(function(container) {
-    container.addEventListener('mouseover', readingListButtonMouseOver);
-    container.addEventListener('mouseout', readingListButtonMouseOut);
+    // we use `bind` so that the event handler will have the correct text in its
+    // `this` local variable
+    container.addEventListener(
+      'mouseover',
+      readingListButtonMouseHandler.bind('UNSAVE'),
+    );
+    container.addEventListener(
+      'mouseout',
+      readingListButtonMouseHandler.bind('SAVED'),
+    );
   });
 }
 
 /*
   Determines if the element is the target of the reading list button hover.
 */
-function isReadingListButtonHoverTarrget(element) {
+function isReadingListButtonHoverTarget(element) {
   var classList = element.classList;
 
   return (
@@ -149,10 +157,10 @@ function isReadingListButtonHoverTarrget(element) {
 function readingListButtonMouseHandler(event) {
   var target = event.target;
 
-  if (isReadingListButtonHoverTarrget(target)) {
+  if (isReadingListButtonHoverTarget(target)) {
     event.preventDefault();
 
-    var textReplacement = this; // see .bind below, this becomes the bound text
+    var textReplacement = this; // `this` is the text to be replaced
     var textSpan;
     if (target.tagName === 'BUTTON') {
       textSpan = target.getElementsByClassName('bm-success')[0];
@@ -163,8 +171,6 @@ function readingListButtonMouseHandler(event) {
     textSpan.innerHTML = textReplacement;
   }
 }
-var readingListButtonMouseOver = readingListButtonMouseHandler.bind('UNSAVE');
-var readingListButtonMouseOut = readingListButtonMouseHandler.bind('SAVED');
 
 /* eslint-enable no-use-before-define */
 /* eslint-enable no-undef */

--- a/app/assets/javascripts/initializers/initializeReadingListIcons.js
+++ b/app/assets/javascripts/initializers/initializeReadingListIcons.js
@@ -125,21 +125,15 @@ function addHoverEffectToReadingListButton(button) {
   }
 }
 
-function readingListButtonMouseEnter(event) {
+function readingListButtonMouseHandler(event) {
   event.preventDefault();
+  var textReplacement = this; // see .bind below, this becomes the bound text
 
-  // replace 'SAVED' with 'UNSAVE'
   var textSpan = event.target.getElementsByClassName('bm-success')[0];
-  textSpan.innerHTML = 'UNSAVE';
+  textSpan.innerHTML = textReplacement;
 }
-
-function readingListButtonMouseLeave(event) {
-  event.preventDefault();
-
-  // replace 'UNSAVE' with 'SAVED'
-  var textSpan = event.target.getElementsByClassName('bm-success')[0];
-  textSpan.innerHTML = 'SAVED';
-}
+var readingListButtonMouseEnter = readingListButtonMouseHandler.bind('UNSAVE');
+var readingListButtonMouseLeave = readingListButtonMouseHandler.bind('SAVED');
 
 /* eslint-enable no-use-before-define */
 /* eslint-enable no-undef */

--- a/app/assets/javascripts/initializers/initializeReadingListIcons.js
+++ b/app/assets/javascripts/initializers/initializeReadingListIcons.js
@@ -7,6 +7,7 @@
 function initializeReadingListIcons() {
   setReadingListButtonsState();
   addReadingListCountToHomePage();
+  addHoverEffectToReadingListButtons();
 }
 
 // set SAVE or SAVED articles buttons
@@ -22,7 +23,6 @@ function highlightButton(button) {
   var buttonIdInt = parseInt(button.dataset.reactableId, 10);
   if (user && user.reading_list_ids.indexOf(buttonIdInt) > -1) {
     button.classList.add('selected');
-    addHoverEffectToReadingListButton(button);
   } else {
     button.classList.remove('selected');
   }
@@ -118,22 +118,44 @@ function properButtonFromEvent(event) {
   return properElement;
 }
 
-function addHoverEffectToReadingListButton(button) {
-  if (button.classList.contains('selected')) {
-    button.addEventListener('mouseenter', readingListButtonMouseEnter);
-    button.addEventListener('mouseleave', readingListButtonMouseLeave);
-  }
+/*
+  Add the hover effect to reading list buttons.
+
+  This function makes use of mouseover/mouseevent bubbling behaviors to attach
+  only two event handlers to the articles container for performance reasons.
+*/
+function addHoverEffectToReadingListButtons() {
+  var articlesList = document.getElementsByClassName('articles-list');
+  Array.from(articlesList).forEach(function(container) {
+    container.addEventListener('mouseover', readingListButtonMouseOver);
+    container.addEventListener('mouseout', readingListButtonMouseOut);
+  });
 }
 
 function readingListButtonMouseHandler(event) {
-  event.preventDefault();
-  var textReplacement = this; // see .bind below, this becomes the bound text
+  var target = event.target;
+  var performTheSwap =
+    (target.tagName === 'BUTTON' &&
+      target.classList.contains('bookmark-engage') &&
+      target.classList.contains('selected')) ||
+    (target.tagName === 'SPAN' && target.classList.contains('bm-success'));
 
-  var textSpan = event.target.getElementsByClassName('bm-success')[0];
-  textSpan.innerHTML = textReplacement;
+  if (performTheSwap) {
+    event.preventDefault();
+
+    var textReplacement = this; // see .bind below, this becomes the bound text
+    var textSpan;
+    if (target.tagName === 'BUTTON') {
+      textSpan = target.getElementsByClassName('bm-success')[0];
+    } else {
+      textSpan = target;
+    }
+
+    textSpan.innerHTML = textReplacement;
+  }
 }
-var readingListButtonMouseEnter = readingListButtonMouseHandler.bind('UNSAVE');
-var readingListButtonMouseLeave = readingListButtonMouseHandler.bind('SAVED');
+var readingListButtonMouseOver = readingListButtonMouseHandler.bind('UNSAVE');
+var readingListButtonMouseOut = readingListButtonMouseHandler.bind('SAVED');
 
 /* eslint-enable no-use-before-define */
 /* eslint-enable no-undef */

--- a/app/assets/javascripts/initializers/initializeReadingListIcons.js
+++ b/app/assets/javascripts/initializers/initializeReadingListIcons.js
@@ -12,7 +12,7 @@ function initializeReadingListIcons() {
 // set SAVE or SAVED articles buttons
 function setReadingListButtonsState() {
   var readingListButtons = document.getElementsByClassName('bookmark-engage');
-  Array.from(readingListButtons).forEach(button => highlightButton(button));
+  Array.from(readingListButtons).forEach(highlightButton);
 }
 
 // private
@@ -22,6 +22,7 @@ function highlightButton(button) {
   var buttonIdInt = parseInt(button.dataset.reactableId, 10);
   if (user && user.reading_list_ids.indexOf(buttonIdInt) > -1) {
     button.classList.add('selected');
+    addHoverEffectToReadingListButton(button);
   } else {
     button.classList.remove('selected');
   }
@@ -75,6 +76,7 @@ function reactToReadingListButtonClick(event) {
 function renderButtonState(button, json) {
   if (json.result === 'create') {
     button.classList.add('selected');
+    addHoverEffectToReadingListButton(button);
   } else {
     button.classList.remove('selected');
   }
@@ -114,6 +116,29 @@ function properButtonFromEvent(event) {
     properElement = event.target.parentElement;
   }
   return properElement;
+}
+
+function addHoverEffectToReadingListButton(button) {
+  if (button.classList.contains('selected')) {
+    button.addEventListener('mouseenter', readingListButtonMouseEnter);
+    button.addEventListener('mouseleave', readingListButtonMouseLeave);
+  }
+}
+
+function readingListButtonMouseEnter(event) {
+  event.preventDefault();
+
+  // replace 'SAVED' with 'UNSAVE'
+  var textSpan = event.target.getElementsByClassName('bm-success')[0];
+  textSpan.innerHTML = 'UNSAVE';
+}
+
+function readingListButtonMouseLeave(event) {
+  event.preventDefault();
+
+  // replace 'UNSAVE' with 'SAVED'
+  var textSpan = event.target.getElementsByClassName('bm-success')[0];
+  textSpan.innerHTML = 'SAVED';
 }
 
 /* eslint-enable no-use-before-define */

--- a/app/assets/javascripts/utilities/buildArticleHTML.js.erb
+++ b/app/assets/javascripts/utilities/buildArticleHTML.js.erb
@@ -77,15 +77,15 @@ function buildArticleHTML(article) {
     }
     var saveButton = '';
     if (article.class_name === "Article") {
-      var saveButton = '<button class="article-engagement-count bookmark-engage" data-reactable-id="'+article.id+'">\
-                        <span class="bm-success"></span>\
-                        <span class="bm-initial"></span>\
-                      </button>'
+      saveButton = '<button class="article-engagement-count bookmark-engage" data-reactable-id="'+article.id+'">\
+                      <span class="bm-initial">SAVE</span>\
+                      <span class="bm-success">SAVED</span>\
+                    </button>'
     } else if (article.class_name === "User") {
-      var saveButton = '<button style="width: 122px" class="article-engagement-count bookmark-engage follow-action-button"\
+      saveButton = '<button style="width: 122px" class="article-engagement-count bookmark-engage follow-action-button"\
                        data-info=\'{"id":'+article.id+',"className":"User"}\' data-follow-action-button>\
                        &nbsp;\
-                      </button>'
+                    </button>'
     }
 
     var publishDate = '';

--- a/app/assets/stylesheets/articles.scss
+++ b/app/assets/stylesheets/articles.scss
@@ -746,11 +746,6 @@
           position: relative;
           top: 1px;
         }
-        .bm-initial {
-          &:after {
-            content: 'SAVE';
-          }
-        }
         &.selected {
           color: darken($purple, 33%);
           background: transparent;
@@ -760,14 +755,6 @@
           }
           .bm-success {
             display: inline-block;
-
-            &:before {
-              content: 'SAVED';
-            }
-
-            &:hover:before {
-              content: 'UNSAVE';
-            }
           }
         }
         &.following-butt {

--- a/app/views/articles/_sidebar_nav.html.erb
+++ b/app/views/articles/_sidebar_nav.html.erb
@@ -20,24 +20,18 @@
       </div>
       <div class="sidebar-nav-element">
         <a class="sidebar-nav-link" href="/readinglist?we-hope-you-like-the-new-and-improved-reading-list---more-positive-changes-coming=woohoo">
-          <img class="nav-emoji" src="<%= asset_path("emoji/emoji-one-bookmark.png") %>" /> Reading List
+          <img class="nav-emoji" src="<%= asset_path("emoji/emoji-one-bookmark.png") %>" alt="reading list icon" /> Reading List
           <span id="reading-list-count"></span>
         </a>
         <a class="sidebar-nav-link" href="/listings">
-          <img class="nav-emoji" src="<%= asset_path("emoji/emoji-one-clipboard.png") %>" /> Listings
+          <img class="nav-emoji" src="<%= asset_path("emoji/emoji-one-clipboard.png") %>" alt="listings icon" /> Listings
         </a>
         <a class="sidebar-nav-link" href="/videos">
-          <img class="nav-emoji" src="<%= asset_path("emoji/emoji-one-videocamera.png") %>" /> Videos
+          <img class="nav-emoji" src="<%= asset_path("emoji/emoji-one-videocamera.png") %>" alt="videos icon" /> Videos
         </a>
         <a class="sidebar-nav-link" href="/pod">
-          <img class="nav-emoji" src="<%= asset_path("emoji/emoji-one-headphones.png") %>" /> Podcasts
+          <img class="nav-emoji" src="<%= asset_path("emoji/emoji-one-headphones.png") %>" alt="podcasts icon" /> Podcasts
         </a>
-        <% if 1==2 #not for display yet %>
-          <a class="sidebar-nav-link" href="/listings">
-            listings
-            <span id="reading-list-count"></span>
-          </a>
-        <% end %>
       </div>
     <% end %>
     <div class="sidebar-nav-header sidebar-nav-header-middle">

--- a/app/views/articles/_single_story.html.erb
+++ b/app/views/articles/_single_story.html.erb
@@ -59,7 +59,7 @@
     data-reactable-id="<%= story.id %>"
     aria-label="Save to reading list"
     title="Save to reading list">
-    <span class="bm-success"></span>
-    <span class="bm-initial"></span>
+    <span class="bm-initial">SAVE</span>
+    <span class="bm-success">SAVED</span>
   </button>
 </div>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -130,8 +130,8 @@
               data-reactable-id="<%= @featured_story.id %>"
               aria-label="Add to reading list"
               title="Add to reading list">
-              <span class="bm-success"></span>
-              <span class="bm-initial"></span>
+              <span class="bm-initial">SAVE</span>
+              <span class="bm-success">SAVED</span>
             </button>
           </div>
         </a>

--- a/app/views/layouts/_top_bar.html.erb
+++ b/app/views/layouts/_top_bar.html.erb
@@ -3,9 +3,9 @@
 <div class="top-bar" id="top-bar">
   <nav>
     <div id="pwa-nav-buttons" class="pwa-nav-buttons">
-      <button id="app-back-button"><img src="<%= asset_path("keyboard-left-arrow-button.svg") %>" /></button>
-      <button id="app-forward-button"><img src="<%= asset_path("keyboard-right-arrow-button.svg") %>" /></button>
-      <button id="app-refresh-button"><img src="<%= asset_path("refresh-button.svg") %>" /></button>
+      <button id="app-back-button"><img src="<%= asset_path("keyboard-left-arrow-button.svg") %>" alt="back icon" /></button>
+      <button id="app-forward-button"><img src="<%= asset_path("keyboard-right-arrow-button.svg") %>" alt="forward icon" /></button>
+      <button id="app-refresh-button"><img src="<%= asset_path("refresh-button.svg") %>" alt="refresh icon" /></button>
     </div>
     <a href="#articles-list" class="skip-content-link">Skip to content</a>
     <a href="/" class="logo-link" id="logo-link" aria-label="<%= ApplicationConfig["COMMUNITY_NAME"] %> Home"><%= logo_svg %></a>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,7 +26,7 @@
           margin: auto;
           max-width: 1250px;
         }
-        
+
         @media screen and (min-width: 950px) {
           .home {
             margin-top: 26px;
@@ -97,8 +97,8 @@
         <%= render "layouts/signup_modal" unless user_signed_in? %>
       <% end %>
       <div id="live-article-indicator" class="live-article-indicator"></div>
-      <%= image_tag("twitter-logo.svg", class: "icon-img", style: "display:none") %>
-      <%= image_tag("github-logo.svg", class: "icon-img", style: "display:none") %>
+      <%= image_tag("twitter-logo.svg", class: "icon-img", style: "display:none", alt: "twitter logo") %>
+      <%= image_tag("github-logo.svg", class: "icon-img", style: "display:none", alt: "github logo") %>
     <% end %>
   </body>
 </html>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

This PR is the result of me checking the local homepage with [WAVE](https://wave.webaim.org/extension/).

Aside from various missing alternative text the main change of this PR is the re-implementation of the SAVE/SAVED/UNSAVE hover effect.

Currently it is implemented through a clever trick in the CSS, but CSS `content` is not supposed to be used for the main text of a button (which WAVE flags as an error). 

My first attempt was to leave the `content` trick in place, add the default text to the buttons and then figure out a way to make the trick work. Although technically CSS `content` [supports text replacement](https://developer.mozilla.org/en-US/docs/Web/CSS/content#Element_replacement), the nature of the feature [doesn't sit well with accessiblity tools](https://developer.mozilla.org/en-US/docs/Web/CSS/content#Accessibility_concerns).

I then decided to leave the text in place in the buttons, and then use JS `mouseenter`/`mouseleave` to swap the text when needed.

More info on the a11y support of CSS generated content: https://a11ysupport.io/tech/css/generated_content

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

**Before**

![Screenshot_2019-05-08 The DEV(local) Community](https://user-images.githubusercontent.com/146201/57340883-2c7ce280-7138-11e9-9178-8bae2e2e2dfd.png)

**After**

![Screenshot_2019-05-08 The DEV(local) Community(1)](https://user-images.githubusercontent.com/146201/57340885-343c8700-7138-11e9-991d-08ef4c4131ed.png)

**hover effect**

![hover](https://user-images.githubusercontent.com/146201/57340922-64842580-7138-11e9-8f21-aa8e1056fa71.gif)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
