### PR TITLE
fix(article): `<hr>` should be visible in night theme

### DIFF
--- a/app/assets/stylesheets/article-show.scss
+++ b/app/assets/stylesheets/article-show.scss
@@ -477,7 +477,13 @@ article {
     hr {
       width: calc(25% + 12px);
       opacity: 0.1;
-      border: 1px solid black;
+      border-width: 1px;
+      border-style: solid;
+      @include themeable(
+        border-color,
+        theme-color,
+        $black
+      );
       margin: 1.3em auto 1.5em;
     }
 


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
I just tried out night mode today (I know, I'm slow... 😋) and I realized that `<hr/>` elements are not that visible:

![Screen Shot 2019-06-17 at 11 49 45 PM](https://user-images.githubusercontent.com/8046636/59618468-dfd6ef00-915a-11e9-9b10-2b9b31ac37f9.png)

A little comparison with the default/minimal light/pink theme:
![Screen Shot 2019-06-17 at 11 46 51 PM](https://user-images.githubusercontent.com/8046636/59619057-309b1780-915c-11e9-831a-b46baf1ee070.png)

### Proposal
I am proposing to change it to something like this:

![Screen Shot 2019-06-17 at 11 46 29 PM](https://user-images.githubusercontent.com/8046636/59618485-eb2a1a80-915a-11e9-9595-f1439877570e.png)

So that it reflects night theme. It should not change anything on the default/minimal light/pink theme tho, since it isn't contrast to the background.

I'm not quite sure if what I'm doing with the `themeable` is correct, so let me know. Also if there's a better color suggestion. Thank you.

## Related Tickets & Documents
- None

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
- None

## Added to documentation?
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![](https://media2.giphy.com/media/mt9btFJ7pgATK/giphy.gif)
