### PR TITLE
Fix access token revoking

### DIFF
--- a/app/controllers/api_secrets_controller.rb
+++ b/app/controllers/api_secrets_controller.rb
@@ -32,6 +32,10 @@ class ApiSecretsController < ApplicationController
   private
 
   def load_api_secret
-    @secret = ApiSecret.find_by(id: params[:id]) || not_found
+    @secret = ApiSecret.find(destroy_params[:id])
+  end
+
+  def destroy_params
+    params.permit(:id)
   end
 end

--- a/app/controllers/api_secrets_controller.rb
+++ b/app/controllers/api_secrets_controller.rb
@@ -1,32 +1,37 @@
 class ApiSecretsController < ApplicationController
-  before_action :set_api_secret, only: :destroy
+  before_action :load_api_secret, only: :destroy
   after_action :verify_authorized
 
   def create
     authorize ApiSecret
+
     @secret = ApiSecret.new(permitted_attributes(ApiSecret))
     @secret.user_id = current_user.id
+
     if @secret.save
       flash[:notice] = "Your access token has been generated: #{@secret.secret}"
     else
       flash[:error] = @secret.errors.full_messages.to_sentence
     end
+
     redirect_back(fallback_location: root_path)
   end
 
   def destroy
     authorize @secret
+
     if @secret.destroy
       flash[:notice] = "Your access token has been revoked."
     else
       flash[:error] = "An error occurred. Please try again or send an email to: yo@dev.to"
     end
+
     redirect_back(fallback_location: root_path)
   end
 
   private
 
-  def set_api_secret
+  def load_api_secret
     @secret = ApiSecret.find_by(id: params[:id]) || not_found
   end
 end

--- a/app/views/users/_account.html.erb
+++ b/app/views/users/_account.html.erb
@@ -35,6 +35,7 @@
 <% if @user.api_secrets.empty? %>
   <p>None yet!</p>
 <% end %>
+
 <% @user.api_secrets.order(created_at: :desc).each do |api_secret| %>
   <div class='api__secret__container'>
     <div class='api__secret__desc'>
@@ -42,9 +43,9 @@
       <p class='content'><%= api_secret.secret %></p>
       <p class='subtitle'>Created <%= api_secret.created_at.to_date.to_s %></p>
     </div>
+
     <div class='api__secret__revoke'>
-      <%= form_tag users_api_secrets_path, method: :delete do %>
-        <%= hidden_field_tag "id", api_secret.id %>
+      <%= form_tag users_api_secret_path(api_secret.id), method: :delete do %>
         <%= button_tag "Revoke", class: "big-action danger-button" %>
       <% end %>
     </div>

--- a/app/views/users/_account.html.erb
+++ b/app/views/users/_account.html.erb
@@ -43,8 +43,9 @@
       <p class='subtitle'>Created <%= api_secret.created_at.to_date.to_s %></p>
     </div>
     <div class='api__secret__revoke'>
-      <%= form_tag users_api_secrets_path(id: api_secret.id), method: :delete do %>
-        <%= button_tag("Revoke", class: "big-action danger-button") %>
+      <%= form_tag users_api_secrets_path, method: :delete do %>
+        <%= hidden_field_tag "id", api_secret.id %>
+        <%= button_tag "Revoke", class: "big-action danger-button" %>
       <% end %>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -205,8 +205,8 @@ Rails.application.routes.draw do
   delete "users/remove_association", to: "users#remove_association"
   delete "users/destroy", to: "users#destroy"
   post "organizations/generate_new_secret" => "organizations#generate_new_secret"
-  post "users/api_secrets" => "api_secrets#create"
-  delete "users/api_secrets" => "api_secrets#destroy"
+  post "users/api_secrets" => "api_secrets#create", as: :users_api_secrets
+  delete "users/api_secrets/:id" => "api_secrets#destroy", as: :users_api_secret
 
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".

