### PR TITLE
Return original body instead of nil for new comment push notifications

### DIFF
--- a/app/services/notifications/new_comment/send.rb
+++ b/app/services/notifications/new_comment/send.rb
@@ -60,7 +60,7 @@ module Notifications
               alert: {
                 title: title,
                 subtitle: subtitle,
-                body: CGI.unescapeHTML(body.strip!)
+                body: CGI.unescapeHTML(body.strip)
               }
             },
             data: {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This fixes a strange bug where `comment.title.strip!` would return `nil`, and thus `CGI.unescapeHTML(nil)` would result in a run time error.

I'm not sure why it's an issue now as opposed to before though 🤷‍♂️

Resolves #3272 