### PR TITLE
Add description to articles create/update API

### DIFF
--- a/app/controllers/api/v0/articles_controller.rb
+++ b/app/controllers/api/v0/articles_controller.rb
@@ -73,7 +73,7 @@ module Api
       def article_params
         allowed_params = [
           :title, :body_markdown, :published, :series, :publish_under_org,
-          :main_image, :canonical_url, tags: []
+          :main_image, :canonical_url, :description, tags: []
         ]
         params.require(:article).permit(allowed_params)
       end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -474,7 +474,6 @@ class Article < ApplicationRecord
   end
 
   def evaluate_front_matter(front_matter)
-    token_msg = body_text[0..80] + "..."
     self.title = front_matter["title"] if front_matter["title"].present?
     if front_matter["tags"].present?
       ActsAsTaggableOn::Taggable::Cache.included(Article)
@@ -488,7 +487,7 @@ class Article < ApplicationRecord
     self.published_at = parsed_date(front_matter["date"]) if published
     self.main_image = front_matter["cover_image"] if front_matter["cover_image"].present?
     self.canonical_url = front_matter["canonical_url"] if front_matter["canonical_url"].present?
-    self.description = front_matter["description"] || token_msg
+    self.description = front_matter["description"] || description || "#{body_text[0..80]}..."
     self.collection_id = nil if front_matter["title"].present?
     self.collection_id = Collection.find_series(front_matter["series"], user).id if front_matter["series"].present?
     self.automatically_renew = front_matter["automatically_renew"] if front_matter["automatically_renew"].present? && tag_list.include?("hiring")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

Enable API to add or update an article description

## Related Tickets & Documents

#2844

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
