### PR TITLE
Validate usernames and organization slugs against podcast slugs

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -51,7 +51,7 @@ class Organization < ApplicationRecord
   before_validation :check_for_slug_change
   before_validation :evaluate_markdown
 
-  validate :unique_slug_including_users
+  validate :unique_slug_including_users_and_podcasts, if: :slug_changed?
 
   mount_uploader :profile_image, ProfileImageUploader
   mount_uploader :nav_image, ProfileImageUploader
@@ -131,7 +131,7 @@ class Organization < ApplicationRecord
   end
   handle_asynchronously :bust_cache
 
-  def unique_slug_including_users
-    errors.add(:slug, "is taken.") if User.find_by(username: slug)
+  def unique_slug_including_users_and_podcasts
+    errors.add(:slug, "is taken.") if User.find_by(username: slug) || Podcast.find_by(slug: slug)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -136,7 +136,7 @@ class User < ApplicationRecord
   validate  :conditionally_validate_summary
   validate  :validate_mastodon_url
   validate  :validate_feed_url, if: :feed_url_changed?
-  validate  :unique_including_orgs, if: :username_changed?
+  validate  :unique_including_orgs_and_podcasts, if: :username_changed?
 
   scope :dev_account, -> { find_by(id: ApplicationConfig["DEVTO_USER_ID"]) }
 
@@ -370,8 +370,8 @@ class User < ApplicationRecord
     OrganizationMembership.exists?(user: user, organization: organization, type_of_user: "admin")
   end
 
-  def unique_including_orgs
-    errors.add(:username, "is taken.") if Organization.find_by(slug: username)
+  def unique_including_orgs_and_podcasts
+    errors.add(:username, "is taken.") if Organization.find_by(slug: username) || Podcast.find_by(slug: username)
   end
 
   def subscribe_to_mailchimp_newsletter_without_delay

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -74,6 +74,26 @@ RSpec.describe Organization, type: :model do
       organization.save
       expect(organization.slug).to eq("hahaha")
     end
+
+    it "rejects reserved slug" do
+      organization = build(:organization, slug: "settings")
+      expect(organization).not_to be_valid
+      expect(organization.errors[:slug].to_s.include?("reserved")).to be true
+    end
+
+    it "takes organization slug into account " do
+      create(:user, username: "lightalloy")
+      organization = build(:organization, slug: "lightalloy")
+      expect(organization).not_to be_valid
+      expect(organization.errors[:slug].to_s.include?("taken")).to be true
+    end
+
+    it "takes podcast slug into account" do
+      create(:podcast, slug: "devpodcast")
+      organization = build(:organization, slug: "devpodcast")
+      expect(organization).not_to be_valid
+      expect(organization.errors[:slug].to_s.include?("taken")).to be true
+    end
   end
 
   describe "#url" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -36,6 +36,26 @@ RSpec.describe User, type: :model do
     it { is_expected.to validate_length_of(:username).is_at_most(30).is_at_least(2) }
     it { is_expected.to validate_length_of(:name).is_at_most(100) }
     it { is_expected.to validate_inclusion_of(:inbox_type).in_array(%w[open private]) }
+
+    it "validates username against reserved words" do
+      user = build(:user, username: "readinglist")
+      expect(user).not_to be_valid
+      expect(user.errors[:username].to_s.include?("reserved")).to be true
+    end
+
+    it "takes organization slug into account" do
+      create(:organization, slug: "lightalloy")
+      user = build(:user, username: "lightalloy")
+      expect(user).not_to be_valid
+      expect(user.errors[:username].to_s.include?("taken")).to be true
+    end
+
+    it "takes podcast slug into account" do
+      create(:podcast, slug: "lightpodcast")
+      user = build(:user, username: "lightpodcast")
+      expect(user).not_to be_valid
+      expect(user.errors[:username].to_s.include?("taken")).to be true
+    end
   end
 
   # the followings are failing


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
- validate usernames and organization slugs not only against each other but also against podcast slugs
- added specs to test usernames and org slugs uniqueness and not being equal to reserved words

Podcast `slug`s validation is in another pr #3123 