### PR TITLE
Add awesome_print to development/test gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -123,6 +123,7 @@ group :development do
 end
 
 group :development, :test do
+  gem "awesome_print", "~> 1.8" # Great Ruby dubugging companion: pretty print Ruby objects to visualize their structure
   gem "capybara", "~> 3.19" # Capybara is an integration testing tool for rack based web applications
   gem "faker", "~> 1.9" # A library for generating fake data such as names, addresses, and phone numbers
   gem "parallel_tests", "~> 2.29" # Run Test::Unit / RSpec / Cucumber / Spinach in parallel

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,7 @@ GEM
     ast (2.4.0)
     autoprefixer-rails (9.5.1.1)
       execjs
+    awesome_print (1.8.0)
     aws-eventstream (1.0.3)
     aws-partitions (1.154.0)
     aws-sdk-core (3.48.6)
@@ -836,6 +837,7 @@ DEPENDENCIES
   ancestry (~> 3.0)
   approvals (~> 0.0)
   autoprefixer-rails (~> 9.5)
+  awesome_print (~> 1.8)
   aws-sdk-lambda (~> 1.22)
   better_errors (~> 2.5)
   binding_of_caller (~> 0.8)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

This PR adds the gem [awesome_print](https://rubygems.org/gems/awesome_print) to aid debugging locally. An example:

```ruby
[3] pry(main)> p Notification
Notification(id: integer, action: string, created_at: datetime, json_data: jsonb, notifiable_id: integer, notifiable_type: string, notified_at: datetime, organization_id: integer, read: boolean, updated_at: datetime, user_id: integer)
=> Notification(id: integer, action: string, created_at: datetime, json_data: jsonb, notifiable_id: integer, notifiable_type: string, notified_at: datetime, organization_id: integer, read: boolean, updated_at: datetime, user_id: integer)
[4] pry(main)> ap Notification
class Notification < ApplicationRecord {
               :id => :integer,
           :action => :string,
       :created_at => :datetime,
        :json_data => :jsonb,
    :notifiable_id => :integer,
  :notifiable_type => :string,
      :notified_at => :datetime,
  :organization_id => :integer,
             :read => :boolean,
       :updated_at => :datetime,
          :user_id => :integer
}
=> nil
```

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
