### PR TITLE
Fix Reaction pane on mobile

### DIFF
--- a/app/assets/stylesheets/article-show.scss
+++ b/app/assets/stylesheets/article-show.scss
@@ -848,7 +848,7 @@ article {
 
   .article-actions {
     text-align: center;
-    padding: 5px 0 12px;
+    padding: 8px 0;
     position: fixed;
     bottom: 0;
     z-index: 22;


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [x] Refactor

## Description
This PR centralizes the reaction button when viewed on mobile

## Related Tickets & Documents
Ticket - #2877 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
**BEFORE**

<img width="451" alt="Screenshot 2019-06-10 at 7 45 48 PM" src="https://user-images.githubusercontent.com/28215750/59219072-88181100-8bb9-11e9-959b-7127cf08346e.png">

**AFETR**

<img width="456" alt="Screenshot 2019-06-10 at 7 46 11 PM" src="https://user-images.githubusercontent.com/28215750/59219095-9403d300-8bb9-11e9-8e43-cdde3adb8cc3.png">


## Added to documentation?
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?
![giphy](https://user-images.githubusercontent.com/28215750/59220133-1d1c0980-8bbc-11e9-8ea9-672852af785d.gif)

