### PR TITLE
Add comment context for notifications and comment pages

### DIFF
--- a/app/assets/stylesheets/articles.scss
+++ b/app/assets/stylesheets/articles.scss
@@ -82,7 +82,7 @@
         width: 27%;
         padding: 9px 0px;
         text-align: center;
-        color: $black;
+        @include themeable(color, theme-secondary-color, $medium-gray);
         margin: 1%;
       }
       .query-filter-button {
@@ -111,7 +111,11 @@
             theme-container-accent-background,
             lighten($bold-blue, 8%)
           );
-          color: white;
+          @include themeable(
+            color,
+            theme-color,
+            white
+          );
         }
       }
     }

--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -181,7 +181,7 @@ a.header-link {
   }
 
   .top-level-actions {
-    margin: 0px 8px 85px;
+    margin: 0px 0px 85px;
     padding: 3px 0px;
     z-index: 4;
     position: relative;
@@ -194,6 +194,7 @@ a.header-link {
         background: $black;
         color: white;
         margin: 2px 0px 2px;
+        margin-right: 5px;
         vertical-align: 2px;
       }
     }
@@ -210,8 +211,8 @@ a.header-link {
       color: $black;
       font-family: $helvetica-condensed;
       font-stretch: condensed;
-      padding: 4px 12px;
-      font-size: 0.8em;
+      padding: 4px 8px;
+      font-size: 0.77em;
       vertical-align: 1px;
       margin: 8px 0px 2px;
     }
@@ -450,6 +451,16 @@ a.header-link {
     }
     .root-comment {
       margin-top: -80px;
+      .comment-parent-link {
+        @include themeable(background, theme-container-background, white);
+        @include themeable(border, theme-container-border, 1px solid $medium-gray);
+        display: block;
+        padding: 9px 12px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        font-size: 0.8em;
+      }
     }
   }
   .comment-view-parent {
@@ -787,6 +798,7 @@ a.header-link {
         font-family: $helvetica-condensed;
         font-stretch: condensed;
         font-size: 0.78em;
+        border-radius: 3px;
       }
     }
     a {

--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -460,6 +460,7 @@ a.header-link {
         overflow: hidden;
         text-overflow: ellipsis;
         font-size: 0.8em;
+        @include themeable(background, theme-container-accent-background, lighten($lightest-gray, 1%));
       }
     }
   }

--- a/app/assets/stylesheets/notifications.scss
+++ b/app/assets/stylesheets/notifications.scss
@@ -175,13 +175,27 @@
           border-radius: 3px;
           @include themeable(color, theme-color, $black);
           position: relative;
+          .comment-text-header {
+            display: block;
+            padding: 5px 10px;
+            margin-left: -10px;
+            margin-top: -10px;
+            margin-bottom: 8px;
+            border-bottom: 1px solid lighten($dark-gray, 18%);
+            width: 100%;
+            font-weight: bold;
+            font-size: 0.76em;
+            position: relative;
+            z-index:6;
+            border-top-left-radius: 3px;
+            border-top-right-radius: 3px;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            @include themeable(background, theme-container-accent-background, lighten($lightest-gray, 1%));
+          }
           &:hover {
             border: 1px solid $black;
-            @include themeable(
-              background,
-              theme-container-background-hover,
-              #fff
-            );
           }
           h1,
           h2,

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -165,10 +165,10 @@ class Comment < ApplicationRecord
     end.join
   end
 
-  def title
+  def title(length = 80)
     return "[deleted]" if deleted
 
-    ActionController::Base.helpers.truncate(ActionController::Base.helpers.strip_tags(processed_html), length: 80)
+    ActionController::Base.helpers.truncate(ActionController::Base.helpers.strip_tags(processed_html).strip, length: length)
   end
 
   def video

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -72,9 +72,9 @@
       <h3>re: <%= @commentable.title %> <a href="<%= @commentable.path %>">VIEW POST</a></h3>
       <span class="comment-action-buttons">
         <% unless @root_comment.is_root? %>
-          <a href="<%= @root_comment.parent.path %>">VIEW PARENT COMMENT</a>
+          <a href="<%= @root_comment.root.path %>">TOP OF THREAD</a>
         <% end %>
-        <a href="<%= @commentable.path %>/comments">VIEW FULL DISCUSSION</a>
+        <a href="<%= @commentable.path %>/comments">FULL DISCUSSION</a>
       </span>
     </div>
   <% else %>
@@ -85,6 +85,11 @@
   <div class="comment-trees" id="comment-trees-container">
     <% if @root_comment.present? %>
       <div class="root-comment">
+        <% if @root_comment.depth > 0 && parent = @root_comment.parent %>
+          <a href="<%= parent.path %>" class="comment-parent-link">
+            re: <%= parent.title(150).strip %>
+          </a>
+        <% end %>
         <% cache ["comment_root-view-root_#{user_signed_in?}", @root_comment] do %>
           <%= tree_for(@root_comment, @root_comment.subtree.includes(:user).arrange[@root_comment], @commentable) %>
         <% end %>

