### PR TITLE
Pro Analytics: stats for a single article

### DIFF
--- a/app/assets/javascripts/initializers/initializeBaseUserData.js
+++ b/app/assets/javascripts/initializers/initializeBaseUserData.js
@@ -1,59 +1,4 @@
-function initializeBaseUserData() {
-  var user = userData();
-  var userProfileLinkHTML =
-    '<a href="/' +
-    user.username +
-    '" id="first-nav-link"><div class="option prime-option">@' +
-    user.username +
-    '</div></a>';
-  document.getElementById(
-    'user-profile-link-placeholder',
-  ).innerHTML = userProfileLinkHTML;
-  document.getElementById('nav-profile-image').src = user.profile_image_90;
-  initializeUserSidebar(user);
-  addRelevantButtonsToArticle(user);
-}
-
-function initializeUserSidebar(user) {
-  if (!document.getElementById('sidebar-nav')) return;
-  initializeUserProfileContent(user);
-  var tagHTML = '';
-  var followedTags = JSON.parse(user.followed_tags);
-  document.getElementById('tag-separator').innerHTML =
-    followedTags.length === 0
-      ? 'Follow tags to improve your feed'
-      : 'Other Popular Tags';
-
-  // sort tags by descending weigth, descending popularity and name
-  followedTags.sort(function(tagA, tagB) {
-    return (
-      tagB.points - tagA.points ||
-      tagB.hotness_score - tagA.hotness_score ||
-      tagA.name.localeCompare(tagB.name)
-    );
-  });
-
-  followedTags.forEach(function(t) {
-    var element = document.getElementById('default-sidebar-element-' + t.name);
-    tagHTML +=
-      t.points > 0.0
-        ? '<div class="sidebar-nav-element" id="sidebar-element-' +
-          t.name +
-          '">' +
-          '<a class="sidebar-nav-link" href="/t/' +
-          t.name +
-          '">' +
-          '<span class="sidebar-nav-tag-text">#' +
-          t.name +
-          '</span>' +
-          '</a>' +
-          '</div>'
-        : '';
-    if (element) element.remove();
-  });
-  document.getElementById('sidebar-nav-followed-tags').innerHTML = tagHTML;
-  document.getElementById('sidebar-nav-default-tags').classList.add('showing');
-}
+/* globals userData, filterXSS */
 
 function initializeUserProfileContent(user) {
   document.getElementById('sidebar-profile-pic').innerHTML =
@@ -71,21 +16,69 @@ function initializeUserProfileContent(user) {
     '/' + user.username;
 }
 
+function initializeUserSidebar(user) {
+  if (!document.getElementById('sidebar-nav')) return;
+  initializeUserProfileContent(user);
+
+  let followedTags = JSON.parse(user.followed_tags);
+  const tagSeparatorLabel =
+    followedTags.length === 0
+      ? 'Follow tags to improve your feed'
+      : 'Other Popular Tags';
+  document.getElementById('tag-separator').innerHTML = tagSeparatorLabel;
+
+  // sort tags by descending weigth, descending popularity and name
+  followedTags.sort((tagA, tagB) => {
+    return (
+      tagB.points - tagA.points ||
+      tagB.hotness_score - tagA.hotness_score ||
+      tagA.name.localeCompare(tagB.name)
+    );
+  });
+
+  let tagHTML = '';
+  followedTags.forEach(tag => {
+    var element = document.getElementById(
+      'default-sidebar-element-' + tag.name,
+    );
+    tagHTML +=
+      tag.points > 0.0
+        ? '<div class="sidebar-nav-element" id="sidebar-element-' +
+          tag.name +
+          '">' +
+          '<a class="sidebar-nav-link" href="/t/' +
+          tag.name +
+          '">' +
+          '<span class="sidebar-nav-tag-text">#' +
+          tag.name +
+          '</span>' +
+          '</a>' +
+          '</div>'
+        : '';
+    if (element) element.remove();
+  });
+  document.getElementById('sidebar-nav-followed-tags').innerHTML = tagHTML;
+  document.getElementById('sidebar-nav-default-tags').classList.add('showing');
+}
+
 function addRelevantButtonsToArticle(user) {
   var articleContainer = document.getElementById('article-show-container');
   if (articleContainer) {
-    if (parseInt(articleContainer.dataset.authorId) == user.id) {
-      var manageButtonHTML =
-        '<a href="' +
-        articleContainer.dataset.path +
-        '/manage" rel="nofollow">MANAGE</a>';
-      document.getElementById('action-space').innerHTML =
-        '<a href="' +
-        articleContainer.dataset.path +
-        '/edit" rel="nofollow">EDIT</a>' +
-        (JSON.parse(articleContainer.dataset.published) == true
-          ? manageButtonHTML
-          : '');
+    if (parseInt(articleContainer.dataset.authorId, 10) === user.id) {
+      let actions = [
+        `<a href="${articleContainer.dataset.path}/edit" rel="nofollow">EDIT</a>`,
+      ];
+      if (JSON.parse(articleContainer.dataset.published) === true) {
+        actions.push(
+          `<a href="${articleContainer.dataset.path}/manage" rel="nofollow">MANAGE</a>`,
+        );
+      }
+      if (user.pro) {
+        actions.push(
+          `<a href="${articleContainer.dataset.path}/stats" rel="nofollow">STATS</a>`,
+        );
+      }
+      document.getElementById('action-space').innerHTML = actions.join('');
     } else if (user.trusted) {
       document.getElementById('action-space').innerHTML =
         '<a href="' +
@@ -93,13 +86,15 @@ function addRelevantButtonsToArticle(user) {
         '/mod" rel="nofollow">MODERATE <span class="post-word">POST</span></a>';
     }
   }
-  var commentsContainer = document.getElementById('comments-container');
-  if (commentsContainer) {
+}
+
+function addRelevantButtonsToComments(user) {
+  if (document.getElementById('comments-container')) {
     var settingsButts = document.getElementsByClassName('comment-actions');
 
-    for (var i = 0; i < settingsButts.length; i++) {
-      var butt = settingsButts[i];
-      if (parseInt(butt.dataset.userId) === user.id) {
+    for (let i = 0; i < settingsButts.length; i += 1) {
+      let butt = settingsButts[i];
+      if (parseInt(butt.dataset.userId, 10) === user.id) {
         butt.className = 'comment-actions';
         butt.style.display = 'inline-block';
       }
@@ -107,11 +102,28 @@ function addRelevantButtonsToArticle(user) {
 
     if (user.trusted) {
       var modButts = document.getElementsByClassName('mod-actions');
-      for (var i = 0; i < modButts.length; i++) {
-        var butt = modButts[i];
+      for (let i = 0; i < modButts.length; i += 1) {
+        let butt = modButts[i];
         butt.className = 'mod-actions';
         butt.style.display = 'inline-block';
       }
     }
   }
+}
+
+function initializeBaseUserData() {
+  const user = userData();
+  const userProfileLinkHTML =
+    '<a href="/' +
+    user.username +
+    '" id="first-nav-link"><div class="option prime-option">@' +
+    user.username +
+    '</div></a>';
+  document.getElementById(
+    'user-profile-link-placeholder',
+  ).innerHTML = userProfileLinkHTML;
+  document.getElementById('nav-profile-image').src = user.profile_image_90;
+  initializeUserSidebar(user);
+  addRelevantButtonsToArticle(user);
+  addRelevantButtonsToComments(user);
 }

--- a/app/assets/javascripts/utilities/userData.js
+++ b/app/assets/javascripts/utilities/userData.js
@@ -1,6 +1,10 @@
 function userData() {
-  if (document.getElementsByTagName('body')[0].getAttribute('data-user') === null) {
+  const dataUser = document
+    .getElementsByTagName('body')[0]
+    .getAttribute('data-user');
+
+  if (dataUser === null) {
     return null;
   }
-  return JSON.parse(document.getElementsByTagName('body')[0].getAttribute('data-user'));
+  return JSON.parse(dataUser);
 }

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,7 +1,8 @@
 class ArticlesController < ApplicationController
   include ApplicationHelper
+
   before_action :authenticate_user!, except: %i[feed new]
-  before_action :set_article, only: %i[edit manage update destroy]
+  before_action :set_article, only: %i[edit manage update destroy stats]
   before_action :raise_banned, only: %i[new create update]
   before_action :set_cache_control_headers, only: %i[feed]
   after_action :verify_authorized
@@ -146,7 +147,7 @@ class ArticlesController < ApplicationController
 
     respond_to do |format|
       format.html do
-        if article_params_json[:archived] && @article.archived #just to get archived working
+        if article_params_json[:archived] && @article.archived # just to get archived working
           render json: @article.to_json(only: [:id], methods: [:current_state_path])
           return
         end
@@ -179,6 +180,11 @@ class ArticlesController < ApplicationController
       format.html { redirect_to "/dashboard", notice: "Article was successfully deleted." }
       format.json { head :no_content }
     end
+  end
+
+  def stats
+    authorize current_user, :pro_user?
+    authorize @article
   end
 
   private

--- a/app/controllers/async_info_controller.rb
+++ b/app/controllers/async_info_controller.rb
@@ -50,7 +50,8 @@ class AsyncInfoController < ApplicationController
         trusted: @user.trusted,
         experience_level: @user.experience_level,
         preferred_languages_array: @user.preferred_languages_array,
-        config_body_class: @user.config_body_class
+        config_body_class: @user.config_body_class,
+        pro: @user.pro?
       }
     end
   end

--- a/app/javascript/analytics/dashboard.js
+++ b/app/javascript/analytics/dashboard.js
@@ -164,13 +164,16 @@ function drawCharts(data, timeRangeLabel) {
   });
 }
 
-function callAnalyticsApi(date, timeRangeLabel, organizationId) {
+function callAnalyticsApi(date, timeRangeLabel, { organizationId, articleId }) {
   let url = `/api/analytics/historical?start=${
     date.toISOString().split('T')[0]
   }`;
 
   if (organizationId) {
     url = `${url}&organization_id=${organizationId}`;
+  }
+  if (articleId) {
+    url = `${url}&article_id=${articleId}`;
   }
 
   fetch(url)
@@ -181,46 +184,46 @@ function callAnalyticsApi(date, timeRangeLabel, organizationId) {
     });
 }
 
-function drawWeekCharts(organizationId) {
+function drawWeekCharts({ organizationId, articleId }) {
   resetActive(document.getElementById('week-button'));
   const oneWeekAgo = new Date();
   oneWeekAgo.setDate(oneWeekAgo.getDate() - 7);
-  callAnalyticsApi(oneWeekAgo, 'this Week', organizationId);
+  callAnalyticsApi(oneWeekAgo, 'this Week', { organizationId, articleId });
 }
 
-function drawMonthCharts(organizationId) {
+function drawMonthCharts({ organizationId, articleId }) {
   resetActive(document.getElementById('month-button'));
   const oneMonthAgo = new Date();
   oneMonthAgo.setMonth(oneMonthAgo.getMonth() - 1);
-  callAnalyticsApi(oneMonthAgo, 'this Month', organizationId);
+  callAnalyticsApi(oneMonthAgo, 'this Month', { organizationId, articleId });
 }
 
-function drawInfinityCharts(organizationId) {
+function drawInfinityCharts({ organizationId, articleId }) {
   resetActive(document.getElementById('infinity-button'));
   // April 1st is when the DEV analytics feature went into place
   const beginningOfTime = new Date('2019-4-1');
-  callAnalyticsApi(beginningOfTime, '', organizationId);
+  callAnalyticsApi(beginningOfTime, '', { organizationId, articleId });
 }
 
-export default function initCharts({ organizationId }) {
+export default function initCharts({ organizationId, articleId }) {
   const weekButton = document.getElementById('week-button');
   weekButton.addEventListener(
     'click',
-    drawWeekCharts.bind(null, organizationId),
+    drawWeekCharts.bind(null, { organizationId, articleId }),
   );
 
   const monthButton = document.getElementById('month-button');
   monthButton.addEventListener(
     'click',
-    drawMonthCharts.bind(null, organizationId),
+    drawMonthCharts.bind(null, { organizationId, articleId }),
   );
 
   const infinityButton = document.getElementById('infinity-button');
   infinityButton.addEventListener(
     'click',
-    drawInfinityCharts.bind(null, organizationId),
+    drawInfinityCharts.bind(null, { organizationId, articleId }),
   );
 
   // draw week charts by default
-  drawWeekCharts(organizationId);
+  drawWeekCharts({ organizationId, articleId });
 }

--- a/app/javascript/packs/analyticsArticle.js
+++ b/app/javascript/packs/analyticsArticle.js
@@ -1,0 +1,12 @@
+import initCharts from '../analytics/dashboard';
+
+function initDashboardArticle() {
+  const article = document.getElementById('article');
+  initCharts({ articleId: article.dataset.articleId });
+}
+
+window.InstantClick.on('change', () => {
+  initDashboardArticle();
+});
+
+initDashboardArticle();

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -333,6 +333,10 @@ class User < ApplicationRecord
     has_role?(:tech_admin) || has_role?(:super_admin)
   end
 
+  def pro?
+    has_role?(:pro)
+  end
+
   def trusted
     Rails.cache.fetch("user-#{id}/has_trusted_role", expires_in: 200.hours) do
       has_role? :trusted

--- a/app/policies/article_policy.rb
+++ b/app/policies/article_policy.rb
@@ -23,6 +23,10 @@ class ArticlePolicy < ApplicationPolicy
     true
   end
 
+  def stats?
+    user_is_author? || user_admin?
+  end
+
   def permitted_attributes
     %i[title body_html body_markdown main_image published canonical_url
        description allow_small_edits allow_big_edits tag_list publish_under_org

--- a/app/services/analytics_service.rb
+++ b/app/services/analytics_service.rb
@@ -24,6 +24,7 @@ class AnalyticsService
 
     # cache all stats in the date range for the requested user or organization
     cache_key = "analytics-for-dates-#{start_date}-#{end_date}-#{user_or_org.class.name}-#{user_or_org.id}"
+    cache_key = "#{cache_key}-article-#{article_id}" if article_id
 
     Rails.cache.fetch(cache_key, expires_in: 7.days) do
       # 1. calculate all stats using group queries at once
@@ -51,7 +52,7 @@ class AnalyticsService
   private
 
   attr_reader(
-    :user_or_org, :start_date, :end_date,
+    :user_or_org, :article_id, :start_date, :end_date,
     :article_data, :reaction_data, :comment_data, :follow_data, :page_view_data
   )
 

--- a/app/views/articles/stats.html.erb
+++ b/app/views/articles/stats.html.erb
@@ -1,0 +1,1 @@
+<% title "Stats for Your Post" %>

--- a/app/views/articles/stats.html.erb
+++ b/app/views/articles/stats.html.erb
@@ -1,1 +1,61 @@
-<% title "Stats for Your Post" %>
+<% title "Stats for Your Article" %>
+
+<div class="dashboard-container pro-container" id="user-dashboard">
+  <a
+    href="<%= @article.current_state_path %>"
+    class="rounded-btn rounded-btn--transparent"
+    id="article"
+    data-article-id="<%= @article.id %>">
+    👈 Back to the article
+  </a>
+
+  <section class="header-card card">
+    <h1 class="pro-header">Stats for "<%= @article.title %>"</h1>
+  </section>
+
+  <div class="toggles">
+    <button class="selected timerange-button" id="week-button">Week</button>
+    <button class="timerange-button" id="month-button">Month</button>
+    <button class="timerange-button" id="infinity-button">Infinity</button>
+  </div>
+
+  <div class="summary-stats">
+    <div class="card" id="readers-card"></div>
+    <div class="card" id="reactions-card"></div>
+    <div class="card" id="comments-card"></div>
+    <div class="card" id="followers-card"></div>
+  </div>
+
+  <div class="graphs">
+    <div class="row">
+      <div class="card">
+        <h2>Readers Summary</h2>
+        <div class="charts-container">
+          <canvas id="readersChart"></canvas>
+        </div>
+      </div>
+      <div class="card">
+        <h2>New Followers Summary</h2>
+        <div class="charts-container">
+          <canvas id="followersChart"></canvas>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="card">
+        <h2>Reactions Summary ❤🦄🔖</h2>
+        <div class="charts-container">
+          <canvas id="reactionsChart"></canvas>
+        </div>
+      </div>
+      <div class="card">
+        <h2>Comments Summary 💬</h2>
+        <div class="charts-container">
+          <canvas id="commentsChart"></canvas>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<%= javascript_pack_tag "analyticsArticle", defer: true %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -338,6 +338,7 @@ Rails.application.routes.draw do
   get "/:username/:slug/manage" => "articles#manage"
   get "/:username/:slug/edit" => "articles#edit"
   get "/:username/:slug/delete_confirm" => "articles#delete_confirm"
+  get "/:username/:slug/stats" => "articles#stats"
   get "/:username/:view" => "stories#index",
       constraints: { view: /comments|moderate|admin/ }
   get "/:username/:slug" => "stories#show"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -615,4 +615,15 @@ RSpec.describe User, type: :model do
       expect { organization_membership.reload }.to raise_error ActiveRecord::RecordNotFound
     end
   end
+
+  describe "#pro?" do
+    it "returns false if the user is not a pro" do
+      expect(user.pro?).to be(false)
+    end
+
+    it "returns true if the user is a pro" do
+      user.add_role(:pro)
+      expect(user.pro?).to be(true)
+    end
+  end
 end

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -122,16 +122,40 @@ RSpec.describe "Articles", type: :request do
   describe "GET /:path/manage" do
     before { sign_in user }
 
-    it "returns a new article" do
-      article = create(:article, user_id: user.id)
+    it "works successfully" do
+      article = create(:article, user: user)
       get "#{article.path}/manage"
+      expect(response).to have_http_status(:ok)
       expect(response.body).to include("Manage Your Post")
     end
 
-    it "returns unauthorized if user not author" do
+    it "returns unauthorized if the user is not the author" do
       second_user = create(:user)
-      article = create(:article, user_id: second_user.id)
+      article = create(:article, user: second_user)
       expect { get "#{article.path}/manage" }.to raise_error(Pundit::NotAuthorizedError)
+    end
+  end
+
+  describe "GET /:path/stats" do
+    before { sign_in user }
+
+    it "returns unauthorized if the user is not the author" do
+      second_user = create(:user)
+      article = create(:article, user: second_user)
+      expect { get "#{article.path}/stats" }.to raise_error(Pundit::NotAuthorizedError)
+    end
+
+    it "returns unauthorized if the user is not pro" do
+      article = create(:article, user: user)
+      expect { get "#{article.path}/stats" }.to raise_error(Pundit::NotAuthorizedError)
+    end
+
+    it "works successfully" do
+      user.add_role(:pro)
+      article = create(:article, user: user)
+      get "#{article.path}/stats"
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Stats for Your Post")
     end
   end
 end

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe "Articles", type: :request do
       article = create(:article, user: user)
       get "#{article.path}/stats"
       expect(response).to have_http_status(:ok)
-      expect(response.body).to include("Stats for Your Post")
+      expect(response.body).to include("Stats for Your Article")
     end
   end
 end

--- a/spec/system/articles/user_visits_article_stats.rb
+++ b/spec/system/articles/user_visits_article_stats.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe "Viewing an article stats", type: :system, js: true do
+  let_it_be(:user) { create(:user) }
+  let_it_be(:article, reload: true) { create(:article, user: user) }
+
+  it "shows stats for pro users by clicking on the stats button" do
+    path = "/#{user.username}/#{article.slug}/stats"
+    user.add_role(:pro)
+    sign_in user
+    visit path
+    expect(page).to have_current_path(path)
+    expect(page).to have_selector(".summary-stats")
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

This PR contains stats/analytics for a single article. 

The feature consists of two parts:

* a "STATS" button, enabled only for the user if they are both the owner and a pro user
* a `/stats` page containing the analytics

NOTE: I'm not sure about wording, titles and links, please let me know if the path of the titles should be different

## Related Tickets & Documents

#3102 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

STATS button:

![Screenshot_2019-06-11 this is an article for me](https://user-images.githubusercontent.com/146201/59265803-6ca71780-8c46-11e9-89f4-3a766fe671c6.png)

article stats:

![Screenshot_2019-06-11 this is an article for me(1)](https://user-images.githubusercontent.com/146201/59265826-7a5c9d00-8c46-11e9-99e8-8149271f69d9.png)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
