### PR TITLE
Add PWA target blank functionality

### DIFF
--- a/app/assets/javascripts/initializers/initializePWAFunctionality.js
+++ b/app/assets/javascripts/initializers/initializePWAFunctionality.js
@@ -15,5 +15,20 @@ function initializePWAFunctionality() {
       e.preventDefault();
       window.location.reload();
     };
+    var isTouchDevice = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini|DEV-Native-ios/i.test(navigator.userAgent);
+    if (!isTouchDevice) {
+      var domain = window.location.protocol + '//' + window.location.host
+      var links = document.getElementsByTagName("a");
+      for(var i=0, max=links.length; i<max; i++) {
+        var a = links[i];
+        if (a.href.indexOf(domain + '/') === 0
+          || a.href.indexOf('/') === 0
+          ) {
+            // Is internal link. Do nothing right now.
+        } else {
+          a.setAttribute('target', '_blank');    
+        }
+      }  
+    }
   }
 }


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Adds `target="_blank"` to anchor tags if the page is being rendered by a _desktop_ PWA. It seems like this is the appropriate functionality for a computer device, but touch screens should keep opening in the _pseudobrowser_.

Quick solution while we experiment with PWA functionality.