### PR TITLE
Move bust_cache methods in own jobs

### DIFF
--- a/app/controllers/concerns/classified_listings_toolkit.rb
+++ b/app/controllers/concerns/classified_listings_toolkit.rb
@@ -28,11 +28,6 @@ module ClassifiedListingsToolkit
   end
 
   def clear_listings_cache
-    cb = CacheBuster.new
-    cb.bust("/listings")
-    cb.bust("/listings?i=i")
-    cb.bust("/listings/#{@classified_listing.category}/#{@classified_listing.slug}")
-    cb.bust("/listings/#{@classified_listing.category}/#{@classified_listing.slug}?i=i")
-    cb.bust("/listings/#{@classified_listing.category}")
+    ClassifiedListings::BustCacheJob.perform_now(@classified_listing.id)
   end
 end

--- a/app/jobs/classified_listings/bust_cache_job.rb
+++ b/app/jobs/classified_listings/bust_cache_job.rb
@@ -1,0 +1,13 @@
+module ClassifiedListings
+  class BustCacheJob < ApplicationJob
+    queue_as :classified_listings_bust_cache
+
+    def perform(classified_listing_id, cache_buster = CacheBuster.new)
+      classified_listing = ClassifiedListing.find_by(id: classified_listing_id)
+
+      return unless classified_listing
+
+      cache_buster.bust_classified_listings(classified_listing)
+    end
+  end
+end

--- a/app/jobs/events/bust_cache_job.rb
+++ b/app/jobs/events/bust_cache_job.rb
@@ -1,0 +1,9 @@
+module Events
+  class BustCacheJob < ApplicationJob
+    queue_as :events_bust_cache
+
+    def perform(cache_buster = CacheBuster.new)
+      cache_buster.bust_events
+    end
+  end
+end

--- a/app/jobs/organizations/bust_cache_job.rb
+++ b/app/jobs/organizations/bust_cache_job.rb
@@ -1,0 +1,13 @@
+module Organizations
+  class BustCacheJob < ApplicationJob
+    queue_as :organizations_bust_cache
+
+    def perform(organization_id, slug, cache_buster = CacheBuster.new)
+      organization = Organization.find_by(id: organization_id)
+
+      return unless organization
+
+      cache_buster.bust_organization(organization, slug)
+    end
+  end
+end

--- a/app/jobs/pages/bust_cache_job.rb
+++ b/app/jobs/pages/bust_cache_job.rb
@@ -1,0 +1,9 @@
+module Pages
+  class BustCacheJob < ApplicationJob
+    queue_as :pages_bust_cache
+
+    def perform(slug, cache_buster = CacheBuster.new)
+      cache_buster.bust_page(slug)
+    end
+  end
+end

--- a/app/jobs/podcast_episodes/bust_cache_job.rb
+++ b/app/jobs/podcast_episodes/bust_cache_job.rb
@@ -1,0 +1,12 @@
+module PodcastEpisodes
+  class BustCacheJob < ApplicationJob
+    queue_as :podcast_episodes_bust_cache
+
+    def perform(podcast_episode_id, path, podcast_slug, cache_buster = CacheBuster.new)
+      podcast_episode = PodcastEpisode.find_by(id: podcast_episode_id)
+      return unless podcast_episode
+
+      cache_buster.bust_podcast_episode(podcast_episode, path, podcast_slug)
+    end
+  end
+end

--- a/app/jobs/podcasts/bust_cache_job.rb
+++ b/app/jobs/podcasts/bust_cache_job.rb
@@ -1,0 +1,9 @@
+module Podcasts
+  class BustCacheJob < ApplicationJob
+    queue_as :podcasts_bust_cache
+
+    def perform(path, cache_buster = CacheBuster.new)
+      cache_buster.bust_podcast(path)
+    end
+  end
+end

--- a/app/jobs/tags/bust_cache_job.rb
+++ b/app/jobs/tags/bust_cache_job.rb
@@ -1,0 +1,9 @@
+module Tags
+  class BustCacheJob < ApplicationJob
+    queue_as :tags_bust_cache
+
+    def perform(name, cache_buster = CacheBuster.new)
+      cache_buster.bust_tag(name)
+    end
+  end
+end

--- a/app/labor/cache_buster.rb
+++ b/app/labor/cache_buster.rb
@@ -111,4 +111,62 @@ class CacheBuster
       end
     end
   end
