### PR TITLE
Fix 404 issue when submitting abuse report

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -109,7 +109,7 @@ Rails.application.routes.draw do
   end
   resources :twitch_live_streams, only: :show, param: :username
   resources :reactions, only: %i[index create]
-  resources :feedback_messages, only: %i[create]
+  resources :feedback_messages, only: %i[index create]
   resources :organizations, only: %i[update create]
   resources :followed_articles, only: [:index]
   resources :follows, only: %i[show create update]

--- a/spec/requests/feedback_messages_create_spec.rb
+++ b/spec/requests/feedback_messages_create_spec.rb
@@ -74,6 +74,15 @@ RSpec.describe "feedback_messages", type: :request do
       it "send a Slack message when completed" do
         expect(SlackBot).to have_received(:ping)
       end
+
+      it "redirects to /feedback_message and continues to the index page" do
+        expect(response).to redirect_to "/feedback_messages"
+      end
+
+      it "redirects and continues to the index page with the correct message" do
+        follow_redirect!
+        expect(response.body).to include "Thank you for your report."
+      end
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This fixes an issue where submitting an abuse report would lead to a 404. The report would still successfully submit, but the reporter would see the 404 instead of a successful response page.

Also adds a test to check that.