--- a/app/views/notifications/_comment.html.erb
+++ b/app/views/notifications/_comment.html.erb
@@ -12,7 +12,11 @@
   <div class="content notification-content comment-content">
     <% if notification.action.blank? %>
       <a href="<%= json_data["user"]["path"] %>"><%= json_data["user"]["name"] %></a>
+      <% if json_data["comment"]["depth"] && json_data["comment"]["depth"] > 0 %>
+      replied to a thread in 
+      <% else %>
       commented on
+      <% end %>
       <a href="<%= json_data["comment"]["commentable"]["path"] %>">
         <%= sanitize(json_data["comment"]["commentable"]["title"]) %>
       </a>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -56,7 +56,7 @@
         <% @organizations.each do |org| %>
           <div class="notifications-mobile-filters">
             <hr>
-            <span class="organization-name"><%= org.name %></span>
+            <span class="organization-name">@<%= org.slug %>:</span>
             <a class="query-filter-button <%= "selected" if params[:filter].to_s.casecmp("org").zero? && params[:org_id].to_i == org.id %>" href="/notifications/org/<%= org.id %>">ALL</a>
             <a class="query-filter-button <%= "selected" if params[:filter].to_s.casecmp("comments").zero? && params[:org_id].to_i == org.id %>" href="/notifications/comments/<%= org.id %>">COMMENTS</a>
           </div>

--- a/app/views/notifications/shared/_comment_box.html.erb
+++ b/app/views/notifications/shared/_comment_box.html.erb
@@ -1,6 +1,11 @@
 <% cache "comment-box-#{@last_user_reaction}-#{@last_user_comment}-#{json_data['comment']['updated_at']}-#{json_data['comment']['id']}" do %>
   <% if json_data["comment"]["commentable"] %>
     <div class="comment-text">
+      <% if json_data["comment"]["depth"] && json_data["comment"]["depth"] > 0 %>
+        <a href="<%= json_data["comment"]["ancestors"].last["path"] %>" class="comment-text-header">
+          re: <%= json_data["comment"]["ancestors"].last["title"].strip %>
+        </a>
+      <% end %>
       <a href="<%= json_data["comment"]["path"] %>" class="comment-link-wrapper"></a>
       <%= json_data["comment"]["processed_html"].html_safe %>
     </div>

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -171,6 +171,11 @@ RSpec.describe Comment, type: :model do
       expect(comment.title.length).to be <= 80
     end
 
+    it "is allows title of greater length if passed" do
+      expect(comment.title(5).length).to eq(5)
+    end
+
+
     it "retains content from #processed_html" do
       text = comment.title.gsub("...", "").delete("\n")
       expect(comment.processed_html).to include CGI.unescapeHTML(text)

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -44,13 +44,13 @@ RSpec.describe "Comments", type: :request do
     context "when the a child comment" do
       it "displays proper button and text for child comment" do
         child = create(:comment,
-          parent_id: comment.id,
-          commentable_id: article.id,
-          commentable_type: "Article",
-          user_id: user.id)
+                       parent_id: comment.id,
+                       commentable_id: article.id,
+                       commentable_type: "Article",
+                       user_id: user.id)
         get child.path
         expect(response.body).to include("TOP OF THREAD")
-        expect(response.body).to include(comment.title)
+        expect(response.body).to include(comment.title(150))
         expect(response.body).to include(child.processed_html)
       end
     end

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -29,6 +29,32 @@ RSpec.describe "Comments", type: :request do
       expect(response.body).to include(comment.processed_html)
     end
 
+    it "displays full discussion text" do
+      get comment.path
+      expect(response.body).to include("FULL DISCUSSION")
+    end
+
+    context "when the comment a root" do
+      it "does not display top of thread button" do
+        get comment.path
+        expect(response.body).not_to include("TOP OF THREAD")
+      end
+    end
+
+    context "when the a child comment" do
+      it "displays proper button and text for child comment" do
+        child = create(:comment,
+          parent_id: comment.id,
+          commentable_id: article.id,
+          commentable_type: "Article",
+          user_id: user.id)
+        get child.path
+        expect(response.body).to include("TOP OF THREAD")
+        expect(response.body).to include(comment.title)
+        expect(response.body).to include(child.processed_html)
+      end
+    end
+
     context "when the comment is for a podcast's episode" do
       it "works" do
         get podcast_comment.path


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Add more context to notifications and single comment page.

![Screen Shot 2019-06-21 at 9 10 10 PM](https://user-images.githubusercontent.com/3102842/59957775-d48d0780-9469-11e9-8163-b09be5c388d9.png)
![Screen Shot 2019-06-21 at 9 13 30 PM](https://user-images.githubusercontent.com/3102842/59957776-d5be3480-9469-11e9-8b5e-6312c6f13429.png)
