### PR TITLE
Fix mention validation when validating an empty instance

### DIFF
--- a/app/models/mention.rb
+++ b/app/models/mention.rb
@@ -31,6 +31,6 @@ class Mention < ApplicationRecord
   end
 
   def permission
-    errors.add(:mentionable_id, "is not valid.") unless mentionable.valid?
+    errors.add(:mentionable_id, "is not valid.") unless mentionable&.valid?
   end
 end

--- a/spec/factories/mentions.rb
+++ b/spec/factories/mentions.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
   factory :mention do
     user
-    mentionable_id { rand(1000) }
-    mentionable_type { "Comment" }
+    association :mentionable, factory: :article
   end
 end

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe NotifyMailer, type: :mailer do
   end
 
   describe "#new_mention_email" do
-    let(:mention) { create(:mention, user_id: user2.id, mentionable_id: comment.id) }
+    let(:mention) { create(:mention, user_id: user2.id, mentionable: comment) }
 
     it "renders proper subject" do
       email = described_class.new_mention_email(mention)

--- a/spec/models/mention_spec.rb
+++ b/spec/models/mention_spec.rb
@@ -10,4 +10,12 @@ RSpec.describe Mention, type: :model do
       expect(Mentions::CreateAllJob).to have_received(:perform_later).with(comment.id, "Comment")
     end
   end
+
+  it "creates a valid mention" do
+    expect(create(:mention)).to be_valid
+  end
+
+  it "doesn't raise undefined method for NilClass on valid?" do
+    expect(Mention.new.valid?).to eq(false)
+  end
 end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
- fixed `Mention.new.valid?` failing on `undefined method for Nilclass`
- creating a valid mention when using a factory

