### PR TITLE
Fix bug to allow users to remove org from article

### DIFF
--- a/spec/requests/articles_update_spec.rb
+++ b/spec/requests/articles_update_spec.rb
@@ -38,6 +38,22 @@ RSpec.describe "ArticlesUpdate", type: :request do
     expect(article.reload.organization_id).to eq organization.id
   end
 
+  it "removes organization ID when user updates" do
+    article.update_column(:organization_id, organization.id)
+    put "/articles/#{article.id}", params: {
+      article: { post_under_org: false }
+    }
+    expect(article.reload.organization_id).to eq nil
+  end
+
+  it "does not modify the organization ID when the user neither adds nor removes the org" do
+    article.update_column(:organization_id, organization.id)
+    put "/articles/#{article.id}", params: {
+      article: { title: "new_title", body_markdown: "Yo ho ho#{rand(100)}", tag_list: "yo" }
+    }
+    expect(article.reload.organization_id).to eq organization.id
+  end
+
   it "does not modify the organization ID when updating someone else's article as an admin" do
     article.update_columns(organization_id: organization2.id, user_id: user2.id)
     user.add_role(:super_admin)


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
While changing up the code, we solved some problems with _adding_ orgs and not inappropriately removing them, but that left us with some bugs when deliberately removing an org.