### PR TITLE
Articles API: create and update

### DIFF
--- a/app/controllers/api/v0/analytics_controller.rb
+++ b/app/controllers/api/v0/analytics_controller.rb
@@ -1,8 +1,8 @@
 module Api
   module V0
     class AnalyticsController < ApiController
-      rescue_from ArgumentError, with: :unprocessable_entity
-      rescue_from UnauthorizedError, with: :not_authorized
+      rescue_from ArgumentError, with: :error_unprocessable_entity
+      rescue_from UnauthorizedError, with: :error_unauthorized
 
       def totals
         user = get_authenticated_user!

--- a/app/controllers/api/v0/articles_controller.rb
+++ b/app/controllers/api/v0/articles_controller.rb
@@ -77,31 +77,11 @@ module Api
 
       def article_params
         allowed_params = [
-          :title, :body_markdown, :published, :series,
-          :publish_under_org, tags: []
+          :title, :body_markdown, :published, :series, :publish_under_org,
+          :main_image, :canonical_url, tags: []
         ]
         params.require(:article).permit(allowed_params)
       end
-
-      # def article_params
-      #   params["article"].transform_keys!(&:underscore)
-      #   params["article"]["organization_id"] = (@user.organization_id if params["article"]["post_under_org"])
-      #   if params["article"]["series"].present?
-      #     params["article"]["collection_id"] = Collection.find_series(params["article"]["series"], @user)&.id
-      #   elsif params["article"]["series"] == ""
-      #     params["article"]["collection_id"] = nil
-      #   end
-      #   if params["article"]["version"] == "v1"
-      #     params.require(:article).permit(
-      #       :body_markdown, :organization_id
-      #     )
-      #   else
-      #     params.require(:article).permit(
-      #       :title, :body_markdown, :main_image, :published, :description,
-      #       :tag_list, :organization_id, :canonical_url, :series, :collection_id
-      #     )
-      #   end
-      # end
     end
   end
 end

--- a/app/controllers/api/v0/articles_controller.rb
+++ b/app/controllers/api/v0/articles_controller.rb
@@ -59,18 +59,13 @@ module Api
       end
 
       def create
-        @article = ArticleCreationService.new(@user, article_params, {}).create!
+        @article = ArticleCreationService.new(@user, article_params).create!
         render "show", status: :created, location: @article.url
       end
 
       def update
-        @article = Article.find(params[:id])
-        not_found if @article.user_id != @user.id && !@user.has_role?(:super_admin)
-        render json: if @article.update(article_params)
-                       @article.to_json(only: [:id], methods: [:current_state_path])
-                     else
-                       @article.errors.to_json
-                     end
+        @article = Articles::Updater.call(@user, params[:id], article_params)
+        render "show", status: :ok
       end
 
       private

--- a/app/controllers/api/v0/comments_controller.rb
+++ b/app/controllers/api/v0/comments_controller.rb
@@ -1,6 +1,6 @@
 module Api
   module V0
-    class CommentsController < ApplicationController
+    class CommentsController < ApiController
       # before_action :set_cache_control_headers, only: [:index, :show]
       caches_action :index,
                     cache_path: proc { |c| c.params.permit! },
@@ -13,12 +13,12 @@ module Api
       respond_to :json
 
       def index
-        @commentable = Article.find(params[:a_id]) # or not_found
+        @commentable = Article.find(params[:a_id])
         @commentable_type = "Article"
       end
 
       def show
-        (@comment = Comment.find(params[:id].to_i(26))) || not_found
+        @comment = Comment.find(params[:id].to_i(26))
       end
     end
   end

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -110,8 +110,7 @@ class ArticlesController < ApplicationController
             title: parsed["title"],
             tags: (Article.new.tag_list.add(parsed["tags"], parser: ActsAsTaggableOn::TagParser) if parsed["tags"]),
             cover_image: (ApplicationController.helpers.cloud_cover_url(parsed["cover_image"]) if parsed["cover_image"])
-          },
-                 status: 200
+          }
         end
       end
     end

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -124,16 +124,14 @@ class ArticlesController < ApplicationController
     respond_to do |format|
       format.html do
         @article = ArticleCreationService.
