### PR TITLE
Bug/Action Buttons Fix

### DIFF
--- a/app/assets/stylesheets/article-show.scss
+++ b/app/assets/stylesheets/article-show.scss
@@ -278,6 +278,9 @@ article {
       }
 
       .action-space {
+        padding: 5px 0 0 0;
+        display: inline-flex;
+
         a {
           display: inline-block;
           background: $green;


### PR DESCRIPTION
Bug Fix - Action Space

 Buttons Edit and Manage |  Add inline-flex to have action buttons always on same line

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Documentation Update

## Description
Fixes the Action Space Buttons on Mobile to display in the same line. Added `display: inline-flex` to have the elements always maintain the same horizontal space.. causing them to wrap around together when there isn't enough space

## Related Tickets & Documents
Fixes #3061 
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

<img width="1440" alt="Screen Shot 2019-06-10 at 8 19 40 PM" src="https://user-images.githubusercontent.com/32174912/59213276-2659a600-8bbd-11e9-81d9-0a70dbee9ee6.png">
<img width="1440" alt="Screen Shot 2019-06-10 at 8 20 01 PM" src="https://user-images.githubusercontent.com/32174912/59213294-2eb1e100-8bbd-11e9-8538-c8e2a32259a3.png">


## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![Peter Griffin Struggling to roll up a window shade](https://media.giphy.com/media/13FrpeVH09Zrb2/giphy.gif)
