### PR TITLE
Guard bust_comment against nil commentable

### DIFF
--- a/app/labor/cache_buster.rb
+++ b/app/labor/cache_buster.rb
@@ -13,24 +13,30 @@ class CacheBuster
   end
 
   def bust_comment(commentable, username)
-    bust("/") if Article.published.order("hotness_score DESC").limit(3).pluck(:id).include?(commentable.id)
-    if commentable.decorate.cached_tag_list_array.include?("discuss") &&
-        commentable.featured_number.to_i > 35.hours.ago.to_i
-      bust("/")
-      bust("/?i=i")
-      bust("?i=i")
+    if commentable
+      bust("/") if Article.published.order("hotness_score DESC").limit(3).pluck(:id).include?(commentable.id)
+      if commentable.decorate.cached_tag_list_array.include?("discuss") &&
+          commentable.featured_number.to_i > 35.hours.ago.to_i
+        bust("/")
+        bust("/?i=i")
+        bust("?i=i")
+      end
+      bust("#{commentable.path}/comments/")
+      bust(commentable.path.to_s)
+      commentable.comments.includes(:user).find_each do |c|
+        bust(c.path)
+        bust(c.path + "?i=i")
+      end
+      bust("#{commentable.path}/comments/*")
     end
-    bust("#{commentable.path}/comments/")
-    bust(commentable.path.to_s)
-    commentable.comments.includes(:user).find_each do |c|
-      bust(c.path)
-      bust(c.path + "?i=i")
-    end
-    bust("#{commentable.path}/comments/*")
-    bust("/#{username}")
-    bust("/#{username}/comments")
-    bust("/#{username}/comments?i=i")
-    bust("/#{username}/comments/?i=i")
+
+    return unless username
+
+    paths = [
+      "/#{username}", "/#{username}/comments",
+      "/#{username}/comments?i=i", "/#{username}/comments/?i=i"
+    ]
+    paths.each { |path| bust(path) }
   end
 
   def bust_article(article)

--- a/spec/labor/cache_buster_spec.rb
+++ b/spec/labor/cache_buster_spec.rb
@@ -1,22 +1,33 @@
 require "rails_helper"
 
 RSpec.describe CacheBuster do
+  let(:cache_buster) { described_class.new }
   let(:user) { create(:user) }
   let(:article) { create(:article, user_id: user.id) }
   let(:comment) { create(:comment, user_id: user.id, commentable_id: article.id) }
 
-  it "busts comment" do
-    commentable = Article.find(comment.commentable_id)
-    username = User.find(comment.user_id).username
-    described_class.new.bust_comment(commentable, username)
+  describe "#bust_comment" do
+    it "busts comment" do
+      cache_buster.bust_comment(comment.commentable, user.username)
+    end
+
+    it "works if commentable is missing" do
+      cache_buster.bust_comment(nil, user.username)
+    end
+
+    it "works if username is missing" do
+      cache_buster.bust_comment(comment.commentable, "")
+    end
   end
 
-  it "busts article" do
-    described_class.new.bust_article(article)
-  end
+  describe "#bust_article" do
+    it "busts article" do
+      cache_buster.bust_article(article)
+    end
 
-  it "busts featured article" do
-    article.update(featured: true)
-    described_class.new.bust_article(article)
+    it "busts featured article" do
+      article.update_columns(featured: true)
+      cache_buster.bust_article(article)
+    end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

It can happen that `bust_comment` is called on a recently destroyed article, and it fails because such article is the `nil`.

This fixes that.

ps. I think this method should be called either `bust_commentable` or `bust_commentable_comments` or something more appropriate than `bust_comment` because it's busting the cache for the commentable which might include the homepage, the comments and the user's comments.

## Related Tickets & Documents

Closes #1831

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
