### PR TITLE
Fix date related spec failures

### DIFF
--- a/spec/system/articles/user_visits_an_article_spec.rb
+++ b/spec/system/articles/user_visits_an_article_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Views an article", type: :system do
       article.update_column(:published_at, Time.zone.parse(timestamp))
     end
 
-    it "shows the readable publish date" do
+    it "shows the readable publish date", js: true do
       visit "/#{user.username}/#{article.slug}"
       expect(page).to have_selector("article time", text: "Mar 4")
     end

--- a/spec/system/homepage/user_visits_homepage_articles_spec.rb
+++ b/spec/system/homepage/user_visits_homepage_articles_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "User visits a homepage", type: :system do
         expect(page).to have_selector(".big-article", visible: true)
       end
 
-      it "shows the main article readable date" do
+      it "shows the main article readable date", js: true do
         expect(page).to have_selector(".big-article time", text: "Mar 4")
       end
 
@@ -43,7 +43,7 @@ RSpec.describe "User visits a homepage", type: :system do
         expect(page).not_to have_text(bad_article.title)
       end
 
-      it "shows all articles dates" do
+      it "shows all articles dates", js: true do
         expect(page).to have_selector(".single-article time", text: "Mar 4", count: 2)
       end
 


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description

![](https://d1sz9tkli0lfjq.cloudfront.net/items/0s2y2Y3m1y2m3c3W0x02/Image%202019-05-20%20at%201.48.19%20PM.png)

Zonebie is the cause of our random spec failures (ie "American Samoa"). Enabling JS on those test will enable the display date be properly updated to browser's locale.
## Related Tickets & Documents
n/a
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
n/a
## Added to documentation?

- [x] no documentation needed