### PR TITLE
fix(reading-list): better spacing for Save and Bookmark span

### DIFF
--- a/app/assets/stylesheets/readinglist.scss
+++ b/app/assets/stylesheets/readinglist.scss
@@ -129,12 +129,16 @@
     .readinglist-empty {
       text-align: center;
       padding: 100px 0px;
-      span {
+      span.highlight {
         background: $bold-blue;
         border-radius: 3px;
         padding: 3px 8px;
+        margin: 0px 8px;
         color: white;
         display: inline-block;
+        span[role="img"] {
+          margin-left: 8px;
+        }
       }
     }
   }

--- a/app/javascript/readingList/readingList.jsx
+++ b/app/javascript/readingList/readingList.jsx
@@ -159,9 +159,9 @@ export class ReadingList extends Component {
             </h1>
             <h3>
               Hit the
-              <span>SAVE</span>
+              <span class="highlight">SAVE</span>
               or
-              <span>
+              <span class="highlight">
                 Bookmark
                 <span role="img" aria-label="Bookmark">
                   🔖


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
When filtering reading list and there is no result, it looks like this:
![Screen Shot 2019-05-29 at 10 25 47 PM](https://user-images.githubusercontent.com/8046636/58565255-faefc680-8260-11e9-88ed-f9a87d5e6582.png)

In my opinion, it needs some margin between the highlighted words and the Bookmark icon padding looked extra big. That is likely due to the CSS targetting all [`spans`](https://github.com/thepracticaldev/dev.to/blob/master/app/assets/stylesheets/readinglist.scss#L132) which was intended for Save and Bookmark but apparently it affected the icon as well.

I'm proposing for something like this:
![Screen Shot 2019-05-29 at 10 25 35 PM](https://user-images.githubusercontent.com/8046636/58565274-02af6b00-8261-11e9-8e7b-7231d56fff1f.png)

The highlight styling should only affect Save and Bookmark span, and the Bookmark icon should only have margin left. Let me know what you think! Thank you.

## Related Tickets & Documents
- None

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
- Attached above

## Added to documentation?
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![](https://media.giphy.com/media/l4FGwtw3PWPAt6ZxK/source.gif)
