### PR TITLE
Articles update API: send publishing notification and set edited_at

### DIFF
--- a/app/services/articles/updater.rb
+++ b/app/services/articles/updater.rb
@@ -33,6 +33,10 @@ module Articles
 
       article.update!(article_params)
 
+      # send notification only the first time an article is published
+      send_notification = article.published && article.saved_change_to_published_at.present?
+      Notification.send_to_followers(article, "Published") if send_notification
+
       article.decorate
     end
 

--- a/app/services/articles/updater.rb
+++ b/app/services/articles/updater.rb
@@ -31,6 +31,10 @@ module Articles
         article_params.delete(:tags)
       end
 
+      # updated edited time only if already published and not edited by an admin
+      update_edited_at = article.user == user && article.published
+      article_params[:edited_at] = Time.current if update_edited_at
+
       article.update!(article_params)
 
       # send notification only the first time an article is published


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

This PR adds two missing things from the Articles update API:

* sends the "published" notification only the first time the article gets published
* sets `edited_at` when appropriate

## Related Tickets & Documents

* https://github.com/thepracticaldev/dev.to/pull/2844#issuecomment-493140089
* #2844

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
