### PR TITLE
Set max file size limit for profile images

### DIFF
--- a/app/uploaders/profile_image_uploader.rb
+++ b/app/uploaders/profile_image_uploader.rb
@@ -14,6 +14,10 @@ class ProfileImageUploader < CarrierWave::Uploader::Base
     %w[jpg jpeg jpe gif png ico bmp dng]
   end
 
+  def size_range
+    1..2.megabytes
+  end
+
   protected
 
   def secure_token

--- a/spec/requests/user_settings_spec.rb
+++ b/spec/requests/user_settings_spec.rb
@@ -58,6 +58,12 @@ RSpec.describe "UserSettings", type: :request do
       expect(response.body).to include("Username is too short")
     end
 
+    it "returns error if Profile image is too large" do
+      profile_image = fixture_file_upload("files/large_profile_img.jpg", "image/jpeg")
+      put "/users/#{user.id}", params: { user: { tab: "profile", profile_image: profile_image } }
+      expect(response.body).to include("Profile image File size should be less than 2 MB")
+    end
+
     context "when requesting an export of the articles" do
       def send_request(flag = true)
         put "/users/#{user.id}", params: {


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Set max file size limit to 2MB for profile images.

## Related Tickets & Documents
Resolves #3271 

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed