### PR TITLE
Removed fetching podcasts from a callback

### DIFF
--- a/app/controllers/admin/podcasts_controller.rb
+++ b/app/controllers/admin/podcasts_controller.rb
@@ -1,19 +1,20 @@
 module Admin
   class PodcastsController < Admin::ApplicationController
-    # To customize the behavior of this controller,
-    # simply overwrite any of the RESTful actions. For example:
-    #
-    # def index
-    #   super
-    #   @resources = Podcast.all.paginate(10, params[:page])
-    # end
+    def create
+      resource = resource_class.new(resource_params)
+      authorize_resource(resource)
 
-    # Define a custom finder by overriding the `find_resource` method:
-    # def find_resource(param)
-    #   Podcast.find_by!(slug: param)
-    # end
-
-    # See https://administrate-docs.herokuapp.com/customizing_controller_actions
-    # for more information
+      if resource.save
+        Podcasts::GetEpisodesJob.perform_later(resource.id)
+        redirect_to(
+          [namespace, resource],
+          notice: translate_with_resource("create.success"),
+        )
+      else
+        render :new, locals: {
+          page: Administrate::Page::Form.new(dashboard, resource)
+        }
+      end
+    end
   end
 end

--- a/app/models/podcast.rb
+++ b/app/models/podcast.rb
@@ -7,7 +7,6 @@ class Podcast < ApplicationRecord
   validates :main_color_hex, presence: true
 
   after_save :bust_cache
-  after_create :pull_all_episodes
 
   def path
     slug
@@ -25,13 +24,5 @@ class Podcast < ApplicationRecord
 
   def bust_cache
     CacheBuster.new.bust("/" + path)
-  end
-
-  def pull_all_episodes
-    Podcasts::GetEpisodesJob.perform_later(id)
-  end
-
-  def pull_all_episodes_without_delay
-    Podcasts::GetEpisodesJob.perform_now(id)
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -169,13 +169,9 @@ podcast_objects = [
   },
 ]
 
-# skip after create callback to avoid pulling 1000 episodes during seeding
-Podcast.skip_callback(:create, :after, :pull_all_episodes)
 podcast_objects.each do |attributes|
   Podcast.create!(attributes)
 end
-# restore the callback for future usage
-Podcast.set_callback(:create, :after, :pull_all_episodes)
 
 ##############################################################################
 

--- a/spec/factories/podcasts.rb
+++ b/spec/factories/podcasts.rb
@@ -11,6 +11,5 @@ FactoryBot.define do
     slug            { "slug-#{rand(10_000)}" }
     feed_url        { Faker::Internet.url }
     main_color_hex  { "ffffff" }
-    after(:build)   { |pod| pod.define_singleton_method(:pull_all_episodes) {} }
   end
 end

--- a/spec/requests/admin/podcasts_spec.rb
+++ b/spec/requests/admin/podcasts_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe "Admin::Podcasts", type: :request do
+  let(:super_admin) { create(:user, :super_admin) }
+
+  before do
+    sign_in super_admin
+  end
+
+  describe "POST #create" do
+    let(:valid_attributes) do
+      {
+        title: "Developer Tea",
+        description: "Super Podcast",
+        feed_url: "http://feeds.feedburner.com/developertea",
+        slug: "devtea",
+        main_color_hex: "333333"
+      }
+    end
+
+    it "creates a podcast" do
+      expect do
+        post "/admin/podcasts", params: { podcast: valid_attributes }
+      end.to change(Podcast, :count).by(1)
+    end
+
+    it "enqueues a job after creating a podcast" do
+      expect do
+        post "/admin/podcasts", params: { podcast: valid_attributes }
+      end.to have_enqueued_job(Podcasts::GetEpisodesJob).exactly(:once)
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
- removed an `after_create` callback for fetching podcast episodes
- added fetching podcast episodes to the admin controller action
- created request specs for podcast creating from `/admin/podcasts/new`
- removed hacks that disable fetching podcasts while seeding and running tests

Creating a podcast and fetching episodes shouldn't be tightly coupled. We sometimes want to create a podcast without fetching episodes, e.g. for tests or for seeding the database.

## Related Tickets & Documents
#2952 