### PR TITLE
Moved notifying followers to a separate ActiveJob #1996

### DIFF
--- a/app/jobs/notifications/notifiable_action_job.rb
+++ b/app/jobs/notifications/notifiable_action_job.rb
@@ -1,0 +1,13 @@
+module Notifications
+  class NotifiableActionJob < ApplicationJob
+    queue_as :send_notifiable_action_notification
+
+    def perform(notifiable_id, notifiable_type, action, service = Notifications::NotifiableAction::Send)
+      # checking type, but leaving space for notifyable types
+      return unless notifiable_type == "Article"
+
+      notifiable = notifiable_type.constantize.find_by(id: notifiable_id)
+      service.call(notifiable, action) if notifiable
+    end
+  end
+end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -26,27 +26,7 @@ class Notification < ApplicationRecord
     end
 
     def send_to_followers(notifiable, action = nil)
-      # for now, arguments are always: notifiable = article, action = "Published"
-      json_data = {
-        user: user_data(notifiable.user),
-        article: Notifications.article_data(notifiable)
-      }
-      followers = if notifiable.organization_id
-                    json_data[:organization] = organization_data(notifiable.organization)
-                    (notifiable.user.followers + notifiable.organization.followers).uniq
-                  else
-                    notifiable.user.followers
-                  end
-      # followers is an array and not an activerecord object
-      followers.sort_by(&:updated_at).reverse[0..10_000].each do |follower|
-        Notification.create(
-          user_id: follower.id,
-          notifiable_id: notifiable.id,
-          notifiable_type: notifiable.class.name,
-          action: action,
-          json_data: json_data,
-        )
-      end
+      Notifications::NotifiableAction::Send.call(notifiable, action)
     end
     handle_asynchronously :send_to_followers
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -26,9 +26,12 @@ class Notification < ApplicationRecord
     end
 
     def send_to_followers(notifiable, action = nil)
-      Notifications::NotifiableAction::Send.call(notifiable, action)
+      Notifications::NotifiableActionJob.perform_later(notifiable.id, notifiable.class.name, action)
     end
-    handle_asynchronously :send_to_followers
+
+    def send_to_followers_without_delay(notifiable, action = nil)
+      Notifications::NotifiableActionJob.perform_now(notifiable.id, notifiable.class.name, action)
+    end
 
     def send_new_comment_notifications(comment)
       return if comment.commentable_type == "PodcastEpisode"

--- a/app/services/notifications/notifiable_action/send.rb
+++ b/app/services/notifications/notifiable_action/send.rb
@@ -22,7 +22,8 @@ module Notifications
         }
         json_data[:organization] = organization_data(notifiable.organization) if notifiable.organization_id
         # followers is an array and not an activerecord object
-        followers.sort_by(&:updated_at).reverse[0..10_000].each do |follower|
+        # followers can occasionally be nil because orphaned follows can possibly exist in the db (for now)
+        followers.compact.sort_by(&:updated_at).reverse[0..10_000].each do |follower|
           Notification.create(
             user_id: follower.id,
             notifiable_id: notifiable.id,

--- a/app/services/notifications/notifiable_action/send.rb
+++ b/app/services/notifications/notifiable_action/send.rb
@@ -24,7 +24,7 @@ module Notifications
         notifications = []
         # followers is an array and not an activerecord object
         # followers can occasionally be nil because orphaned follows can possibly exist in the db (for now)
-        followers.compact.sort_by(&:updated_at).reverse[0..10_000].each do |follower|
+        followers.sort_by(&:updated_at).reverse[0..10_000].each do |follower|
           notifications.push Notification.new(
             user_id: follower.id,
             notifiable_id: notifiable.id,
@@ -44,7 +44,7 @@ module Notifications
       def followers
         followers = notifiable.user.followers
         followers += notifiable.organization.followers if notifiable.organization_id
-        followers.uniq
+        followers.uniq.compact
       end
     end
   end

--- a/app/services/notifications/notifiable_action/send.rb
+++ b/app/services/notifications/notifiable_action/send.rb
@@ -21,10 +21,11 @@ module Notifications
           article: article_data(notifiable)
         }
         json_data[:organization] = organization_data(notifiable.organization) if notifiable.organization_id
+        notifications = []
         # followers is an array and not an activerecord object
         # followers can occasionally be nil because orphaned follows can possibly exist in the db (for now)
         followers.compact.sort_by(&:updated_at).reverse[0..10_000].each do |follower|
-          Notification.create(
+          notifications.push Notification.new(
             user_id: follower.id,
             notifiable_id: notifiable.id,
             notifiable_type: notifiable.class.name,
@@ -32,6 +33,7 @@ module Notifications
             json_data: json_data,
           )
         end
+        Notification.import notifications
       end
 
       private

--- a/app/services/notifications/notifiable_action/send.rb
+++ b/app/services/notifications/notifiable_action/send.rb
@@ -31,9 +31,10 @@ module Notifications
             notifiable_type: notifiable.class.name,
             action: action,
             json_data: json_data,
+            notified_at: Time.current,
           )
         end
-        Notification.import notifications
+        Notification.import! notifications
       end
 
       private

--- a/app/services/notifications/notifiable_action/send.rb
+++ b/app/services/notifications/notifiable_action/send.rb
@@ -1,0 +1,46 @@
+# send notification about the action ("Published") that happened on a notifiable (Article)
+module Notifications
+  module NotifiableAction
+    class Send
+      # @param notifiable [Article]
+      # @param action [String] for now only "Published"
+      def initialize(notifiable, action = nil)
+        @notifiable = notifiable
+        @action = action
+      end
+
+      delegate :user_data, :article_data, :organization_data, to: Notifications
+
+      def self.call(*args)
+        new(*args).call
+      end
+
+      def call
+        json_data = {
+          user: user_data(notifiable.user),
+          article: article_data(notifiable)
+        }
+        followers = if notifiable.organization_id
+                      json_data[:organization] = organization_data(notifiable.organization)
+                      (notifiable.user.followers + notifiable.organization.followers).uniq
+                    else
+                      notifiable.user.followers
+                    end
+        # followers is an array and not an activerecord object
+        followers.sort_by(&:updated_at).reverse[0..10_000].each do |follower|
+          Notification.create(
+            user_id: follower.id,
+            notifiable_id: notifiable.id,
+            notifiable_type: notifiable.class.name,
+            action: action,
+            json_data: json_data,
+          )
+        end
+      end
+
+      private
+
+      attr_reader :notifiable, :action
+    end
+  end
+end

--- a/app/services/notifications/notifiable_action/send.rb
+++ b/app/services/notifications/notifiable_action/send.rb
@@ -20,12 +20,7 @@ module Notifications
           user: user_data(notifiable.user),
           article: article_data(notifiable)
         }
