### PR TITLE
Podcasts validations

### DIFF
--- a/app/models/podcast.rb
+++ b/app/models/podcast.rb
@@ -4,26 +4,21 @@ class Podcast < ApplicationRecord
   mount_uploader :image, ProfileImageUploader
   mount_uploader :pattern_image, ProfileImageUploader
 
-  validates :main_color_hex, presence: true
+  validates :main_color_hex, :title, :feed_url, :image, :slug, presence: true
+  validates :feed_url, :slug, uniqueness: true
 
   after_save :bust_cache
   after_create :pull_all_episodes
 
-  def path
-    slug
-  end
-
-  def profile_image_url
-    image_url
-  end
-
-  def name
-    title
-  end
+  alias_attribute :path, :slug
+  alias_attribute :profile_image_url, :image_url
+  alias_attribute :name, :title
 
   private
 
   def bust_cache
+    return unless path
+
     CacheBuster.new.bust("/" + path)
   end
 

--- a/app/models/podcast.rb
+++ b/app/models/podcast.rb
@@ -11,7 +11,7 @@ class Podcast < ApplicationRecord
             uniqueness: true,
             format: { with: /\A[a-zA-Z0-9\-_]+\Z/ },
             exclusion: { in: ReservedWords.all, message: "slug is reserved" }
-  validate :unique_slug_including_users_orgs
+  validate :unique_slug_including_users_and_orgs, if: :slug_changed?
 
   after_save :bust_cache
   after_create :pull_all_episodes
@@ -22,7 +22,7 @@ class Podcast < ApplicationRecord
 
   private
 
-  def unique_slug_including_users_orgs
+  def unique_slug_including_users_and_orgs
     errors.add(:slug, "is taken.") if User.find_by(username: slug) || Organization.find_by(slug: slug)
   end
 

--- a/app/models/podcast_episode.rb
+++ b/app/models/podcast_episode.rb
@@ -69,6 +69,8 @@ class PodcastEpisode < ApplicationRecord
   end
 
   def path
+    return nil unless podcast&.slug
+
     "/#{podcast.slug}/#{slug}"
   end
 

--- a/db/migrate/20190611102309_add_constraints_to_podcasts.rb
+++ b/db/migrate/20190611102309_add_constraints_to_podcasts.rb
@@ -1,0 +1,21 @@
+class AddConstraintsToPodcasts < ActiveRecord::Migration[5.2]
+  def up
+    change_table :podcasts do |t|
+      t.change :main_color_hex, :string, null: false
+      t.change :title, :string, null: false
+      t.change :image, :string, null: false
+      t.change :slug, :string, null: false
+      t.change :feed_url, :string, null: false
+    end
+  end
+
+  def down
+    change_table :podcasts do |t|
+      t.change :main_color_hex, :string
+      t.change :title, :string
+      t.change :image, :string
+      t.change :slug, :string
+      t.change :feed_url, :string
+    end
+  end
+end

--- a/db/migrate/20190611102923_add_unique_indexes_to_podcasts.rb
+++ b/db/migrate/20190611102923_add_unique_indexes_to_podcasts.rb
@@ -1,0 +1,8 @@
+class AddUniqueIndexesToPodcasts < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :podcasts, :slug, unique: true, algorithm: :concurrently
+    add_index :podcasts, :feed_url, unique: true, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20190612095748_add_constraints_to_podcast_episodes.rb
+++ b/db/migrate/20190612095748_add_constraints_to_podcast_episodes.rb
@@ -1,0 +1,19 @@
+class AddConstraintsToPodcastEpisodes < ActiveRecord::Migration[5.2]
+  def up
+    change_table :podcast_episodes do |t|
+      t.change :title, :string, null: false
+      t.change :slug, :string, null: false
+      t.change :media_url, :string, null: false
+      t.change :guid, :string, null: false
+    end
+  end
+
+  def down
+    change_table :podcast_episodes do |t|
+      t.change :title, :string
+      t.change :slug, :string
+      t.change :media_url, :string
+      t.change :guid, :string
+    end
+  end
+end

--- a/db/migrate/20190612095959_add_unique_indexes_to_podcast_episodes.rb
+++ b/db/migrate/20190612095959_add_unique_indexes_to_podcast_episodes.rb
@@ -1,0 +1,8 @@
+class AddUniqueIndexesToPodcastEpisodes < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :podcast_episodes, :media_url, unique: true, algorithm: :concurrently
+    add_index :podcast_episodes, :guid, unique: true, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_11_102923) do
+ActiveRecord::Schema.define(version: 2019_06_12_095959) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -626,23 +626,25 @@ ActiveRecord::Schema.define(version: 2019_06_11_102923) do
     t.integer "duration_in_seconds"
     t.boolean "featured", default: true
     t.integer "featured_number"
-    t.string "guid"
+    t.string "guid", null: false
     t.string "image"
     t.string "itunes_url"
-    t.string "media_url"
+    t.string "media_url", null: false
     t.string "order_key"
     t.integer "podcast_id"
     t.text "processed_html"
     t.datetime "published_at"
     t.text "quote"
     t.integer "reactions_count", default: 0, null: false
-    t.string "slug"
+    t.string "slug", null: false
     t.string "social_image"
     t.string "subtitle"
     t.text "summary"
-    t.string "title"
+    t.string "title", null: false
     t.datetime "updated_at", null: false
     t.string "website_url"
+    t.index ["guid"], name: "index_podcast_episodes_on_guid", unique: true
+    t.index ["media_url"], name: "index_podcast_episodes_on_media_url", unique: true
   end
 
   create_table "podcasts", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_07_110030) do
