### PR TITLE
Fix user liquid tag text color

### DIFF
--- a/app/assets/stylesheets/ltags/UserTag.scss
+++ b/app/assets/stylesheets/ltags/UserTag.scss
@@ -1,7 +1,8 @@
 @import 'variables';
 @import 'mixins';
 .ltag__user__link {
-  color: #111111 !important;
+  color: $black;
+  color: var(--theme-color, $black);
   &:active {
     opacity: 0.7;
   }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
This commit fixes the styles for the user liquid tag to match the
current theme.

## Related Tickets & Documents
Closes https://github.com/thepracticaldev/dev.to/issues/2847

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
<img width="850" alt="Screen Shot 2019-05-15 at 6 25 50 PM" src="https://user-images.githubusercontent.com/25459752/57813758-4b363700-773f-11e9-86ae-2d62bd4ded70.png">

<img width="859" alt="Screen Shot 2019-05-15 at 6 25 19 PM" src="https://user-images.githubusercontent.com/25459752/57813772-55583580-773f-11e9-9dc2-9a4bb1239edc.png">


## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

