### PR TITLE
Comments: remove double stripping undoing escaping

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -168,7 +168,8 @@ class Comment < ApplicationRecord
   def title(length = 80)
     return "[deleted]" if deleted
 
-    ActionController::Base.helpers.truncate(ActionController::Base.helpers.strip_tags(processed_html).strip, length: length)
+    text = ActionController::Base.helpers.strip_tags(processed_html).strip
+    ActionController::Base.helpers.truncate(text, length: length)
   end
 
   def video

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -87,7 +87,7 @@
       <div class="root-comment">
         <% if @root_comment.depth > 0 && parent = @root_comment.parent %>
           <a href="<%= parent.path %>" class="comment-parent-link">
-            re: <%= parent.title(150).strip %>
+            re: <%= parent.title(150) %>
           </a>
         <% end %>
         <% cache ["comment_root-view-root_#{user_signed_in?}", @root_comment] do %>

--- a/app/views/notifications/shared/_comment_box.html.erb
+++ b/app/views/notifications/shared/_comment_box.html.erb
@@ -3,7 +3,7 @@
     <div class="comment-text">
       <% if json_data["comment"]["depth"] && json_data["comment"]["depth"] > 0 %>
         <a href="<%= json_data["comment"]["ancestors"].last["path"] %>" class="comment-text-header">
-          re: <%= json_data["comment"]["ancestors"].last["title"].strip %>
+          re: <%= json_data["comment"]["ancestors"].last["title"] %>
         </a>
       <% end %>
       <a href="<%= json_data["comment"]["path"] %>" class="comment-link-wrapper"></a>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

I've noticed an escaping issue in the new comment view. This fixes it

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Before

![Screenshot_2019-06-23 The DEV(local) Community](https://user-images.githubusercontent.com/146201/59974528-9a2c8300-95ad-11e9-8089-64095a5f9125.png)

After

![Screenshot_2019-06-23 Discussion of The Skull Beneath the Skin](https://user-images.githubusercontent.com/146201/59974531-9ef13700-95ad-11e9-8b3e-8e4853a1e68f.png)


## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
