### PR TITLE
Add support for hotkey to toggle article preview

### DIFF
--- a/app/javascript/article-form/articleForm.jsx
+++ b/app/javascript/article-form/articleForm.jsx
@@ -17,6 +17,7 @@ import ImageManagement from './elements/imageManagement';
 import MoreConfig from './elements/moreConfig';
 import OrgSettings from './elements/orgSettings';
 import Errors from './elements/errors';
+import HotkeyLinstener from './elements/hotkeyLinstener';
 
 export default class ArticleForm extends Component {
   static handleGistPreview() {
@@ -459,6 +460,7 @@ IMAGES
           edited={this.state.edited}
           onChange={linkState(this, 'published')}
         />
+        <HotkeyLinstener togglePreview={this.fetchPreview} />
         {notice}
         {imageManagement}
         {moreConfig}

--- a/app/javascript/article-form/articleForm.jsx
+++ b/app/javascript/article-form/articleForm.jsx
@@ -17,7 +17,7 @@ import ImageManagement from './elements/imageManagement';
 import MoreConfig from './elements/moreConfig';
 import OrgSettings from './elements/orgSettings';
 import Errors from './elements/errors';
-import HotkeyLinstener from './elements/hotkeyLinstener';
+import KeyboardShortcutsHandler from './elements/keyboardShortcutsHandler';
 
 export default class ArticleForm extends Component {
   static handleGistPreview() {
@@ -460,7 +460,7 @@ IMAGES
           edited={this.state.edited}
           onChange={linkState(this, 'published')}
         />
-        <HotkeyLinstener togglePreview={this.fetchPreview} />
+        <KeyboardShortcutsHandler togglePreview={this.fetchPreview} />
         {notice}
         {imageManagement}
         {moreConfig}

--- a/app/javascript/article-form/elements/hotkeyLinstener.jsx
+++ b/app/javascript/article-form/elements/hotkeyLinstener.jsx
@@ -1,0 +1,38 @@
+import { Component } from 'preact';
+import PropTypes from 'prop-types';
+
+class HotkeyLinstener extends Component {
+  componentDidMount() {
+    document.addEventListener('keydown', this.handleKeyDowm());
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('keydown', this.globalKeysListener);
+  }
+
+  handleKeyDowm = () => {
+    this.globalKeysListener = event => {
+      const controlOrCommandKey = event.ctrlKey || event.metaKey;
+      if (
+        controlOrCommandKey &&
+        event.shiftKey &&
+        event.key.toUpperCase() === 'P'
+      ) {
+        const { togglePreview } = this.props;
+        togglePreview(event);
+      }
+    };
+
+    return this.globalKeysListener;
+  };
+
+  render() {
+    return null;
+  }
+}
+
+HotkeyLinstener.propTypes = {
+  togglePreview: PropTypes.func.isRequired,
+};
+
+export default HotkeyLinstener;

--- a/app/javascript/article-form/elements/keyboardShortcutsHandler.jsx
+++ b/app/javascript/article-form/elements/keyboardShortcutsHandler.jsx
@@ -3,14 +3,14 @@ import PropTypes from 'prop-types';
 
 class KeyboardShortcutsHandler extends Component {
   componentDidMount() {
-    document.addEventListener('keydown', this.handleKeyDowm());
+    document.addEventListener('keydown', this.handleKeyDown());
   }
 
   componentWillUnmount() {
     document.removeEventListener('keydown', this.globalKeysListener);
   }
 
-  handleKeyDowm = () => {
+  handleKeyDown = () => {
     this.globalKeysListener = event => {
       const controlOrCommandKey = event.ctrlKey || event.metaKey;
       if (

--- a/app/javascript/article-form/elements/keyboardShortcutsHandler.jsx
+++ b/app/javascript/article-form/elements/keyboardShortcutsHandler.jsx
@@ -1,7 +1,7 @@
 import { Component } from 'preact';
 import PropTypes from 'prop-types';
 
-class HotkeyLinstener extends Component {
+class KeyboardShortcutsHandler extends Component {
   componentDidMount() {
     document.addEventListener('keydown', this.handleKeyDowm());
   }
@@ -31,8 +31,8 @@ class HotkeyLinstener extends Component {
   }
 }
 
-HotkeyLinstener.propTypes = {
+KeyboardShortcutsHandler.propTypes = {
   togglePreview: PropTypes.func.isRequired,
 };
 
-export default HotkeyLinstener;
+export default KeyboardShortcutsHandler;


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

hotkey for toggle article preview <kbd>command shift p</kbd> for mac and <kbd>control shift p</kbd> for window.

I implement `HotkeyLinstener` for handle keyboard shortcuts because I think it's better to separate of concern so that `ArticleForm` component doesn't do too many thing. (more easy to maintenance in my opinion). In React, I'd use custom hook for doing this. (I'm not sure preact have hooks or similar concept). I'd love to hear you thought on this one.

I have some concern, one concern is `componentWillUnmount` doesn't fire when I change route(I tried on other component, e.g., [Listings component](https://github.com/thepracticaldev/dev.to/blob/master/app/javascript/listings/listings.jsx), and it also doesn't fire  `componentWillUnmount`.  so event listener can't be removed. Any suggestion on this one ? 

Another concern is, husky try to fixes lint issue on changed file(like unused state which it's from old commit). I'm not sure if it's ok to implement new feature and fixes lint on the same pull request. 

## Related Tickets & Documents

## Desktop Screenshots/Recordings

![devto2](https://user-images.githubusercontent.com/13183413/60232721-a83d1500-98c7-11e9-97c7-b7f3b49c1bf8.gif)


Resolves #3129

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

In the future, I think it'd be best if we implement page showing hotkey (like on [github](https://help.github.com/en/articles/using-keyboard-shortcuts))
