### PR TITLE
Allow stackoverflow sub communities profiles

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -80,7 +80,7 @@ class User < ApplicationRecord
   validates :stackoverflow_url,
             allow_blank: true,
             format:
-            /\A(http(s)?:\/\/)?(www.stackoverflow.com|stackoverflow.com|www.stackexchange.com|stackexchange.com)\/.*\Z/
+            /\A(http(s)?:\/\/)?(((www|pt|ru|es|ja).)?stackoverflow.com|(www.)?stackexchange.com)\/.*\Z/
   validates :behance_url,
             allow_blank: true,
             format: /\A(http(s)?:\/\/)?(www.behance.net|behance.net)\/.*\Z/

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -194,6 +194,20 @@ RSpec.describe User, type: :model do
       expect(user).not_to be_valid
     end
 
+    it "accepts valid stackoverflow sub community url" do
+      %w[pt ru es ja].each do |subcommunity|
+        user.stackoverflow_url = "https://#{subcommunity}.stackoverflow.com/users/7381391/mazen"
+        expect(user).to be_valid
+      end
+    end
+
+
+    it "does not accept invalid stackoverflow sub community url" do
+      user.stackoverflow_url = "https://fr.stackoverflow.com/users/7381391/mazen"
+      expect(user).not_to be_valid
+    end
+
+
     it "accepts valid https linkedin url" do
       %w[jessleenyc jessleenyc/ jess-lee-nyc].each do |username|
         user.linkedin_url = "https://linkedin.com/in/#{username}"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
Stack overflow has 4 sub communities: Spanish, Russian, Japanese and Portuguese. This PR will make it possible to link a profile in one of these communities as well.

## Related Tickets & Documents
Fix #3204 

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed