### PR TITLE
Use correct org id when updating articles as an admin

### DIFF
--- a/app/controllers/api/v0/articles_controller.rb
+++ b/app/controllers/api/v0/articles_controller.rb
@@ -80,7 +80,7 @@ module Api
 
       def article_params
         params["article"].transform_keys!(&:underscore)
-        params["article"]["organization_id"] = (@user.organization_id if params["article"]["post_under_org"])
+        params["article"]["organization_id"] = (@article&.organization_id || @article&.user&.organization_id || @user.organization_id if params["article"]["post_under_org"])
         if params["article"]["series"].present?
           params["article"]["collection_id"] = Collection.find_series(params["article"]["series"], @user)&.id
         elsif params["article"]["series"] == ""

--- a/spec/requests/api/v0/articles_spec.rb
+++ b/spec/requests/api/v0/articles_spec.rb
@@ -183,6 +183,18 @@ RSpec.describe "Api::V0::Articles", type: :request do
       expect(Article.last.title).to eq(new_title)
     end
 
+    it "does not modify the organization ID when updating someone else's article as an admin" do
+      article_org = create(:organization)
+      article.update_columns(organization_id: article_org.id, user_id: user2.id)
+      new_org = create(:organization)
+      user1.update_column(:organization_id, new_org.id)
+      user1.add_role(:super_admin)
+      put "/api/articles/#{article.id}", params: {
+        article: { publish_under_org: true }
+      }
+      expect(article.organization_id).to eq article_org.id
+    end
+
     it "allows collection to be assigned via api" do
       new_title = "NEW TITLE #{rand(100)}"
       collection = Collection.create(user_id: article.user_id, slug: "yoyoyo")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Fixes a bug where an article's `organization_id` would be flipped incorrectly when updating an article as an admin.