### PR TITLE
Require only used parts of Rails

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,18 @@
 require_relative "boot"
 
-require "rails/all"
+# only require Rails parts that we actually use, this shaves off some memory
+# ActiveStorage, ActionCable and TestUnit are not currently used by the app
+# see <https://github.com/rails/rails/blob/v5.2.3/railties/lib/rails/all.rb>
+%w[
+  active_record/railtie
+  action_controller/railtie
+  action_view/railtie
+  action_mailer/railtie
+  active_job/railtie
+  sprockets/railtie
+].each do |railtie|
+  require railtie
+end
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -31,7 +31,7 @@ Rails.application.configure do
   config.action_controller.allow_forgery_protection = false
 
   # Store uploaded files on the local file system in a temporary directory
-  config.active_storage.service = :test
+  # config.active_storage.service = :test
 
   config.action_mailer.perform_caching = false
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

Rails by defaults loads all its railties and engines, the current app does not use neither ActiveStorage, nor ActionCable nor TestUnit.

This shaves off some memory usage, not much.

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
