### PR TITLE
Strip org secret before searching and add better error handling for invalid secrets

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -110,7 +110,7 @@ class UsersController < ApplicationController
 
   def join_org
     authorize User
-    if (@organization = Organization.find_by(secret: params[:org_secret]))
+    if (@organization = Organization.find_by(secret: params[:org_secret].strip))
       ActiveRecord::Base.transaction do
         current_user.update(organization_id: @organization.id)
         OrganizationMembership.create(user_id: current_user.id, organization_id: current_user.organization_id, type_of_user: "member")

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -110,7 +110,7 @@ class UsersController < ApplicationController
 
   def join_org
     authorize User
-    if (@organization = Organization.find_by(secret: params[:org_secret].strip))
+    if (@organization = Organization.find_by(secret: "params[:org_secret].strip"))
       ActiveRecord::Base.transaction do
         current_user.update(organization_id: @organization.id)
         OrganizationMembership.create(user_id: current_user.id, organization_id: current_user.organization_id, type_of_user: "member")
@@ -118,7 +118,8 @@ class UsersController < ApplicationController
       redirect_to "/settings/organization",
                   notice: "You have joined the #{@organization.name} organization."
     else
-      not_found
+      flash[:error] = "The given organization secret was invalid."
+      redirect_to "/settings/organization"
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -110,7 +110,7 @@ class UsersController < ApplicationController
 
   def join_org
     authorize User
-    if (@organization = Organization.find_by(secret: "params[:org_secret].strip"))
+    if (@organization = Organization.find_by(secret: params[:org_secret].strip))
       ActiveRecord::Base.transaction do
         current_user.update(organization_id: @organization.id)
         OrganizationMembership.create(user_id: current_user.id, organization_id: current_user.organization_id, type_of_user: "member")

--- a/spec/requests/user_organization_spec.rb
+++ b/spec/requests/user_organization_spec.rb
@@ -21,9 +21,9 @@ RSpec.describe "UserOrganization", type: :request do
       expect(org_membership.type_of_user).to eq "member"
     end
 
-    it "returns 404 if secret is wrong" do
-      expect { post "/users/join_org", params: { org_secret: "NOT SECRET" } }.
-        to raise_error ActiveRecord::RecordNotFound
+    it "shows an error message if secret is invalid" do
+      post "/users/join_org", params: { org_secret: "NOT SECRET" }
+      expect(flash[:error]).to eq "The given organization secret was invalid."
     end
 
     it "correctly strips the secret of the org_secret param" do

--- a/spec/requests/user_organization_spec.rb
+++ b/spec/requests/user_organization_spec.rb
@@ -25,6 +25,11 @@ RSpec.describe "UserOrganization", type: :request do
       expect { post "/users/join_org", params: { org_secret: "NOT SECRET" } }.
         to raise_error ActiveRecord::RecordNotFound
     end
+
+    it "correctly strips the secret of the org_secret param" do
+      post "/users/join_org", params: { org_secret: organization.secret + "     " }
+      expect(user.organization_id).to eq(organization.id)
+    end
   end
 
   context "when leaving an org" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Sometimes the `org_secret` parameter has an extra space. This PR removes any whitespace.

Also, we currently send a 404 response if the submitted `org_secret` is invalid. This PR redirects the user back to `/settings/organization` and shows an error message instead.

Resolves #2828 