+
+  def bust_page(slug)
+    bust "/page/#{slug}"
+    bust "/page/#{slug}?i=i"
+    bust "/#{slug}"
+    bust "/#{slug}?i=i"
+  end
+
+  def bust_tag(name)
+    bust("/t/#{name}")
+    bust("/t/#{name}?i=i")
+    bust("/t/#{name}/?i=i")
+    bust("/t/#{name}/")
+    bust("/tags")
+  end
+
+  def bust_events
+    bust("/events")
+    bust("/events?i=i")
+  end
+
+  def bust_podcast(path)
+    bust("/" + path)
+  end
+
+  def bust_organization(organization, slug)
+    bust("/#{slug}")
+    begin
+      organization.articles.find_each do |article|
+        bust(article.path)
+      end
+    rescue StandardError => e
+      Rails.logger.error("Tag issue: #{e}")
+    end
+  end
+
+  def bust_podcast_episode(podcast_episode, path, podcast_slug)
+    podcast_episode.purge
+    podcast_episode.purge_all
+    begin
+      bust(path)
+      bust("/" + podcast_slug)
+      bust("/pod")
+      bust(path)
+    rescue StandardError => e
+      Rails.logger.warn(e)
+    end
+    podcast_episode.purge
+    podcast_episode.purge_all
+  end
+
+  def bust_classified_listings(classified_listing)
+    bust("/listings")
+    bust("/listings?i=i")
+    bust("/listings/#{classified_listing.category}/#{classified_listing.slug}")
+    bust("/listings/#{classified_listing.category}/#{classified_listing.slug}?i=i")
+    bust("/listings/#{classified_listing.category}")
+  end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -45,8 +45,6 @@ class Event < ApplicationRecord
   end
 
   def bust_cache
-    cache_buster = CacheBuster.new
-    cache_buster.bust("/events")
-    cache_buster.bust("/events?i=i")
+    Events::BustCacheJob.perform_later
   end
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -119,17 +119,8 @@ class Organization < ApplicationRecord
   end
 
   def bust_cache
-    cache_buster = CacheBuster.new
-    cache_buster.bust("/#{slug}")
-    begin
-      articles.find_each do |article|
-        cache_buster.bust(article.path)
-      end
-    rescue StandardError => e
-      Rails.logger.error("Tag issue: #{e}")
-    end
+    Organizations::BustCacheJob.perform_later(id, slug)
   end
-  handle_asynchronously :bust_cache
 
   def unique_slug_including_users_and_podcasts
     errors.add(:slug, "is taken.") if User.find_by(username: slug) || Podcast.find_by(slug: slug) || Page.find_by(slug: slug)

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -40,9 +40,6 @@ class Page < ApplicationRecord
   end
 
   def bust_cache
-    CacheBuster.new.bust "/page/#{slug}"
-    CacheBuster.new.bust "/page/#{slug}?i=i"
-    CacheBuster.new.bust "/#{slug}"
-    CacheBuster.new.bust "/#{slug}?i=i"
+    Pages::BustCacheJob.perform_later(slug)
   end
 end

--- a/app/models/podcast.rb
+++ b/app/models/podcast.rb
@@ -28,6 +28,10 @@ class Podcast < ApplicationRecord
   def bust_cache
     return unless path
 
-    CacheBuster.new.bust("/" + path)
+    Podcasts::BustCacheJob.perform_later(path)
+  end
+
+  def pull_all_episodes
+    Podcasts::GetEpisodesJob.perform_later(id)
   end
 end

--- a/app/models/podcast_episode.rb
+++ b/app/models/podcast_episode.rb
@@ -114,19 +114,7 @@ class PodcastEpisode < ApplicationRecord
   alias positive_reactions_count zero_method
 
   def bust_cache
-    purge
-    purge_all
-    begin
-      cache_buster = CacheBuster.new
-      cache_buster.bust(path)
-      cache_buster.bust("/" + podcast_slug)
-      cache_buster.bust("/pod")
-      cache_buster.bust(path)
-    rescue StandardError => e
-      Rails.logger.warn(e)
-    end
-    purge
-    purge_all
+    PodcastEpisodes::BustCacheJob.perform_later(id, path, podcast_slug)
   end
 
   def class_name

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -77,12 +77,7 @@ class Tag < ActsAsTaggableOn::Tag
   end
 
   def bust_cache
