### PR TITLE
Update Slack Notifications

### DIFF
--- a/app/observers/application_observer.rb
+++ b/app/observers/application_observer.rb
@@ -2,7 +2,7 @@ class ApplicationObserver < ActiveRecord::Observer
   def warned_user_ping(activity)
     return unless activity.user.warned == true
 
-    SlackBot.delay.ping "@#{activity.user.username} just posted.\nThey've been warned since #{activity.user.roles.where(name: 'warned')[0].updated_at.strftime('%d %B %Y')}\nhttps://dev.to#{activity.path}",
+    SlackBot.delay.ping "@#{activity.user.username} just posted.\nManage User- https://dev.to/internal/users/#{activity.user.id}\nPost- https://dev.to#{activity.path}",
                         channel: "warned-user-activity",
                         username: "sloan_watch_bot",
                         icon_emoji: ":sloan:"

--- a/app/observers/application_observer.rb
+++ b/app/observers/application_observer.rb
@@ -2,7 +2,7 @@ class ApplicationObserver < ActiveRecord::Observer
   def warned_user_ping(activity)
     return unless activity.user.warned == true
 
-    SlackBot.delay.ping "@#{activity.user.username} just posted.\nManage User- https://dev.to/internal/users/#{activity.user.id}\nPost- https://dev.to#{activity.path}",
+    SlackBot.delay.ping "Activity: https://dev.to/#{activity.path}\nManage @#{activity.user.username}: https://dev.to/internal/users/#{activity.user.id}",
                         channel: "warned-user-activity",
                         username: "sloan_watch_bot",
                         icon_emoji: ":sloan:"

--- a/app/observers/article_observer.rb
+++ b/app/observers/article_observer.rb
@@ -1,9 +1,8 @@
 class ArticleObserver < ApplicationObserver
-  def after_create(article)
+  def after_save(article)
     return if Rails.env.development?
 
     ping_new_article(article)
-    warned_user_ping(article)
   rescue StandardError => e
     Rails.logger.error(e)
   end

--- a/app/observers/article_observer.rb
+++ b/app/observers/article_observer.rb
@@ -2,13 +2,13 @@ class ArticleObserver < ApplicationObserver
   def after_create(article)
     return if Rails.env.development?
 
-    ping_new_article
+    ping_new_article(article)
     warned_user_ping(article)
   rescue StandardError => e
     Rails.logger.error(e)
   end
 
-  def ping_new_article
+  def ping_new_article(article)
     return unless article.published && article.published_at > 30.seconds.ago
 
     SlackBot.delay.ping "New Article Published: #{article.title}\nhttps://dev.to#{article.path}",

--- a/app/observers/article_observer.rb
+++ b/app/observers/article_observer.rb
@@ -2,15 +2,18 @@ class ArticleObserver < ApplicationObserver
   def after_create(article)
     return if Rails.env.development?
 
-    if article.published && article.published_at > 30.seconds.ago
-      SlackBot.delay.ping "New Article Published: #{article.title}\nhttps://dev.to#{article.path}",
-                          channel: "activity",
-                          username: "article_bot",
-                          icon_emoji: ":writing_hand:"
-
-    end
+    ping_new_article
     warned_user_ping(article)
   rescue StandardError => e
     Rails.logger.error(e)
+  end
+
+  def ping_new_article
+    return unless article.published && article.published_at > 30.seconds.ago
+
+    SlackBot.delay.ping "New Article Published: #{article.title}\nhttps://dev.to#{article.path}",
+                        channel: "activity",
+                        username: "article_bot",
+                        icon_emoji: ":writing_hand:"
   end
 end

--- a/app/observers/article_observer.rb
+++ b/app/observers/article_observer.rb
@@ -1,5 +1,5 @@
 class ArticleObserver < ApplicationObserver
-  def after_save(article)
+  def after_create(article)
     return if Rails.env.development?
 
     if article.published && article.published_at > 30.seconds.ago

--- a/app/observers/comment_observer.rb
+++ b/app/observers/comment_observer.rb
@@ -1,5 +1,5 @@
 class CommentObserver < ApplicationObserver
-  def after_save(comment)
+  def after_create(comment)
     return if Rails.env.development?
 
     warned_user_ping(comment)

--- a/spec/observers/article_observer_spec.rb
+++ b/spec/observers/article_observer_spec.rb
@@ -7,13 +7,12 @@ RSpec.describe ArticleObserver, type: :observer do
     allow(SlackBot).to receive(:ping).and_return(true)
   end
 
-  it "pings slack if user with warned role creates an article" do
-    user.add_role :warned
+  it "pings slack #activity if new article is created" do
     Article.observers.enable :article_observer do
       run_background_jobs_immediately do
         create(:article, user_id: user.id)
       end
     end
-    expect(SlackBot).to have_received(:ping).twice
+    expect(SlackBot).to have_received(:ping).once
   end
 end

--- a/spec/observers/comment_observer_spec.rb
+++ b/spec/observers/comment_observer_spec.rb
@@ -17,6 +17,6 @@ RSpec.describe CommentObserver, type: :observer do
         end
       end
     end
-    expect(SlackBot).to have_received(:ping).twice
+    expect(SlackBot).to have_received(:ping).once
   end
 end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

Note:  I'm also not totally sure if I updated this properly but it passed all the tests so figured it wouldn't break anything and we can wait to see. Also, are observers actually deprecated? Seems to still be working w/ Slack so not sure there..

- Previously we were displaying when the 'warned' role was created, which is the wrong date. We don't actually track the date of when a user is warned so I removed that. 
- There was a lot of noise in slack bc comments/articles records sometimes get updated, even if the user isn't updating the article or comment. This changes the observer to look for after_create instead of after_save. 
- I think we can rely on community mods if people post inappropriate content by updating existing comments (that wouldn't send a slack alert to us).
- Refactors the article observer based on codeclimate response


