### PR TITLE
Create comments notification subscription upon creation

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -60,6 +60,7 @@ class CommentsController < ApplicationController
       current_user.update(checked_code_of_conduct: true) if params[:checked_code_of_conduct].present? && !current_user.checked_code_of_conduct
 
       Mention.create_all(@comment)
+      NotificationSubscription.create(user: current_user, notifiable_id: @comment.id, notifiable_type: "Comment", config: "all_comments")
       Notification.send_new_comment_notifications_without_delay(@comment)
 
       if @comment.invalid?

--- a/spec/requests/comments_create_spec.rb
+++ b/spec/requests/comments_create_spec.rb
@@ -21,6 +21,6 @@ RSpec.describe "CommentsCreate", type: :request do
     post "/comments", params: {
       comment: { body_markdown: new_body, commentable_id: article.id, commentable_type: "Article" }
     }
-    expect(NotificationSubscription.last.notifiable).to eq(comment.last)
+    expect(NotificationSubscription.last.notifiable).to eq(Comment.last)
   end
 end

--- a/spec/requests/comments_create_spec.rb
+++ b/spec/requests/comments_create_spec.rb
@@ -15,4 +15,12 @@ RSpec.describe "CommentsCreate", type: :request do
     }
     expect(Comment.last.user_id).to eq(user.id)
   end
+
+  it "creates NotificationSubscription for comment" do
+    new_body = "NEW BODY #{rand(100)}"
+    post "/comments", params: {
+      comment: { body_markdown: new_body, commentable_id: article.id, commentable_type: "Article" }
+    }
+    expect(NotificationSubscription.last.notifiable).to eq(comment.last)
+  end
 end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
Need to create subscription when comment is created (even though we aren't yet using that functionality fully)