### PR TITLE
Moved Podcast#pull_all_episodes to a separate ActiveJob #2952 #2497

### DIFF
--- a/app/jobs/podcasts/get_episodes_job.rb
+++ b/app/jobs/podcasts/get_episodes_job.rb
@@ -1,0 +1,12 @@
+module Podcasts
+  class GetEpisodesJob < ApplicationJob
+    queue_as :podcasts_get_episodes
+
+    def perform(podcast_id, limit = 1000, feed = PodcastFeed.new)
+      podcast = Podcast.find_by(id: podcast_id)
+      return unless podcast
+
+      feed.get_episodes(podcast, limit)
+    end
+  end
+end

--- a/app/labor/podcast_feed.rb
+++ b/app/labor/podcast_feed.rb
@@ -2,12 +2,6 @@ require "rss"
 require "rss/itunes"
 
 class PodcastFeed
-  def get_all_episodes
-    Podcast.find_each do |podcast|
-      get_episodes(podcast)
-    end
-  end
-
   def get_episodes(podcast, num = 1000)
     rss = HTTParty.get(podcast.feed_url).body
     feed = RSS::Parser.parse(rss, false)

--- a/app/models/podcast.rb
+++ b/app/models/podcast.rb
@@ -28,7 +28,10 @@ class Podcast < ApplicationRecord
   end
 
   def pull_all_episodes
-    PodcastFeed.new.get_episodes(self)
+    Podcasts::GetEpisodesJob.perform_later(id)
   end
-  handle_asynchronously :pull_all_episodes
+
+  def pull_all_episodes_without_delay
+    Podcasts::GetEpisodesJob.perform_now(id)
+  end
 end

--- a/lib/tasks/fetch.rake
+++ b/lib/tasks/fetch.rake
@@ -1,9 +1,8 @@
 desc "This task is called by the Heroku scheduler add-on"
 
 task get_podcast_episodes: :environment do
-  feed = PodcastFeed.new
-  Podcast.find_each do |p|
-    feed.get_episodes(p, 5)
+  Podcast.select(:id).find_each do |podcast|
+    Podcasts::GetEpisodesJob.perform_later(podcast.id, 5)
   end
 end
 

--- a/lib/tasks/fetch.rake
+++ b/lib/tasks/fetch.rake
@@ -1,8 +1,9 @@
 desc "This task is called by the Heroku scheduler add-on"
 
 task get_podcast_episodes: :environment do
+  feed = PodcastFeed.new
   Podcast.find_each do |p|
-    PodcastFeed.new.get_episodes(p, 5)
+    feed.get_episodes(p, 5)
   end
 end
 

--- a/spec/jobs/podcasts/get_episodes_job_spec.rb
+++ b/spec/jobs/podcasts/get_episodes_job_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe Podcasts::GetEpisodesJob, type: :job do
+  include_examples "#enqueues_job", "podcasts_get_episodes", [1, 4]
+
+  describe "#perform_now" do
+    let(:feed) { double }
+    let(:podcast) { create(:podcast) }
+
+    before do
+      allow(feed).to receive(:get_episodes)
+    end
+
+    it "calls the service" do
+      described_class.perform_now(podcast.id, 5, feed)
+      expect(feed).to have_received(:get_episodes).with(podcast, 5).once
+    end
+
+    it "doesn't call the service when the podcast is not found" do
+      described_class.perform_now(Podcast.maximum(:id).to_i + 1, 5, feed)
+      expect(feed).not_to have_received(:get_episodes)
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
- moved Podcast#pull_all_episodes to a separate ActiveJob
- deleted unused `PodcastFeed#get_all_episodes` method

## Related Tickets & Documents
#2952, #2497