### PR TITLE
3035 - Increase tag length limit from 20 to 30 chars

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -44,7 +44,7 @@ class Article < ApplicationRecord
   validate :validate_collection_permission
   validate :validate_liquid_tag_permissions
   validates :video_state, inclusion: { in: %w[PROGRESSING COMPLETED] }, allow_nil: true
-  validates :cached_tag_list, length: { maximum: 86 }
+  validates :cached_tag_list, length: { maximum: 126 }
   validates :main_image, url: { allow_blank: true, schemes: %w[https http] }
   validates :main_image_background_hex_color, format: /\A#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})\z/
   validates :video, url: { allow_blank: true, schemes: %w[https http] }
@@ -506,7 +506,7 @@ class Article < ApplicationRecord
 
     # check tags names aren't too long
     tag_list.each do |tag|
-      errors.add(:tag, "\"#{tag}\" is too long (maximum is 20 characters)") if tag.length > 20
+      errors.add(:tag, "\"#{tag}\" is too long (maximum is 30 characters)") if tag.length > 30
     end
   end
 
@@ -524,7 +524,8 @@ class Article < ApplicationRecord
     errors.add(:collection_id, "must be one you have permission to post to") if collection && collection.user_id != user_id
   end
 
-  def validate_liquid_tag_permissions #Admin only beta tags etc.
+  # Admin only beta tags etc.
+  def validate_liquid_tag_permissions
     errors.add(:body_markdown, "must only use permitted tags") if liquid_tags_used.include?(PollTag) && !(user.has_role?(:super_admin) || user.has_role?(:admin))
   end
 

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Article, type: :model do
   it { is_expected.to validate_uniqueness_of(:feed_source_url).allow_blank }
   it { is_expected.to validate_presence_of(:title) }
   it { is_expected.to validate_length_of(:title).is_at_most(128) }
-  it { is_expected.to validate_length_of(:cached_tag_list).is_at_most(86) }
+  it { is_expected.to validate_length_of(:cached_tag_list).is_at_most(126) }
   it { is_expected.to belong_to(:user) }
   it { is_expected.to belong_to(:organization).optional }
   it { is_expected.to belong_to(:collection).optional }
@@ -181,6 +181,11 @@ RSpec.describe Article, type: :model do
       it "rejects if there are more than 4 tags" do
         five_tags = "one, two, three, four, five"
         expect(build(:article, tags: five_tags).valid?).to be(false)
+      end
+
+      it "rejects if there are tags with length > 30" do
+        tags = "'testing tag length with more than 30 chars', tag"
+        expect(build(:article, tags: tags).valid?).to be(false)
       end
     end
 


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Solves #3035 
This commit increases the `tag` length limit from 20 to 30 chars and also increases the `cached_tag_list` length limit to 126 chars aiming to maintain the four tags limit. Specs were adapted to respect the changes.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [ ] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)