### PR TITLE
Remove double presence validator in PollVote

### DIFF
--- a/app/models/poll_vote.rb
+++ b/app/models/poll_vote.rb
@@ -6,21 +6,21 @@ class PollVote < ApplicationRecord
   counter_culture :poll_option
   counter_culture :poll
 
-  validates :poll_id, presence: true, presence: true, uniqueness: { scope: :user_id } # In the future we'll remove this constraint if/when we allow multi-answer polls
+  validates :poll_id, presence: true, uniqueness: { scope: :user_id } # In the future we'll remove this constraint if/when we allow multi-answer polls
   validates :poll_option_id, presence: true, uniqueness: { scope: :user_id }
   validate :one_vote_per_poll_per_user
 
   after_save :touch_poll_votes_count
   after_destroy :touch_poll_votes_count
 
-  def poll
-    poll_option.poll
-  end
+  delegate :poll, to: :poll_option
 
   private
 
   def one_vote_per_poll_per_user
-    errors.add(:base, "cannot vote more than once in one poll") if poll.poll_votes.where(user_id: user_id).any? || poll.poll_skips.where(user_id: user_id).any?
+    has_votes = (
+      poll.poll_votes.where(user_id: user_id).any? || poll.poll_skips.where(user_id: user_id).any?)
+    errors.add(:base, "cannot vote more than once in one poll") if has_votes
   end
 
   def touch_poll_votes_count

--- a/app/models/poll_vote.rb
+++ b/app/models/poll_vote.rb
@@ -13,11 +13,13 @@ class PollVote < ApplicationRecord
   after_save :touch_poll_votes_count
   after_destroy :touch_poll_votes_count
 
-  delegate :poll, to: :poll_option
+  delegate :poll, to: :poll_option, allow_nil: true
 
   private
 
   def one_vote_per_poll_per_user
+    return false unless poll
+
     has_votes = (
       poll.poll_votes.where(user_id: user_id).any? || poll.poll_skips.where(user_id: user_id).any?)
     errors.add(:base, "cannot vote more than once in one poll") if has_votes

--- a/spec/models/poll_vote_spec.rb
+++ b/spec/models/poll_vote_spec.rb
@@ -5,6 +5,10 @@ RSpec.describe PollVote, type: :model do
   let(:user) { create(:user) }
   let(:poll) { create(:poll, article_id: article.id) }
 
+  it "is not valid as a new object" do
+    expect(PollVote.new.valid?).to be(false)
+  end
+
   it "limits one vote per user per poll" do
     create(:poll_vote, poll_option_id: poll.poll_options.last.id, user_id: user.id, poll_id: poll.id)
     PollVote.create(poll_option_id: poll.poll_options.first.id, user_id: user.id, poll_id: poll.id)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

There's a double `presence: true` validator in `PollVote`

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