-    cache_buster = CacheBuster.new
-    cache_buster.bust("/t/#{name}")
-    cache_buster.bust("/t/#{name}?i=i")
-    cache_buster.bust("/t/#{name}/?i=i")
-    cache_buster.bust("/t/#{name}/")
-    cache_buster.bust("/tags")
+    Tags::BustCacheJob.perform_later(name)
   end
 
   def validate_alias

--- a/spec/jobs/classified_listings/bust_cache_job_spec.rb
+++ b/spec/jobs/classified_listings/bust_cache_job_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe ClassifiedListings::BustCacheJob, type: :job do
+  include_examples "#enqueues_job", "classified_listings_bust_cache", 789
+
+  describe "#perform_now" do
+    let(:user) { create(:user) }
+    let!(:classified_listing) { FactoryBot.create(:classified_listing, user_id: user.id) }
+    let(:cache_buster) { double }
+
+    before do
+      allow(cache_buster).to receive(:bust_classified_listings)
+    end
+
+    describe "when no listing is found" do
+      it "doest not call the service" do
+        allow(ClassifiedListing).to receive(:find_by).and_return(nil)
+        described_class.perform_now(789, cache_buster)
+        expect(cache_buster).not_to have_received(:bust_classified_listings)
+      end
+    end
+
+    it "busts cache" do
+      described_class.perform_now(classified_listing.id, cache_buster)
+      expect(cache_buster).to have_received(:bust_classified_listings).with(classified_listing)
+    end
+  end
+end

--- a/spec/jobs/events/bust_cache_job_spec.rb
+++ b/spec/jobs/events/bust_cache_job_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe Events::BustCacheJob do
+  let(:cache_buster) { instance_double(CacheBuster) }
+
+  before do
+    allow(CacheBuster).to receive(:new).and_return(cache_buster)
+    allow(cache_buster).to receive(:bust_events)
+  end
+
+  include_examples "#enqueues_job", "events_bust_cache"
+
+  describe "#perform_now" do
+    it "busts cache" do
+      cache_buster = double
+      allow(cache_buster).to receive(:bust_events)
+
+      described_class.perform_now(cache_buster)
+      expect(cache_buster).to have_received(:bust_events)
+    end
+  end
+end

--- a/spec/jobs/organizations/bust_cache_job_spec.rb
+++ b/spec/jobs/organizations/bust_cache_job_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe Organizations::BustCacheJob, type: :job do
+  include_examples "#enqueues_job", "organizations_bust_cache", 789, "SlUg"
+
+  describe "#perform_now" do
+    let!(:organization) { FactoryBot.create(:organization) }
+    let(:cache_buster) { instance_double(CacheBuster) }
+
+    before do
+      allow(CacheBuster).to receive(:new).and_return(cache_buster)
+      allow(cache_buster).to receive(:bust_organization)
+    end
+
+    describe "when no organization is found" do
+      it "doest not call the service" do
+        allow(Organization).to receive(:find_by).and_return(nil)
+        described_class.perform_now(789, "SlUg", cache_buster)
+        expect(cache_buster).not_to have_received(:bust_organization)
+      end
+    end
+
+    it "busts cache" do
+      described_class.perform_now(organization.id, "SlUg", cache_buster)
+      expect(cache_buster).to have_received(:bust_organization).with(organization, "SlUg")
+    end
+  end
+end

--- a/spec/jobs/pages/bust_cache_job_spec.rb
+++ b/spec/jobs/pages/bust_cache_job_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe Pages::BustCacheJob do
+  let(:cache_buster) { instance_double(CacheBuster) }
+
+  before do
+    allow(CacheBuster).to receive(:new).and_return(cache_buster)
+    allow(cache_buster).to receive(:bust_page)
+  end
+
+  include_examples "#enqueues_job", "pages_bust_cache", "SlUg"
+
+  describe "#perform_now" do
+    it "busts cache" do
+      described_class.perform_now("SlUg", cache_buster)
+      expect(cache_buster).to have_received(:bust_page).with("SlUg")
+    end
+  end
+end

