### PR TITLE
Update RssReader's liquid & youtube parsing logic

### DIFF
--- a/app/liquid_tags/liquid_variable.rb
+++ b/app/liquid_tags/liquid_variable.rb
@@ -1,11 +1,7 @@
 module Liquid
   class Variable
-    def initialize(markup, _parse_context)
-      @markup = markup
-    end
-
-    def render(_context)
-      "{{#{@markup}}}"
+    def initialize(_markup, _parse_context)
+      raise StandardError, "Liquid variables are disabled"
     end
   end
 end

--- a/app/liquid_tags/liquid_variable.rb
+++ b/app/liquid_tags/liquid_variable.rb
@@ -1,7 +1,11 @@
 module Liquid
   class Variable
-    def initialize(_markup, _parse_context)
-      raise StandardError, "Liquid variables are disabled"
+    def initialize(markup, _parse_context)
+      @markup = markup
+    end
+
+    def render(_context)
+      "{{#{@markup}}}"
     end
   end
 end

--- a/app/services/rss_reader/assembler.rb
+++ b/app/services/rss_reader/assembler.rb
@@ -37,9 +37,14 @@ class RssReader
     def assemble_body_markdown
       cleaned_content = HtmlCleaner.new.clean_html(get_content)
       cleaned_content = thorough_parsing(cleaned_content, @feed.url)
-      ReverseMarkdown.
+      content = ReverseMarkdown.
         convert(cleaned_content, github_flavored: true).
-        gsub("```\n\n```", "").gsub(/&nbsp;|\u00A0/, " ")
+        gsub("```\n\n```", "").
+        gsub(/&nbsp;|\u00A0/, " ")
+      content.gsub!(/{%\syoutube\s(.{11,18})\s%}/) do |tag|
+        tag.gsub("\\_", "_")
+      end
+      content
     end
 
     def get_content
@@ -97,7 +102,7 @@ class RssReader
       html_doc.css("iframe").each do |iframe|
         if /youtube\.com/.match?(iframe.attributes["src"].value)
           iframe.name = "p"
-          youtube_id = iframe.attributes["src"].value.scan(/embed%2F(.{4,12})%3F/).flatten.first
+          youtube_id = iframe.attributes["src"].value.scan(/embed%2F(.{4,11})/).flatten.first
           iframe.keys.each { |attr| iframe.remove_attribute(attr) }
           iframe.inner_html = "{% youtube #{youtube_id} %}"
         end

--- a/app/services/rss_reader/assembler.rb
+++ b/app/services/rss_reader/assembler.rb
@@ -106,7 +106,7 @@ class RssReader
       # Medium articles does not wrap {{ }} content in liquid tag.
       # This will wrap do so for content that isn't in pre and code tag
       html_doc.css("//body :not(pre):not(code)").each do |node|
-        node.inner_html = node.text.gsub(/{{.*?}}/) { |liquid| "`#{liquid}`" }
+        node.inner_html = node.inner_html.gsub(/{{.*?}}/) { |liquid| "`#{liquid}`" }
       end
     end
 


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
- Pre-escape `{{ }}` expression that is breaking MarkdownParser with backtick.
- Loosen up RssReader's youtube id parsing logic.

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/issues/3070
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?
- [x] no documentation needed
