### PR TITLE
Upgrade fog-aws from 2.0 to 3.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ gem "fastly", "~> 1.15" # Client library for the Fastly acceleration system
 gem "fastly-rails", "~> 0.8" # Fastly dynamic caching integration for Rails
 gem "feedjira", "~> 2.2" # A feed fetching and parsing library
 gem "figaro", "~> 1.1" # Simple, Heroku-friendly Rails app configuration using ENV and a single YAML file
-gem "fog-aws", "3.4.0" # 'fog' gem to support Amazon Web Services
+gem "fog-aws", "~> 3.5" # 'fog' gem to support Amazon Web Services
 gem "front_matter_parser", "~> 0.2" # Parse a front matter from syntactically correct strings or files
 gem "gemoji", "~> 3.0.1" # Character information and metadata for standard and custom emoji
 gem "gibbon", "~> 3.2" # API wrapper for MailChimp's API

--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ gem "fastly", "~> 1.15" # Client library for the Fastly acceleration system
 gem "fastly-rails", "~> 0.8" # Fastly dynamic caching integration for Rails
 gem "feedjira", "~> 2.2" # A feed fetching and parsing library
 gem "figaro", "~> 1.1" # Simple, Heroku-friendly Rails app configuration using ENV and a single YAML file
-gem "fog-aws", "3.0.0" # 'fog' gem to support Amazon Web Services
+gem "fog-aws", "3.1.0" # 'fog' gem to support Amazon Web Services
 gem "front_matter_parser", "~> 0.2" # Parse a front matter from syntactically correct strings or files
 gem "gemoji", "~> 3.0.1" # Character information and metadata for standard and custom emoji
 gem "gibbon", "~> 3.2" # API wrapper for MailChimp's API

--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ gem "fastly", "~> 1.15" # Client library for the Fastly acceleration system
 gem "fastly-rails", "~> 0.8" # Fastly dynamic caching integration for Rails
 gem "feedjira", "~> 2.2" # A feed fetching and parsing library
 gem "figaro", "~> 1.1" # Simple, Heroku-friendly Rails app configuration using ENV and a single YAML file
-gem "fog-aws", "2.0.1" # 'fog' gem to support Amazon Web Services
+gem "fog-aws", "3.0.0" # 'fog' gem to support Amazon Web Services
 gem "front_matter_parser", "~> 0.2" # Parse a front matter from syntactically correct strings or files
 gem "gemoji", "~> 3.0.1" # Character information and metadata for standard and custom emoji
 gem "gibbon", "~> 3.2" # API wrapper for MailChimp's API

--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ gem "fastly", "~> 1.15" # Client library for the Fastly acceleration system
 gem "fastly-rails", "~> 0.8" # Fastly dynamic caching integration for Rails
 gem "feedjira", "~> 2.2" # A feed fetching and parsing library
 gem "figaro", "~> 1.1" # Simple, Heroku-friendly Rails app configuration using ENV and a single YAML file
-gem "fog-aws", "3.3.0" # 'fog' gem to support Amazon Web Services
+gem "fog-aws", "3.4.0" # 'fog' gem to support Amazon Web Services
 gem "front_matter_parser", "~> 0.2" # Parse a front matter from syntactically correct strings or files
 gem "gemoji", "~> 3.0.1" # Character information and metadata for standard and custom emoji
 gem "gibbon", "~> 3.2" # API wrapper for MailChimp's API

--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ gem "fastly", "~> 1.15" # Client library for the Fastly acceleration system
 gem "fastly-rails", "~> 0.8" # Fastly dynamic caching integration for Rails
 gem "feedjira", "~> 2.2" # A feed fetching and parsing library
 gem "figaro", "~> 1.1" # Simple, Heroku-friendly Rails app configuration using ENV and a single YAML file
-gem "fog-aws", "2.0.0" # 'fog' gem to support Amazon Web Services
+gem "fog-aws", "2.0.1" # 'fog' gem to support Amazon Web Services
 gem "front_matter_parser", "~> 0.2" # Parse a front matter from syntactically correct strings or files
 gem "gemoji", "~> 3.0.1" # Character information and metadata for standard and custom emoji
 gem "gibbon", "~> 3.2" # API wrapper for MailChimp's API

