### PR TITLE
Fix visibility of unread channel name

### DIFF
--- a/app/assets/stylesheets/chat.scss
+++ b/app/assets/stylesheets/chat.scss
@@ -830,6 +830,7 @@
 
 .chatchanneltab--new {
   background: lighten($yellow, 10%);
+  color: $black;
 }
 
 .chatchanneltab--video {


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] (Design) Bug Fix
- [ ] Documentation Update

## Description

The channel with unread messages gets a yellow highlight but the text is hardly readable (See screenshot below). This PR fixes it by making the text black (#0a0a0a).

**Before**

![image](https://user-images.githubusercontent.com/7039523/59382554-971ad280-8d23-11e9-88bb-8e54e1695492.png)

**After**

![image](https://user-images.githubusercontent.com/7039523/59382501-7f434e80-8d23-11e9-88ef-5a3ea19ef5f9.png)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
