### PR TITLE
Added organization_id index to notifications

### DIFF
--- a/db/migrate/20190614093041_add_notifications_organization_id_index.rb
+++ b/db/migrate/20190614093041_add_notifications_organization_id_index.rb
@@ -1,0 +1,7 @@
+class AddNotificationsOrganizationIdIndex < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :notifications, :organization_id, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_12_095959) do
+ActiveRecord::Schema.define(version: 2019_06_14_093041) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -527,6 +527,7 @@ ActiveRecord::Schema.define(version: 2019_06_12_095959) do
     t.index ["notifiable_type"], name: "index_notifications_on_notifiable_type"
     t.index ["organization_id", "notifiable_id", "notifiable_type", "action"], name: "index_notifications_on_org_notifiable_and_action_not_null", unique: true, where: "(action IS NOT NULL)"
     t.index ["organization_id", "notifiable_id", "notifiable_type"], name: "index_notifications_on_org_notifiable_action_is_null", unique: true, where: "(action IS NULL)"
+    t.index ["organization_id"], name: "index_notifications_on_organization_id"
     t.index ["user_id", "notifiable_id", "notifiable_type", "action"], name: "index_notifications_on_user_notifiable_and_action_not_null", unique: true, where: "(action IS NOT NULL)"
     t.index ["user_id", "notifiable_id", "notifiable_type"], name: "index_notifications_on_user_notifiable_action_is_null", unique: true, where: "(action IS NULL)"
     t.index ["user_id"], name: "index_notifications_on_user_id"


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
Added `organization_id` index to the `notifications` table.

Explaining query without an index:
```
Notification.where("organization_id = 3 and read = false").select("count(*)").explain
------------------------------------------------------------------------
 Aggregate  (cost=780.32..780.33 rows=1 width=8)
   ->  Seq Scan on notifications  (cost=0.00..775.94 rows=1753 width=0)
         Filter: ((NOT read) AND (organization_id = 3))
(3 rows)
```
With the provided index:
```
Notification.where("organization_id = 3 and read = false").select("count(*)").explain
-----------------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=338.36..338.37 rows=1 width=8)
   ->  Index Scan using index_notifications_on_organization_id on notifications  (cost=0.28..333.98 rows=1753 width=0)
         Index Cond: (organization_id = 3)
         Filter: (NOT read)
(4 rows)
```
