### PR TITLE
WIP: Enables DECS liquid tag

### DIFF
--- a/app/liquid_tags/decs_tag.rb
+++ b/app/liquid_tags/decs_tag.rb
@@ -11,7 +11,7 @@ class DecsTag < LiquidTagBase
     ActionController::Base.new.render_to_string(
       partial: PARTIAL,
       locals: {
-        link: @link,
+        link: @snippet["url"],
         height: @snippet["height"]
       },
     )

--- a/app/liquid_tags/decs_tag.rb
+++ b/app/liquid_tags/decs_tag.rb
@@ -1,0 +1,45 @@
+class DecsTag < LiquidTagBase
+  PARTIAL = "liquids/decs".freeze
+
+  def initialize(tag_name, link, tokens)
+    super
+    @link = parse_link(link)
+    @snippet = parse_url_for_decs_snippet(link)
+  end
+
+  def render(_context)
+    ActionController::Base.new.render_to_string(
+      partial: PARTIAL,
+      locals: {
+        link: @link,
+        height: @snippet["height"]
+      },
+    )
+  end
+
+  def parse_url_for_decs_snippet(url)
+    sanitized_article_url = ActionController::Base.helpers.strip_tags(url).strip
+
+    DECSSnippetService.new("https://www.decs.xyz/oembed?url=" + sanitized_article_url).call
+  rescue StandardError
+    raise_error
+  end
+
+  def parse_link(link)
+    stripped_link = ActionController::Base.helpers.strip_tags(link)
+    the_link = stripped_link.split(" ").first
+    raise_error unless valid_link?(the_link)
+    the_link
+  end
+
+  def valid_link?(link)
+    link_no_space = link.delete(" ")
+    (link_no_space =~ /^(https):\/\/(www\.decs\.xyz)\/[a-zA-Z0-9\.\-\/]*\/[a-zA-Z0-9\.\-\/]*\z/)&.zero?
+  end
+
+  def raise_error
+    raise StandardError, "Invalid DECS Code Snippet URL"
+  end
+end
+
+Liquid::Template.register_tag("decs", DecsTag)

--- a/app/services/decs_snippet_service.rb
+++ b/app/services/decs_snippet_service.rb
@@ -1,0 +1,11 @@
+class DECSSnippetService
+  attr_reader :url
+
+  def initialize(url)
+    @url = url
+  end
+
+  def call
+    HTTParty.get(url).parsed_response
+  end
+end

--- a/app/views/liquids/_decs.html.erb
+++ b/app/views/liquids/_decs.html.erb
@@ -1,0 +1,1 @@
+<iframe src="<%= link %>" width="100%" height="<%= height %>" frameborder="no" allowtransparency="true"></iframe>

--- a/spec/liquid_tags/decs_tag_spec.rb
+++ b/spec/liquid_tags/decs_tag_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe DecsTag, type: :liquid_template do
+  setup { Liquid::Template.register_tag("decs", DecsTag) }
+
+  subject { Liquid::Template.parse("{% decs #{link} %}") }
+
+  let(:stubbed_scraper) { instance_double("DECSSnippetService") }
+  let(:decs_link) { "https://www.decs.xyz/creativex.id/0377f202-661b-ca5f-2d88-cb2c2cbc9057/main" }
+  let(:response) do
+    {
+      title: "DECS Tour - Snippet example",
+      description: "Guided tour will walk you through all the functionality of DECS web app and this is an example description of the snippet. Use this field to briefly describe what you are storing in this snippet and what does it do. Simple!",
+      url: "https://www.decs.xyz/creativex.id/0377f202-661b-ca5f-2d88-cb2c2cbc9057/main",
+      type: "rich",
+      html: "<iframe width='600' height='329' src='https://www.decs.xyz/creativex.id/0377f202-661b-ca5f-2d88-cb2c2cbc9057/main' frameborder='0'></iframe>",
+      width: 600,
+      height: 329,
+      version: "1.0",
+      provider_name: "DECS",
+      provider_url: "https://www.decs.xyz",
+      author_name: "Venkata Chandrasekhar Nainala",
+      author_url: "https://gaia.blockstack.org/hub/1F5xX8hpB3SKqeNV2aHNoSatBA1eW2CoHZ//avatar-0"
+    }
+  end
+
+  def generate_decs_tag(link)
+    Liquid::Template.parse("{% decs #{link} %}")
+  end
+
+  context "when given valid decs url" do
+    before do
+      allow(DECSSnippetService).to receive(:new).with("https://www.decs.xyz/oembed?url=" + decs_link).and_return(stubbed_scraper)
+      allow(stubbed_scraper).to receive(:call).and_return(response)
+    end
+
+    it "renders decs html" do
+      liquid = generate_decs_tag(decs_link)
+      expect(liquid.render).to include("<iframe")
+    end
+  end
+
+  it "raises an error when invalid" do
+    expect { generate_decs_tag("invalid link") }.to raise_error("Invalid DECS Code Snippet URL")
+  end
+end

--- a/spec/support/fixtures/approvals/decs_liquid_tag.received.html
+++ b/spec/support/fixtures/approvals/decs_liquid_tag.received.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <body>
+    <iframe src="https://www.decs.xyz/creativex.id/0377f202-661b-ca5f-2d88-cb2c2cbc9057/main" width="100%" height="" frameborder="no" allowtransparency="true"></iframe>
+  </body>
+</html>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
[DECS](https://app.decs.xyz) is a decentralized app to manage code snippets and sensitive app information like configs, keys etc. It enables developers to share code snippets and one of the key features is code snippet embed. 

This feature would enable DECS feature-rich code snippet to be embedded on dev.to 

Example embed links

{% decs https://www.decs.xyz/creativex.id/0377f202-661b-ca5f-2d88-cb2c2cbc9057/main %}

{% decs https://www.decs.xyz/creativex.id/ab74062a-77fe-2150-5659-bac2338e74bb/InterfacePayroll %}

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
<img width="1279" alt="decs-liquid-tag" src="https://user-images.githubusercontent.com/4065285/59968027-1762e400-952b-11e9-83f5-3c1a3bef0513.png">

![decs-snippets-rendered-editor-vies](https://user-images.githubusercontent.com/4065285/59968035-31042b80-952b-11e9-9dd8-bf274fdfc058.png)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed