### PR TITLE
Article creation: fix improper error messaging

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -122,7 +122,6 @@ class ArticlesController < ApplicationController
     authorize Article
 
     @user = current_user
-
     @article = ArticleCreationService.new(@user, article_params_json).create!
 
     render json: if @article.persisted?

--- a/app/javascript/article-form/elements/errors.jsx
+++ b/app/javascript/article-form/elements/errors.jsx
@@ -3,13 +3,17 @@ import PropTypes from 'prop-types';
 
 const Errors = ({ errorsList }) => (
   <div className="articleform__errors">
-    <h2>😱 Heads up:</h2>
+    <h2>
+      <span role="img" aria-label="face screaming in fear">
+        😱
+      </span>{' '}
+      Heads up:
+    </h2>
     <ul>
       {Object.keys(errorsList).map(key => {
         return (
           <li>
-            {key}
-:
+            {key}: &nbsp;
             {errorsList[key]}
           </li>
         );
@@ -19,8 +23,7 @@ const Errors = ({ errorsList }) => (
 );
 
 Errors.propTypes = {
-  onChange: PropTypes.func.isRequired,
-  defaultValue: PropTypes.string.isRequired,
+  errorsList: PropTypes.objectOf(PropTypes.string).isRequired,
 };
 
 export default Errors;

--- a/app/services/article_creation_service.rb
+++ b/app/services/article_creation_service.rb
@@ -26,7 +26,7 @@ class ArticleCreationService
     article.organization = user.organization if publish_under_org
     article.collection = Collection.find_series(series, user) if series.present?
 
-    if article.save!
+    if article.save
       Notification.send_to_followers(article, "Published") if article.published
     end
     article.decorate


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

`ArticleCreationService` was raising an exception instead of sending back Rails errors.

I also fixed some linting errors in the errors component

## Related Tickets & Documents

Closes https://github.com/thepracticaldev/dev.to/issues/2868 and closes https://github.com/thepracticaldev/dev.to/issues/2916

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
