### PR TITLE
Make item count 'empty' instead of '0' when reading list is empty

### DIFF
--- a/app/javascript/readingList/readingList.jsx
+++ b/app/javascript/readingList/readingList.jsx
@@ -298,7 +298,7 @@ min read・
           >
             <div className="readinglist-results-header">
               {statusView === 'valid' ? 'Reading List' : 'Archive'}
-              {` (${totalReadingList})`}
+              {` (${totalReadingList > 0 ? totalReadingList : 'empty'})`}
             </div>
             <div>{allItems}</div>
           </div>


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
I noticed the count for the reading list header displayed '0' when the reading list is empty. To keep things consistent with the item count on the sidebar. I changed the count to display 'empty' when the reading list is empty. This had been mistakenly omitted with the original PR for adding the item count.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![reading-list-item-count-empty](https://user-images.githubusercontent.com/24629960/60279714-92cbe900-98cf-11e9-9794-81258351975a.png)

## Added to documentation?
- [x] no documentation needed