### PR TITLE
Bug/markdown underscores in usernames

### DIFF
--- a/app/labor/markdown_fixer.rb
+++ b/app/labor/markdown_fixer.rb
@@ -47,7 +47,7 @@ class MarkdownFixer
     end
 
     def underscores_in_usernames(markdown)
-      markdown.gsub(/@_/, "@\\_")
+      markdown.gsub(/_/, "\\_")
     end
 
     private

--- a/app/labor/markdown_fixer.rb
+++ b/app/labor/markdown_fixer.rb
@@ -48,6 +48,7 @@ class MarkdownFixer
 
     def underscores_in_usernames(markdown)
       markdown.gsub(/^(@)(_\w+)(_)$/, '\1\\\\\2\\\\\3')
+      # markdown.match(/(?<beginning>@_)(.+)(?<last_underscore>_)/)
       # escaped_user_names = user_names.map { |name| name.gsub(/_/, "\\_") }
       # markdown.gsub(/_/, "\\_")
       # return markdown

--- a/app/labor/markdown_fixer.rb
+++ b/app/labor/markdown_fixer.rb
@@ -47,11 +47,7 @@ class MarkdownFixer
     end
 
     def underscores_in_usernames(markdown)
-      markdown.gsub(/^(@)(_\w+)(_)$/, '\1\\\\\2\\\\\3')
-      # markdown.match(/(?<beginning>@_)(.+)(?<last_underscore>_)/)
-      # escaped_user_names = user_names.map { |name| name.gsub(/_/, "\\_") }
-      # markdown.gsub(/_/, "\\_")
-      # return markdown
+      markdown.gsub(/(@)(_\w+)(_)/, '\1\\\\\2\\\\\3')
     end
 
     private

--- a/app/labor/markdown_fixer.rb
+++ b/app/labor/markdown_fixer.rb
@@ -47,7 +47,10 @@ class MarkdownFixer
     end
 
     def underscores_in_usernames(markdown)
-      markdown.gsub(/_/, "\\_")
+      markdown.gsub(/^(@)(_\w+)(_)$/, '\1\\\\\2\\\\\3')
+      # escaped_user_names = user_names.map { |name| name.gsub(/_/, "\\_") }
+      # markdown.gsub(/_/, "\\_")
+      # return markdown
     end
 
     private

--- a/app/labor/markdown_fixer.rb
+++ b/app/labor/markdown_fixer.rb
@@ -47,7 +47,6 @@ class MarkdownFixer
     end
 
     def underscores_in_usernames(markdown)
-      # markdown.gsub(/@_\w+_/, /@\\_\w+\\_/)
       markdown.gsub(/@_/, "@\\_")
     end
 

--- a/app/labor/markdown_fixer.rb
+++ b/app/labor/markdown_fixer.rb
@@ -5,13 +5,18 @@ class MarkdownFixer
     def fix_all(markdown)
       methods = %i[
         add_quotes_to_title add_quotes_to_description
-        modify_hr_tags convert_new_lines split_tags
+        modify_hr_tags convert_new_lines split_tags underscores_in_usernames
       ]
       methods.reduce(markdown) { |result, method| send(method, result) }
     end
 
     def fix_for_preview(markdown)
-      methods = %i[add_quotes_to_title add_quotes_to_description modify_hr_tags]
+      methods = %i[add_quotes_to_title add_quotes_to_description modify_hr_tags underscores_in_usernames]
+      methods.reduce(markdown) { |result, method| send(method, result) }
+    end
+
+    def fix_for_comment(markdown)
+      methods = %I[modify_hr_tags underscores_in_usernames]
       methods.reduce(markdown) { |result, method| send(method, result) }
     end
 
@@ -39,6 +44,11 @@ class MarkdownFixer
       markdown.gsub(/\ntags:.*\n/) do |tags|
         tags.split(" #").join(",").delete("#").gsub(":,", ": ")
       end
+    end
+
+    def underscores_in_usernames(markdown)
+      # markdown.gsub(/@_\w+_/, /@\\_\w+\\_/)
+      markdown.gsub(/@_/, "@\\_")
     end
 
     private

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -199,7 +199,7 @@ class Comment < ApplicationRecord
   end
 
   def evaluate_markdown
-    fixed_body_markdown = MarkdownFixer.modify_hr_tags(body_markdown)
+    fixed_body_markdown = MarkdownFixer.fix_for_comment(body_markdown)
     parsed_markdown = MarkdownParser.new(fixed_body_markdown)
     self.processed_html = parsed_markdown.finalize
     wrap_timestamps_if_video_present!

--- a/spec/labor/markdown_fixer_spec.rb
+++ b/spec/labor/markdown_fixer_spec.rb
@@ -117,11 +117,14 @@ RSpec.describe MarkdownFixer do
   end
 
   describe "::underscores_in_usernames" do
-    it "escapes the leading underscore in a username" do
-      test_string = "@_x_y_"
-      expected_result = "@\\_x_y_"
+    it "escapes underscores in a username" do
+      test_string1 = "@_x_y_"
+      expected_result1 = "@\\_x\\_y\\_"
+      test_string2 = "@_x__y_"
+      expected_result2 = "@\\_x\\_\\_y\\_"
 
-      expect(described_class.underscores_in_usernames(test_string)).to eq(expected_result)
+      expect(described_class.underscores_in_usernames(test_string1)).to eq(expected_result1)
+      expect(described_class.underscores_in_usernames(test_string2)).to eq(expected_result2)
     end
   end
 end

--- a/spec/labor/markdown_fixer_spec.rb
+++ b/spec/labor/markdown_fixer_spec.rb
@@ -115,4 +115,13 @@ RSpec.describe MarkdownFixer do
       expect(result).to eq(expected_result)
     end
   end
+
+  describe "::underscores_in_usernames" do
+    it "escapes the leading underscore in a username" do
+      test_string = "@_x_y_"
+      expected_result = "@\\_x_y_"
+
+      expect(described_class.underscores_in_usernames(test_string)).to eq(expected_result)
+    end
+  end
 end

--- a/spec/labor/markdown_fixer_spec.rb
+++ b/spec/labor/markdown_fixer_spec.rb
@@ -118,13 +118,18 @@ RSpec.describe MarkdownFixer do
 
   describe "::underscores_in_usernames" do
     it "escapes underscores in a username" do
-      test_string1 = "@_x_y_"
-      expected_result1 = "@\\_x\\_y\\_"
-      test_string2 = "@_x__y_"
-      expected_result2 = "@\\_x\\_\\_y\\_"
+      test_string1 = "@_xy_"
+      expected_result1 = "@\\_xy\\_"
+      test_string2 = "@_x_y_"
+      expected_result2 = "@\\_x_y\\_"
 
       expect(described_class.underscores_in_usernames(test_string1)).to eq(expected_result1)
       expect(described_class.underscores_in_usernames(test_string2)).to eq(expected_result2)
+    end
+    it "does not escape underscores when it is not a username" do
+      test_string = "_make this cursive_"
+      expected_result = "_make this cursive_"
+      expect(described_class.underscores_in_usernames(test_string)).to eq(expected_result)
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
Fixes #1491 - usernames which started and ended with underscores would be interpreted as markdown. Hence, they were italicized instead of linked.
I added another method into the markdown_fixer.rb which gsubs the underscores in usernames and escapes them.
I also wrote two tests.

## Related Tickets & Documents
./.
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
./.
## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?
my first open source contribution
![really proud](https://media.giphy.com/media/HvvpNczg8Dcw8/giphy.gif)
