### PR TITLE
Fix improper archive redirect

### DIFF
--- a/app/assets/javascripts/initializers/initializeEllipsisMenu.js
+++ b/app/assets/javascripts/initializers/initializeEllipsisMenu.js
@@ -68,6 +68,8 @@ function handleFormSubmit(e) {
 
     if (xhr.status === 200) {
       onXhrSuccess(form, article, values);
+      var message = values.commit === 'Mute Notifications' ? 'Notifications Muted' : 'Notifications Restored';
+      article.querySelector('.dashboard-meta-details').innerHTML = message;
     } else {
       article.querySelector('.dashboard-meta-details').innerHTML =
         'Failed to update article.';

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -146,6 +146,10 @@ class ArticlesController < ApplicationController
 
     respond_to do |format|
       format.html do
+        if article_params_json[:archived] && @article.archived #just to get archived working
+          render json: @article.to_json(only: [:id], methods: [:current_state_path])
+          return
+        end
         # NOTE: destination is used by /dashboard/organization when it re-assigns an article
         # not a great solution but for now it will do
         redirect_to(params[:destination] || @article.path)
@@ -241,7 +245,7 @@ class ArticlesController < ApplicationController
                      else
                        %i[
                          title body_markdown main_image published description
-                         tag_list canonical_url series collection_id
+                         tag_list canonical_url series collection_id archived
                        ]
                      end
 

--- a/spec/requests/articles_update_spec.rb
+++ b/spec/requests/articles_update_spec.rb
@@ -75,4 +75,11 @@ RSpec.describe "ArticlesUpdate", type: :request do
     expect(article.reload.user).to eq(other_user)
     expect(article.organization_id).to eq(admin_org_id)
   end
+
+  it "archives" do
+    put "/articles/#{article.id}", params: {
+      article: { archived: true }
+    }
+    expect(article.archived).to eq(false)
+  end
 end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
We were getting an "improper http loaded to https" issue, which is kind of related to a broader handling of how redirects are handled via ajax on our site.

But the reason this was inducing a redirect had to do with a different logical error. This fixes it up. Could be cleaner but this is solid and adds a test.

Also took the time to add a better visual response to muting a thread—which is related to this area of the code and needed to be improved.

Fixes #2995 