### PR TITLE
Remove switch organizations tab from settings and clear Rails cache for PUT /admin/organizations

### DIFF
--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -8,6 +8,11 @@ module Admin
     #   @resources = Organization.all.paginate(10, params[:page])
     # end
 
+    def update
+      super
+      @requested_resource.touch(:profile_updated_at)
+    end
+
     # Define a custom finder by overriding the `find_resource` method:
     # def find_resource(param)
     #   Organization.find_by!(slug: param)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -404,16 +404,16 @@ class User < ApplicationRecord
   end
 
   def settings_tab_list
-    tab_list = %w[
+    %w[
       Profile
       Integrations
       Notifications
       Publishing\ from\ RSS
       Organization
       Billing
+      Account
+      Misc
     ]
-    tab_list << "Switch Organizations" if has_role?(:switch_between_orgs)
-    tab_list.push("Account", "Misc")
   end
 
   def profile_image_90

--- a/app/views/users/_switch_organizations.html.erb
+++ b/app/views/users/_switch_organizations.html.erb
@@ -1,4 +1,0 @@
-<% if @user.has_role?(:switch_between_orgs) %>
-  <h1 style="color:#00cc44">Hey Mary 👋</h1>
-  <%= render "users/org_non_member" %>
-<% end %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This removes the "Switch Organizations" tab and the related partial. Also clears any Rails caches when updating an organization via `/admin`.