### PR TITLE
Fixes Twitter video control bug

### DIFF
--- a/app/views/liquids/_tweet.html.erb
+++ b/app/views/liquids/_tweet.html.erb
@@ -7,7 +7,7 @@
           <img src="/assets/play-butt.svg" class="ltag__twitter-tweet__play-butt" alt="Play butt">
         </div>
         <div class='ltag__twitter-tweet__video'>
-          <video loop>
+          <video loop controls>
             <source src="<%= tweet.extended_entities_serialized[:media].first[:video_info][:variants].last[:url] %>"
               type="<%= tweet.extended_entities_serialized[:media].first[:video_info][:variants].last[:content_type] %>">
           </video>

--- a/spec/support/fixtures/approvals/liquid_tweet_tag_spec.approved.html
+++ b/spec/support/fixtures/approvals/liquid_tweet_tag_spec.approved.html
@@ -6,7 +6,7 @@
         <div class="ltag__twitter-tweet__media--video-preview">
           <img src="https://pbs.twimg.com/tweet_video_thumb/DiPm8-WXcAI3_qS.jpg" alt="unknown tweet media content" /><img src="/assets/play-butt.svg" class="ltag__twitter-tweet__play-butt" alt="Play butt" /></div>
         <div class="ltag__twitter-tweet__video">
-          <video loop=""><source src="https://video.twimg.com/tweet_video/DiPm8-WXcAI3_qS.mp4" type="video/mp4"></source></video></div>
+          <video loop="" controls=""><source src="https://video.twimg.com/tweet_video/DiPm8-WXcAI3_qS.mp4" type="video/mp4"></source></video></div>
       </div>
 
   <div class="ltag__twitter-tweet__main" data-url="https://twitter.com/thepracticaldev/status/1018911886862057472">


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
The `controls` attribute adds video controls, like play, pause, and volume to an HTML <video> element.

## Related Tickets & Documents
#2673 
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
User should now be able to pause, mute and play embedded video tweets.
 
## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

closes #2673 .