--- a/spec/requests/api_secrets_destroy_spec.rb
+++ b/spec/requests/api_secrets_destroy_spec.rb
@@ -9,14 +9,30 @@ RSpec.describe "ApiSecretsDestroy", type: :request do
   describe "DELETE /users/api_secrets" do
     context "when delete succeeds" do
       it "deletes the ApiSecret for the user" do
-        expect { delete "/users/api_secrets", params: { id: api_secret.id } }.
-          to change { user.api_secrets.count }.by(-1)
+        expect do
+          delete "/users/api_secrets", params: { id: api_secret.id }
+        end.to change(user.api_secrets, :count).by(-1)
       end
 
       it "flashes a notice" do
         delete "/users/api_secrets", params: { id: api_secret.id }
         expect(flash[:notice]).to be_truthy
         expect(flash[:error]).to be_nil
+      end
+
+      it "cannot delete a non existing secret" do
+        expect do
+          delete "/users/api_secrets", params: { id: 9999 }
+        end.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      it "cannot delete another user's secret" do
+        another_user = create(:user)
+        secret = create(:api_secret, user: another_user)
+
+        expect do
+          delete "/users/api_secrets", params: { id: secret.id }
+        end.to raise_error(Pundit::NotAuthorizedError)
       end
     end
 

--- a/spec/requests/api_secrets_destroy_spec.rb
+++ b/spec/requests/api_secrets_destroy_spec.rb
@@ -10,19 +10,19 @@ RSpec.describe "ApiSecretsDestroy", type: :request do
     context "when delete succeeds" do
       it "deletes the ApiSecret for the user" do
         expect do
-          delete "/users/api_secrets", params: { id: api_secret.id }
+          delete "/users/api_secrets/#{api_secret.id}"
         end.to change(user.api_secrets, :count).by(-1)
       end
 
       it "flashes a notice" do
-        delete "/users/api_secrets", params: { id: api_secret.id }
+        delete "/users/api_secrets/#{api_secret.id}"
         expect(flash[:notice]).to be_truthy
         expect(flash[:error]).to be_nil
       end
 
       it "cannot delete a non existing secret" do
         expect do
-          delete "/users/api_secrets", params: { id: 9999 }
+          delete "/users/api_secrets/9999"
         end.to raise_error(ActiveRecord::RecordNotFound)
       end
 
@@ -31,24 +31,24 @@ RSpec.describe "ApiSecretsDestroy", type: :request do
         secret = create(:api_secret, user: another_user)
 
         expect do
-          delete "/users/api_secrets", params: { id: secret.id }
+          delete "/users/api_secrets/#{secret.id}"
         end.to raise_error(Pundit::NotAuthorizedError)
       end
     end
 
     context "when delete fails" do
       before do
-        allow(ApiSecret).to receive(:find_by).with(id: api_secret.id.to_s).and_return api_secret
-        allow(api_secret).to receive(:destroy).and_return false
+        allow(ApiSecret).to receive(:find).with(api_secret.id.to_s).and_return(api_secret)
+        allow(api_secret).to receive(:destroy).and_return(false)
       end
 
       it "does not delete the ApiSecret" do
-        expect { delete "/users/api_secrets", params: { id: api_secret.id } }.
-          not_to(change { user.api_secrets.count })
+        path = "/users/api_secrets/#{api_secret.id}"
+        expect { delete path }.not_to change(user.api_secrets, :count)
       end
 
       it "flashes an error message" do
-        delete "/users/api_secrets", params: { id: api_secret.id }
+        delete "/users/api_secrets/#{api_secret.id}"
         expect(flash[:error]).to be_truthy
         expect(flash[:notice]).to be_nil
       end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

I'm not 100% sure why but it seems that putting the ID as a keyword parameter for a `DELETE` does not play nice with Rails. I've converted it to use an inline parameter following the same convention Rails uses for any other `DELETE`/destroy action

## Related Tickets & Documents

Closes #3079

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
