### PR TITLE
Fix reading list filters input's color in night theme

### DIFF
--- a/app/assets/stylesheets/readinglist.scss
+++ b/app/assets/stylesheets/readinglist.scss
@@ -22,6 +22,7 @@
       box-sizing: border-box;
       margin-bottom: 4px;
       @include themeable(background, theme-container-accent-background, lighten($light-gray, 2%));
+      @include themeable(color, theme-color, $black);
     }
     .readinglist-tags {
       padding-bottom: 25px;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
This fixes the input's color of the reading list filters in night theme ( or any future theme that does not have black as theme color )

![reading list filter](https://user-images.githubusercontent.com/14861869/59165482-8ba98a80-8b1c-11e9-889f-d09bc3fdabed.PNG)

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

before
![before](https://user-images.githubusercontent.com/14861869/59165485-92d09880-8b1c-11e9-9606-c918c3a86da1.PNG)

after
![after](https://user-images.githubusercontent.com/14861869/59165487-95cb8900-8b1c-11e9-920e-d2da9158a921.PNG)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
