### PR TITLE
Destroy organization memberships if user is destroyed

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@ class User < ApplicationRecord
   acts_as_followable
   acts_as_follower
 
-  has_many    :organization_memberships
+  has_many    :organization_memberships, dependent: :destroy
   has_many    :organizations, through: :organization_memberships
   has_many    :api_secrets, dependent: :destroy
   has_many    :articles, dependent: :destroy

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -664,5 +664,11 @@ RSpec.describe User, type: :model do
       user.destroy
       expect(user.persisted?).to be false
     end
+
+    it "destroys associated organization memberships" do
+      organization_membership = create(:organization_membership, user_id: user.id, organization_id: org.id)
+      user.destroy
+      expect { organization_membership.reload }.to raise_error ActiveRecord::RecordNotFound
+    end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Fixes a minor bug where a user's organization memberships were not destroyed when the user was destroyed.

Related #3077 