-        followers = if notifiable.organization_id
-                      json_data[:organization] = organization_data(notifiable.organization)
-                      (notifiable.user.followers + notifiable.organization.followers).uniq
-                    else
-                      notifiable.user.followers
-                    end
+        json_data[:organization] = organization_data(notifiable.organization) if notifiable.organization_id
         # followers is an array and not an activerecord object
         followers.sort_by(&:updated_at).reverse[0..10_000].each do |follower|
           Notification.create(
@@ -41,6 +36,12 @@ module Notifications
       private
 
       attr_reader :notifiable, :action
+
+      def followers
+        followers = notifiable.user.followers
+        followers += notifiable.organization.followers if notifiable.organization_id
+        followers.uniq
+      end
     end
   end
 end

--- a/spec/jobs/notifications/notifiable_action_job_spec.rb
+++ b/spec/jobs/notifications/notifiable_action_job_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe Notifications::NotifiableActionJob, type: :job do
+  include_examples "#enqueues_job", "send_notifiable_action_notification", 5
+
+  describe "#perform_now" do
+    let(:service) { double }
+
+    before do
+      allow(service).to receive(:call)
+    end
+
+    it "calls the service when existing notifiable passed" do
+      notifiable = create(:article)
+      described_class.perform_now(notifiable.id, "Article", "Published", service)
+      expect(service).to have_received(:call).with(notifiable, "Published").once
+    end
+
+    it "doesn't call a service when notifiable doesn't exist" do
+      described_class.perform_now(Article.maximum(:id).to_i + 1, "Article", "Published", service)
+      expect(service).not_to have_received(:call)
+    end
+
+    it "doesn't call a service when unexpected notifiable type passed" do
+      user = create(:user)
+      described_class.perform_now(user.id, "User", "Upgraded", service)
+      expect(service).not_to have_received(:call)
+    end
+  end
+end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -274,7 +274,7 @@ RSpec.describe Notification, type: :model do
     context "when the notifiable is an article from a user" do
       before do
         user2.follow(user)
-        run_background_jobs_immediately { Notification.send_to_followers(article, "Published") }
+        perform_enqueued_jobs { Notification.send_to_followers(article, "Published") }
       end
 
       it "sends a notification to the author's followers" do
@@ -288,7 +288,7 @@ RSpec.describe Notification, type: :model do
       before do
         user2.follow(user)
         user3.follow(organization)
-        run_background_jobs_immediately { Notification.send_to_followers(article, "Published") }
+        perform_enqueued_jobs { Notification.send_to_followers(article, "Published") }
       end
 
       it "sends a notification to author's followers" do

--- a/spec/services/notifications/notifiable_action/send_spec.rb
+++ b/spec/services/notifications/notifiable_action/send_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe Notifications::NotifiableAction::Send, type: :service do
+  let(:user) { create(:user) }
+  let(:organization) { create(:organization) }
+  let(:article) { create(:article, user: user, organization: organization) }
+
+  let(:user2) { create(:user) }
+  let(:user3) { create(:user) }
+
+  before do
+    user2.follow(user)
+    user3.follow(organization)
+  end
+
+  it "creates notifications" do
+    expect do
+      described_class.call(article, "Published")
+    end.to change(Notification, :count).by(2)
+  end
+
+  it "creates a correct user notification" do
+    described_class.call(article, "Published")
+    notifications = Notification.where(user_id: user2.id, notifiable_id: article.id, notifiable_type: "Article")
+    expect(notifications.size).to eq(1)
+    notification = notifications.first
+    expect(notification.action).to eq("Published")
+    expect(notification.json_data["article"]["id"]).to eq(article.id)
+    expect(notification.json_data["user"]["id"]).to eq(user.id)
+    expect(notification.json_data["user"]["username"]).to eq(user.username)
+  end
+
+  it "creates a correct organization notification" do
+    described_class.call(article, "Published")
+    notifications = Notification.where(user_id: user3.id, notifiable_id: article.id, notifiable_type: "Article")
+    expect(notifications.size).to eq(1)
+    notification = notifications.first
+    expect(notification.action).to eq("Published")
+    expect(notification.json_data["article"]["id"]).to eq(article.id)
+    expect(notification.json_data["user"]["id"]).to eq(user.id)
+    expect(notification.json_data["organization"]["id"]).to eq(organization.id)
+    expect(notification.json_data["organization"]["name"]).to eq(organization.name)
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Bug Fix

## Description
- moved async method `Notification#send_to_followers` to a separate job
- added a check to avoid trying to sort `nil` followers (fix the dj error)
-  bulk-create corresponding notifications to make fewer SQL-queries

## Related Tickets & Documents
#1996 
