### PR TITLE
Fixes Listing Items Spacing Inconsistency and Content Overflow Issue #2846

### DIFF
--- a/app/javascript/listings/listings.jsx
+++ b/app/javascript/listings/listings.jsx
@@ -51,6 +51,14 @@ export class Listings extends Component {
     t.setUser()
 
     document.body.addEventListener('keydown', t.handleKeyDown)
+    
+    /* 
+      The width of the columns also changes when the browser is resized 
+      so we will also call this function on window resize to recalculate
+      each grid item's height to avoid content overflow
+    */
+    window.addEventListener("resize", resizeAllMasonryItems);
+
   }
 
   componentDidUpdate() {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
The width of the columns changes when the browser is resized so we will also call `resizeAllMasonryItems` function on window resize to recalculate each grid item height to avoid content overflow.

## Related Tickets & Documents
#2846 
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![Peek 2019-05-31 14-02](https://user-images.githubusercontent.com/20579660/58696463-db65b480-83ac-11e9-9ce4-deeca24b8ce9.gif)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed