### PR TITLE
Move updating twitch username to a separate action #2784

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,7 +9,7 @@ class UsersController < ApplicationController
       return redirect_to "/enter"
     end
     set_user
-    set_tabs(params["tab"])
+    set_tabs(params["tab"] || "profile")
     handle_settings_tab
   end
 

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -11,6 +11,10 @@ class UserPolicy < ApplicationPolicy
     current_user?
   end
 
+  def update_twitch_username?
+    current_user?
+  end
+
   def update_language_settings?
     current_user?
   end

--- a/app/views/users/_integrations.html.erb
+++ b/app/views/users/_integrations.html.erb
@@ -7,11 +7,11 @@
   <%= javascript_pack_tag "githubRepos", defer: true %>
 <% end %>
 
-<%= form_for(@user) do |f| %>
+<%= form_tag users_update_twitch_username_path do |f| %>
   <h2>Live Streaming (Beta)</h2>
   <div class="field">
-    <%= f.label :twitch_username, "Twitch Username" %>
-    <%= f.text_field :twitch_username %>
+    <%= label_tag "user[twitch_username]", "Twitch Username" %>
+    <%= text_field_tag "user[twitch_username]", @user.twitch_username %>
   </div>
   <p><em>Add your Twitch username, and then checkout <a href="/live/<%= @user.username %>">dev.to/live/<%= @user.username %></a>.</em></p>
   <p><em>It's a new thing we're trying out. Soon we'll be able to indicate when any community member is currently streaming.</em></p>

--- a/app/views/users/_integrations.html.erb
+++ b/app/views/users/_integrations.html.erb
@@ -16,5 +16,5 @@
   <p><em>Add your Twitch username, and then checkout <a href="/live/<%= @user.username %>">dev.to/live/<%= @user.username %></a>.</em></p>
   <p><em>It's a new thing we're trying out. Soon we'll be able to indicate when any community member is currently streaming.</em></p>
 
-  <%= f.submit "SUBMIT", class: "cta" %>
+  <%= submit_tag "SUBMIT", class: "cta" %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -203,6 +203,7 @@ Rails.application.routes.draw do
 
   # Settings
   post "users/update_language_settings" => "users#update_language_settings"
+  post "users/update_twitch_username" => "users#update_twitch_username"
   post "users/join_org" => "users#join_org"
   post "users/leave_org" => "users#leave_org"
   post "users/add_org_admin" => "users#add_org_admin"

--- a/spec/system/user/user_edits_integrations_spec.rb
+++ b/spec/system/user/user_edits_integrations_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "User edits their integrations", type: :system, js: true do
 
       expect(page).to have_content "Your profile was successfully updated."
 
-      click_link "Integrations"
+      visit "/settings/integrations"
       expect(find_field("Twitch Username").value).to eq "TestTwitchUser"
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
- attempt to register a twitch webhook (schedule a job) only when `twitch_username` changes instead of every time when a user updates their profile
- moved `update_twitch_username` to a separate action
- DRYed `UsersController` a bit
- specs for updating twitch username
- redirect to `/settings/integrations` after updating `twitch_username`

## Related Tickets & Documents
#2784 
