### PR TITLE
Add Fetch Now to RSS Settings

### DIFF
--- a/app/assets/javascripts/initializers/initializeSettings.js
+++ b/app/assets/javascripts/initializers/initializeSettings.js
@@ -1,7 +1,27 @@
-function initializeSettings(){
-  if (document.getElementById("settings-org-secret")){
-    document.getElementById("settings-org-secret").onclick = function(event){
-      event.target.select()
-    }
+/* global timestampToLocalDateTime */
+
+function initializeSettings() {
+  if (document.getElementById('settings-org-secret')) {
+    document.getElementById('settings-org-secret').onclick = function(event) {
+      event.target.select();
+    };
+  }
+
+  if (document.getElementById('rss-fetch-time')) {
+    var timeNode = document.getElementById('rss-fetch-time');
+    var timeStamp = timeNode.getAttribute('datetime');
+    var timeOptions = {
+      month: 'long',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+      second: 'numeric',
+    };
+
+    timeNode.textContent = timestampToLocalDateTime(
+      timeStamp,
+      navigator.language,
+      timeOptions,
+    );
   }
 }

--- a/app/views/users/_publishing_from_rss.html.erb
+++ b/app/views/users/_publishing_from_rss.html.erb
@@ -5,9 +5,11 @@
       <label></label>
       <%= f.hidden_field :feed_url, value: @user.feed_url %>
       <%= f.hidden_field :tab, value: @tab %>
-      <%= f.submit "Re-Fetch" %>
+      <%= f.submit "Refresh Feed" %>
       <p><em>
-        Last Updated: <%= @user.feed_fetched_at.getlocal.strftime("%b %d, %I:%M%p") %>
+        Last Updated: <time id="rss-fetch-time" datetime="<%= @user.feed_fetched_at.iso8601 %>">
+          <%= @user.feed_fetched_at.strftime("%b %d, %H:%M:%S %Z") %>
+        </time>
       </em></p>
     </div>
   <% end %>

--- a/app/views/users/_publishing_from_rss.html.erb
+++ b/app/views/users/_publishing_from_rss.html.erb
@@ -1,4 +1,17 @@
 <h3>Publishing to dev.to from RSS</h3>
+<% if @user.feed_url.present? %>
+  <%= form_for(@user) do |f| %>
+    <div class="field">
+      <label></label>
+      <%= f.hidden_field :feed_url, value: @user.feed_url %>
+      <%= f.hidden_field :tab, value: @tab %>
+      <%= f.submit "Re-Fetch" %>
+      <p><em>
+        Last Updated: <%= @user.feed_fetched_at.getlocal.strftime("%b %d, %I:%M%p") %>
+      </em></p>
+    </div>
+  <% end %>
+<% end %>
 <p>
   Posts will land in your <a href="/dashboard">dashboard</a>
   <b><em>as drafts</em></b>, and then you can publish from there (or give dev.to admins permission to do so).
@@ -37,6 +50,7 @@
   <div class="field">
     <label></label>
     <%= f.hidden_field :tab, value: @tab %>
-    <%= f.submit "SUBMIT", class: "cta" %>
+    <% button_text = @user.feed_url.present? ? "UPDATE" : "SUBMIT" %>
+    <%= f.submit button_text, class: "cta" %>
   </div>
 <% end %>


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Add Fetch Now button to  `https://dev.to/settings/publishing-from-rss` to allow users to force a fetch of posts from RSS URL provided. The Submit button now changes to update if a RSS URL is present so users are aware that they can fetch posts using it.

## Related Tickets & Documents
Resolves #539

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
* When no URL is provided ![When no URL provided](https://user-images.githubusercontent.com/24629960/57421453-e8421e80-71d9-11e9-8422-f71d1c4b1b46.png)

* When URL is provided ![When URL is provided](https://user-images.githubusercontent.com/24629960/57498634-9ddca280-72aa-11e9-8b66-d44c0f60d954.png)

## Potential Issue
Right now, there is a bit of a delay with the text change

   ![Delay with text change](https://user-images.githubusercontent.com/24629960/57499383-8357f880-72ad-11e9-8faf-1acf32d1c40a.gif)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed