### PR TITLE
Make `AdditionalContentBoxesController#randomize` private

### DIFF
--- a/app/controllers/additional_content_boxes_controller.rb
+++ b/app/controllers/additional_content_boxes_controller.rb
@@ -20,6 +20,8 @@ class AdditionalContentBoxesController < ApplicationController
     render "boxes", layout: false
   end
 
+  private
+
   def randomize
     return true unless Rails.env.production?
 


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

Currently, `AdditionalContentBoxesController#randomize` is a `public` method and it does not make a lot of sense to leave it `public`. This PR makes it `private` as it is only used in `AdditionalContentBoxesController`

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
