### PR TITLE
Ensure the collection always belongs to the article owner

### DIFF
--- a/app/services/articles/updater.rb
+++ b/app/services/articles/updater.rb
@@ -20,7 +20,7 @@ module Articles
       # the client can change the series the article belongs to
       if article_params.key?(:series)
         series = article_params[:series]
-        article.collection = Collection.find_series(series, user) if series.present?
+        article.collection = Collection.find_series(series, article.user) if series.present?
         article.collection = nil if series.nil?
       end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

Make sure the created collection always belongs to the article's owner. Also avoid triggering a 422 error in case the API user is the super admin, because of this https://github.com/thepracticaldev/dev.to/blob/master/app/models/article.rb#L526

## Related Tickets & Documents

#2844 

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
