### PR TITLE
Fix org credits in internal view

### DIFF
--- a/app/controllers/internal/users_controller.rb
+++ b/app/controllers/internal/users_controller.rb
@@ -23,6 +23,7 @@ class Internal::UsersController < Internal::ApplicationController
 
   def show
     @user = User.find(params[:id])
+    @organizations = @user.organizations
   end
 
   def update
@@ -104,13 +105,13 @@ class Internal::UsersController < Internal::ApplicationController
   end
 
   def add_org_credits
-    org = Organization.find(@user.organization_id)
+    org = Organization.find(user_params[:organization_id])
     amount = user_params[:add_org_credits].to_i
     Credit.add_to_org(org, amount)
   end
 
   def remove_org_credits
-    org = Organization.find(@user.organization_id)
+    org = Organization.find(user_params[:organization_id])
     amount = user_params[:remove_org_credits].to_i
     Credit.remove_from_org(org, amount)
   end
@@ -120,6 +121,7 @@ class Internal::UsersController < Internal::ApplicationController
       new_note note_for_current_role user_status
       pro merge_user_id add_credits remove_credits
       add_org_credits remove_org_credits ghostify
+      organization_id
     ]
     params.require(:user).permit(allowed_params)
   end

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -22,18 +22,29 @@ class Credit < ApplicationRecord
   def self.add_to(user, amount)
     credit_objects = Array.new(amount) { Credit.new(user_id: user.id) }
     Credit.import credit_objects
+    Credit.update_cache_columns(user)
   end
 
   def self.remove_from(user, amount)
     user.credits.where(spent: false).limit(amount).delete_all
+    Credit.update_cache_columns(user)
   end
 
   def self.add_to_org(org, amount)
     credit_objects = Array.new(amount) { Credit.new(organization_id: org.id) }
     Credit.import credit_objects
+    Credit.update_cache_columns(org)
   end
 
   def self.remove_from_org(org, amount)
     org.credits.where(spent: false).limit(amount).delete_all
+    Credit.update_cache_columns(org)
+  end
+
+  def self.update_cache_columns(user_or_org)
+    user_or_org.credits_count = user_or_org.credits.size
+    user_or_org.spent_credits_count = user_or_org.credits.where(spent: true).size
+    user_or_org.unspent_credits_count = user_or_org.credits.where(spent: false).size
+    user_or_org.save
   end
 end

--- a/app/views/internal/users/_credits.erb
+++ b/app/views/internal/users/_credits.erb
@@ -1,6 +1,6 @@
 <div class="row">
   <h3><u>Credits</u></h3>
-  <p>Available User Credits: <%= @user.credits.where(spent: false).size %></p>
+  <p>Available User Credits: <%= @user.unspent_credits_count %></p>
   <%= form_for [:internal, @user] do |f| %>
     <%= f.label "Add Credit(s): " %>
     <br>
@@ -16,11 +16,12 @@
     <%= f.submit "Remove Credits"%>
   <% end %>
   <br>
-  <% if @user.organization_id %>
-    <p>Available <%= Organization.find(@user.organization_id).name %> Credits: <%= Organization.find(@user.organization_id).credits.where(spent: false).size %></p>
+  <% @organizations.each do |org| %>
+    <p>Available <%= org.name %> Credits: <%= org.unspent_credits_count %></p>
     <%= form_for [:internal, @user] do |f| %>
       <%= f.label "Add Org Credit(s): " %>
       <br>
+      <%= f.hidden_field :organization_id, value: org.id %>
       <%= f.text_field :add_org_credits, placeholder: "#", size: 5 %>
       <%= f.text_field :new_note, placeholder: "Why are you adding these credits?", size: 50, required: true %>
       <%= f.submit "Add Org Credits" %>
@@ -28,6 +29,7 @@
     <%= form_for [:internal, @user] do |f| %>
       <%= f.label "Remove Org Credits(s)" %>
       <br>
+      <%= f.hidden_field :organization_id, value: org.id %>
       <%= f.text_field :remove_org_credits, placeholder: "#", size: 5 %>
       <%= f.text_field :new_note, placeholder: "Why are you removing these credits?", size: 50, required: true %>
       <%= f.submit "Remove Org Credits"%>

--- a/spec/requests/internal/users_spec.rb
+++ b/spec/requests/internal/users_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe "Internal::Users", type: :request do
   let(:article2) { create(:article, user: user2) }
   let(:badge) { create(:badge, title: "one-year-club") }
   let(:ghost) { create(:user, username: "ghost", github_username: "Ghost") }
+  let(:organization) { create(:organization) }
 
   before do
     sign_in super_admin
@@ -118,7 +119,7 @@ RSpec.describe "Internal::Users", type: :request do
     end
   end
 
-  context "when managing activty and roles" do
+  context "when managing activity and roles" do
     it "adds comment ban role" do
       patch "/internal/users/#{user.id}/user_status", params: { user: { user_status: "Comment Ban", note_for_current_role: "comment ban this user" } }
       expect(user.roles.first.name).to eq("comment_banned")
@@ -228,6 +229,56 @@ RSpec.describe "Internal::Users", type: :request do
       user.follow(user2)
       banish_user
       expect(user.follows.count).to eq(0)
+    end
+  end
+
+  context "when handling credits" do
+    before do
+      create(:organization_membership, user: super_admin, organization: organization, type_of_user: "admin")
+    end
+
+    it "adds the proper amount of credits for organizations" do
+      put "/internal/users/#{super_admin.id}", params: {
+        user: {
+          add_org_credits: 5,
+          organization_id: organization.id
+        }
+      }
+      expect(organization.reload.credits_count).to eq 5
+      expect(organization.reload.unspent_credits_count).to eq 5
+    end
+
+    it "removes the proper amount of credits for organizations" do
+      Credit.add_to_org(organization, 10)
+      put "/internal/users/#{super_admin.id}", params: {
+        user: {
+          remove_org_credits: 5,
+          organization_id: organization.id
+        }
+      }
+      expect(organization.reload.credits_count).to eq 5
+      expect(organization.reload.unspent_credits_count).to eq 5
+    end
+
+    it "add the proper amount of credits to a user" do
+      put "/internal/users/#{super_admin.id}", params: {
+        user: {
+          add_credits: 5,
+        }
+      }
+      expect(super_admin.reload.credits_count).to eq 5
+      expect(super_admin.reload.unspent_credits_count).to eq 5
+    end
+
+    it "removes the proper amount of credits from a user" do
+      Credit.add_to(super_admin, 10)
+      put "/internal/users/#{super_admin.id}", params: {
+        user: {
+          remove_credits: 5,
+        }
+      }
+      expect(super_admin.reload.credits_count).to eq 5
+      expect(super_admin.reload.unspent_credits_count).to eq 5
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This fixes an issue where we couldn't give credits to organizations, if the user did not have an `organization_id`. Also adds some tests for adding credits via internal.