### PR TITLE
Fix global keys

### DIFF
--- a/app/javascript/packs/homePage.js
+++ b/app/javascript/packs/homePage.js
@@ -1,18 +1,22 @@
 function toggleListingsMinimization() {
-  const body = document.getElementsByTagName("body")[0]
-  if( body.classList.contains('config_minimize_newest_listings')) {
-    //Un-minimize
-    localStorage.setItem(
-      'config_minimize_newest_listings',
-      'no') 
-      body.classList.remove("config_minimize_newest_listings");
+  const body = document.getElementsByTagName('body')[0];
+  if (body.classList.contains('config_minimize_newest_listings')) {
+    // Un-minimize
+    localStorage.setItem('config_minimize_newest_listings', 'no');
+    body.classList.remove('config_minimize_newest_listings');
   } else {
-    //Minimize
-    localStorage.setItem(
-      'config_minimize_newest_listings',
-      'yes')
-      body.classList.add("config_minimize_newest_listings");
+    // Minimize
+    localStorage.setItem('config_minimize_newest_listings', 'yes');
+    body.classList.add('config_minimize_newest_listings');
   }
 }
 
-document.getElementById('sidebar-listings-widget-minimize-button').addEventListener('click', toggleListingsMinimization);
+const sidebarListingsMinimizeButton = document.getElementById(
+  'sidebar-listings-widget-minimize-button',
+);
+if (sidebarListingsMinimizeButton) {
+  sidebarListingsMinimizeButton.addEventListener(
+    'click',
+    toggleListingsMinimization,
+  );
+}

--- a/app/javascript/src/components/Search/Search.jsx
+++ b/app/javascript/src/components/Search/Search.jsx
@@ -57,6 +57,10 @@ export class Search extends Component {
     this.enableSearchPageChecker = true;
   };
 
+  hasKeyModifiers = event => {
+    return event.altKey || event.ctrlKey || event.metaKey || event.shiftKey;
+  };
+
   search = event => {
     const {
       key,
@@ -109,7 +113,10 @@ export class Search extends Component {
         document.getElementsByTagName('body')[0].classList.remove('zen-mode');
         searchBox.focus();
         searchBox.select();
-      } else if (event.key === GLOBAL_MINIMIZE_KEY) {
+      } else if (
+        event.key === GLOBAL_MINIMIZE_KEY &&
+        !this.hasKeyModifiers(event)
+      ) {
         event.preventDefault();
         document.getElementsByTagName('body')[0].classList.toggle('zen-mode');
       }

--- a/app/javascript/src/components/Search/Search.jsx
+++ b/app/javascript/src/components/Search/Search.jsx
@@ -9,24 +9,34 @@ import {
 } from '../../utils/search';
 import { SearchForm } from './SearchForm';
 
-const GLOBAL_SEARCH_KEY_CODE = 191;
-const GLOBAL_MINIMIZE_KEY_CODE = 48;
-const ENTER_KEY_CODE = 13;
+const GLOBAL_MINIMIZE_KEY = '0';
+const GLOBAL_SEARCH_KEY = '/';
+const ENTER_KEY = 'Enter';
 
 export class Search extends Component {
   static defaultProps = {
     searchBoxId: 'nav-search',
   };
 
+  constructor(props) {
+    super(props);
+    this.enableSearchPageChecker = true;
+  }
+
   componentWillMount() {
+    let searchTerm;
+
+    ({ searchTerm } = this.state);
     this.setState(
       { searchTerm: getInitialSearchTerm(window.location.search) },
-      () => preloadSearchResults({ searchTerm: this.state.searchTerm }),
+      () => preloadSearchResults({ searchTerm }),
     );
+
+    ({ searchTerm } = this.state);
     const searchPageChecker = () => {
       if (
         this.enableSearchPageChecker &&
-        this.state.searchTerm !== '' &&
+        searchTerm !== '' &&
         /^http(s)?:\/\/[^/]+\/search/.exec(window.location.href) === null
       ) {
         this.setState({ searchTerm: '' });
@@ -39,73 +49,74 @@ export class Search extends Component {
   }
 
   componentDidMount() {
-    this.registerGlobalSearchKeyListener();
+    this.registerGlobalKeysListener();
     InstantClick.on('change', this.enableSearchPageListener);
   }
-
-  componentDidUnmount() {
-    document.removeEventListener('keydown', this.globalSearchKeyListener);
-    InstantClick.off('change', this.enableSearchPageListener);
-  }
-
-  enableSearchPageChecker = true;
-
-  globalSearchKeyListener;
 
   enableSearchPageListener = () => {
     this.enableSearchPageChecker = true;
   };
 
-  registerGlobalSearchKeyListener() {
-    const searchBox = document.getElementById(this.props.searchBoxId);
-
-    this.globalSearchKeyListener = event => {
-      const { tagName, classList } = document.activeElement;
-      if (
-        (event.which !== GLOBAL_SEARCH_KEY_CODE && event.which !== GLOBAL_MINIMIZE_KEY_CODE) ||
-        tagName === 'INPUT' ||
-        tagName === 'TEXTAREA' ||
-        classList.contains('input')
-      ) {
-        return;
-      }
-      if (event.which === GLOBAL_SEARCH_KEY_CODE) {
-        document.getElementsByTagName('body')[0].classList.remove('zen-mode')
-        event.preventDefault();
-        searchBox.focus();
-        searchBox.select();  
-      } else if (event.which === GLOBAL_MINIMIZE_KEY_CODE) {
-        event.preventDefault();
-        document.getElementsByTagName('body')[0].classList.toggle('zen-mode')
-      }
-    };
-
-    document.addEventListener('keydown', this.globalSearchKeyListener);
-  }
-
   search = event => {
     const {
-      keyCode,
+      key,
       target: { value },
     } = event;
 
     this.enableSearchPageChecker = false;
 
-    if (hasInstantClick() && keyCode === ENTER_KEY_CODE) {
+    if (hasInstantClick() && key === ENTER_KEY) {
       this.setState({ searchTerm: value }, () => {
-        preloadSearchResults({ searchTerm: this.state.searchTerm });
+        const { searchTerm } = this.state;
+        preloadSearchResults({ searchTerm });
       });
     }
   };
 
   submit = event => {
     if (hasInstantClick) {
-      const { searchTerm } = this.state;
-
       event.preventDefault();
+
+      const { searchTerm } = this.state;
       displaySearchResults({ searchTerm });
     }
   };
+
+  componentDidUnmount() {
+    document.removeEventListener('keydown', this.globalKeysListener);
+    InstantClick.off('change', this.enableSearchPageListener);
+  }
+
+  registerGlobalKeysListener() {
+    const { searchBoxId } = this.props;
+    const searchBox = document.getElementById(searchBoxId);
+
+    this.globalKeysListener = event => {
+      const { tagName, classList } = document.activeElement;
+
+      if (
+        (event.key !== GLOBAL_SEARCH_KEY &&
+          event.key !== GLOBAL_MINIMIZE_KEY) ||
+        tagName === 'INPUT' ||
+        tagName === 'TEXTAREA' ||
+        classList.contains('input')
+      ) {
+        return;
+      }
+
+      if (event.key === GLOBAL_SEARCH_KEY) {
+        event.preventDefault();
+        document.getElementsByTagName('body')[0].classList.remove('zen-mode');
+        searchBox.focus();
+        searchBox.select();
+      } else if (event.key === GLOBAL_MINIMIZE_KEY) {
+        event.preventDefault();
+        document.getElementsByTagName('body')[0].classList.toggle('zen-mode');
+      }
+    };
+
+    document.addEventListener('keydown', this.globalKeysListener);
+  }
 
   render({ searchBoxId }, { searchTerm = '' }) {
     return (


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

This PR fixes two things:

- the `/` search shortcut key wasn't working for me, in my layout the forward slash key requires a modifier
- the `0` minimize shortcut key was triggered also when a modifier was present, see https://github.com/thepracticaldev/dev.to/issues/2968 - which it shouldn't because it overrides the browser's "zoom to normal" shortcut.

Now both work, I've also switched the code to use [event.key](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key) instead of `event.which` which is deprecated (and doesn't work well with modifiers anyway). 

ps. I've also fixed an homepage error because the sidebar listings are not present on local

## Related Tickets & Documents

Closes https://github.com/thepracticaldev/dev.to/issues/2968

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

**Before**

as you can see the forward slash is not working and the minimize is triggered also when I use Cltr or Meta keys.

![before](https://user-images.githubusercontent.com/146201/58422532-15744500-8093-11e9-8324-169c48050902.gif)

**After**

now both the forward slash key and the 0 key work correctly

![after](https://user-images.githubusercontent.com/146201/58422579-389ef480-8093-11e9-8e24-8edd97b3a50f.gif)


## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
