### PR TITLE
Fix Algolia creds documentation URL

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -17,7 +17,7 @@ tasks:
             [ -z "${ALGOLIASEARCH_API_KEY:=$(cat config/application.yml | grep ALGOLIASEARCH_API_KEY | sed 's/.*:\s*//')}" ] ; do
         gp open config/application.yml 2>/dev/null &&
         printf "\n❗ Dev.to requires free Algolia credentials.\n" &&
-        printf "❗ To get them, please follow https://docs.dev.to/get-api-keys-dev-env/#algolia\n\n" &&
+        printf "❗ To get them, please follow https://docs.dev.to/backend/algolia/#get-api-keys\n\n" &&
         read -p "Add them to config/application.yml, save the file, and press any key to continue... " -n 1 -r
       done ;
       bin/setup &&


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Documentation Update

## Description

Fixed the Algolia get-apy-keys URL in the Gitpod console message.

## Related Tickets & Documents

https://github.com/thepracticaldev/dev.to/issues/2765

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![image](https://user-images.githubusercontent.com/585182/57383840-80f68100-717d-11e9-8592-58cc57f7916c.png)
