### PR TITLE
Fix icons size in Safari reader mode

### DIFF
--- a/app/assets/stylesheets/article-show.scss
+++ b/app/assets/stylesheets/article-show.scss
@@ -4,8 +4,8 @@
 
 .stories-show {
   @include themeable(
-    background, 
-    theme-background, 
+    background,
+    theme-background,
     $lightest-gray
   );
 }
@@ -94,21 +94,21 @@ article {
   width: 880px;
   max-width: 100%;
   @include themeable(
-    background, 
-    theme-container-background, 
+    background,
+    theme-container-background,
     white
   );
   margin: 66px auto 20px;
   text-align: left;
   @include themeable(
-    box-shadow, 
-    theme-container-box-shadow, 
+    box-shadow,
+    theme-container-box-shadow,
     $bold-shadow
   );
   @media screen and (min-width: 880px) {
     @include themeable(
-      border, 
-      theme-container-border, 
+      border,
+      theme-container-border,
       1px solid darken(
         $light-medium-gray, 2%
       )
@@ -147,8 +147,8 @@ article {
 
     .org-branded-title-link {
       @include themeable(
-        color, 
-        theme-color, 
+        color,
+        theme-color,
         lighten($black, 4%)
       );
       .org-branded-title {
@@ -226,8 +226,8 @@ article {
       padding: 0 3px 16px;
       font-weight: 500;
       @include themeable(
-        color, 
-        theme-secondary-color, 
+        color,
+        theme-secondary-color,
         $medium-gray
       );
       font-size: 13.5px;
@@ -249,14 +249,15 @@ article {
 
       a {
         @include themeable(
-          color, 
-          theme-secondary-color, 
+          color,
+          theme-secondary-color,
           $medium-gray
         );
         text-decoration: none;
       }
 
-      .icon-img {
+      .icon-img,
+      .reader-image-tiny {
         opacity: 0.5;
         width: 18px;
         height: 18px;
@@ -400,8 +401,8 @@ article {
     font-size: 21px;
     line-height: 32px;
     @include themeable(
-      background, 
-      theme-container-background, 
+      background,
+      theme-container-background,
       #fff
     );
     position: relative;
@@ -529,8 +530,8 @@ article {
       font-size: 0.8em;
       line-height: 1.4em;
       @include themeable(
-        color, 
-        theme-color, 
+        color,
+        theme-color,
         darken($medium-gray, 8%)
       );
       display: block;
@@ -717,8 +718,8 @@ article {
         border: 1px solid $light-medium-gray;
         padding: 5px 1vw;
         @include themeable(
-          background, 
-          theme-background, 
+          background,
+          theme-background,
           $lightest-gray
         );
         text-align: left;
@@ -744,16 +745,16 @@ article {
     overflow: hidden;
     padding: 0px 0px 5px;
     @include themeable(
-      background, 
-      theme-container-background, 
+      background,
+      theme-container-background,
       white
     );
     font-family: $helvetica;
 
     a {
       @include themeable(
-        color, 
-        theme-color, 
+        color,
+        theme-color,
         $black
       );
     }
@@ -823,7 +824,7 @@ article {
 
         a {
           @include themeable(
-            color, 
+            color,
             theme-secondary-color,
             $medium-gray
           );
@@ -839,8 +840,8 @@ article {
             opacity: 0.7;
             background: transparent;
             @include themeable(
-              background, 
-              theme-secondary-color, 
+              background,
+              theme-secondary-color,
               transparent
             );
           }
@@ -858,21 +859,21 @@ article {
     background: white;
     border: 1px solid darken($light-medium-gray, 2%);
     @include themeable(
-      border, 
-      theme-container-border, 
+      border,
+      theme-container-border,
       1px solid darken(
         $light-medium-gray, 2%
       )
     );
     @include themeable(
-      box-shadow, 
-      theme-container-box-shadow, 
+      box-shadow,
+      theme-container-box-shadow,
       $bold-shadow
     );
     width: 100%;
     @include themeable(
-      background, 
-      theme-background, 
+      background,
+      theme-background,
       $tan
     );
     .dropdown-content {
@@ -1026,8 +1027,8 @@ article {
         border-radius: 100px;
         transition: box-shadow 0.18s;
         @include themeable(
-          background, 
-          theme-reaction-background, 
+          background,
+          theme-reaction-background,
           darken($light-gray, 3%)
         );
         @media screen and (min-width: 500px) {
@@ -1060,8 +1061,8 @@ article {
         margin-left: 5px;
         vertical-align: 10px;
         @include themeable(
-          color, 
-          theme-secondary-color, 
+          color,
+          theme-secondary-color,
           $medium-gray
         );
         font-size: 13px;
@@ -1212,8 +1213,8 @@ article {
       display: none;
       position: relative;
       @include themeable(
-        color, 
-        theme-secondary-color, 
+        color,
+        theme-secondary-color,
         $medium-gray
       );
       font-weight: bold;
@@ -1381,7 +1382,7 @@ article {
 
   a {
     @include themeable(
-      color, 
+      color,
       theme-color,
       $black
     );


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Documentation Update

## Description
In Safari reader mode, icons become simply huge. I used the **unused** class which is added to icons **only** in reader mode: `.reader-image-tiny`.

Default view: 
![image](https://user-images.githubusercontent.com/5319267/59508415-25bb5b00-8eae-11e9-9570-84141623ee26.png)

Safari reader mode view:
![image](https://user-images.githubusercontent.com/5319267/59508431-34a20d80-8eae-11e9-9c04-40d6c444b5ef.png)

## Related Tickets & Documents
I saw nothing about that.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
The same on Apple smartphones

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?
![excited](https://media.giphy.com/media/rVbAzUUSUC6dO/giphy.gif)
(impatient given that it's my first contribution to this awesome project 🤘)

