### PR TITLE
Fix Negative Number Beside Discuss in Article

### DIFF
--- a/app/views/articles/_actions.html.erb
+++ b/app/views/articles/_actions.html.erb
@@ -17,7 +17,7 @@
   </a>
   <a class="article-actions-comments-count" href="#comments" id="jump-to-comments">
     DISCUSS
-    <% if @article.comments_count.nonzero? %>
+    <% if @article.comments_count.positive? %>
       <span class="article-actions-comments-count-number">(<%= @article.comments_count %>)</span>
     <% else %>
     <% end %>


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
A negative number found beside the Discuss in the article reaction section. I just made a change so the comment count is checked to be positive before displaying beside Discuss.

## Related Tickets & Documents
Resolves #2614

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed