### PR TITLE
Clear Rails cache for destroyed comment's ancestors and destroy buffer_updates for articles

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -22,7 +22,7 @@ class Article < ApplicationRecord
   counter_culture :organization
 
   has_many :comments, as: :commentable, inverse_of: :commentable
-  has_many :buffer_updates
+  has_many :buffer_updates, dependent: :destroy
   has_many :notifications, as: :notifiable, inverse_of: :notifiable
   has_many :rating_votes
   has_many :page_views

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -251,6 +251,7 @@ class Comment < ApplicationRecord
 
   def before_destroy_actions
     commentable.touch(:last_comment_at) if commentable.respond_to?(:last_comment_at)
+    ancestors.update_all(updated_at: Time.current)
     remove_notifications
     bust_cache_without_delay
     remove_algolia_index


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
1. Clear the Rails cache for a destroyed comment's ancestors. This will hopefully resolve some caching issues that are caused by comments being destroyed.
2. Add `dependent: :destroy` for `buffer_updates` so there aren't any orphaned `buffer_updates` that cause issues in `/internal/articles`.