-          new(@user, article_params, job_opportunity_params).
+          new(@user, article_params, job_opportunity_params: job_opportunity_params).
           create!
 
         redirect_after_creation
       end
 
       format.json do
-        @article = ArticleCreationService.
-          new(@user, article_params_json, {}).
-          create!
+        @article = ArticleCreationService.new(@user, article_params_json).create!
 
         render json: if @article.persisted?
                        @article.to_json(only: [:id], methods: [:current_state_path])

--- a/app/javascript/article-form/actions.js
+++ b/app/javascript/article-form/actions.js
@@ -20,7 +20,7 @@ export function getArticle() {}
 
 export function submitArticle(payload, clearStorage, errorCb, failureCb) {
   const method = payload.id ? 'PUT' : 'POST';
-  const url = payload.id ? `/api/articles/${payload.id}` : '/api/articles';
+  const url = payload.id ? `/api/articles/${payload.id}` : '/articles';
   fetch(url, {
     method,
     headers: {

--- a/app/javascript/article-form/actions.js
+++ b/app/javascript/article-form/actions.js
@@ -20,7 +20,7 @@ export function getArticle() {}
 
 export function submitArticle(payload, clearStorage, errorCb, failureCb) {
   const method = payload.id ? 'PUT' : 'POST';
-  const url = payload.id ? `/api/articles/${payload.id}` : '/articles';
+  const url = payload.id ? `/articles/${payload.id}` : '/articles';
   fetch(url, {
     method,
     headers: {

--- a/app/services/article_creation_service.rb
+++ b/app/services/article_creation_service.rb
@@ -1,5 +1,5 @@
 class ArticleCreationService
-  def initialize(user, article_params, job_opportunity_params)
+  def initialize(user, article_params, job_opportunity_params: {})
     @user = user
     @article_params = article_params
     @job_opportunity_params = job_opportunity_params
@@ -17,8 +17,8 @@ class ArticleCreationService
 
     # convert tags from array to a string
     if tags.present?
-      @article_params.delete(:tags)
-      @article_params[:tag_list] = tags.join(", ")
+      article_params.delete(:tags)
+      article_params[:tag_list] = tags.join(", ")
     end
 
     article = Article.new(article_params)
@@ -45,5 +45,6 @@ class ArticleCreationService
 
   private
 
-  attr_reader :user, :article_params, :job_opportunity_params
+  attr_reader :user, :job_opportunity_params
+  attr_accessor :article_params
 end

--- a/app/services/article_creation_service.rb
+++ b/app/services/article_creation_service.rb
@@ -1,6 +1,4 @@
 class ArticleCreationService
-  attr_accessor :user, :article_params, :job_opportunity_params
-
   def initialize(user, article_params, job_opportunity_params)
     @user = user
     @article_params = article_params
@@ -10,13 +8,28 @@ class ArticleCreationService
   def create!
     raise if RateLimitChecker.new(user).limit_by_situation("published_article_creation")
 
+    tags = article_params[:tags]
+    series = article_params[:series]
+    publish_under_org = (
+      article_params[:publish_under_org] == true ||
+      article_params[:publish_under_org].to_i == 1
+    )
+
+    # convert tags from array to a string
+    if tags.present?
+      @article_params.delete(:tags)
+      @article_params[:tag_list] = tags.join(", ")
+    end
+
     article = Article.new(article_params)
     article.user_id = user.id
     article.show_comments = true
-    article.organization_id = user.organization_id if user.organization_id.present? && article_params[:publish_under_org].to_i == 1
-    article.collection_id = Collection.find_series(article_params[:series], user).id if article_params[:series].present?
+    article.organization = user.organization if publish_under_org
+    article.collection = Collection.find_series(series, user) if series.present?
+
     create_job_opportunity(article)
-    if article.save
+
+    if article.save!
       Notification.send_to_followers(article, "Published") if article.published
     end
     article.decorate
@@ -29,4 +42,8 @@ class ArticleCreationService
     article.job_opportunity = job_opportunity
     raise unless article.tag_list.include? "hiring"
   end
+
+  private
+
+  attr_reader :user, :article_params, :job_opportunity_params
 end

--- a/app/services/articles/updater.rb
+++ b/app/services/articles/updater.rb
@@ -1,0 +1,44 @@
+module Articles
+  class Updater
+    def initialize(user, article_id, article_params)
+      @user = user
+      @article_id = article_id
+      @article_params = article_params
+    end
+
+    def self.call(*args)
+      new(*args).call
+    end
+
+    def call
+      article = if user.has_role?(:super_admin)
+                  Article.includes(:user).find(article_id)
+                else
+                  user.articles.find(article_id)
+                end
+
+      # the client can change the series the article belongs to
+      if article_params.key?(:series)
+        series = article_params[:series]
+        article.collection = Collection.find_series(series, user) if series.present?
+        article.collection = nil if series.nil?
+      end
+
+      # convert tags from array to a string
+      tags = article_params[:tags]
+      if tags.present?
+        article_params[:tag_list] = tags.join(", ")
+        article_params.delete(:tags)
+      end
+
+      article.update!(article_params)
+
+      article.decorate
+    end
+
+    private
+
+    attr_reader :user, :article_id
+    attr_accessor :article_params
+  end
+end

--- a/app/views/api/v0/articles/show.json.jbuilder
+++ b/app/views/api/v0/articles/show.json.jbuilder
@@ -7,6 +7,7 @@ json.published_at       @article.published_at
 json.readable_publish_date @article.readable_publish_date
 json.social_image       article_social_image_url(@article)
 json.tag_list           @article.cached_tag_list
+json.tags               @article.cached_tag_list.split(", ")
 json.slug               @article.slug
 json.path               @article.path
 json.url                @article.url

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :collection do
+    slug { "word-#{rand(10_000)}" }
+  end
+end

--- a/spec/fixtures/files/article_published.txt
+++ b/spec/fixtures/files/article_published.txt
@@ -1,0 +1,8 @@
+---
+title: Sample Article
+published: true
+description: this is a sample article
+tags: test
+---
+
+Suspendisse ac lobortis velit, a feugiat sapien. Aenean condimentum, nulla at fermentum sagittis, tellus nisi suscipit velit, vel sollicitudin odio ligula a odio. Integer eget efficitur massa, in sodales velit. Nunc fermentum consequat scelerisque. Morbi elementum tristique faucibus. Nulla vel lectus non justo euismod varius. Vivamus id nisl sit amet odio tincidunt fringilla. Pellentesque odio odio, vulputate in risus eu, lacinia porttitor lorem. Nunc posuere tempus est, imperdiet suscipit odio maximus id. Nam eget feugiat magna.

--- a/spec/fixtures/files/article_published_canonical_url.txt
+++ b/spec/fixtures/files/article_published_canonical_url.txt
@@ -1,0 +1,9 @@
+---
+title: Sample Article
+published: true
+description: this is a sample article
+tags: test
+canonical_url: https://example.com/
+---
+
+Suspendisse ac lobortis velit, a feugiat sapien. Aenean condimentum, nulla at fermentum sagittis, tellus nisi suscipit velit, vel sollicitudin odio ligula a odio. Integer eget efficitur massa, in sodales velit. Nunc fermentum consequat scelerisque. Morbi elementum tristique faucibus. Nulla vel lectus non justo euismod varius. Vivamus id nisl sit amet odio tincidunt fringilla. Pellentesque odio odio, vulputate in risus eu, lacinia porttitor lorem. Nunc posuere tempus est, imperdiet suscipit odio maximus id. Nam eget feugiat magna.

--- a/spec/fixtures/files/article_published_cover_image.txt
+++ b/spec/fixtures/files/article_published_cover_image.txt
@@ -1,0 +1,9 @@
+---
+title: Sample Article
+published: true
+description: this is a sample article
+tags: test
+cover_image: https://dummyimage.com/100x100
+---
+
+Suspendisse ac lobortis velit, a feugiat sapien. Aenean condimentum, nulla at fermentum sagittis, tellus nisi suscipit velit, vel sollicitudin odio ligula a odio. Integer eget efficitur massa, in sodales velit. Nunc fermentum consequat scelerisque. Morbi elementum tristique faucibus. Nulla vel lectus non justo euismod varius. Vivamus id nisl sit amet odio tincidunt fringilla. Pellentesque odio odio, vulputate in risus eu, lacinia porttitor lorem. Nunc posuere tempus est, imperdiet suscipit odio maximus id. Nam eget feugiat magna.

--- a/spec/fixtures/files/article_published_series.txt
+++ b/spec/fixtures/files/article_published_series.txt
@@ -1,0 +1,9 @@
+---
+title: Sample Article
+published: true
+description: this is a sample article
+tags: test
+series: a series
+---
+
+Suspendisse ac lobortis velit, a feugiat sapien. Aenean condimentum, nulla at fermentum sagittis, tellus nisi suscipit velit, vel sollicitudin odio ligula a odio. Integer eget efficitur massa, in sodales velit. Nunc fermentum consequat scelerisque. Morbi elementum tristique faucibus. Nulla vel lectus non justo euismod varius. Vivamus id nisl sit amet odio tincidunt fringilla. Pellentesque odio odio, vulputate in risus eu, lacinia porttitor lorem. Nunc posuere tempus est, imperdiet suscipit odio maximus id. Nam eget feugiat magna.

--- a/spec/fixtures/files/article_unpublished.txt
+++ b/spec/fixtures/files/article_unpublished.txt
@@ -1,0 +1,8 @@
+---
+title: Sample Article
+published: false
+description: this is a sample article
+tags: test
+---
+
+Suspendisse ac lobortis velit, a feugiat sapien. Aenean condimentum, nulla at fermentum sagittis, tellus nisi suscipit velit, vel sollicitudin odio ligula a odio. Integer eget efficitur massa, in sodales velit. Nunc fermentum consequat scelerisque. Morbi elementum tristique faucibus. Nulla vel lectus non justo euismod varius. Vivamus id nisl sit amet odio tincidunt fringilla. Pellentesque odio odio, vulputate in risus eu, lacinia porttitor lorem. Nunc posuere tempus est, imperdiet suscipit odio maximus id. Nam eget feugiat magna.

--- a/spec/requests/api/v0/articles_spec.rb
+++ b/spec/requests/api/v0/articles_spec.rb
@@ -251,6 +251,52 @@ RSpec.describe "Api::V0::Articles", type: :request do
         end.to change(Article, :count).by(1)
         expect(Article.find(json_response["id"]).organization).to eq(user.organization)
       end
+
+      it "creates an article with a main/cover image" do
+        image_url = "https://dummyimage.com/100x100"
+        expect do
+          post_article(
+            title: Faker::Book.title + rand(100).to_s,
+            body_markdown: "Yo ho ho #{rand(100)}",
+            main_image: image_url,
+          )
+          expect(response).to have_http_status(:created)
+        end.to change(Article, :count).by(1)
+        expect(Article.find(json_response["id"]).main_image).to eq(image_url)
+      end
+
+      it "creates an article with a main/cover image in the front matter" do
+        image_url = "https://dummyimage.com/100x100"
+        body_markdown = file_fixture("article_published_cover_image.txt").read
+        expect do
+          post_article(body_markdown: body_markdown)
+          expect(response).to have_http_status(:created)
+        end.to change(Article, :count).by(1)
+        expect(Article.find(json_response["id"]).main_image).to eq(image_url)
+      end
+
+      it "creates an article with a canonical url" do
+        canonical_url = "https://example.com/"
+        expect do
+          post_article(
+            title: Faker::Book.title + rand(100).to_s,
+            body_markdown: "Yo ho ho #{rand(100)}",
+            canonical_url: canonical_url,
+          )
+          expect(response).to have_http_status(:created)
+        end.to change(Article, :count).by(1)
+        expect(Article.find(json_response["id"]).canonical_url).to eq(canonical_url)
+      end
+
+      it "creates an article with a canonical url in the front matter" do
+        canonical_url = "https://example.com/"
+        body_markdown = file_fixture("article_published_canonical_url.txt").read
+        expect do
+          post_article(body_markdown: body_markdown)
+          expect(response).to have_http_status(:created)
+        end.to change(Article, :count).by(1)
+        expect(Article.find(json_response["id"]).canonical_url).to eq(canonical_url)
+      end
     end
   end
 

--- a/spec/requests/api/v0/comments_spec.rb
+++ b/spec/requests/api/v0/comments_spec.rb
@@ -1,7 +1,6 @@
-# http://localhost:3000/api/comments?a_id=23
 require "rails_helper"
 
-RSpec.describe "CommentsApi", type: :request do
+RSpec.describe "Api::V0::Comments", type: :request do
   let(:article) { create(:article) }
 
   before do
@@ -11,7 +10,8 @@ RSpec.describe "CommentsApi", type: :request do
 
   describe "GET /api/comments" do
     it "returns not found if inproper article id" do
-      expect { get "/api/comments?a_id=gobbledygook" }.to raise_error(ActiveRecord::RecordNotFound)
+      get "/api/comments?a_id=gobbledygook"
+      expect(response).to have_http_status(:not_found)
     end
 
     it "returns comments for article passed" do

--- a/spec/requests/api/v0/podcasts_episodes_spec.rb
+++ b/spec/requests/api/v0/podcasts_episodes_spec.rb
@@ -31,10 +31,8 @@ RSpec.describe "Api::V0::PodcastEpisodes", type: :request do
     end
 
     it "returns not found if the username does not exist" do
-      invalid_request = lambda do
-        get "/api/podcast_episodes?username=foobar"
-      end
-      expect(invalid_request).to raise_error(ActiveRecord::RecordNotFound)
+      get "/api/podcast_episodes?username=foobar"
+      expect(response).to have_http_status(:not_found)
     end
   end
 end

--- a/spec/requests/podcast_episodes_api_spec.rb
+++ b/spec/requests/podcast_episodes_api_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe "ArticlesApi", type: :request, vcr: vcr_option do
     end
 
     it "returns nothing is passed invalid podcast slug" do
-      expect { get "/api/podcast_episodes?username=nothing_#{rand(1_000_000_000_000_000)}" }.
-        to raise_error(ActiveRecord::RecordNotFound)
+      get "/api/podcast_episodes?username=nothing_#{rand(1_000_000_000_000_000)}"
+      expect(response).to have_http_status(:not_found)
     end
   end
 end

--- a/spec/support/api_analytics_shared_examples.rb
+++ b/spec/support/api_analytics_shared_examples.rb
@@ -13,8 +13,8 @@ RSpec.shared_examples "GET /api/analytics/:endpoint authorization examples" do |
   context "when an invalid token is given" do
     before { get "/api/analytics/#{endpoint}?#{params}", headers: { "api-key" => "abadskajdlsak" } }
 
-    it "renders an error message: 'Not authorized' in JSON" do
-      expect(JSON.parse(response.body)["error"]).to eq "Not authorized"
+    it "renders an error message: 'unauthorized' in JSON" do
+      expect(JSON.parse(response.body)["error"]).to eq "unauthorized"
     end
 
     it "has a status 401" do
@@ -25,8 +25,8 @@ RSpec.shared_examples "GET /api/analytics/:endpoint authorization examples" do |
   context "when a valid token is given but the user is not a pro" do
     before { get "/api/analytics/#{endpoint}?#{params}", headers: { "api-key" => "abadskajdlsak" } }
 
-    it "renders an error message: 'Not authorized' in JSON" do
-      expect(JSON.parse(response.body)["error"]).to eq "Not authorized"
+    it "renders an error message: 'unauthorized' in JSON" do
+      expect(JSON.parse(response.body)["error"]).to eq "unauthorized"
     end
 
     it "has a status 401" do
@@ -47,8 +47,8 @@ RSpec.shared_examples "GET /api/analytics/:endpoint authorization examples" do |
       get "/api/analytics/#{endpoint}?organization_id=#{org.id}#{params}", headers: { "api-key" => pro_api_token.secret }
     end
 
-    it "renders an error message: 'Not authorized' in JSON" do
-      expect(JSON.parse(response.body)["error"]).to eq "Not authorized"
+    it "renders an error message: 'unauthorized' in JSON" do
+      expect(JSON.parse(response.body)["error"]).to eq "unauthorized"
     end
 
     it "has a status 401" do

--- a/spec/system/articles/user_creates_an_article_spec.rb
+++ b/spec/system/articles/user_creates_an_article_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe "Creating an article with the editor", type: :system do
+  let(:user) { create(:user) }
+  let!(:article_body) { file_fixture("article_published.txt").read }
+
+  before do
+    sign_in user
+  end
+
+  it "creates a new article", js: true, retry: 3 do
+    visit new_path
+    fill_in "article_body_markdown", with: article_body
+    click_button "SAVE CHANGES"
+    expect(page).to have_selector("header h1", text: "Sample Article")
+  end
+end

--- a/spec/system/articles/user_creates_an_article_spec.rb
+++ b/spec/system/articles/user_creates_an_article_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Creating an article with the editor", type: :system do
   let(:user) { create(:user) }
-  let!(:article_body) { file_fixture("article_published.txt").read }
+  let!(:template) { file_fixture("article_published.txt").read }
 
   before do
     sign_in user
@@ -10,7 +10,7 @@ RSpec.describe "Creating an article with the editor", type: :system do
 
   it "creates a new article", js: true, retry: 3 do
     visit new_path
-    fill_in "article_body_markdown", with: article_body
+    fill_in "article_body_markdown", with: template
     click_button "SAVE CHANGES"
     expect(page).to have_selector("header h1", text: "Sample Article")
   end

--- a/spec/system/articles/user_edits_an_article_spec.rb
+++ b/spec/system/articles/user_edits_an_article_spec.rb
@@ -1,37 +1,39 @@
 require "rails_helper"
 
 RSpec.describe "Editing with an editor", type: :system do
-  let(:user) { create(:user) }
-  let(:dir) { "../../support/fixtures/sample_article.txt" }
-  let(:template) { File.read(File.join(File.dirname(__FILE__), dir)) }
-  let(:article) do
-    create(:article,
-           user_id: user.id,
-           body_markdown: template.gsub("false", "true"),
-           body_html: "")
-  end
+  let!(:user) { create(:user) }
+  let!(:template) { file_fixture("article_published.txt").read }
+  let(:article) { create(:article, user: user, body_markdown: template) }
 
   before do
     sign_in user
   end
 
-  it "user click the edit-post button", js: true, retry: 3 do
+  it "user clicks the edit button", js: true, retry: 3 do
     link = "/#{user.username}/#{article.slug}"
     visit link
     find("#action-space").click
     expect(page).to have_current_path(link + "/edit")
   end
 
-  xit "user preview their edit post" do
+  it "user previews their changes", js: true, retry: 3 do
     visit "/#{user.username}/#{article.slug}/edit"
-    click_button("previewbutt")
-    expect(page).to have_text(template[-200..-1])
+    fill_in "article_body_markdown", with: template.gsub("Suspendisse", "Yooo")
+    click_button("PREVIEW")
+    expect(page).to have_text("Yooo")
   end
 
-  xit "user update their post", retry: 3 do
+  it "user updates their post", js: true, retry: 3 do
+    visit "/#{user.username}/#{article.slug}/edit"
+    fill_in "article_body_markdown", with: template.gsub("Suspendisse", "Yooo")
+    click_button("SAVE CHANGES")
+    expect(page).to have_text("Yooo")
+  end
+
+  it "user unpublishes their post", js: true, retry: 3 do
     visit "/#{user.username}/#{article.slug}/edit"
     fill_in "article_body_markdown", with: template.gsub("true", "false")
-    click_button("article-submit")
+    click_button("SAVE CHANGES")
     expect(page).to have_text("Unpublished Post.")
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

This PR accomplishes two main things:

* moves the editor to use regular controllers instead of the articles API controllers
* reworks the articles API to use the API key and adds a slightly better interface to the outside world

A few points of discussion:

* should the description be part of the public API? Currently it's either taken from the front matter or from the article's body:

https://github.com/thepracticaldev/dev.to/blob/master/app/models/article.rb#L491

* the collection seems to be reset if there's a title in the front matter, is this correct or a bug?:

https://github.com/thepracticaldev/dev.to/blob/master/app/models/article.rb#L492

* should we send a notification if the previously unpublished article becomes published during the update?

see https://github.com/thepracticaldev/dev.to/blob/master/app/services/article_creation_service.rb#L20

## Related Tickets & Documents

Refers to #911 
Closes #2040

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
