### PR TITLE
Change notifications unique indexes #2525

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
-    "ruby.lint": {
-        "rubocop": true,
-        "fasterer": false,
-    }
+  "ruby.lint": {
+    "rubocop": true,
+    "fasterer": false
+  },
+  "ruby.intellisense": "rubyLocate"
 }

--- a/db/migrate/20190531085252_remove_notifications_unique_index.rb
+++ b/db/migrate/20190531085252_remove_notifications_unique_index.rb
@@ -1,0 +1,7 @@
+class RemoveNotificationsUniqueIndex < ActiveRecord::Migration[5.2]
+  def change
+    remove_index :notifications, column: %i[user_id organization_id notifiable_id notifiable_type action],
+                                 unique: true,
+                                 name: "index_notifications_on_user_organization_notifiable_and_action"
+  end
+end

--- a/db/migrate/20190531094609_add_unique_user_id_notifications_index.rb
+++ b/db/migrate/20190531094609_add_unique_user_id_notifications_index.rb
@@ -1,0 +1,12 @@
+class AddUniqueUserIdNotificationsIndex < ActiveRecord::Migration[5.2]
+  def change
+    add_index :notifications, %i[user_id notifiable_id notifiable_type action],
+              where: "action IS NOT NULL",
+              unique: true,
+              name: "index_notifications_on_user_notifiable_and_action_not_null"
+    add_index :notifications, %i[user_id notifiable_id notifiable_type],
+              where: "action IS NULL",
+              unique: true,
+              name: "index_notifications_on_user_notifiable_action_is_null"
+  end
+end

--- a/db/migrate/20190531094609_add_unique_user_id_notifications_index.rb
+++ b/db/migrate/20190531094609_add_unique_user_id_notifications_index.rb
@@ -1,12 +1,16 @@
 class AddUniqueUserIdNotificationsIndex < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
   def change
     add_index :notifications, %i[user_id notifiable_id notifiable_type action],
               where: "action IS NOT NULL",
               unique: true,
-              name: "index_notifications_on_user_notifiable_and_action_not_null"
+              name: "index_notifications_on_user_notifiable_and_action_not_null",
+              algorithm: :concurrently
     add_index :notifications, %i[user_id notifiable_id notifiable_type],
               where: "action IS NULL",
               unique: true,
-              name: "index_notifications_on_user_notifiable_action_is_null"
+              name: "index_notifications_on_user_notifiable_action_is_null",
+              algorithm: :concurrently
   end
 end

--- a/db/migrate/20190531094926_add_unique_organization_id_notifications_index.rb
+++ b/db/migrate/20190531094926_add_unique_organization_id_notifications_index.rb
@@ -1,0 +1,12 @@
+class AddUniqueOrganizationIdNotificationsIndex < ActiveRecord::Migration[5.2]
+  def change
+    add_index :notifications, %i[organization_id notifiable_id notifiable_type action],
+              where: "action IS NOT NULL",
+              unique: true,
+              name: "index_notifications_on_org_notifiable_and_action_not_null"
+    add_index :notifications, %i[organization_id notifiable_id notifiable_type],
+              where: "action IS NULL",
+              unique: true,
+              name: "index_notifications_on_org_notifiable_action_is_null"
+  end
+end

--- a/db/migrate/20190531094926_add_unique_organization_id_notifications_index.rb
+++ b/db/migrate/20190531094926_add_unique_organization_id_notifications_index.rb
@@ -1,12 +1,16 @@
 class AddUniqueOrganizationIdNotificationsIndex < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
   def change
     add_index :notifications, %i[organization_id notifiable_id notifiable_type action],
               where: "action IS NOT NULL",
               unique: true,
-              name: "index_notifications_on_org_notifiable_and_action_not_null"
+              name: "index_notifications_on_org_notifiable_and_action_not_null",
+              algorithm: :concurrently
     add_index :notifications, %i[organization_id notifiable_id notifiable_type],
               where: "action IS NULL",
               unique: true,
-              name: "index_notifications_on_org_notifiable_action_is_null"
+              name: "index_notifications_on_org_notifiable_action_is_null",
+              algorithm: :concurrently
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -521,7 +521,10 @@ ActiveRecord::Schema.define(version: 2019_06_06_202826) do
     t.index ["json_data"], name: "index_notifications_on_json_data", using: :gin
     t.index ["notifiable_id"], name: "index_notifications_on_notifiable_id"
     t.index ["notifiable_type"], name: "index_notifications_on_notifiable_type"
-    t.index ["user_id", "organization_id", "notifiable_id", "notifiable_type", "action"], name: "index_notifications_on_user_organization_notifiable_and_action", unique: true
+    t.index ["organization_id", "notifiable_id", "notifiable_type", "action"], name: "index_notifications_on_org_notifiable_and_action_not_null", unique: true, where: "(action IS NOT NULL)"
+    t.index ["organization_id", "notifiable_id", "notifiable_type"], name: "index_notifications_on_org_notifiable_action_is_null", unique: true, where: "(action IS NULL)"
+    t.index ["user_id", "notifiable_id", "notifiable_type", "action"], name: "index_notifications_on_user_notifiable_and_action_not_null", unique: true, where: "(action IS NOT NULL)"
+    t.index ["user_id", "notifiable_id", "notifiable_type"], name: "index_notifications_on_user_notifiable_action_is_null", unique: true, where: "(action IS NULL)"
     t.index ["user_id"], name: "index_notifications_on_user_id"
   end
 

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -11,6 +11,82 @@ RSpec.describe Notification, type: :model do
 
   it { is_expected.to validate_uniqueness_of(:user_id).scoped_to(%i[organization_id notifiable_id notifiable_type action]) }
 
