### PR TITLE
Add Anchor Links To The Post Editor Guide

### DIFF
--- a/app/views/pages/_editor_guide_text.html.erb
+++ b/app/views/pages/_editor_guide_text.html.erb
@@ -21,6 +21,14 @@
 
     <h3><strong>Links</strong></h3>
     <p><a href="https://dev.to">I'm an inline link</a>: <code>[I'm an inline link](put-link-here)</code></p>
+    <p><a name="anchored">Anchored links</a> (For things like a Table of Contents)</p>
+    <pre>
+      ## Table Of Contents
+        * [Chapter 1](#chapter-1)
+        * [Chapter 2](#chapter-2)
+
+      ### Chapter 1 <%= "<a name=\"chapter-1\"></a>" %>
+    </pre>
 
     <h3><strong>Inline Images</strong></h3>
     <p>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Added an explanation about how to setup anchor links(for things like a Table of Contents) to the blog post Editor Guide. When trying to figure out how to do this myself I ended up messaging a few people and was finally pointed towards [this comment](https://dev.to/rhymes/comment/5apb) from @rhymes. I figured I am probably not the only one that would find this information useful so I decided to add it to the Editor Guide. Let me know what you think!  

## Related Tickets & Documents
NONE

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
<img width="838" alt="Screen Shot 2019-05-19 at 6 40 27 PM" src="https://user-images.githubusercontent.com/1813380/57989913-08d66800-7a67-11e9-80b0-28ba24d65dea.png">

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

![](https://media0.giphy.com/media/3oz8xOu5Gw81qULRh6/giphy.gif)