+ActiveRecord::Schema.define(version: 2019_06_11_102923) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -649,20 +649,22 @@ ActiveRecord::Schema.define(version: 2019_06_07_110030) do
     t.string "android_url"
     t.datetime "created_at", null: false
     t.text "description"
-    t.string "feed_url"
-    t.string "image"
+    t.string "feed_url", null: false
+    t.string "image", null: false
     t.string "itunes_url"
-    t.string "main_color_hex"
+    t.string "main_color_hex", null: false
     t.string "overcast_url"
     t.string "pattern_image"
-    t.string "slug"
+    t.string "slug", null: false
     t.string "soundcloud_url"
     t.text "status_notice", default: ""
-    t.string "title"
+    t.string "title", null: false
     t.string "twitter_username"
     t.boolean "unique_website_url?", default: true
     t.datetime "updated_at", null: false
     t.string "website_url"
+    t.index ["feed_url"], name: "index_podcasts_on_feed_url", unique: true
+    t.index ["slug"], name: "index_podcasts_on_slug", unique: true
   end
 
   create_table "push_notification_subscriptions", force: :cascade do |t|

--- a/spec/models/podcast_episode_spec.rb
+++ b/spec/models/podcast_episode_spec.rb
@@ -3,8 +3,34 @@ require "rails_helper"
 RSpec.describe PodcastEpisode, type: :model do
   let(:podcast_episode) { create(:podcast_episode) }
 
-  it "accepts valid podcast episode" do
-    expect(podcast_episode).to be_valid
+  it { is_expected.to validate_presence_of(:title) }
+  it { is_expected.to validate_presence_of(:slug) }
+  it { is_expected.to validate_presence_of(:media_url) }
+  it { is_expected.to validate_presence_of(:guid) }
+
+  describe "validations" do
+    # Couldn't use shoulda matchers for these tests because:
+    # Shoulda uses `save(validate: false)` which skips validations, but runs callbacks
+    # So an invalid record is saved and the algolia callback fails to run because there's no associated podcast
+    # https://git.io/fjg2g
+
+    it "validates guid uniqueness" do
+      ep2 = build(:podcast_episode, guid: podcast_episode.guid)
+
+      expect(ep2).not_to be_valid
+      expect(ep2.errors[:guid]).to be_present
+    end
+
+    it "validates media_url uniqueness" do
+      ep2 = build(:podcast_episode, media_url: podcast_episode.media_url)
+
+      expect(ep2).not_to be_valid
+      expect(ep2.errors[:media_url]).to be_present
+    end
+
+    it "accepts valid podcast episode" do
+      expect(podcast_episode).to be_valid
+    end
   end
 
   describe "#description" do

--- a/spec/models/podcast_spec.rb
+++ b/spec/models/podcast_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe Podcast, type: :model do
+  it { is_expected.to validate_presence_of(:image) }
+  it { is_expected.to validate_presence_of(:slug) }
+  it { is_expected.to validate_presence_of(:title) }
+  it { is_expected.to validate_presence_of(:main_color_hex) }
+  it { is_expected.to validate_presence_of(:feed_url) }
+
+  describe "validations" do
+    let(:podcast) { create(:podcast) }
+
+    it "is valid" do
+      expect(podcast).to be_valid
+    end
+
+    # Couldn't use shoulda uniqueness matchers for these tests because:
+    # Shoulda uses `save(validate: false)` which skips validations
+    # So an invalid record is trying to be saved but fails because of the db constraints
+    # https://git.io/fjg2g
+
+    it "validates slug uniqueness" do
+      podcast2 = build(:podcast, slug: podcast.slug)
+
+      expect(podcast2).not_to be_valid
+      expect(podcast2.errors[:slug]).to be_present
+    end
+
+    it "validates feed_url uniqueness" do
+      podcast2 = build(:podcast, feed_url: podcast.feed_url)
+
+      expect(podcast2).not_to be_valid
+      expect(podcast2.errors[:feed_url]).to be_present
+    end
+  end
+end

--- a/spec/models/podcast_spec.rb
+++ b/spec/models/podcast_spec.rb
@@ -32,5 +32,25 @@ RSpec.describe Podcast, type: :model do
       expect(podcast2).not_to be_valid
       expect(podcast2.errors[:feed_url]).to be_present
     end
+
+    it "doesn't allow to create a podcast with a reserved word slug" do
+      enter_podcast = build(:podcast, slug: "enter")
+      expect(enter_podcast).not_to be_valid
+      expect(enter_podcast.errors[:slug]).to be_present
+    end
+
+    it "is invalid when a user with a username equal to the podcast slug exists" do
+      create(:user, username: "annabu")
+      user_podcast = build(:podcast, slug: "annabu")
+      expect(user_podcast).not_to be_valid
+      expect(user_podcast.errors[:slug]).to be_present
+    end
+
+    it "is invalid when an org with a slug equal to the podcast slug exists" do
+      create(:organization, slug: "superorganization")
+      user_podcast = build(:podcast, slug: "superorganization")
+      expect(user_podcast).not_to be_valid
+      expect(user_podcast.errors[:slug]).to be_present
+    end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Implemented proper validations for podcasts and podcast episodes to avoid failing in the future.
- added model validations: fields presence, `slug` uniqueness, `slug` uniqueness with `username`s and organization `slug`s
- added db constraints
- added validation specs

Before merging need to check that all the `podcasts` and `podcast_episodes` records don't violate the provided constraints (non-null values and uniqueness)

## Related Tickets & Documents
#271
https://github.com/thepracticaldev/team/issues/177