--- a/spec/jobs/podcast_episodes/bust_cache_job_spec.rb
+++ b/spec/jobs/podcast_episodes/bust_cache_job_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe PodcastEpisodes::BustCacheJob do
+  include_examples "#enqueues_job", "podcast_episodes_bust_cache", 789, "/PodCAst/SlUg", "SlUg"
+
+  describe "#perform_now" do
+    let!(:podcast) { create(:podcast) }
+    let!(:podcast_episode) { FactoryBot.create(:podcast_episode, podcast_id: podcast.id) }
+    let(:cache_buster) { instance_double(CacheBuster) }
+
+    before do
+      allow(CacheBuster).to receive(:new).and_return(cache_buster)
+      allow(cache_buster).to receive(:bust_podcast_episode)
+    end
+
+    describe "when no podcast episode is found" do
+      it "does not call the service" do
+        allow(PodcastEpisode).to receive(:find_by).and_return(nil)
+        described_class.perform_now(789, "/PodCAst/SlUg", "SlUg", cache_buster)
+        expect(cache_buster).not_to have_received(:bust_podcast_episode)
+      end
+    end
+
+    it "busts cache" do
+      described_class.perform_now(podcast_episode.id, "/PodCAst/SlUg", "SlUg", cache_buster)
+      expect(cache_buster).to have_received(:bust_podcast_episode).with(podcast_episode, "/PodCAst/SlUg", "SlUg")
+    end
+  end
+end

--- a/spec/jobs/podcasts/bust_cache_job_spec.rb
+++ b/spec/jobs/podcasts/bust_cache_job_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe Podcasts::BustCacheJob do
+  let(:cache_buster) { instance_double(CacheBuster) }
+
+  before do
+    allow(CacheBuster).to receive(:new).and_return(cache_buster)
+    allow(cache_buster).to receive(:bust_podcast)
+  end
+
+  include_examples "#enqueues_job", "podcasts_bust_cache"
+
+  describe "#perform_now" do
+    it "busts cache" do
+      described_class.perform_now("path", cache_buster)
+      expect(cache_buster).to have_received(:bust_podcast).with("path")
+    end
+  end
+end

--- a/spec/jobs/tags/bust_cache_job_spec.rb
+++ b/spec/jobs/tags/bust_cache_job_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe Tags::BustCacheJob do
+  let(:cache_buster) { instance_double(CacheBuster) }
+
+  before do
+    allow(CacheBuster).to receive(:new).and_return(cache_buster)
+    allow(cache_buster).to receive(:bust_tag)
+  end
+
+  include_examples "#enqueues_job", "tags_bust_cache", "PHP"
+
+  describe "#perform_now" do
+    it "busts cache" do
+      described_class.perform_now("PHP", cache_buster)
+      expect(cache_buster).to have_received(:bust_tag).with("PHP")
+    end
+  end
+end

--- a/spec/labor/cache_buster_spec.rb
+++ b/spec/labor/cache_buster_spec.rb
@@ -5,6 +5,10 @@ RSpec.describe CacheBuster do
   let(:user) { create(:user) }
   let(:article) { create(:article, user_id: user.id) }
   let(:comment) { create(:comment, user_id: user.id, commentable_id: article.id) }
+  let(:organization) { create(:organization) }
+  let(:listing) { create(:classified_listing, user_id: user.id, category: "cfp") }
+  let(:podcast) { create(:podcast) }
+  let(:podcast_episode) { create(:podcast_episode, podcast_id: podcast.id) }
 
   describe "#bust_comment" do
     it "busts comment" do
@@ -28,6 +32,66 @@ RSpec.describe CacheBuster do
     it "busts featured article" do
       article.update_columns(featured: true)
       cache_buster.bust_article(article)