--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ gem "fastly", "~> 1.15" # Client library for the Fastly acceleration system
 gem "fastly-rails", "~> 0.8" # Fastly dynamic caching integration for Rails
 gem "feedjira", "~> 2.2" # A feed fetching and parsing library
 gem "figaro", "~> 1.1" # Simple, Heroku-friendly Rails app configuration using ENV and a single YAML file
-gem "fog-aws", "3.2.0" # 'fog' gem to support Amazon Web Services
+gem "fog-aws", "3.3.0" # 'fog' gem to support Amazon Web Services
 gem "front_matter_parser", "~> 0.2" # Parse a front matter from syntactically correct strings or files
 gem "gemoji", "~> 3.0.1" # Character information and metadata for standard and custom emoji
 gem "gibbon", "~> 3.2" # API wrapper for MailChimp's API

--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ gem "fastly", "~> 1.15" # Client library for the Fastly acceleration system
 gem "fastly-rails", "~> 0.8" # Fastly dynamic caching integration for Rails
 gem "feedjira", "~> 2.2" # A feed fetching and parsing library
 gem "figaro", "~> 1.1" # Simple, Heroku-friendly Rails app configuration using ENV and a single YAML file
-gem "fog-aws", "3.1.0" # 'fog' gem to support Amazon Web Services
+gem "fog-aws", "3.2.0" # 'fog' gem to support Amazon Web Services
 gem "front_matter_parser", "~> 0.2" # Parse a front matter from syntactically correct strings or files
 gem "gemoji", "~> 3.0.1" # Character information and metadata for standard and custom emoji
 gem "gibbon", "~> 3.2" # API wrapper for MailChimp's API

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -333,7 +333,7 @@ GEM
       thor (~> 0.14)
     fix-db-schema-conflicts (3.0.3)
       rubocop (>= 0.38.0)
-    fog-aws (3.2.0)
+    fog-aws (3.3.0)
       fog-core (~> 2.1)
       fog-json (~> 1.1)
       fog-xml (~> 0.1)
@@ -870,7 +870,7 @@ DEPENDENCIES
   feedjira (~> 2.2)
   figaro (~> 1.1)
   fix-db-schema-conflicts (~> 3.0)
