### PR TITLE
Moved SlackBot.delay.ping calls to ActiveJob #3136

### DIFF
--- a/app/jobs/slack_bot_ping_job.rb
+++ b/app/jobs/slack_bot_ping_job.rb
@@ -1,0 +1,10 @@
+class SlackBotPingJob < ApplicationJob
+  queue_as :slack_bot_ping
+
+  def perform(message:, channel:, username:, icon_emoji:)
+    SlackBot.ping message,
+                  channel: channel,
+                  username: username,
+                  icon_emoji: icon_emoji
+  end
+end

--- a/app/observers/application_observer.rb
+++ b/app/observers/application_observer.rb
@@ -2,9 +2,9 @@ class ApplicationObserver < ActiveRecord::Observer
   def warned_user_ping(activity)
     return unless activity.user.warned == true
 
-    SlackBot.delay.ping "Activity: https://dev.to/#{activity.path}\nManage @#{activity.user.username}: https://dev.to/internal/users/#{activity.user.id}",
-                        channel: "warned-user-activity",
-                        username: "sloan_watch_bot",
-                        icon_emoji: ":sloan:"
+    SlackBotPingJob.perform_later message: "Activity: https://dev.to/#{activity.path}\nManage @#{activity.user.username}: https://dev.to/internal/users/#{activity.user.id}",
+                                  channel: "warned-user-activity",
+                                  username: "sloan_watch_bot",
+                                  icon_emoji: ":sloan:"
   end
 end

--- a/app/observers/article_observer.rb
+++ b/app/observers/article_observer.rb
@@ -10,9 +10,9 @@ class ArticleObserver < ApplicationObserver
   def ping_new_article(article)
     return unless article.published && article.published_at > 30.seconds.ago
 
-    SlackBot.delay.ping "New Article Published: #{article.title}\nhttps://dev.to#{article.path}",
-                        channel: "activity",
-                        username: "article_bot",
-                        icon_emoji: ":writing_hand:"
+    SlackBotPingJob.perform_later message: "New Article Published: #{article.title}\nhttps://dev.to#{article.path}",
+                                  channel: "activity",
+                                  username: "article_bot",
+                                  icon_emoji: ":writing_hand:"
   end
 end

--- a/app/observers/organization_observer.rb
+++ b/app/observers/organization_observer.rb
@@ -2,8 +2,8 @@ class OrganizationObserver < ActiveRecord::Observer
   def after_create(organization)
     return if Rails.env.development?
 
-    SlackBot.delay.ping(
-      "New Org Created: #{organization.name}\nhttps://dev.to/#{organization.username}",
+    SlackBotPingJob.perform_later(
+      message: "New Org Created: #{organization.name}\nhttps://dev.to/#{organization.username}",
       channel: "orgactivity",
       username: "org_bot",
       icon_emoji: ":office:",

--- a/app/observers/reaction_observer.rb
+++ b/app/observers/reaction_observer.rb
@@ -1,8 +1,8 @@
 class ReactionObserver < ActiveRecord::Observer
   def after_create(reaction)
     if reaction.category == "vomit"
-      SlackBot.delay.ping(
-        "#{reaction.user.name} (https://dev.to#{reaction.user.path}) \nreacted with a #{reaction.category} on\nhttps://dev.to#{reaction.reactable.path}",
+      SlackBotPingJob.perfom_later(
+        message: "#{reaction.user.name} (https://dev.to#{reaction.user.path}) \nreacted with a #{reaction.category} on\nhttps://dev.to#{reaction.reactable.path}",
         channel: "abuse-reports",
         username: "abuse_bot",
         icon_emoji: ":cry:",

--- a/app/services/rss_reader.rb
+++ b/app/services/rss_reader.rb
@@ -112,8 +112,8 @@ class RssReader
   def send_slack_notification(article)
     return unless Rails.env.production?
 
-    SlackBot.delay.ping(
-      "New Article Retrieved via RSS: #{article.title}\nhttps://dev.to#{article.path}",
+    SlackBotPingJob.perform_later(
+      message: "New Article Retrieved via RSS: #{article.title}\nhttps://dev.to#{article.path}",
       channel: "activity",
       username: "article_bot",
       icon_emoji: ":robot_face:",

--- a/spec/jobs/slack_bot_ping_job_spec.rb
+++ b/spec/jobs/slack_bot_ping_job_spec.rb
@@ -2,8 +2,6 @@ require "rails_helper"
 
 RSpec.describe SlackBotPingJob, type: :job do
   describe "#perform_now" do
-    let(:user) { create(:user) }
-
     before do
       allow(SlackBot).to receive(:ping)
     end

--- a/spec/jobs/slack_bot_ping_job_spec.rb
+++ b/spec/jobs/slack_bot_ping_job_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe SlackBotPingJob, type: :job do
+  describe "#perform_now" do
+    let(:user) { create(:user) }
+
+    before do
+      allow(SlackBot).to receive(:ping)
+    end
+
+    it "calls the SlackBot" do
+      described_class.perform_now(message: "hello",
+                                  channel: "#help",
+                                  username: "sloan_watch_bot",
+                                  icon_emoji: ":sloan:")
+      expect(SlackBot).to have_received(:ping).with("hello", channel: "#help",
+                                                             username: "sloan_watch_bot",
+                                                             icon_emoji: ":sloan:")
+    end
+  end
+end

--- a/spec/observers/article_observer_spec.rb
+++ b/spec/observers/article_observer_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ArticleObserver, type: :observer do
 
   it "pings slack #activity if new article is created" do
     Article.observers.enable :article_observer do
-      run_background_jobs_immediately do
+      perform_enqueued_jobs do
         create(:article, user_id: user.id)
       end
     end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
Moved SlackBot.delay.ping calls to a separate ActiveJob.
This may seem redundant compared with moving `handle_asynchronous` methods to `ActiveJob`s, but still I think it's worth doing because in such a way:
- we reduce dependency on the DelayedJob 
- it's easier to debug in case of errors

## Related Tickets & Documents
#3136 