### PR TITLE
Pro: Deduplicate history items

### DIFF
--- a/app/javascript/history/history.jsx
+++ b/app/javascript/history/history.jsx
@@ -83,14 +83,7 @@ export class History extends Component {
     }
 
     index.search(query, filters).then(content => {
-      // add new items to the bottom
-      const allItems = items;
-      const itemsIds = items.map(i => i.objectID);
-      content.hits.forEach(item => {
-        if (!itemsIds.includes(item.objectID)) {
-          allItems.push(item);
-        }
-      });
+      const allItems = [...items, ...content.hits];
 
       this.setState({
         query,
@@ -184,9 +177,8 @@ min read・
           </button>
         </div>
       );
-    } 
-      return '';
-    
+    }
+    return '';
   }
 
   render() {

--- a/app/models/page_view.rb
+++ b/app/models/page_view.rb
@@ -5,7 +5,7 @@ class PageView < ApplicationRecord
   belongs_to :article
 
   algoliasearch index_name: "UserHistory", per_environment: true, if: :belongs_to_pro_user? do
-    attributes :referrer, :time_tracked_in_seconds, :user_agent, :article_tags
+    attributes :referrer, :user_agent, :article_tags
 
     attribute(:article_title) { article.title }
     attribute(:article_path) { article.path }
@@ -37,6 +37,9 @@ class PageView < ApplicationRecord
     tags { article_tags }
 
     attributesForFaceting ["filterOnly(viewable_by)"]
+
+    attributeForDistinct :article_path
+    distinct true
 
     customRanking ["desc(visited_at_timestamp)"]
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

Right now the history items are duplicated, because each visit counts separately. 

To properly show a history page (like a browser's history) those items need to be de-duplicated. By building the index with `distinct: true` the default response is only unique visits.

Keep in mind that the separate entries are still in the index (they can be accessed with `distinct: false` in the query).

Maybe in the future we can add statistics of frequency (for example: "here's the top 10 articles you visit") but that's another separate feature.

**for whomever is going to merge this: the index for the history (model `PageView` and index name `UserHistory`) needs to be rebuilt**

## Related Tickets & Documents

#3220 

## Screenshots

**Before**

![Screenshot_2019-06-24 History - The DEV(local) Community](https://user-images.githubusercontent.com/146201/60003589-50a26d80-966b-11e9-8bcb-2b4263690049.png)

**After**

![Screenshot_2019-06-24 History - The DEV(local) Community(1)](https://user-images.githubusercontent.com/146201/60003702-88a9b080-966b-11e9-8255-81fbe8f91ba3.png)

**What happens when you visit again an article that you've already visit**

![Screenshot_2019-06-24 History - The DEV(local) Community(2)](https://user-images.githubusercontent.com/146201/60003715-9101eb80-966b-11e9-8237-0f5c1c89b6dd.png)

Notice how the article "Number the stars" goes back at the top of the list

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
