### PR TITLE
Add warn_on_records_fetched_greater_than setting in development [skip ci]

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -45,6 +45,11 @@ Rails.application.configure do
   # Highlight code that triggered database queries in logs.
   config.active_record.verbose_query_logs = true
 
+  # Allows setting a warning threshold for query result size.
+  # If the number of records returned by a query exceeds the threshold, a warning is logged.
+  # This can be used to identify queries which might be causing a memory bloat.
+  config.active_record.warn_on_records_fetched_greater_than = 1500
+
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

This should help keeping an eye on the cases where too many records are accidentally loaded in a single query. The comment has been taken from https://guides.rubyonrails.org/configuring.html

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
