### PR TITLE
Add context data to comment notifications

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -31,7 +31,7 @@ class Comment < ApplicationRecord
   before_create  :adjust_comment_parent_based_on_depth
   after_update   :update_notifications, if: proc { |comment| comment.saved_changes.include? "body_markdown" }
   after_update   :remove_notifications, if: :deleted
-  after_update   :update_familial_notifications, if: :deleted
+  after_update   :update_descendant_notifications, if: :deleted
   before_validation :evaluate_markdown, if: -> { body_markdown && commentable }
   validate :permissions, if: :commentable
 
@@ -195,10 +195,10 @@ class Comment < ApplicationRecord
     Notification.update_notifications(self)
   end
 
-  def update_familial_notifications
+  def update_descendant_notifications
     return unless has_children?
 
-    Comment.where(id: ancestor_ids + descendant_ids).find_each do |comment|
+    Comment.where(id: descendant_ids).find_each do |comment|
       Notification.update_notifications(comment)
     end
   end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -31,7 +31,7 @@ class Comment < ApplicationRecord
   before_create  :adjust_comment_parent_based_on_depth
   after_update   :update_notifications, if: proc { |comment| comment.saved_changes.include? "body_markdown" }
   after_update   :remove_notifications, if: :deleted
-  after_update   :update_descendant_notifications, if: :deleted
+  after_update   :update_familial_notifications, if: :deleted
   before_validation :evaluate_markdown, if: -> { body_markdown && commentable }
   validate :permissions, if: :commentable
 
@@ -195,10 +195,10 @@ class Comment < ApplicationRecord
     Notification.update_notifications(self)
   end
 
-  def update_descendant_notifications
+  def update_familial_notifications
     return unless has_children?
 
-    Comment.where(id: descendant_ids).find_each do |comment|
+    Comment.where(id: ancestor_ids + descendant_ids).find_each do |comment|
       Notification.update_notifications(comment)
     end
   end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -7,6 +7,7 @@ class Comment < ApplicationRecord
   belongs_to :user
   counter_culture :user
   has_many :mentions, as: :mentionable, inverse_of: :mentionable, dependent: :destroy
+  has_many :notifications, as: :notifiable, inverse_of: :notifiable, dependent: :destroy
   has_many :notification_subscriptions, as: :notifiable, inverse_of: :notifiable, dependent: :destroy
 
   validates :body_markdown, presence: true, length: { in: 1..25_000 },

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -31,6 +31,7 @@ class Comment < ApplicationRecord
   before_create  :adjust_comment_parent_based_on_depth
   after_update   :update_notifications, if: proc { |comment| comment.saved_changes.include? "body_markdown" }
   after_update   :remove_notifications, if: :deleted
+  after_update   :update_descendant_notifications, if: :deleted
   before_validation :evaluate_markdown, if: -> { body_markdown && commentable }
   validate :permissions, if: :commentable
 
@@ -192,6 +193,14 @@ class Comment < ApplicationRecord
 
   def update_notifications
     Notification.update_notifications(self)
+  end
+
+  def update_descendant_notifications
+    return unless has_children?
+
+    Comment.where(id: descendant_ids).find_each do |comment|
+      Notification.update_notifications(comment)
+    end
   end
 
   def send_to_moderator

--- a/app/services/notifications.rb
+++ b/app/services/notifications.rb
@@ -65,7 +65,7 @@ module Notifications
         depth: ancestor.depth,
         user: {
           username: ancestor.user.username,
-          name: ancestor.user.name,
+          name: ancestor.user.name
         }
       }
     end

--- a/app/services/notifications.rb
+++ b/app/services/notifications.rb
@@ -19,6 +19,9 @@ module Notifications
       path: comment.path,
       processed_html: comment.processed_html,
       updated_at: comment.updated_at,
+      ancestry: comment.ancestry,
+      depth: comment.depth,
+      ancestors: ancestor_data(comment),
       commentable: {
         id: comment.commentable.id,
         title: comment.commentable.title,
@@ -50,5 +53,21 @@ module Notifications
       path: organization.path,
       profile_image_90: organization.profile_image_90
     }
+  end
+
+  def self.ancestor_data(comment)
+    comment.ancestors.includes(:user).map do |ancestor|
+      {
+        id: ancestor.id,
+        title: ancestor.title,
+        path: ancestor.path,
+        ancestry: ancestor.ancestry,
+        depth: ancestor.depth,
+        user: {
+          username: ancestor.user.username,
+          name: ancestor.user.name,
+        }
+      }
+    end
   end
 end

--- a/app/services/notifications.rb
+++ b/app/services/notifications.rb
@@ -70,4 +70,5 @@ module Notifications
       }
     end
   end
+  private_class_method :ancestor_data
 end

--- a/app/services/notifications/remove_each.rb
+++ b/app/services/notifications/remove_each.rb
@@ -14,7 +14,7 @@ module Notifications
       Notification.where(
         notifiable_id: notifiable_collection_ids,
         notifiable_type: "Mention",
-      ).destroy_all
+      ).delete_all
     end
 
     private

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Comment, type: :model do
     it { is_expected.to belong_to(:commentable) }
     it { is_expected.to have_many(:reactions).dependent(:destroy) }
     it { is_expected.to have_many(:mentions).dependent(:destroy) }
+    it { is_expected.to have_many(:notifications).dependent(:destroy) }
     it { is_expected.to have_many(:notification_subscriptions).dependent(:destroy) }
     it { is_expected.to validate_presence_of(:commentable_id) }
 

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -238,7 +238,7 @@ RSpec.describe Comment, type: :model do
       create(:notification, notifiable: child_comment, user: user)
       perform_enqueued_jobs do
         comment.update(deleted: true)
-        expect(child_of_child_comment.notifications.first.json_data["comment"]["ancestors"][1]["title"]).to eq "[deleted]"
+        expect(child_comment.notifications.first.json_data["comment"]["ancestors"][0]["title"]).to eq "[deleted]"
       end
     end
   end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -387,7 +387,7 @@ RSpec.describe Notification, type: :model do
   end
 
   describe "#update_notifications" do
-    context "when there are notifications to update" do
+    context "when there are article notifications to update" do
       before do
         user2.follow(user)
         Notification.send_to_followers_without_delay(article, "Published")

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "StoriesIndex", type: :request do
       user = create(:user)
       listing = create(:classified_listing, user_id: user.id)
       get "/"
-      expect(response.body).to include(listing.title)
+      expect(response.body).to include(CGI.escapeHTML(listing.title))
     end
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
This adds additional data to comment notifications, specifically data regarding it's ancestors. The data lays the groundwork for more informative and useful comment notifications.

Also:
- Updates descendant comment notifications properly to make sure their associated notification data deleted as well
- changed mention `notifications.destroy_all` to `.delete_all`