### PR TITLE
Improve social card caching 🚀

### DIFF
--- a/app/views/social_previews/article.html.erb
+++ b/app/views/social_previews/article.html.erb
@@ -128,7 +128,7 @@
       <%= truncate @article.user.name, length: 25 %>・<%= @article.readable_publish_date %>
     </div>
     <div class="preview-dev-logo">
-      <%= inline_svg("devplain.svg", class: "logo", size: "9vw * 9vw", aria: true, title: "DEV logo") %>
+      <%= inline_svg("devplain.svg", class: "logo", size: "9vw * 9vw", aria: false, title: "DEV logo") %>
     </div>
   </div>
 </div>

--- a/app/views/social_previews/listing.html.erb
+++ b/app/views/social_previews/listing.html.erb
@@ -74,13 +74,13 @@
       <h1 style="font-size:<%= font_size %>vw;"><%= @listing.title %></h1>
     </div>
     <div class="preview-body">
-      <%= @listing.processed_html.html_safe %>
+      <%= @listing.processed_html.html_safe # rubocop:disable Rails/OutputSafety %>
     </div>
     <div class="preview-category">
       <%= @category %>
     </div>
     <div class="preview-dev-logo">
-      <%= inline_svg("devlistings-horizontal.svg", class: "logo", size: "30vw*10vw", aria: true, title: "DEV logo") %>
+      <%= inline_svg("devlistings-horizontal.svg", class: "logo", size: "30vw*10vw", aria: false, title: "DEV logo") %>
     </div>
   </div>
 </div>

--- a/app/views/social_previews/listing.html.erb
+++ b/app/views/social_previews/listing.html.erb
@@ -74,7 +74,7 @@
       <h1 style="font-size:<%= font_size %>vw;"><%= @listing.title %></h1>
     </div>
     <div class="preview-body">
-      <%= @listing.processed_html.html_safe # rubocop:disable Rails/OutputSafety %>
+      <%= sanitize_rendered_markdown(@listing.processed_html) %>
     </div>
     <div class="preview-category">
       <%= @category %>

--- a/app/views/social_previews/tag.html.erb
+++ b/app/views/social_previews/tag.html.erb
@@ -102,7 +102,7 @@
       </h2>
     <% end %>
     <div class="preview-dev-logo">
-      <%= inline_svg("devplain.svg", class: "logo", size: "9vw * 9vw", aria: true, title: "DEV logo") %>
+      <%= inline_svg("devplain.svg", class: "logo", size: "9vw * 9vw", aria: false, title: "DEV logo") %>
     </div>
   </div>
 </div>

--- a/app/views/social_previews/user.html.erb
+++ b/app/views/social_previews/user.html.erb
@@ -90,7 +90,7 @@
       <%= @user.name %>
     </h1>
     <div class="preview-dev-logo">
-      <%= inline_svg("devplain.svg", class: "logo", size: "9vw * 9vw", aria: true, title: "DEV logo") %>
+      <%= inline_svg("devplain.svg", class: "logo", size: "9vw * 9vw", aria: false, title: "DEV logo") %>
     </div>
   </div>
 </div>

--- a/spec/requests/social_previews_spec.rb
+++ b/spec/requests/social_previews_spec.rb
@@ -21,6 +21,17 @@ RSpec.describe "SocialPreviews", type: :request do
       expect(response.body).to include CGI.escapeHTML(article.title)
     end
 
+    it "renders consistent HTML between requests" do
+      # We use the HTML for caching. It needs to be deterministic (if data is unchanged, the HTML should be the same)
+      get "/social_previews/article/#{article.id}"
+      first_request_body = response.body
+
+      get "/social_previews/article/#{article.id}"
+      second_request_body = response.body
+
+      expect(first_request_body).to eq second_request_body
+    end
+
     it "renders shecoded template when tagged with shecoded" do
       she_coded_article = create(:article, tags: "shecoded")
 
@@ -42,6 +53,17 @@ RSpec.describe "SocialPreviews", type: :request do
       expect(response.body).to include CGI.escapeHTML(user.name)
     end
 
+    it "renders consistent HTML between requests" do
+      # We use the HTML for caching. It needs to be deterministic (if data is unchanged, the HTML should be the same)
+      get "/social_previews/user/#{user.id}"
+      first_request_body = response.body
+
+      get "/social_previews/user/#{user.id}"
+      second_request_body = response.body
+
+      expect(first_request_body).to eq second_request_body
+    end
+
     it "renders an image when requested and redirects to image url" do
       get "/social_previews/user/#{user.id}.png"
 
@@ -53,6 +75,17 @@ RSpec.describe "SocialPreviews", type: :request do
     it "renders proper organization name" do
       get "/social_previews/organization/#{organization.id}"
       expect(response.body).to include CGI.escapeHTML(organization.name)
+    end
+
+    it "renders consistent HTML between requests" do
+      # We use the HTML for caching. It needs to be deterministic (if data is unchanged, the HTML should be the same)
+      get "/social_previews/organization/#{organization.id}"
+      first_request_body = response.body
+
+      get "/social_previews/organization/#{organization.id}"
+      second_request_body = response.body
+
+      expect(first_request_body).to eq second_request_body
     end
 
     it "renders an image when requested and redirects to image url" do
@@ -68,6 +101,17 @@ RSpec.describe "SocialPreviews", type: :request do
       expect(response.body).to include CGI.escapeHTML(tag.name)
     end
 
+    it "renders consistent HTML between requests" do
+      # We use the HTML for caching. It needs to be deterministic (if data is unchanged, the HTML should be the same)
+      get "/social_previews/tag/#{tag.id}"
+      first_request_body = response.body
+
+      get "/social_previews/tag/#{tag.id}"
+      second_request_body = response.body
+
+      expect(first_request_body).to eq second_request_body
+    end
+
     it "renders an image when requested and redirects to image url" do
       get "/social_previews/tag/#{tag.id}.png"
 
@@ -79,6 +123,17 @@ RSpec.describe "SocialPreviews", type: :request do
     it "renders pretty category name" do
       get "/social_previews/listing/#{listing.id}"
       expect(response.body).to include CGI.escapeHTML("Call For Proposal")
+    end
+
+    it "renders consistent HTML between requests" do
+      # We use the HTML for caching. It needs to be deterministic (if data is unchanged, the HTML should be the same)
+      get "/social_previews/listing/#{listing.id}"
+      first_request_body = response.body
+
+      get "/social_previews/listing/#{listing.id}"
+      second_request_body = response.body
+
+      expect(first_request_body).to eq second_request_body
     end
 
     it "renders and image when requested and redirects to iamge url" do


### PR DESCRIPTION
This PR improves the social card caching. ⚡️ 

## Why
Since we use the generated HTML as the [cache key for social cards](https://github.com/thepracticaldev/dev.to/blob/bfa1bdc37f4bf33c76d767ed815e30a384b369e0/app/lib/html_css_to_image.rb#L16), if there is any randomness at all, it makes the hit rate really low (caches keep regenerating).

This PR adds tests for randomness (to avoid regressions), plus removes the `aria` tags from the SVG (which were random & not needed when generating an image).

Social card endpoint will better use memcached & be even faster. ⚡️

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Documentation Update

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed
