### PR TITLE
Fix a validation error when creating notifications #2525

### DIFF
--- a/app/services/notifications/reactions/send.rb
+++ b/app/services/notifications/reactions/send.rb
@@ -32,7 +32,6 @@ module Notifications
           notifiable_type: reaction.reactable_type,
           notifiable_id: reaction.reactable_id,
           action: "Reaction"
-          # user_id or organization_id: receiver.id
         }
         if receiver.is_a?(User)
           notification_params[:user_id] = receiver.id
@@ -41,7 +40,7 @@ module Notifications
         end
 
         if aggregated_reaction_siblings.size.zero?
-          notification = Notification.where(notification_params).delete_all
+          Notification.where(notification_params).delete_all
         else
           recent_reaction = reaction_siblings.first
 
@@ -53,14 +52,33 @@ module Notifications
           notification.json_data = json_data
           notification.notified_at = Time.current
           notification.read = false if json_data[:reaction][:aggregated_siblings].size > previous_siblings_size
-          notification.save!
+
+          save_notification(notification)
         end
-        notification
       end
 
       private
 
       attr_reader :reaction, :receiver
+
+      # when a notification exists in the db already it's safe to just save
+      # when it doesn't, there could be a race condition when 2 jobs try to create duplicate notifications concurrently
+      # in this case upsert is used to rely on postgres constraints and update or insert depending on if the record exists in the db at this point
+      # currently, activerecord-import upsert is used
+      # when the app is upgraded to Rails 6 this can be refactored to use rails upsert
+      def save_notification(notification)
+        if notification.persisted?
+          notification.save!
+        else
+          import_result = Notification.import! [notification],
+                                               on_duplicate_key_update: {
+                                                 conflict_target: %i[notifiable_id notifiable_type user_id organization_id action],
+                                                 columns: %i[json_data notified_at read]
+                                               }
+          notification = Notification.find(import_result.ids.first)
+        end
+        notification
+      end
 
       def reaction_json_data(recent_reaction, siblings)
         {

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -163,14 +163,18 @@ RSpec.describe Notification, type: :model do
       it "sends a notification to the author of a comment" do
         comment = create(:comment, user: user2, commentable: article)
         reaction = create(:reaction, reactable: comment, user: user)
-        Notification.send_reaction_notification_without_delay(reaction, reaction.reactable.user)
-        expect(user2.notifications.count).to eq 1
+        perform_enqueued_jobs do
+          Notification.send_reaction_notification(reaction, reaction.reactable.user)
+          expect(user2.notifications.count).to eq 1
+        end
       end
 
       it "sends a notification to the author of an article" do
         reaction = create(:reaction, reactable: article, user: user2)
-        Notification.send_reaction_notification_without_delay(reaction, reaction.reactable.user)
-        expect(user.notifications.count).to eq 1
+        perform_enqueued_jobs do
+          Notification.send_reaction_notification(reaction, reaction.reactable.user)
+          expect(user.notifications.count).to eq 1
+        end
       end
     end
 
@@ -239,34 +243,38 @@ RSpec.describe Notification, type: :model do
     end
 
     it "creates positive reaction notification" do
-      reaction = Reaction.create!(
+      reaction = article.reactions.create!(
         user_id: user2.id,
-        reactable_id: article.id,
-        reactable_type: "Article",
         category: "like",
       )
-      notification = Notification.send_reaction_notification_without_delay(reaction, reaction.reactable.user)
-      expect(notification).to be_valid
+      perform_enqueued_jobs do
+        expect do
+          Notification.send_reaction_notification(reaction, reaction.reactable.user)
+        end.to change(Notification, :count).by(1)
+      end
     end
 
     it "does not create negative notification" do
       user2.add_role(:trusted)
-      reaction = Reaction.create!(
+      reaction = article.reactions.create!(
         user_id: user2.id,
-        reactable_id: article.id,
-        reactable_type: "Article",
         category: "vomit",
       )
-      notification = Notification.send_reaction_notification_without_delay(reaction, reaction.reactable.user)
-      expect(notification).to eq nil
+      perform_enqueued_jobs do
+        expect do
+          Notification.send_reaction_notification(reaction, reaction.reactable.user)
+        end.not_to change(Notification, :count)
+      end
     end
 
     it "destroys the notification properly" do
       reaction = create(:reaction, user: user2, reactable: article, category: "like")
-      Notification.send_reaction_notification_without_delay(reaction, reaction.reactable.user)
-      reaction.destroy!
-      Notification.send_reaction_notification_without_delay(reaction, reaction.reactable.user)
-      expect(Notification.count).to eq 0
+      perform_enqueued_jobs do
+        Notification.send_reaction_notification(reaction, reaction.reactable.user)
+        reaction.destroy!
+        Notification.send_reaction_notification(reaction, reaction.reactable.user)
+        expect(Notification.count).to eq 0
+      end
     end
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Bug Fix

## Description
- do upsert (insert + on conflict update) when trying to create a new reaction notification
That should fix a validation error when 2 notifications are created concurrently #2525
I've used upsert implementation from `activerecord-import` because it is already used in the app. When the app will be upgraded to Rails 6 it'll be possible to refactor and use rails `upsert`. 
- made `Notifications::Reactions::Send` return a more consistent result

## Related Tickets & Documents
#2525 