+  describe "when trying to create duplicate notifications" do
+    # Duplicate notifications are not allowed even when validations are skipped
+    it "doesn't allow to create a duplicate notification via import" do
+      create(:notification, user: user, notifiable: article, action: "Reaction")
+      duplicate_notification = build(:notification, user: user, notifiable: article, action: "Reaction")
+      expect do
+        Notification.import([duplicate_notification],
+                            on_duplicate_key_update: {
+                              conflict_target: %i[notifiable_id notifiable_type user_id action],
+                              index_predicate: "action IS NOT NULL",
+                              columns: %i[json_data notified_at read]
+                            })
+      end.not_to change(Notification, :count)
+    end
+
+    it "updates when trying to create a duplicate notification via import" do
+      notification = create(:notification, user: user, notifiable: article, action: "Reaction", json_data: { "user_id" => 1 })
+      duplicate_notification = build(:notification, user: user, notifiable: article, action: "Reaction", json_data: { "user_id" => 2 })
+      Notification.import([duplicate_notification],
+                          on_duplicate_key_update: {
+                            conflict_target: %i[notifiable_id notifiable_type user_id action],
+                            index_predicate: "action IS NOT NULL",
+                            columns: %i[json_data notified_at read]
+                          })
+      notification.reload
+      expect(notification.json_data["user_id"]).to eq(2)
+    end
+
+    it "doesn't allow to create a duplicate organization notification via import" do
+      create(:notification, organization: organization, notifiable: article, action: "Reaction")
+      duplicate_notification = build(:notification, organization: organization, notifiable: article, action: "Reaction")
+      expect do
+        Notification.import([duplicate_notification],
+                            on_duplicate_key_update: {
+                              conflict_target: %i[notifiable_id notifiable_type organization_id action],
+                              index_predicate: "action IS NOT NULL",
+                              columns: %i[json_data notified_at read]
+                            })
+      end.not_to change(Notification, :count)
+    end
+
+    describe "when notifiable is a Comment" do
+      let!(:comment) { create(:comment, commentable: article) }
+
+      # rubocop:disable RSpec/ExampleLength
+      it "doesn't allow to create a duplicate user notification via import when action is nil" do
+        notification_attributes = { user: user, notifiable: comment, action: nil }
+        create(:notification, notification_attributes)
+        duplicate_notification = build(:notification, notification_attributes)
+        expect do
+          Notification.import([duplicate_notification],
+                              on_duplicate_key_update: {
+                                conflict_target: %i[notifiable_id notifiable_type user_id],
+                                index_predicate: "action IS NULL",
+                                columns: %i[json_data notified_at read]
+                              })
+        end.not_to change(Notification, :count)
+      end
+
+      it "doesn't allow to create a duplicate org notification via import when action is nil" do
+        notification_attributes = { organization: organization, notifiable: comment, action: nil }
+        create(:notification, notification_attributes)
+        duplicate_notification = build(:notification, notification_attributes)
+        expect do
+          Notification.import([duplicate_notification],
+                              on_duplicate_key_update: {
+                                conflict_target: %i[notifiable_id notifiable_type organization_id],
+                                index_predicate: "action IS NULL",
+                                columns: %i[json_data notified_at read]
+                              })
+        end.not_to change(Notification, :count)
+      end
+      # rubocop:enable RSpec/ExampleLength
+    end
+  end
+
   describe "when trying to #send_new_follower_notification after following a tag" do
     let(:tag) { create(:tag) }
     let(:tag_follow) { user.follow(tag) }

--- a/spec/services/notifications/remove_all_spec.rb
+++ b/spec/services/notifications/remove_all_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe Notifications::RemoveAll do
   let(:comment) { create(:comment, user_id: user.id, commentable_id: article.id, commentable_type: "Article") }
 
   before do
-    create(:notification, user: user, organization: organization, notifiable_id: article.id, notifiable_type: "Article", action: "Published")
-    create(:notification, user: user2, organization: organization, notifiable_id: article.id, notifiable_type: "Article", action: "Published")
-    create(:notification, user: user, organization: organization, notifiable_id: comment.id, notifiable_type: "Comment", action: "Reaction")
+    create(:notification, user: user, notifiable_id: article.id, notifiable_type: "Article", action: "Published")
+    create(:notification, user: user2, notifiable_id: article.id, notifiable_type: "Article", action: "Published")
+    create(:notification, organization: organization, notifiable_id: comment.id, notifiable_type: "Comment", action: "Reaction")
   end
 
   it "checks all notifications for an article are deleted and only for an article" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
- сhanged notifications indexes so that they take into account possible null values in `user_id`, `organization_id`, `action` fields
Postgres allows to create records which contain the same fields if some of them contain null values, so I
  - created separate indexes for `user_id` and `organization_id` because notifications has either `user_id` or `organization_id`
  - made partial indexes for cases when `action` is null and when it's not null
- added specs to check that notifications are not duplicated even when validations are skipped

Before merging, all the notifications that have duplicate fields `%i[user_id organization_id notifiable_id notifiable_type action]` must be deleted

## Related Tickets & Documents
#2525 
