### PR TITLE
fix(article): scroll to top when inserting image

### DIFF
--- a/app/javascript/article-form/articleForm.jsx
+++ b/app/javascript/article-form/articleForm.jsx
@@ -128,6 +128,7 @@ export default class ArticleForm extends Component {
 
   toggleImageManagement = e => {
     e.preventDefault();
+    window.scrollTo(0, 0);
     this.setState({
       imageManagementShowing: !this.state.imageManagementShowing,
     });


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
I found out that when inserting an image, I have to scroll all the way up to find the upload form.
![May-29-2019 13-51-40](https://user-images.githubusercontent.com/8046636/58532775-1931d400-8219-11e9-9f24-6eeab6393b74.gif)

Maybe it's a different UX problem (maybe using a modal instead, maybe the Image button shouldn't be at the footer), but in my opinion, it should have been scrolled to the top in the first place.

This is my first time doing a PR here, let me know if I'm doing this right! I searched the issues and seems like no one is reporting this (CMIIW) so it could be subjective, let me know. Thank you.

## Related Tickets & Documents
- None

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
- None

## Added to documentation?
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![scrollingscrolling](https://i.giphy.com/media/xT8qBdemIGlrdIEr1S/giphy.gif)
