### PR TITLE
Use publish date for article notifications

### DIFF
--- a/app/services/notifications.rb
+++ b/app/services/notifications.rb
@@ -40,7 +40,10 @@ module Notifications
       class: { name: "Article" },
       title: article.title,
       path: article.path,
-      updated_at: article.updated_at
+      updated_at: article.updated_at,
+      published_at: article.published_at,
+      readable_publish_date: article.readable_publish_date,
+      reading_time: article.reading_time
     }
   end
 

--- a/app/views/notifications/_article.html.erb
+++ b/app/views/notifications/_article.html.erb
@@ -31,7 +31,11 @@
         under <a href="<%= json_data["organization"]["path"] %>"><%= json_data["organization"]["name"] %></a>:
       <% end %>
       <div>
-        <small><%= time_ago_in_words notification.notifiable.created_at %> ago</small>
+        <% if json_data["article"]["published_at"] %>
+          <small><%= time_ago_in_words json_data["article"]["published_at"] %> ago</small>
+        <% else %>
+          <small><%= time_ago_in_words notification.notifiable.published_at %> ago</small>
+        <% end %>
       </div>
       <a href="<%= json_data["article"]["path"] %>">
         <div class="notification-new-post">

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+include ActionView::Helpers::DateHelper
 
 RSpec.describe "NotificationsIndex", type: :request do
   let(:dev_account) { create(:user) }
@@ -336,6 +337,10 @@ RSpec.describe "NotificationsIndex", type: :request do
 
       it "does not render the reaction as reacted if it was not reacted on" do
         expect(response.body).not_to include "reaction-button reacted"
+      end
+
+      it "renders the article's published at" do
+        expect(response.body).to include time_ago_in_words(article.published_at)
       end
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This fixes an issue where an article notification was showing the `created_at` date instead of the `published_at` date. I also added some minor adjustments to handle it the way we usually handle notification data.

Resolves #3300 