### PR TITLE
Register Medium Liquid Tag

### DIFF
--- a/app/liquid_tags/medium_tag.rb
+++ b/app/liquid_tags/medium_tag.rb
@@ -32,3 +32,5 @@ class MediumTag < LiquidTagBase
     raise StandardError, "Invalid link URL or link URL does not exist"
   end
 end
+
+Liquid::Template.register_tag("medium", MediumTag)

--- a/app/views/pages/_editor_guide_text.html.erb
+++ b/app/views/pages/_editor_guide_text.html.erb
@@ -225,7 +225,7 @@
     <p>All you need is the data-id code from the embed link:</p>
     <pre>
       <span style="color: gray;"># Given this embed link:</span>
-      < script async class="speakerdeck-embed"
+      <script async class="speakerdeck-embed"
             data-id="<span style='color: orange;'>7e9f8c0fa0c949bd8025457181913fd0</span>"
             data-ratio="1.77777777777778" src="//speakerdeck.com/assets/embed.js">< /script >
     </pre>
@@ -257,6 +257,10 @@
     <pre>
       {% parler https://www.parler.io/audio/73240183203/d53cff009eac2ab1bc9dd8821a638823c39cbcea.7dd28611-b7fc-4cf8-9977-b6e3aaf644a1.mp3 %}
     </pre>
+
+    <h3><strong>Medium Embed</strong></h3>
+    <p>Just enter the full URL of the Medium article you are trying to embed.</p>
+    <code>{% medium https://medium.com/s/story/boba-science-how-can-i-drink-a-bubble-tea-to-ensure-that-i-dont-finish-the-tea-before-the-bobas-7fc5fd0e442d %}</code>
 
     <h3><strong>Parsing Liquid Tags as a Code Example</strong></h3>
     <p>To parse Liquid tags as code, simply wrap it with a single backtick or triple backticks.</p>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature Release

## Description
After refactoring liquid tags, including the Medium Liquid tag, I noticed that it was left unregistered for quite some time. It seems like in the Medium Liquid tag PR #1161, there was intention to make it publicly available, so I am registering it. 

## Related Tickets & Documents
#1161 [comment](https://github.com/thepracticaldev/dev.to/pull/1161#pullrequestreview-220679222)

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
N/A

## Added to documentation?

- [x] no documentation needed
