### PR TITLE
Fix link to FAQ on information page

### DIFF
--- a/app/views/pages/information.html.erb
+++ b/app/views/pages/information.html.erb
@@ -50,7 +50,7 @@
       <li><a href="/about">About</a></li>
       <li><a href="https://shop.dev.to/">DEV Shop</a></li>
       <li><a href="/sponsors">Sponsors</a></li>
-      <li><a href="/FAQ">FAQ</a></li>
+      <li><a href="/faq">FAQ</a></li>
       <li><a href="/privacy">Privacy Policy</a></li>
       <li><a href="/terms">Terms of Use</a></li>
       <li><a href="/contact">Contact</a></li>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
On the about page the FAQ link, links to a 404 page. The links are case sensitive and the lowercase `/faq` works so I changed it to that.

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed