### PR TITLE
Fix escape key handling and add space in single listing view

### DIFF
--- a/app/javascript/listings/listings.jsx
+++ b/app/javascript/listings/listings.jsx
@@ -112,12 +112,13 @@ export class Listings extends Component {
   handleKeyDown = e => {
     // Enable Escape key to close an open listing.
     if (this.openedListing !== null && e.key === 'Escape') {
-      this.handleCloseModal();
+      this.handleCloseModal(e);
     }
   };
 
   handleCloseModal = e => {
     if (
+      e.key === 'Escape' ||
       e.target.id === 'single-classified-listing-container__inner' ||
       e.target.id === 'classified-filters' ||
       e.target.id === 'classified-listings-modal-background'
@@ -370,10 +371,11 @@ export class Listings extends Component {
           >
             <p>
               <b>
-Contact
+                Contact
+                {' '}
                 {openedListing.author.name}
                 {' '}
-via DEV Connect
+                via DEV Connect
               </b>
             </p>
             <textarea

--- a/app/javascript/listings/listings.jsx
+++ b/app/javascript/listings/listings.jsx
@@ -111,14 +111,13 @@ export class Listings extends Component {
 
   handleKeyDown = e => {
     // Enable Escape key to close an open listing.
-    if (this.openedListing !== null && e.key === 'Escape') {
-      this.handleCloseModal(e);
-    }
+    this.handleCloseModal(e);
   };
 
   handleCloseModal = e => {
+    const { openedListing } = this.state;
     if (
-      e.key === 'Escape' ||
+      openedListing !== null && e.key === 'Escape' ||
       e.target.id === 'single-classified-listing-container__inner' ||
       e.target.id === 'classified-filters' ||
       e.target.id === 'classified-listings-modal-background'


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description
- Handles escape key exit by passing event from KeyDown method to CloseModal method and checking for key value and openedListing state.
- Adds space before name in messaging modal

## Related Tickets & Documents
resolves #3302 
resolves #3303 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![2019-06-25 19 59 34](https://user-images.githubusercontent.com/13403332/60141613-0e208400-9784-11e9-8f68-c5e25b709877.gif)


## Added to documentation?

- [x] no documentation needed

