### PR TITLE
Add rel="nofollow" to links in comments

### DIFF
--- a/app/labor/markdown_parser.rb
+++ b/app/labor/markdown_parser.rb
@@ -6,7 +6,8 @@ class MarkdownParser
     @content = content
   end
 
-  def finalize(options = { hard_wrap: true, filter_html: false })
+  def finalize(link_attributes: {})
+    options = { hard_wrap: true, filter_html: false, link_attributes: link_attributes }
     renderer = Redcarpet::Render::HTMLRouge.new(options)
     markdown = Redcarpet::Markdown.new(renderer, REDCARPET_CONFIG)
     catch_xss_attempts(@content)

--- a/app/labor/markdown_parser.rb
+++ b/app/labor/markdown_parser.rb
@@ -6,8 +6,8 @@ class MarkdownParser
     @content = content
   end
 
-  def finalize
-    renderer = Redcarpet::Render::HTMLRouge.new(hard_wrap: true, filter_html: false)
+  def finalize(options = { hard_wrap: true, filter_html: false })
+    renderer = Redcarpet::Render::HTMLRouge.new(options)
     markdown = Redcarpet::Markdown.new(renderer, REDCARPET_CONFIG)
     catch_xss_attempts(@content)
     escaped_content = escape_liquid_tags_in_codeblock(@content)

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -213,8 +213,7 @@ class Comment < ApplicationRecord
   def evaluate_markdown
     fixed_body_markdown = MarkdownFixer.fix_for_comment(body_markdown)
     parsed_markdown = MarkdownParser.new(fixed_body_markdown)
-    options = { hard_wrap: true, filter_html: false, link_attributes: { rel: "nofollow" } }
-    self.processed_html = parsed_markdown.finalize(options)
+    self.processed_html = parsed_markdown.finalize(link_attributes: { rel: "nofollow" })
     wrap_timestamps_if_video_present!
     shorten_urls!
   end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -213,7 +213,8 @@ class Comment < ApplicationRecord
   def evaluate_markdown
     fixed_body_markdown = MarkdownFixer.fix_for_comment(body_markdown)
     parsed_markdown = MarkdownParser.new(fixed_body_markdown)
-    self.processed_html = parsed_markdown.finalize
+    options = { hard_wrap: true, filter_html: false, link_attributes: { rel: "nofollow" } }
+    self.processed_html = parsed_markdown.finalize(options)
     wrap_timestamps_if_video_present!
     shorten_urls!
   end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -79,6 +79,12 @@ RSpec.describe Comment, type: :model do
     expect(comment.processed_html.include?(">1:52:30</a>")).to eq(false)
   end
 
+  it "adds rel=nofollow to links" do
+    comment.body_markdown = "this is a comment with a link: http://dev.to"
+    comment.save
+    expect(comment.processed_html.include?('rel="nofollow"')).to eq(true)
+  end
+
   it "adds a mention url if user is mentioned like @mention" do
     comment.body_markdown = "Hello @#{user.username}, you are cool."
     comment.save


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Added rel="nofollow" to links when parsing the markdown in comments only.

## Related Tickets & Documents
Resolves #3236 

## Added to documentation?
- [x] no documentation needed