+    end
+  end
+
+  describe "#bust_page" do
+    it "busts page + slug " do
+      cache_buster.bust_page("SlUg")
+    end
+  end
+
+  describe "#bust_tag" do
+    it "busts tag name + tags" do
+      cache_buster.bust_tag("cfp")
+    end
+  end
+
+  describe "#bust_events" do
+    it "busts events" do
+      cache_buster.bust_events
+    end
+  end
+
+  describe "#bust_podcast" do
+    it "busts podcast" do
+      cache_buster.bust_podcast("jsparty/the-story-of-konami-js")
+    end
+  end
+
+  describe "#bust_organization" do
+    before do
+      create(:article, organization_id: organization.id)
+    end
+
+    it "busts slug + article path" do
+      cache_buster.bust_organization(organization, "SlUg")
+    end
+
+    it "logs an error from bust_organization" do
+      allow(Rails.logger).to receive(:error)
+      cache_buster.bust_organization(4, 5)
+      expect(Rails.logger).to have_received(:error).once
+    end
+  end
+
+  describe "#bust_podcast_episode" do
+    it "busts podcast episode" do
+      cache_buster.bust_podcast_episode(podcast_episode, "/cfp", "-007")
+    end
+
+    it "logs an error from bust_podcast_episode" do
+      allow(Rails.logger).to receive(:warn)
+      allow(described_class).to receive(:new).and_return(cache_buster)
+      allow(cache_buster).to receive(:bust).and_raise(StandardError)
+      cache_buster.bust_podcast_episode(podcast_episode, 12, "-007")
+      expect(Rails.logger).to have_received(:warn).once
+    end
+  end
+
+  describe "#bust_classified_listings" do
+    it "busts classified listings" do
+      cache_buster.bust_classified_listings(listing)
     end
   end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -22,4 +22,8 @@ RSpec.describe Event, type: :model do
     event.published = true
     expect(event).to be_valid
   end
+
+  it "triggers cache busting on save" do
+    expect { build(:event).save }.to have_enqueued_job.on_queue("events_bust_cache")
+  end
 end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -101,6 +101,10 @@ RSpec.describe Organization, type: :model do
       expect(organization).not_to be_valid
       expect(organization.errors[:slug].to_s.include?("taken")).to be true
     end
+
+    it "triggers cache busting on save" do
+      expect { build(:organization).save }.to have_enqueued_job.on_queue("organizations_bust_cache")
+    end
   end
 
   describe "#url" do

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe Page, type: :model do
       page.body_markdown = nil
       expect(page).not_to be_valid
     end
+
+    it "triggers cache busting on save" do
+      expect { build(:page).save }.to have_enqueued_job.on_queue("pages_bust_cache")
+    end
   end
 
   describe "#validations" do

--- a/spec/models/podcast_episode_spec.rb
+++ b/spec/models/podcast_episode_spec.rb
@@ -82,4 +82,8 @@ RSpec.describe PodcastEpisode, type: :model do
       end
     end
   end
+
+  it "triggers cache busting on save" do
+    expect { build(:podcast_episode).save }.to have_enqueued_job.on_queue("podcast_episodes_bust_cache")
+  end
 end

--- a/spec/models/podcast_spec.rb
+++ b/spec/models/podcast_spec.rb
@@ -14,6 +14,10 @@ RSpec.describe Podcast, type: :model do
       expect(podcast).to be_valid
     end
 
+    it "triggers cache busting on save" do
+      expect { podcast.save }.to have_enqueued_job.on_queue("podcasts_bust_cache").twice
+    end
+
     # Couldn't use shoulda uniqueness matchers for these tests because:
     # Shoulda uses `save(validate: false)` which skips validations
     # So an invalid record is trying to be saved but fails because of the db constraints

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -42,4 +42,8 @@ RSpec.describe Tag, type: :model do
   it "knows class valid categories" do
     expect(Tag.valid_categories).to include("tool")
   end
+
+  it "triggers cache busting on save" do
+    expect { build(:tag).save }.to have_enqueued_job.on_queue("tags_bust_cache")
+  end
 end

--- a/spec/requests/internal/classified_listings_spec.rb
+++ b/spec/requests/internal/classified_listings_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe "/internal/listings", type: :request do
+  describe "PUT /internal/listings/:id" do
+    let(:admin) { create(:user, :super_admin) }
+    let(:classified_listing) { create(:classified_listing, user_id: admin.id) }
+    let(:cache_buster) { instance_double(CacheBuster) }
+
+    before do
+      allow(CacheBuster).to receive(:new).and_return(cache_buster)
+      allow(cache_buster).to receive(:bust_classified_listings)
+      sign_in admin
+    end
+
+    it "clears listing cache" do
+      put "/internal/listings/#{classified_listing.id}", params: {
+        classified_listing: { title: "updated" }
+      }
+      expect(cache_buster).to have_received(:bust_classified_listings)
+    end
+  end
+end


### PR DESCRIPTION
  - that calls cache_buster service
  - specs for jobs + service
  - for: classified listings, events, organizations, pages, podcast_episodes, podcasts, tags
  - refactoring (models, service)

<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Move bust_cache methods in their own jobs
## Related Tickets & Documents
#2497 
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [ ] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
