### PR TITLE
Delete a comment's title if it is deleted

### DIFF
--- a/app/assets/stylesheets/notifications.scss
+++ b/app/assets/stylesheets/notifications.scss
@@ -348,6 +348,9 @@
           }
         }
       }
+      .single-notification {
+        cursor: default;
+      }
       .unseen {
         @include themeable(
           background,

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -164,6 +164,8 @@ class Comment < ApplicationRecord
   end
 
   def title
+    return "[deleted]" if deleted
+
     ActionController::Base.helpers.truncate(ActionController::Base.helpers.strip_tags(processed_html), length: 80)
   end
 

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -1,5 +1,5 @@
 <% if @root_comment.present? %>
-  <% title truncate(strip_tags(@root_comment.processed_html), length: 100) + " — DEV" %>
+  <% title @root_comment.title + " — DEV" %>
 <% else %>
   <% title "Discussion of " + @commentable.title + " — DEV" %>
 <% end %>

--- a/app/views/notifications/_notifications_list.html.erb
+++ b/app/views/notifications/_notifications_list.html.erb
@@ -2,7 +2,7 @@
 <% @notifications.each do |notification| %>
   <% next if notification.notified_at < 24.hours.ago && notification.aggregated? %>
   <% notification_count += 1 %>
-  <div class="single-article single-article-small-pic <%= "unseen" unless notification.read? %>" data-notification-id="<%= notification.id %>">
+  <div class="single-article single-article-small-pic single-notification <%= "unseen" unless notification.read? %>" data-notification-id="<%= notification.id %>">
     <%= render notification.notifiable_type.downcase.to_s, notification: notification %>
   </div>
 <% rescue => e %>

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -174,6 +174,11 @@ RSpec.describe Comment, type: :model do
       text = comment.title.gsub("...", "").delete("\n")
       expect(comment.processed_html).to include CGI.unescapeHTML(text)
     end
+
+    it "is converted to deleted if the comment is deleted" do
+      comment.update_column(:deleted, true)
+      expect(comment.title).to eq "[deleted]"
+    end
   end
 
   describe "#custom_css" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This adds fixes a bug where a comment's `title` attribute returns some of the comment's text even if it is deleted.

Also fixes a small bug for notification cards where the whole notification card `<div>` showed the pointer cursor.