### PR TITLE
Add Item Count to Reading List Header

### DIFF
--- a/app/javascript/readingList/readingList.jsx
+++ b/app/javascript/readingList/readingList.jsx
@@ -33,7 +33,6 @@ export class ReadingList extends Component {
         t.setState({
           totalReadingList: content.nbHits,
           readingListItems: content.hits,
-          totalCount: content.nbHits,
           index,
           itemsLoaded: true,
         });
@@ -82,7 +81,7 @@ export class ReadingList extends Component {
 
   archive = (e, item) => {
     e.preventDefault();
-    const { statusView, readingListItems, totalCount } = this.state;
+    const { statusView, readingListItems, totalReadingList } = this.state;
     const t = this;
     window.fetch(`/reading_list_items/${item.id}`, {
       method: 'PUT',
@@ -98,7 +97,7 @@ export class ReadingList extends Component {
     t.setState({
       archiving: true,
       readingListItems: newItems,
-      totalCount: totalCount - 1,
+      totalReadingList: totalReadingList - 1,
     });
     setTimeout(() => {
       t.setState({ archiving: false });
@@ -126,7 +125,7 @@ export class ReadingList extends Component {
     if (!isLoadMore) {
       this.setState({ page: 0 });
     }
-    const { index, page } = this.state; 
+    const { index, page } = this.state;
     const filters = { page, hitsPerPage: 64, filters: `status:${statusView}` };
     if (tags.length > 0) {
       filters.tagFilters = tags;
@@ -277,16 +276,18 @@ min read・
             </div>
           </div>
         </div>
-        <div
-          className={`readinglist-results ${
-            itemsLoaded ? 'readinglist-results--loaded' : ''
-          }`}
-        >
-          <div className="readinglist-results-header">
-            {statusView === 'valid' ? 'Reading List' : 'Archive'}
-            {` (${totalReadingList})`}
+        <div className="readinglist-result-container">
+          <div
+            className={`readinglist-results ${
+              itemsLoaded ? 'readinglist-results--loaded' : ''
+            }`}
+          >
+            <div className="readinglist-results-header">
+              {statusView === 'valid' ? 'Reading List' : 'Archive'}
+              {` (${totalReadingList})`}
+            </div>
+            <div>{allItems}</div>
           </div>
-          <div>{allItems}</div>
           <div className="loadmore-wrapper">{loadMoreButton}</div>
         </div>
         {snackBar}

--- a/app/javascript/readingList/readingList.jsx
+++ b/app/javascript/readingList/readingList.jsx
@@ -125,12 +125,26 @@ export class ReadingList extends Component {
     if (!isLoadMore) {
       this.setState({ page: 0 });
     }
-    const { index, page } = this.state;
+    const { index, page, readingListItems } = this.state;
     const filters = { page, hitsPerPage: 64, filters: `status:${statusView}` };
     if (tags.length > 0) {
       filters.tagFilters = tags;
     }
     index.search(query, filters).then(content => {
+      if (!isLoadMore) {
+        t.setState({
+          readingListItems: content.hits,
+          totalReadingList: content.nbHits,
+          query,
+        });
+      } else {
+        t.setState({
+          readingListItems: [...readingListItems, ...content.hits],
+          totalReadingList: content.nbHits,
+          query,
+        });
+      }
+      this.shouldShowLoadMoreButton();
       t.setState({
         readingListItems: content.hits,
         totalReadingList: content.nbHits,

--- a/app/javascript/readingList/readingList.jsx
+++ b/app/javascript/readingList/readingList.jsx
@@ -126,26 +126,17 @@ export class ReadingList extends Component {
     if (!isLoadMore) {
       this.setState({ page: 0 });
     }
-    const { index, page, readingListItems } = this.state;
+    const { index, page } = this.state; 
     const filters = { page, hitsPerPage: 64, filters: `status:${statusView}` };
     if (tags.length > 0) {
       filters.tagFilters = tags;
     }
     index.search(query, filters).then(content => {
-      if (!isLoadMore) {
-        t.setState({
-          readingListItems: content.hits,
-          totalReadingList: content.nbHits,
-          query,
-        });
-      } else {
-        t.setState({
-          readingListItems: [...readingListItems, ...content.hits],
-          totalReadingList: content.nbHits,
-          query,
-        });
-      }
-      this.shouldShowLoadMoreButton();
+      t.setState({
+        readingListItems: content.hits,
+        totalReadingList: content.nbHits,
+        query,
+      });
     });
   }
 
@@ -159,6 +150,7 @@ export class ReadingList extends Component {
       selectedTags,
       statusView,
       showLoadMoreButton,
+      totalReadingList,
     } = this.state;
     let allItems = readingListItems.map(item => (
       <div className="readinglist-item-wrapper">
@@ -285,17 +277,16 @@ min read・
             </div>
           </div>
         </div>
-        <div className="readinglist-result-container">
-          <div
-            className={`readinglist-results ${
-              itemsLoaded ? 'readinglist-results--loaded' : ''
-            }`}
-          >
-            <div className="readinglist-results-header">
-              {statusView === 'valid' ? 'Reading List' : 'Archive'}
-            </div>
-            <div>{allItems}</div>
+        <div
+          className={`readinglist-results ${
+            itemsLoaded ? 'readinglist-results--loaded' : ''
+          }`}
+        >
+          <div className="readinglist-results-header">
+            {statusView === 'valid' ? 'Reading List' : 'Archive'}
+            {` (${totalReadingList})`}
           </div>
+          <div>{allItems}</div>
           <div className="loadmore-wrapper">{loadMoreButton}</div>
         </div>
         {snackBar}

--- a/app/javascript/readingList/readingList.jsx
+++ b/app/javascript/readingList/readingList.jsx
@@ -33,6 +33,7 @@ export class ReadingList extends Component {
         t.setState({
           totalReadingList: content.nbHits,
           readingListItems: content.hits,
+          totalCount: content.nbHits,
           index,
           itemsLoaded: true,
         });
@@ -81,7 +82,7 @@ export class ReadingList extends Component {
 
   archive = (e, item) => {
     e.preventDefault();
-    const { statusView, readingListItems } = this.state;
+    const { statusView, readingListItems, totalCount } = this.state;
     const t = this;
     window.fetch(`/reading_list_items/${item.id}`, {
       method: 'PUT',
@@ -94,7 +95,11 @@ export class ReadingList extends Component {
     });
     const newItems = readingListItems;
     newItems.splice(newItems.indexOf(item), 1);
-    t.setState({ archiving: true, readingListItems: newItems });
+    t.setState({
+      archiving: true,
+      readingListItems: newItems,
+      totalCount: totalCount - 1,
+    });
     setTimeout(() => {
       t.setState({ archiving: false });
     }, 1800);
@@ -146,13 +151,13 @@ export class ReadingList extends Component {
 
   render() {
     const {
-      readingListItems,
+      archiving,
       availableTags,
-      selectedTags,
       itemsLoaded,
       query,
+      readingListItems,
+      selectedTags,
       statusView,
-      archiving,
       showLoadMoreButton,
     } = this.state;
     let allItems = readingListItems.map(item => (


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Add a count of articles beside the reading list header. This is different from the reading list count in the main page as this will only displays the count of articles based on the `statusView` so the count depends on the number of articles in that view.

## Related Tickets & Documents
Resolves #3124 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![header-item-count](https://user-images.githubusercontent.com/24629960/59535371-c6197b80-8ebe-11e9-9e9f-967baf134786.gif)

## Added to documentation?
- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed