### PR TITLE
Validate on creating a reaction notification #2525

### DIFF
--- a/app/services/notifications/reactions/send.rb
+++ b/app/services/notifications/reactions/send.rb
@@ -55,7 +55,10 @@ module Notifications
           notification.notified_at = Time.current
           notification.read = false if json_data[:reaction][:aggregated_siblings].size > previous_siblings_size
 
-          notification_id = save_notification(notification)
+          # temporarily returning validations to prevent creating duplicate notifications
+          # notification_id = save_notification(notification)
+          notification.save!
+          notification_id = notification.id
 
           OpenStruct.new(action: :saved, notification_id: notification_id)
         end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
I found out that there is an issue related to notifications unique index on the fields `["user_id", "organization_id", "notifiable_id", "notifiable_type", "action"]`. Several fields can be `nil` and in this case, the unique index allows to create records with the same fields which we don't want. 
In this pr, I returned the validation when saving a reaction notification. This will prevent creating some of the duplicate notifications, though the #2525 error will remain.
This is a temporary workaround. I'm working on finding a way to create correct constraint in the db so we could rely on them.

## Related Tickets & Documents
#2525 