### PR TITLE
Fix analytics grouped by day with nil page views average

### DIFF
--- a/app/services/analytics_service.rb
+++ b/app/services/analytics_service.rb
@@ -162,7 +162,7 @@ class AnalyticsService
     # this transforms the collection of pseudo PageView objects previously selected
     # in a hash, eg. {total: 2, average_read_time_in_seconds: 10, total_read_time_in_seconds: 20}
     page_views.each_with_object({}) do |page_view, hash|
-      average = page_view.average.round # average is a BigDecimal
+      average = (page_view.average || 0).round # average is a BigDecimal
       hash[page_view.date.iso8601] = {
         total: page_view.total,
         average_read_time_in_seconds: average,

--- a/spec/services/analytics_service_spec.rb
+++ b/spec/services/analytics_service_spec.rb
@@ -358,6 +358,16 @@ RSpec.describe AnalyticsService, type: :service do
         expect(analytics_service.grouped_by_day[date][
           :page_views][:total_read_time_in_seconds]).to eq(0)
       end
+
+      it "works correctly if the page views contain nil in time_tracked_in_seconds" do
+        create(:page_view, user: user, article: article, time_tracked_in_seconds: nil)
+        create(:page_view, user: user, article: article, time_tracked_in_seconds: nil)
+        date = format_date(article.created_at)
+        analytics_service = described_class.new(user, start_date: date)
+        expect(analytics_service.grouped_by_day[date][:page_views][:total]).to eq(2)
+        expect(analytics_service.grouped_by_day[date][:page_views][:average_read_time_in_seconds]).to eq(0)
+        expect(analytics_service.grouped_by_day[date][:page_views][:total_read_time_in_seconds]).to eq(0)
+      end
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

I'm not sure how this is happening on production, but I guess there are page views that have `time_tracked_in_seconds` that is nil for specific articles. If the average results in `NULL` then the analytics page breaks. 

This is a fix for that.

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
