### PR TITLE
Don't try to register webhook when twitch returns empty data

### DIFF
--- a/app/services/streams/twitch_webhook/register.rb
+++ b/app/services/streams/twitch_webhook/register.rb
@@ -14,9 +14,10 @@ module Streams
 
       def call
         user_resp = HTTParty.get("https://api.twitch.tv/helix/users", query: { login: user.twitch_username }, headers: authentication_request_headers)
-        return unless user_resp["data"]
 
-        twitch_user_id = user_resp["data"].first["id"]
+        # user_resp["data"].first["id"]
+        twitch_user_id = user_resp.try(:[], "data").to_a.first.try(:[], "id")
+        return unless twitch_user_id
 
         HTTParty.post(
           "https://api.twitch.tv/helix/webhooks/hub",

--- a/spec/services/streams/twitch_webhook/register_spec.rb
+++ b/spec/services/streams/twitch_webhook/register_spec.rb
@@ -58,5 +58,23 @@ RSpec.describe Streams::TwitchWebhook::Register, type: :service do
         expect(twitch_webhook_registration_stubbed_route).not_to have_been_requested
       end
     end
+
+    context "when twitch returns empty data" do
+      let!(:twitch_user_stubbed_route) do
+        stub_request(:get, "https://api.twitch.tv/helix/users").
+          with(query: expected_twitch_user_params, headers: expected_headers).
+          and_return(body: { "data" => [] }.to_json, headers: { "Content-Type" => "application/json" })
+      end
+
+      it "doesn't fail" do
+        described_class.call(user, twitch_access_token_get)
+        expect(twitch_user_stubbed_route).to have_been_requested
+      end
+
+      it "doesn't register for webhooks" do
+        described_class.call(user, twitch_access_token_get)
+        expect(twitch_webhook_registration_stubbed_route).not_to have_been_requested
+      end
+    end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
I had fixed the error when twitch returns no data earlier in #2865
Sometimes twitch returns empty data, we should handle this situation as well.

## Related Tickets & Documents
#2784
#2865 

