### PR TITLE
Remove trailing dot from API token message [ci skip]

### DIFF
--- a/app/controllers/api_secrets_controller.rb
+++ b/app/controllers/api_secrets_controller.rb
@@ -7,7 +7,7 @@ class ApiSecretsController < ApplicationController
     @secret = ApiSecret.new(permitted_attributes(ApiSecret))
     @secret.user_id = current_user.id
     if @secret.save
-      flash[:notice] = "Your access token has been generated: #{@secret.secret}."
+      flash[:notice] = "Your access token has been generated: #{@secret.secret}"
     else
       flash[:error] = @secret.errors.full_messages.to_sentence
     end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

This removes the trailing dot from the API token creation message

