### PR TITLE
Add a space between "Change meta tag" and canonical_url

### DIFF
--- a/app/javascript/article-form/elements/moreConfig.jsx
+++ b/app/javascript/article-form/elements/moreConfig.jsx
@@ -71,6 +71,7 @@ export default class MoreConfig extends Component {
         </div>
         <small>
           Change meta tag
+          {' '}
           <code>canonical_url</code>
           {' '}
 if this post was first published elsewhere


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

Without the space between these two elements, this shows up as Change meta tag`canonical_url`.

## Related Tickets & Documents

https://github.com/prettier/prettier/issues/4223#issuecomment-380093772 describes how composing JSX elements over multiple lines needs `{' '}`.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

I haven't actually tried this myself, but I saw the before image at https://www.cdevn.com/why-medium-actually-sucks/:

![](https://www.cdevn.com/assets/static/devto.cbab2cf.d3a7c86.png)

and looking at the code, I could see why it looked that way, and what to do to fix it.

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed