### PR TITLE
Use consistent colors for inline code, including night theme

### DIFF
--- a/app/assets/stylesheets/article-show.scss
+++ b/app/assets/stylesheets/article-show.scss
@@ -607,10 +607,10 @@ article {
 
     code {
       margin: auto;
-      background: $lightest-gray;
+      @include themeable(background, theme-code-background, $lightest-gray);
       padding: 0.1em 0.3em 0;
       border-radius: 2px;
-      color: #333842;
+      @include themeable(color, theme-code-color, #333842);
       font-size: 0.84em;
       vertical-align: 0;
       max-width: 100%;

--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -628,10 +628,8 @@ a.header-link {
     code {
       margin: auto;
       white-space: nowrap;
-      @include themeable(background, theme-background, $lightest-gray);
       padding: 1px 5px 0px;
       border-radius: 2px;
-      color: #333842;
       font-size: 0.8em;
       display: inline-block;
       vertical-align: 0.1em;

--- a/app/views/layouts/_user_config.html.erb
+++ b/app/views/layouts/_user_config.html.erb
@@ -10,6 +10,8 @@
         --theme-opposite-color: #0d1219;\
         --theme-logo-background: #0a0a0a;\
         --theme-logo-color: #fff;\
+        --theme-code-background: #29292e;\
+        --theme-code-color: #e6db74;\
         --theme-reaction-background: #202c3d;\
         --theme-anchor-color: #17a1f6;\
         --theme-secondary-color: #cedae2;\
@@ -38,6 +40,8 @@
       --theme-opposite-color: #fff7f9;\
       --theme-logo-background: #fff7f9;\
       --theme-logo-color: #ff4983;\
+      --theme-code-background: #f9f9fa;\
+      --theme-code-color: #f92671;\
       --theme-reaction-background: #eff0f2;\
       --theme-anchor-color: #4e57ef;\
       --theme-secondary-color: #4e57ef;\


### PR DESCRIPTION
Resolve #2210

<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
Fixed the night-theme mode color contrast for inline code comments + match color scheme with code blocks.


## Related Tickets & Documents
#2210 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
article night:
<img width="729" alt="Screenshot 2019-05-23 at 15 49 52" src="https://user-images.githubusercontent.com/1109982/58311684-cff11700-7e09-11e9-97b8-3533c34bf084.png">
comments night:
<img width="654" alt="Screenshot 2019-05-23 at 15 37 51" src="https://user-images.githubusercontent.com/1109982/58311717-e39c7d80-7e09-11e9-9165-ac307828105e.png">
article pink:
<img width="718" alt="Screenshot 2019-05-23 at 15 47 54" src="https://user-images.githubusercontent.com/1109982/58311738-f57e2080-7e09-11e9-8b11-f122ae01661b.png">


## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/9xghRpNzijsqFzrRBG/giphy.gif)
