### PR TITLE
improve contrast of badge-reward-message

### DIFF
--- a/app/assets/stylesheets/notifications.scss
+++ b/app/assets/stylesheets/notifications.scss
@@ -85,6 +85,7 @@
             p.badge-reward-message {
               margin: 8px auto;
               width: 90%;
+              color: #000;
             }
           }
           .follow-action-button {

--- a/app/assets/stylesheets/notifications.scss
+++ b/app/assets/stylesheets/notifications.scss
@@ -85,7 +85,7 @@
             p.badge-reward-message {
               margin: 8px auto;
               width: 90%;
-              color: #000;
+              @include themeable(color, theme-color, $black);
             }
           }
           .follow-action-button {


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Documentation Update

## Description
Improve text-background contrast for Dev.to badges in notifications

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/issues/2883

The bug image is only there for testing purposes (based on which badge I triggered in dev). The only changes were made to the color of the badge message but not the actual content.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
<img width="1440" alt="Screen Shot 2019-05-21 at 9 34 55 AM" src="https://user-images.githubusercontent.com/6998954/58100701-23fec000-7bac-11e9-9289-b240a68d076e.png">
<img width="1440" alt="Screen Shot 2019-05-21 at 9 35 17 AM" src="https://user-images.githubusercontent.com/6998954/58100703-23fec000-7bac-11e9-8569-174720cb53ac.png">
<img width="1401" alt="Screen Shot 2019-05-21 at 9 35 43 AM" src="https://user-images.githubusercontent.com/6998954/58100704-24975680-7bac-11e9-9838-e27a1ffa9680.png">

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![color swatches](https://user-images.githubusercontent.com/6998954/58101043-ddf62c00-7bac-11e9-8998-23723941a26f.gif)
