### PR TITLE
Add article pro stats button in dashboard

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -6,6 +6,8 @@ class DashboardsController < ApplicationController
   def show
     fetch_and_authorize_user
 
+    @current_user_pro = current_user.pro?
+
     target = @user
     not_authorized if params[:org_id] && !@user.org_admin?(params[:org_id] || @user.any_admin?)
 

--- a/app/views/dashboards/_dashboard_article.html.erb
+++ b/app/views/dashboards/_dashboard_article.html.erb
@@ -42,6 +42,10 @@
     <% else %>
       <a href="<%= article.path %>/delete_confirm" data-no-instant class="cta pill black">DELETE</a>
     <% end %>
+    <% if @current_user_pro %>
+      <a href="<%= article.path %>/stats" data-no-instant class="cta pill blue">STATS</a>
+    <% end %>
+
     <% if article.published %>
       <span id="pageviews-<%= article.id %>" class="cta pill dashboard-pageviews-indicator" data-analytics-pageviews data-article-id="<%= article.id %>">
         <span class="page-views-count">

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe "Dashboards", type: :request do
   let(:user)          { create(:user) }
   let(:second_user)   { create(:user) }
   let(:super_admin)   { create(:user, :super_admin) }
-  let(:article)       { create(:article, user_id: user.id) }
+  let(:pro_user)      { create(:user, :pro) }
+  let(:article)       { create(:article, user: user) }
 
   describe "GET /dashboard" do
     context "when not logged in" do
@@ -19,7 +20,14 @@ RSpec.describe "Dashboards", type: :request do
         sign_in user
         article
         get "/dashboard"
-        expect(response.body).to include CGI.escapeHTML(article.title)
+        expect(response.body).to include(CGI.escapeHTML(article.title))
+      end
+
+      it 'does not show "STATS" for articles' do
+        sign_in user
+        article
+        get "/dashboard"
+        expect(response.body).not_to include("STATS")
       end
     end
 
@@ -29,7 +37,17 @@ RSpec.describe "Dashboards", type: :request do
         user
         sign_in super_admin
         get "/dashboard/#{user.username}"
-        expect(response.body).to include CGI.escapeHTML(article.title)
+        expect(response.body).to include(CGI.escapeHTML(article.title))
+      end
+    end
+
+    context "when logged in as a pro user" do
+      it 'shows "STATS" for articles' do
+        article = create(:article, user: pro_user)
+        sign_in pro_user
+        get "/dashboard"
+        expect(response.body).to include("STATS")
+        expect(response.body).to include("#{article.path}/stats")
       end
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

Shows the stats button in the article's dashboard if the current user is a pro user

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![Screenshot_2019-06-19 Dashboard - DEV(local) Community 👩‍💻👨‍💻](https://user-images.githubusercontent.com/146201/59750046-794af180-927e-11e9-8f17-ad17ebbe6bdf.png)


## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
