### PR TITLE
Hide delete article button for non-authors

### DIFF
--- a/app/views/dashboards/_dashboard_article.html.erb
+++ b/app/views/dashboards/_dashboard_article.html.erb
@@ -49,7 +49,7 @@
       <% end %>
     <% elsif article.published %>
       <a href="<%= article.path %>/manage" class="cta pill black">MANAGE</a>
-    <% else %>
+    <% elsif @user == article.user %>
       <a href="<%= article.path %>/delete_confirm" data-no-instant class="cta pill black">DELETE</a>
     <% end %>
     <% if @current_user_pro %>

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "Dashboards", type: :request do
   let(:super_admin)   { create(:user, :super_admin) }
   let(:pro_user)      { create(:user, :pro) }
   let(:article)       { create(:article, user: user) }
+  let(:unpublished_article) { create(:article, user: user, published: false) }
 
   describe "GET /dashboard" do
     context "when not logged in" do
@@ -16,18 +17,25 @@ RSpec.describe "Dashboards", type: :request do
     end
 
     context "when logged in" do
-      it "renders user's articles" do
+      before do
         sign_in user
         article
+      end
+
+      it "renders user's articles" do
         get "/dashboard"
         expect(response.body).to include(CGI.escapeHTML(article.title))
       end
 
       it 'does not show "STATS" for articles' do
-        sign_in user
-        article
         get "/dashboard"
         expect(response.body).not_to include("STATS")
+      end
+
+      it "renders the delete button for drafts" do
+        unpublished_article
+        get "/dashboard"
+        expect(response.body).to include "DELETE"
       end
     end
 
@@ -67,8 +75,18 @@ RSpec.describe "Dashboards", type: :request do
         create(:organization_membership, user: user, organization: organization, type_of_user: "admin")
         article.update(organization_id: organization.id)
         sign_in user
-        get "/dashboard/organization"
-        expect(response.body).to include "#{CGI.escapeHTML(organization.name)} ("
+        get "/dashboard/organization/#{organization.id}"
+        expect(response.body).to include "dashboard-collection-org-details"
+      end
+
+      it "does not render the delete button for other org member's drafts" do
+        create(:organization_membership, user: user, organization: organization, type_of_user: "member")
+        create(:organization_membership, user: second_user, organization: organization, type_of_user: "admin")
+        unpublished_article.update(organization_id: organization.id)
+        sign_in second_user
+        get "/dashboard/organization/#{organization.id}"
+        expect(response.body).not_to include "DELETE"
+        expect(response.body).to include unpublished_article.title
       end
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This prevents non-authors (org admins, DEV admins, for example) from seeing the delete button in the dashboard and manage views. We currently don't allow org admins and DEV admins to delete other people's posts to begin with; this PR gets the UI to match the backend.