### PR TITLE
fix(chat): remove an extra at sign

### DIFF
--- a/app/javascript/chat/chat.jsx
+++ b/app/javascript/chat/chat.jsx
@@ -647,7 +647,6 @@ export default class Chat extends Component {
               You and 
               {' '}
               <a href={`/${activeChannel.channel_modified_slug}`}>
-@
                 {activeChannel.channel_modified_slug}
               </a>
               {' '}


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
I just noticed an extra `@` sign on the chat screen, which can be removed. 
![Screen Shot 2019-06-04 at 8 59 52 PM](https://user-images.githubusercontent.com/8046636/58881737-5ca2ab80-870d-11e9-8a91-679bdf4b5549.png)

## Related Tickets & Documents
- None

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
- None

## Added to documentation?
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![](https://media.giphy.com/media/26n3JcZS59xgsKXkI/giphy.gif)
