### PR TITLE
Updated slack channel name

### DIFF
--- a/app/observers/application_observer.rb
+++ b/app/observers/application_observer.rb
@@ -3,7 +3,7 @@ class ApplicationObserver < ActiveRecord::Observer
     return unless activity.user.warned == true
 
     SlackBotPingJob.perform_later message: "Activity: https://dev.to/#{activity.path}\nManage @#{activity.user.username}: https://dev.to/internal/users/#{activity.user.id}",
-                                  channel: "warned-user-activity",
+                                  channel: "warned-user-comments",
                                   username: "sloan_watch_bot",
                                   icon_emoji: ":sloan:"
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
The slack channel `warned-user-activity` was renamed to `warned-user-comments` but not in the code, so the `SlackBot` was unable to send messages to the channel which causes errors `The slack API returned an error: channel_not_found (HTTP Code 404)`