### PR TITLE
Performance: save some queries when pluck is not needed

### DIFF
--- a/app/controllers/internal/feedback_messages_controller.rb
+++ b/app/controllers/internal/feedback_messages_controller.rb
@@ -9,7 +9,7 @@ class Internal::FeedbackMessagesController < Internal::ApplicationController
       includes(:reporter, :notes).
       order("feedback_messages.created_at DESC").
       page(params[:page] || 1).per(5)
-    @email_messages = EmailMessage.find_for_reports(@feedback_messages.pluck(:id))
+    @email_messages = EmailMessage.find_for_reports(@feedback_messages)
     @vomits = get_vomits
   end
 

--- a/app/controllers/moderations_controller.rb
+++ b/app/controllers/moderations_controller.rb
@@ -11,7 +11,7 @@ class ModerationsController < ApplicationController
       order("hotness_score DESC").limit(100)
     @articles = @articles.cached_tagged_with(params[:tag]) if params[:tag].present?
 
-    @rating_votes = RatingVote.where(article: @articles.pluck(:id), user: current_user)
+    @rating_votes = RatingVote.where(article: @articles, user: current_user)
     @articles = @articles.decorate
   end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -76,7 +76,7 @@ class PagesController < ApplicationController
     @articles = Article.published.tagged_with(%w[shecoded shecodedally theycoded], any: true).
       where(approved: true).where("published_at > ? AND score > ?", 3.weeks.ago, -8).
       order(Arel.sql("RANDOM()")).
-      where.not(id: @top_articles.pluck(:id)).
+      where.not(id: @top_articles).
       includes(:user).decorate
     render layout: false
     set_surrogate_key_header "shecoded_page"

--- a/app/services/mentions/create_all.rb
+++ b/app/services/mentions/create_all.rb
@@ -28,8 +28,8 @@ module Mentions
     private
 
     def delete_removed_mentions(usernames)
-      user_ids = User.where(username: usernames).pluck(:id)
-      mentions = @notifiable.mentions.where.not(user_id: user_ids).destroy_all
+      users = User.where(username: usernames)
+      mentions = @notifiable.mentions.where.not(user_id: users).destroy_all
       Notification.remove_each(mentions) if mentions.present?
     end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

Rails `pluck` forces an additional SQL query, such query is not always needed when the objects are already in memory or the requested ID is the primary key ID.

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
