### PR TITLE
Dashboard Pro: support InstantClick and show org analytics

### DIFF
--- a/app/javascript/analytics/dashboard.js
+++ b/app/javascript/analytics/dashboard.js
@@ -1,7 +1,7 @@
 import Chart from 'chart.js';
 
 function resetActive(activeButton) {
-  const buttons = document.getElementsByClassName('timespan-button');
+  const buttons = document.getElementsByClassName('timerange-button');
   for (let i = 0; i < buttons.length; i += 1) {
     const button = buttons[i];
     button.classList.remove('selected');
@@ -21,7 +21,7 @@ function cardHTML(stat, header) {
   `;
 }
 
-function writeCards(data, timeFrame) {
+function writeCards(data, timeRangeLabel) {
   const readers = sumAnalytics(data, 'page_views');
   const reactions = sumAnalytics(data, 'reactions');
   const comments = sumAnalytics(data, 'comments');
@@ -32,10 +32,10 @@ function writeCards(data, timeFrame) {
   const followerCard = document.getElementById('followers-card');
   const readerCard = document.getElementById('readers-card');
 
-  readerCard.innerHTML = cardHTML(readers, `Readers ${timeFrame}`);
-  commentCard.innerHTML = cardHTML(comments, `Comments ${timeFrame}`);
-  reactionCard.innerHTML = cardHTML(reactions, `Reactions ${timeFrame}`);
-  followerCard.innerHTML = cardHTML(follows, `Followers ${timeFrame}`);
+  readerCard.innerHTML = cardHTML(readers, `Readers ${timeRangeLabel}`);
+  commentCard.innerHTML = cardHTML(comments, `Comments ${timeRangeLabel}`);
+  reactionCard.innerHTML = cardHTML(reactions, `Reactions ${timeRangeLabel}`);
+  followerCard.innerHTML = cardHTML(follows, `Followers ${timeRangeLabel}`);
 }
 
 function drawChart({ canvas, title, labels, datasets }) {
@@ -71,7 +71,7 @@ function drawChart({ canvas, title, labels, datasets }) {
   });
 }
 
-function drawCharts(data, timeRange) {
+function drawCharts(data, timeRangeLabel) {
   const labels = Object.keys(data);
   const parsedData = Object.entries(data).map(date => date[1]);
   const comments = parsedData.map(date => date.comments.total);
@@ -84,7 +84,7 @@ function drawCharts(data, timeRange) {
 
   drawChart({
     canvas: document.getElementById('reactionsChart'),
-    title: `Reactions ${timeRange}`,
+    title: `Reactions ${timeRangeLabel}`,
     labels,
     datasets: [
       {
@@ -120,7 +120,7 @@ function drawCharts(data, timeRange) {
 
   drawChart({
     canvas: document.getElementById('commentsChart'),
-    title: `Comments ${timeRange}`,
+    title: `Comments ${timeRangeLabel}`,
     labels,
     datasets: [
       {
@@ -135,7 +135,7 @@ function drawCharts(data, timeRange) {
 
   drawChart({
     canvas: document.getElementById('followersChart'),
-    title: `New Followers ${timeRange}`,
+    title: `New Followers ${timeRangeLabel}`,
     labels,
     datasets: [
       {
@@ -150,7 +150,7 @@ function drawCharts(data, timeRange) {
 
   drawChart({
     canvas: document.getElementById('readersChart'),
-    title: `Reads ${timeRange}`,
+    title: `Reads ${timeRangeLabel}`,
     labels,
     datasets: [
       {
@@ -164,12 +164,12 @@ function drawCharts(data, timeRange) {
   });
 }
 
-function callAnalyticsApi(date, timeRange) {
+function callAnalyticsApi(date, timeRangeLabel) {
   fetch(`/api/analytics/historical?start=${date.toISOString().split('T')[0]}`)
     .then(data => data.json())
     .then(data => {
-      drawCharts(data, timeRange);
-      writeCards(data, timeRange);
+      drawCharts(data, timeRangeLabel);
+      writeCards(data, timeRangeLabel);
     });
 }
 

--- a/app/javascript/analytics/dashboard.js
+++ b/app/javascript/analytics/dashboard.js
@@ -258,7 +258,7 @@ function drawInfinityCharts() {
   callAnalyticsApi(beginningOfTime, '');
 }
 
-function init() {
+export default function initCharts() {
   const weekButton = document.getElementById('week-button');
   weekButton.addEventListener('click', drawWeekCharts);
 
@@ -271,5 +271,3 @@ function init() {
   // draw week charts by default
   drawWeekCharts();
 }
-
-init();

--- a/app/javascript/analytics/dashboard.js
+++ b/app/javascript/analytics/dashboard.js
@@ -38,6 +38,39 @@ function writeCards(data, timeFrame) {
   followerCard.innerHTML = cardHTML(follows, `Followers ${timeFrame}`);
 }
 
+function drawChart({ canvas, title, labels, datasets }) {
+  const options = {
+    legend: {
+      position: 'bottom',
+    },
+    responsive: true,
+    title: {
+      display: true,
+      text: title,
+    },
+    scales: {
+      yAxes: [
+        {
+          ticks: {
+            suggestedMin: 0,
+            precision: 0,
+          },
+        },
+      ],
+    },
+  };
+
+  // eslint-disable-next-line no-new
+  new Chart(canvas, {
+    type: 'line',
+    data: {
+      labels,
+      datasets,
+      options,
+    },
+  });
+}
+
 function drawCharts(data, timeRange) {
   const labels = Object.keys(data);
   const parsedData = Object.entries(data).map(date => date[1]);
@@ -49,182 +82,85 @@ function drawCharts(data, timeRange) {
   const followers = parsedData.map(date => date.follows.total);
   const readers = parsedData.map(date => date.page_views.total);
 
-  const reactionsCanvas = document.getElementById('reactionsChart');
-  const commentsCanvas = document.getElementById('commentsChart');
-  const readersCanvas = document.getElementById('readersChart');
-  const followersCanvas = document.getElementById('followersChart');
-
-  // eslint-disable-next-line no-new
-  new Chart(reactionsCanvas, {
-    type: 'line',
-    data: {
-      labels,
-      datasets: [
-        {
-          label: 'Total',
-          data: reactions,
-          // data: [5, 10, 15, 17, 25, 23],
-          fill: false,
-          borderColor: 'rgb(75, 192, 192)',
-          lineTension: 0.1,
-        },
-        {
-          label: 'Likes',
-          data: likes,
-          // data: [2, 5, 10, 10, 15, 13],
-          fill: false,
-          borderColor: 'rgb(229, 100, 100)',
-          lineTension: 0.1,
-        },
-        {
-          label: 'Unicorns',
-          data: unicorns,
-          // data: [1, 2, 2, 4, 5, 3],
-          fill: false,
-          borderColor: 'rgb(157, 57, 233)',
-          lineTension: 0.1,
-        },
-        {
-          label: 'Bookmarks',
-          data: readingList,
-          // data: [2, 3, 3, 3, 5, 7],
-          fill: false,
-          borderColor: 'rgb(10, 133, 255)',
-          lineTension: 0.1,
-        },
-      ],
-    },
-    options: {
-      legend: {
-        position: 'bottom',
+  drawChart({
+    canvas: document.getElementById('reactionsChart'),
+    title: `Reactions ${timeRange}`,
+    labels,
+    datasets: [
+      {
+        label: 'Total',
+        data: reactions,
+        fill: false,
+        borderColor: 'rgb(75, 192, 192)',
+        lineTension: 0.1,
       },
-      responsive: true,
-      title: {
-        display: true,
-        text: `Reactions ${timeRange}`,
+      {
+        label: 'Likes',
+        data: likes,
+        fill: false,
+        borderColor: 'rgb(229, 100, 100)',
+        lineTension: 0.1,
       },
-      scales: {
-        yAxes: [
-          {
-            ticks: {
-              suggestedMin: 0,
-              precision: 0,
-            },
-          },
-        ],
+      {
+        label: 'Unicorns',
+        data: unicorns,
+        fill: false,
+        borderColor: 'rgb(157, 57, 233)',
+        lineTension: 0.1,
       },
-    },
+      {
+        label: 'Bookmarks',
+        data: readingList,
+        fill: false,
+        borderColor: 'rgb(10, 133, 255)',
+        lineTension: 0.1,
+      },
+    ],
   });
 
-  // eslint-disable-next-line no-new
-  new Chart(commentsCanvas, {
-    type: 'line',
-    data: {
-      labels,
-      datasets: [
-        {
-          label: 'Comments',
-          data: comments,
-          fill: false,
-          borderColor: 'rgb(75, 192, 192)',
-          lineTension: 0.1,
-        },
-      ],
-    },
-    options: {
-      legend: {
-        position: 'bottom',
+  drawChart({
+    canvas: document.getElementById('commentsChart'),
+    title: `Comments ${timeRange}`,
+    labels,
+    datasets: [
+      {
+        label: 'Comments',
+        data: comments,
+        fill: false,
+        borderColor: 'rgb(75, 192, 192)',
+        lineTension: 0.1,
       },
-      responsive: true,
-      title: {
-        display: true,
-        text: `Comments ${timeRange}`,
-      },
-      scales: {
-        yAxes: [
-          {
-            ticks: {
-              suggestedMin: 0,
-              precision: 0,
-            },
-          },
-        ],
-      },
-    },
+    ],
   });
 
-  // eslint-disable-next-line no-new
-  new Chart(followersCanvas, {
-    type: 'line',
-    data: {
-      labels,
-      datasets: [
-        {
-          label: 'Followers',
-          data: followers,
-          fill: false,
-          borderColor: 'rgb(10, 133, 255)',
-          lineTension: 0.1,
-        },
-      ],
-    },
-    options: {
-      legend: {
-        position: 'bottom',
+  drawChart({
+    canvas: document.getElementById('followersChart'),
+    title: `New Followers ${timeRange}`,
+    labels,
+    datasets: [
+      {
+        label: 'Followers',
+        data: followers,
+        fill: false,
+        borderColor: 'rgb(10, 133, 255)',
+        lineTension: 0.1,
       },
-      responsive: true,
-      title: {
-        display: true,
-        text: `New Followers ${timeRange}`,
-      },
-      scales: {
-        yAxes: [
-          {
-            ticks: {
-              suggestedMin: 0,
-              precision: 0,
-            },
-          },
-        ],
-      },
-    },
+    ],
   });
 
-  // eslint-disable-next-line no-new
-  new Chart(readersCanvas, {
-    type: 'line',
-    data: {
-      labels,
-      datasets: [
-        {
-          label: 'Reads',
-          data: readers,
-          fill: false,
-          borderColor: 'rgb(157, 57, 233)',
-          lineTension: 0.1,
-        },
-      ],
-    },
-    options: {
-      legend: {
-        position: 'bottom',
+  drawChart({
+    canvas: document.getElementById('readersChart'),
+    title: `Reads ${timeRange}`,
+    labels,
+    datasets: [
+      {
+        label: 'Reads',
+        data: readers,
+        fill: false,
+        borderColor: 'rgb(157, 57, 233)',
+        lineTension: 0.1,
       },
-      responsive: true,
-      title: {
-        display: true,
-        text: `Reads ${timeRange}`,
-      },
-      scales: {
-        yAxes: [
-          {
-            ticks: {
-              suggestedMin: 0,
-              precision: 0,
-            },
-          },
-        ],
-      },
-    },
+    ],
   });
 }
 

--- a/app/javascript/analytics/dashboard.js
+++ b/app/javascript/analytics/dashboard.js
@@ -164,8 +164,16 @@ function drawCharts(data, timeRangeLabel) {
   });
 }
 
-function callAnalyticsApi(date, timeRangeLabel) {
-  fetch(`/api/analytics/historical?start=${date.toISOString().split('T')[0]}`)
+function callAnalyticsApi(date, timeRangeLabel, organizationId) {
+  let url = `/api/analytics/historical?start=${
+    date.toISOString().split('T')[0]
+  }`;
+
+  if (organizationId) {
+    url = `${url}&organization_id=${organizationId}`;
+  }
+
+  fetch(url)
     .then(data => data.json())
     .then(data => {
       drawCharts(data, timeRangeLabel);
@@ -173,37 +181,46 @@ function callAnalyticsApi(date, timeRangeLabel) {
     });
 }
 
-function drawWeekCharts() {
+function drawWeekCharts(organizationId) {
   resetActive(document.getElementById('week-button'));
   const oneWeekAgo = new Date();
   oneWeekAgo.setDate(oneWeekAgo.getDate() - 7);
-  callAnalyticsApi(oneWeekAgo, 'this Week');
+  callAnalyticsApi(oneWeekAgo, 'this Week', organizationId);
 }
 
-function drawMonthCharts() {
+function drawMonthCharts(organizationId) {
   resetActive(document.getElementById('month-button'));
   const oneMonthAgo = new Date();
   oneMonthAgo.setMonth(oneMonthAgo.getMonth() - 1);
-  callAnalyticsApi(oneMonthAgo, 'this Month');
+  callAnalyticsApi(oneMonthAgo, 'this Month', organizationId);
 }
 
-function drawInfinityCharts() {
+function drawInfinityCharts(organizationId) {
   resetActive(document.getElementById('infinity-button'));
   // April 1st is when the DEV analytics feature went into place
   const beginningOfTime = new Date('2019-4-1');
-  callAnalyticsApi(beginningOfTime, '');
+  callAnalyticsApi(beginningOfTime, '', organizationId);
 }
 
-export default function initCharts() {
+export default function initCharts({ organizationId }) {
   const weekButton = document.getElementById('week-button');
-  weekButton.addEventListener('click', drawWeekCharts);
+  weekButton.addEventListener(
+    'click',
+    drawWeekCharts.bind(null, organizationId),
+  );
 
   const monthButton = document.getElementById('month-button');
-  monthButton.addEventListener('click', drawMonthCharts);
+  monthButton.addEventListener(
+    'click',
+    drawMonthCharts.bind(null, organizationId),
+  );
 
   const infinityButton = document.getElementById('infinity-button');
-  infinityButton.addEventListener('click', drawInfinityCharts);
+  infinityButton.addEventListener(
+    'click',
+    drawInfinityCharts.bind(null, organizationId),
+  );
 
   // draw week charts by default
-  drawWeekCharts();
+  drawWeekCharts(organizationId);
 }

--- a/app/javascript/packs/analyticsDashboard.js
+++ b/app/javascript/packs/analyticsDashboard.js
@@ -1,7 +1,16 @@
 import initCharts from '../analytics/dashboard';
 
+function initDashboard() {
+  const activeOrg = document.querySelector('.organization.active');
+  if (activeOrg) {
+    initCharts({ organizationId: activeOrg.dataset.organizationId });
+  } else {
+    initCharts({ organizationId: null });
+  }
+}
+
 window.InstantClick.on('change', () => {
-  initCharts();
+  initDashboard();
 });
 
-initCharts();
+initDashboard();

--- a/app/javascript/packs/analyticsDashboard.js
+++ b/app/javascript/packs/analyticsDashboard.js
@@ -1,0 +1,7 @@
+import initCharts from '../analytics/dashboard';
+
+window.InstantClick.on('change', () => {
+  initCharts();
+});
+
+initCharts();

--- a/app/javascript/packs/proCharts.js
+++ b/app/javascript/packs/proCharts.js
@@ -26,8 +26,8 @@ function sumAnalytics(data, key) {
   return Object.entries(data).reduce((sum, day) => sum + day[1][key].total, 0);
 }
 
-function writeCard(stat, element, header) {
-  element.innerHTML = `
+function cardHTML(stat, header) {
+  return `
     <h4>${header}</h4>
     <div class="featured-stat">${stat}</div>
   `;
@@ -39,46 +39,11 @@ function writeCards(data, timeFrame) {
   const comments = sumAnalytics(data, 'comments');
   const follows = sumAnalytics(data, 'follows');
 
-  writeCard(readers, readerCard, `Readers ${timeFrame}`);
-  writeCard(comments, commentCard, `Comments ${timeFrame}`);
-  writeCard(reactions, reactionCard, `Reactions ${timeFrame}`);
-  writeCard(follows, followerCard, `Followers ${timeFrame}`);
+  readerCard.innerHTML = cardHTML(readers, `Readers ${timeFrame}`);
+  commentCard.innerHTML = cardHTML(comments, `Comments ${timeFrame}`);
+  reactionCard.innerHTML = cardHTML(reactions, `Reactions ${timeFrame}`);
+  followerCard.innerHTML = cardHTML(follows, `Followers ${timeFrame}`);
 }
-
-function callAnalyticsApi(date, timeRange) {
-  fetch(`/api/analytics/historical?start=${date.toISOString().split('T')[0]}`)
-    .then(data => data.json())
-    .then(data => {
-      drawCharts(data, timeRange);
-      writeCards(data, timeRange);
-    });
-}
-
-function drawWeekCharts() {
-  resetActive(weekButton);
-  const oneWeekAgo = new Date();
-  oneWeekAgo.setDate(oneWeekAgo.getDate() - 7);
-  callAnalyticsApi(oneWeekAgo, 'this Week');
-}
-
-function drawMonthCharts() {
-  resetActive(monthButton);
-  const oneMonthAgo = new Date();
-  oneMonthAgo.setMonth(oneMonthAgo.getMonth() - 1);
-  callAnalyticsApi(oneMonthAgo, 'this Month');
-}
-
-function drawInfinityCharts() {
-  resetActive(infinityButton);
-  // April 1st is when the DEV analytics feature went into place
-  const beginningOfTime = new Date('2019-4-1');
-  callAnalyticsApi(beginningOfTime, '');
-}
-
-drawWeekCharts();
-weekButton.addEventListener('click', drawWeekCharts);
-monthButton.addEventListener('click', drawMonthCharts);
-infinityButton.addEventListener('click', drawInfinityCharts);
 
 function drawCharts(data, timeRange) {
   const labels = Object.keys(data);
@@ -91,7 +56,8 @@ function drawCharts(data, timeRange) {
   const followers = parsedData.map(date => date.follows.total);
   const readers = parsedData.map(date => date.page_views.total);
 
-  const reactionsChart = new Chart(reactionsCanvas, {
+  // eslint-disable-next-line no-new
+  new Chart(reactionsCanvas, {
     type: 'line',
     data: {
       labels,
@@ -152,7 +118,8 @@ function drawCharts(data, timeRange) {
     },
   });
 
-  const commentsChart = new Chart(commentsCanvas, {
+  // eslint-disable-next-line no-new
+  new Chart(commentsCanvas, {
     type: 'line',
     data: {
       labels,
@@ -188,7 +155,8 @@ function drawCharts(data, timeRange) {
     },
   });
 
-  const followChart = new Chart(followersCanvas, {
+  // eslint-disable-next-line no-new
+  new Chart(followersCanvas, {
     type: 'line',
     data: {
       labels,
@@ -224,7 +192,8 @@ function drawCharts(data, timeRange) {
     },
   });
 
-  const readsChart = new Chart(readersCanvas, {
+  // eslint-disable-next-line no-new
+  new Chart(readersCanvas, {
     type: 'line',
     data: {
       labels,
@@ -259,5 +228,43 @@ function drawCharts(data, timeRange) {
       },
     },
   });
-
 }
+
+function callAnalyticsApi(date, timeRange) {
+  fetch(`/api/analytics/historical?start=${date.toISOString().split('T')[0]}`)
+    .then(data => data.json())
+    .then(data => {
+      drawCharts(data, timeRange);
+      writeCards(data, timeRange);
+    });
+}
+
+function drawWeekCharts() {
+  resetActive(weekButton);
+  const oneWeekAgo = new Date();
+  oneWeekAgo.setDate(oneWeekAgo.getDate() - 7);
+  callAnalyticsApi(oneWeekAgo, 'this Week');
+}
+
+function drawMonthCharts() {
+  resetActive(monthButton);
+  const oneMonthAgo = new Date();
+  oneMonthAgo.setMonth(oneMonthAgo.getMonth() - 1);
+  callAnalyticsApi(oneMonthAgo, 'this Month');
+}
+
+function drawInfinityCharts() {
+  resetActive(infinityButton);
+  // April 1st is when the DEV analytics feature went into place
+  const beginningOfTime = new Date('2019-4-1');
+  callAnalyticsApi(beginningOfTime, '');
+}
+
+function init() {
+  weekButton.addEventListener('click', drawWeekCharts);
+  monthButton.addEventListener('click', drawMonthCharts);
+  infinityButton.addEventListener('click', drawInfinityCharts);
+  drawWeekCharts();
+}
+
+init();

--- a/app/javascript/packs/proCharts.js
+++ b/app/javascript/packs/proCharts.js
@@ -1,23 +1,11 @@
 import Chart from 'chart.js';
 
-const reactionsCanvas = document.getElementById('reactionsChart');
-const commentsCanvas = document.getElementById('commentsChart');
-const readersCanvas = document.getElementById('readersChart');
-const followersCanvas = document.getElementById('followersChart');
-
-const weekButton = document.getElementById('week-button');
-const monthButton = document.getElementById('month-button');
-const infinityButton = document.getElementById('infinity-button');
-
-const reactionCard = document.getElementById('reactions-card');
-const commentCard = document.getElementById('comments-card');
-const followerCard = document.getElementById('followers-card');
-const readerCard = document.getElementById('readers-card');
-
 function resetActive(activeButton) {
-  [weekButton, monthButton, infinityButton].forEach(button => {
+  const buttons = document.getElementsByClassName('timespan-button');
+  for (let i = 0; i < buttons.length; i += 1) {
+    const button = buttons[i];
     button.classList.remove('selected');
-  });
+  }
 
   activeButton.classList.add('selected');
 }
@@ -39,6 +27,11 @@ function writeCards(data, timeFrame) {
   const comments = sumAnalytics(data, 'comments');
   const follows = sumAnalytics(data, 'follows');
 
+  const reactionCard = document.getElementById('reactions-card');
+  const commentCard = document.getElementById('comments-card');
+  const followerCard = document.getElementById('followers-card');
+  const readerCard = document.getElementById('readers-card');
+
   readerCard.innerHTML = cardHTML(readers, `Readers ${timeFrame}`);
   commentCard.innerHTML = cardHTML(comments, `Comments ${timeFrame}`);
   reactionCard.innerHTML = cardHTML(reactions, `Reactions ${timeFrame}`);
@@ -55,6 +48,11 @@ function drawCharts(data, timeRange) {
   const unicorns = parsedData.map(date => date.reactions.unicorn);
   const followers = parsedData.map(date => date.follows.total);
   const readers = parsedData.map(date => date.page_views.total);
+
+  const reactionsCanvas = document.getElementById('reactionsChart');
+  const commentsCanvas = document.getElementById('commentsChart');
+  const readersCanvas = document.getElementById('readersChart');
+  const followersCanvas = document.getElementById('followersChart');
 
   // eslint-disable-next-line no-new
   new Chart(reactionsCanvas, {
@@ -240,30 +238,37 @@ function callAnalyticsApi(date, timeRange) {
 }
 
 function drawWeekCharts() {
-  resetActive(weekButton);
+  resetActive(document.getElementById('week-button'));
   const oneWeekAgo = new Date();
   oneWeekAgo.setDate(oneWeekAgo.getDate() - 7);
   callAnalyticsApi(oneWeekAgo, 'this Week');
 }
 
 function drawMonthCharts() {
-  resetActive(monthButton);
+  resetActive(document.getElementById('month-button'));
   const oneMonthAgo = new Date();
   oneMonthAgo.setMonth(oneMonthAgo.getMonth() - 1);
   callAnalyticsApi(oneMonthAgo, 'this Month');
 }
 
 function drawInfinityCharts() {
-  resetActive(infinityButton);
+  resetActive(document.getElementById('infinity-button'));
   // April 1st is when the DEV analytics feature went into place
   const beginningOfTime = new Date('2019-4-1');
   callAnalyticsApi(beginningOfTime, '');
 }
 
 function init() {
+  const weekButton = document.getElementById('week-button');
   weekButton.addEventListener('click', drawWeekCharts);
+
+  const monthButton = document.getElementById('month-button');
   monthButton.addEventListener('click', drawMonthCharts);
+
+  const infinityButton = document.getElementById('infinity-button');
   infinityButton.addEventListener('click', drawInfinityCharts);
+
+  // draw week charts by default
   drawWeekCharts();
 }
 

--- a/app/views/dashboards/pro.html.erb
+++ b/app/views/dashboards/pro.html.erb
@@ -2,30 +2,36 @@
 
 <div class="dashboard-container pro-container" id="user-dashboard">
   <a href="/dashboard" class="rounded-btn rounded-btn--transparent">👈 Back to Main Dashboard</a>
-    <a class="rounded-btn <%= "active" if params[:org_id].blank? %>" href="/dashboard/pro">
-      Your Pro Dashboard
+
+  <a class="rounded-btn <%= "active" if params[:org_id].blank? %>" href="/dashboard/pro">
+    Your Pro Dashboard
+  </a>
+
+  <% @organizations.each do |org| %>
+    <a class="rounded-btn <%= "active" if params[:org_id].to_i == org.id %>" href="/dashboard/pro/org/<%= org.id %>">
+      <%= org.name %> Pro Dashboard
     </a>
-    <% @organizations.each do |org| %>
-      <a class="rounded-btn <%= "active" if params[:org_id].to_i == org.id %>" href="/dashboard/pro/org/<%= org.id %>">
-        <%= org.name %> Pro Dashboard
-      </a>
-    <% end %>
+  <% end %>
+
   <section class="header-card card">
     <h1 class="pro-header">Pro Dashboard <%= "for #{@dashboard.user_or_org.name}" %></h1>
-    <p>Welcome to the pro dashboard which shows in-depth user metrics so that authors can make data-driven decisions about the developer ecosystem.</p>
+    <p>Welcome to the Pro Dashboard which shows in-depth user metrics so that authors can make data-driven decisions about the developer ecosystem.</p>
     <p>This dashboard will highlight deep insights especially relevant to developer relations authors and serious bloggers.</p>
   </section>
+
   <div class="toggles">
     <button class="selected" id="week-button">Week</button>
     <button id="month-button">Month</button>
     <button id="infinity-button">Infinity</button>
   </div>
+
   <div class="summary-stats">
     <div class="card" id="readers-card"></div>
     <div class="card" id="reactions-card"></div>
     <div class="card" id="comments-card"></div>
     <div class="card" id="followers-card"></div>
   </div>
+
   <div class="graphs">
     <div class="row">
       <div class="card">
@@ -56,5 +62,6 @@
       </div>
     </div>
   </div>
+
   <%= javascript_pack_tag "proCharts", defer: true %>
 </div>

--- a/app/views/dashboards/pro.html.erb
+++ b/app/views/dashboards/pro.html.erb
@@ -20,9 +20,9 @@
   </section>
 
   <div class="toggles">
-    <button class="selected" id="week-button">Week</button>
-    <button id="month-button">Month</button>
-    <button id="infinity-button">Infinity</button>
+    <button class="selected timespan-button" id="week-button">Week</button>
+    <button class="timespan-button" id="month-button">Month</button>
+    <button class="timespan-button" id="infinity-button">Infinity</button>
   </div>
 
   <div class="summary-stats">
@@ -62,6 +62,6 @@
       </div>
     </div>
   </div>
-
-  <%= javascript_pack_tag "proCharts", defer: true %>
 </div>
+
+<%= javascript_pack_tag "proCharts", defer: true %>

--- a/app/views/dashboards/pro.html.erb
+++ b/app/views/dashboards/pro.html.erb
@@ -3,18 +3,21 @@
 <div class="dashboard-container pro-container" id="user-dashboard">
   <a href="/dashboard" class="rounded-btn rounded-btn--transparent">👈 Back to Main Dashboard</a>
 
-  <a class="rounded-btn <%= "active" if params[:org_id].blank? %>" href="/dashboard/pro">
+  <a class="rounded-btn <%= "active" unless params[:org_id] %>" href="/dashboard/pro">
     Your Pro Dashboard
   </a>
 
   <% @organizations.each do |org| %>
-    <a class="rounded-btn <%= "active" if params[:org_id].to_i == org.id %>" href="/dashboard/pro/org/<%= org.id %>">
+    <a
+      class="rounded-btn organization <%= "active" if params[:org_id].to_i == org.id %>"
+      href="/dashboard/pro/org/<%= org.id %>"
+      data-organization-id="<%= org.id %>">
       <%= org.name %> Pro Dashboard
     </a>
   <% end %>
 
   <section class="header-card card">
-    <h1 class="pro-header">Pro Dashboard <%= "for #{@dashboard.user_or_org.name}" %></h1>
+    <h1 class="pro-header">Pro Dashboard for <%= @dashboard.user_or_org.name %></h1>
     <p>Welcome to the Pro Dashboard which shows in-depth user metrics so that authors can make data-driven decisions about the developer ecosystem.</p>
     <p>This dashboard will highlight deep insights especially relevant to developer relations authors and serious bloggers.</p>
   </section>

--- a/app/views/dashboards/pro.html.erb
+++ b/app/views/dashboards/pro.html.erb
@@ -20,9 +20,9 @@
   </section>
 
   <div class="toggles">
-    <button class="selected timespan-button" id="week-button">Week</button>
-    <button class="timespan-button" id="month-button">Month</button>
-    <button class="timespan-button" id="infinity-button">Infinity</button>
+    <button class="selected timerange-button" id="week-button">Week</button>
+    <button class="timerange-button" id="month-button">Month</button>
+    <button class="timerange-button" id="infinity-button">Infinity</button>
   </div>
 
   <div class="summary-stats">

--- a/app/views/dashboards/pro.html.erb
+++ b/app/views/dashboards/pro.html.erb
@@ -64,4 +64,4 @@
   </div>
 </div>
 
-<%= javascript_pack_tag "proCharts", defer: true %>
+<%= javascript_pack_tag "analyticsDashboard", defer: true %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

This PR makes the Pro Dashboard work with InstantClick and displays the correct analytics for organizations.

It moves all the code inside functions, removing globals and then loads the "initializer" inside InstantClick `change` event so that the transition between clicks is smooth.

Right now, if you have your own dashboard and your organization's dashboard, clicking between the two doesn't work. Also, if you go from https://dev.to/dashboard to https://dev.to/dashboard/pro from the internal link you have to refresh the page.

Another thing it does is to display the correct analytics for the organization. Right now we never pass the organization ID to the analytics business logic, which means that the data returned it's always that of the user, not that of the organization the user is looking at.

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
