### PR TITLE
Don't fail when twitch returns no user data, fixes #2784

### DIFF
--- a/app/services/streams/twitch_webhook/register.rb
+++ b/app/services/streams/twitch_webhook/register.rb
@@ -14,6 +14,8 @@ module Streams
 
       def call
         user_resp = HTTParty.get("https://api.twitch.tv/helix/users", query: { login: user.twitch_username }, headers: authentication_request_headers)
+        return unless user_resp["data"]
+
         twitch_user_id = user_resp["data"].first["id"]
 
         HTTParty.post(

--- a/spec/services/streams/twitch_webhook/register_spec.rb
+++ b/spec/services/streams/twitch_webhook/register_spec.rb
@@ -17,24 +17,46 @@ RSpec.describe Streams::TwitchWebhook::Register, type: :service do
         "hub.secret" => ApplicationConfig["TWITCH_WEBHOOK_SECRET"]
       }
     end
+
+    let(:expected_twitch_user_params) { { login: "test-username" } }
+
     let!(:twitch_webhook_registration_stubbed_route) do
       stub_request(:post, "https://api.twitch.tv/helix/webhooks/hub").
         with(body: URI.encode_www_form(expected_twitch_webhook_params), headers: expected_headers).
         and_return(status: 204)
     end
 
-    let(:expected_twitch_user_params) { { login: "test-username" } }
-    let!(:twitch_user_stubbed_route) do
-      stub_request(:get, "https://api.twitch.tv/helix/users").
-        with(query: expected_twitch_user_params, headers: expected_headers).
-        and_return(body: { data: [{ id: 654_321 }] }.to_json, headers: { "Content-Type" => "application/json" })
+    context "when twitch returns data" do
+      let!(:twitch_user_stubbed_route) do
+        stub_request(:get, "https://api.twitch.tv/helix/users").
+          with(query: expected_twitch_user_params, headers: expected_headers).
+          and_return(body: { data: [{ id: 654_321 }] }.to_json, headers: { "Content-Type" => "application/json" })
+      end
+
+      it "registers for webhooks" do
+        described_class.call(user, twitch_access_token_get)
+
+        expect(twitch_webhook_registration_stubbed_route).to have_been_requested
+        expect(twitch_user_stubbed_route).to have_been_requested
+      end
     end
 
-    it "registers for webhooks" do
-      described_class.call(user, twitch_access_token_get)
+    context "when twitch return no data" do
+      let!(:twitch_user_stubbed_route) do
+        stub_request(:get, "https://api.twitch.tv/helix/users").
+          with(query: expected_twitch_user_params, headers: expected_headers).
+          and_return(body: {}.to_json, headers: { "Content-Type" => "application/json" })
+      end
 
-      expect(twitch_webhook_registration_stubbed_route).to have_been_requested
-      expect(twitch_user_stubbed_route).to have_been_requested
+      it "doesn't fail when twitch doesn't return data" do
+        described_class.call(user, twitch_access_token_get)
+        expect(twitch_user_stubbed_route).to have_been_requested
+      end
+
+      it "doesn't register for webhooks" do
+        described_class.call(user, twitch_access_token_get)
+        expect(twitch_webhook_registration_stubbed_route).not_to have_been_requested
+      end
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
- don't try to register a webhook when twitch API doesn't return any user data
- added a couple of specs for this case

## Related Tickets & Documents
#2784 

I mentioned an optimization in the issue description, I'll do in another pr along with the refactoring.
