### PR TITLE
Articles API: fix update org and add datetimes

### DIFF
--- a/app/services/articles/updater.rb
+++ b/app/services/articles/updater.rb
@@ -31,6 +31,9 @@ module Articles
         article_params.delete(:tags)
       end
 
+      # add organization if requested
+      article_params[:organization_id] = user.organization_id if article_params[:publish_under_org] == true
+
       # updated edited time only if already published and not edited by an admin
       update_edited_at = article.user == user && article.published
       article_params[:edited_at] = Time.current if update_edited_at

--- a/app/views/api/v0/articles/show.json.jbuilder
+++ b/app/views/api/v0/articles/show.json.jbuilder
@@ -15,10 +15,10 @@ json.comments_count     @article.comments_count
 json.positive_reactions_count @article.positive_reactions_count
 
 json.created_at         @article.created_at.utc.iso8601
-json.edited_at          @article.edited_at.utc.iso8601
-json.crossposted_at     @article.crossposted_at.utc.iso8601
-json.published_at       @article.published_at.utc.iso8601
-json.last_comment_at    @article.last_comment_at.utc.iso8601
+json.edited_at          @article.edited_at&.utc&.iso8601
+json.crossposted_at     @article.crossposted_at&.utc&.iso8601
+json.published_at       @article.published_at&.utc&.iso8601
+json.last_comment_at    @article.last_comment_at&.utc&.iso8601
 
 json.body_html @article.processed_html
 json.ltag_style(@article.liquid_tags_used.map { |ltag| Rails.application.assets["ltags/#{ltag}.css"].to_s.html_safe })

--- a/app/views/api/v0/articles/show.json.jbuilder
+++ b/app/views/api/v0/articles/show.json.jbuilder
@@ -3,7 +3,6 @@ json.id                 @article.id
 json.title              @article.title
 json.description        @article.description
 json.cover_image        cloud_cover_url @article.main_image
-json.published_at       @article.published_at
 json.readable_publish_date @article.readable_publish_date
 json.social_image       article_social_image_url(@article)
 json.tag_list           @article.cached_tag_list
@@ -14,7 +13,12 @@ json.url                @article.url
 json.canonical_url      @article.processed_canonical_url
 json.comments_count     @article.comments_count
 json.positive_reactions_count @article.positive_reactions_count
-json.published_timestamp @article.published_timestamp
+
+json.created_at         @article.created_at.utc.iso8601
+json.edited_at          @article.edited_at.utc.iso8601
+json.crossposted_at     @article.crossposted_at.utc.iso8601
+json.published_at       @article.published_at.utc.iso8601
+json.last_comment_at    @article.last_comment_at.utc.iso8601
 
 json.body_html @article.processed_html
 json.ltag_style(@article.liquid_tags_used.map { |ltag| Rails.application.assets["ltags/#{ltag}.css"].to_s.html_safe })

--- a/spec/requests/api/v0/articles_spec.rb
+++ b/spec/requests/api/v0/articles_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe "Api::V0::Articles", type: :request do
   end
 
   describe "GET /api/articles/:id" do
-    let(:article) { create(:article) }
+    let(:article) { create(:article, published: true) }
 
     it "gets article based on ID" do
       get "/api/articles/#{article.id}"
@@ -98,6 +98,19 @@ RSpec.describe "Api::V0::Articles", type: :request do
     it "contains tags as an array" do
       get "/api/articles/#{article.id}"
       expect(json_response["tags"]).to eq(article.decorate.cached_tag_list_array)
+    end
+
+    it "contains all the relevant datetimes" do
+      article.update_columns(
+        edited_at: 1.minute.from_now,
+        crossposted_at: 2.minutes.ago, last_comment_at: 30.seconds.ago
+      )
+      get "/api/articles/#{article.id}"
+      expect(json_response["created_at"]).to eq(article.created_at.utc.iso8601)
+      expect(json_response["edited_at"]).to eq(article.edited_at.utc.iso8601)
+      expect(json_response["crossposted_at"]).to eq(article.crossposted_at.utc.iso8601)
+      expect(json_response["published_at"]).to eq(article.published_at.utc.iso8601)
+      expect(json_response["last_comment_at"]).to eq(article.last_comment_at.utc.iso8601)
     end
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

It's not possible to assign an existing article to an org via API, this fixes that.
It also adds relevante datetimes to the article JSON resource, the same available in the export.

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