-  fog-aws (= 3.2.0)
+  fog-aws (= 3.3.0)
   foreman!
   front_matter_parser (~> 0.2)
   gemoji (~> 3.0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -305,7 +305,7 @@ GEM
     et-orbi (1.1.6)
       tzinfo
     eventmachine (1.2.5)
-    excon (0.60.0)
+    excon (0.64.0)
     execjs (2.7.0)
     factory_bot (5.0.2)
       activesupport (>= 4.2.0)
@@ -333,7 +333,7 @@ GEM
       thor (~> 0.14)
     fix-db-schema-conflicts (3.0.3)
       rubocop (>= 0.38.0)
-    fog-aws (2.0.0)
+    fog-aws (2.0.1)
       fog-core (~> 1.38)
       fog-json (~> 1.0)
       fog-xml (~> 0.1)
@@ -342,8 +342,8 @@ GEM
       builder
       excon (~> 0.58)
       formatador (~> 0.2)
-    fog-json (1.0.2)
-      fog-core (~> 1.0)
+    fog-json (1.2.0)
+      fog-core
       multi_json (~> 1.10)
     fog-xml (0.1.3)
       fog-core
@@ -869,7 +869,7 @@ DEPENDENCIES
   feedjira (~> 2.2)
   figaro (~> 1.1)
   fix-db-schema-conflicts (~> 3.0)
-  fog-aws (= 2.0.0)
+  fog-aws (= 2.0.1)
   foreman!
   front_matter_parser (~> 0.2)
   gemoji (~> 3.0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -333,15 +333,16 @@ GEM
       thor (~> 0.14)
     fix-db-schema-conflicts (3.0.3)
       rubocop (>= 0.38.0)
-    fog-aws (2.0.1)
-      fog-core (~> 1.38)
-      fog-json (~> 1.0)
+    fog-aws (3.0.0)
+      fog-core (~> 2.1)
+      fog-json (~> 1.1)
       fog-xml (~> 0.1)
       ipaddress (~> 0.8)
-    fog-core (1.45.0)
+    fog-core (2.1.2)
       builder
       excon (~> 0.58)
       formatador (~> 0.2)
+      mime-types
     fog-json (1.2.0)
       fog-core
       multi_json (~> 1.10)
@@ -869,7 +870,7 @@ DEPENDENCIES
   feedjira (~> 2.2)
   figaro (~> 1.1)
   fix-db-schema-conflicts (~> 3.0)
-  fog-aws (= 2.0.1)
+  fog-aws (= 3.0.0)
   foreman!
   front_matter_parser (~> 0.2)
   gemoji (~> 3.0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -333,7 +333,7 @@ GEM
       thor (~> 0.14)
     fix-db-schema-conflicts (3.0.3)
       rubocop (>= 0.38.0)
-    fog-aws (3.3.0)
+    fog-aws (3.4.0)
       fog-core (~> 2.1)
       fog-json (~> 1.1)
       fog-xml (~> 0.1)
@@ -870,7 +870,7 @@ DEPENDENCIES
   feedjira (~> 2.2)
   figaro (~> 1.1)
   fix-db-schema-conflicts (~> 3.0)
-  fog-aws (= 3.3.0)
+  fog-aws (= 3.4.0)
   foreman!
   front_matter_parser (~> 0.2)
   gemoji (~> 3.0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -333,7 +333,7 @@ GEM
       thor (~> 0.14)
     fix-db-schema-conflicts (3.0.3)
       rubocop (>= 0.38.0)
-    fog-aws (3.0.0)
+    fog-aws (3.1.0)
       fog-core (~> 2.1)
       fog-json (~> 1.1)
       fog-xml (~> 0.1)
@@ -870,7 +870,7 @@ DEPENDENCIES
   feedjira (~> 2.2)
   figaro (~> 1.1)
   fix-db-schema-conflicts (~> 3.0)
-  fog-aws (= 3.0.0)
+  fog-aws (= 3.1.0)
   foreman!
   front_matter_parser (~> 0.2)
   gemoji (~> 3.0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -333,7 +333,7 @@ GEM
       thor (~> 0.14)
     fix-db-schema-conflicts (3.0.3)
       rubocop (>= 0.38.0)
-    fog-aws (3.4.0)
+    fog-aws (3.5.0)
       fog-core (~> 2.1)
       fog-json (~> 1.1)
       fog-xml (~> 0.1)
@@ -870,7 +870,7 @@ DEPENDENCIES
   feedjira (~> 2.2)
   figaro (~> 1.1)
   fix-db-schema-conflicts (~> 3.0)
-  fog-aws (= 3.4.0)
+  fog-aws (~> 3.5)
   foreman!
   front_matter_parser (~> 0.2)
   gemoji (~> 3.0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -333,7 +333,7 @@ GEM
       thor (~> 0.14)
     fix-db-schema-conflicts (3.0.3)
       rubocop (>= 0.38.0)
-    fog-aws (3.1.0)
+    fog-aws (3.2.0)
       fog-core (~> 2.1)
       fog-json (~> 1.1)
       fog-xml (~> 0.1)
@@ -870,7 +870,7 @@ DEPENDENCIES
   feedjira (~> 2.2)
   figaro (~> 1.1)
   fix-db-schema-conflicts (~> 3.0)
-  fog-aws (= 3.1.0)
+  fog-aws (= 3.2.0)
   foreman!
   front_matter_parser (~> 0.2)
   gemoji (~> 3.0.1)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

This PR upgrades [fog-aws](https://github.com/fog/fog-aws) from 2.0.0 to 3.5.0. The full [changelog](https://github.com/fog/fog-aws/blob/master/CHANGELOG.md) can be found here https://github.com/fog/fog-aws/blob/master/CHANGELOG.md

I tested each separate upgraded version both manually uploading images in comments and articles and with the following script:

```ruby
uploader = ArticleImageUploader.new
f = File.open(Rails.root.join("app", "assets", "images", "#{rand(1..40)}.png"))
uploader.store! f
puts uploader.url
```

## Related Tickets & Documents

Continues from https://github.com/thepracticaldev/dev.to/pull/2569

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
