### PR TITLE
Disable use of localStorage when cookie-less

### DIFF
--- a/app/assets/javascripts/utilities/browserStoreCache.js
+++ b/app/assets/javascripts/utilities/browserStoreCache.js
@@ -1,14 +1,22 @@
 function browserStoreCache(action, userData) {
   try {
-    if (action === 'set') {
-      localStorage.setItem('current_user', userData);
-      localStorage.setItem('config_body_class', JSON.parse(userData)['config_body_class']);
-    } else if (action === 'remove') {
-      localStorage.removeItem('current_user');
-    } else {
-      return localStorage.getItem('current_user');
+    switch (action) {
+      case 'set':
+        localStorage.setItem('current_user', userData);
+        localStorage.setItem(
+          'config_body_class',
+          JSON.parse(userData).config_body_class,
+        );
+        break;
+      case 'remove':
+        localStorage.removeItem('current_user');
+        break;
+      default:
+        localStorage.getItem('current_user');
     }
   } catch (err) {
-    browserStoreCache('remove');
+    if (navigator.cookieEnabled) {
+      browserStoreCache('remove');
+    }
   }
 }

--- a/app/assets/javascripts/utilities/browserStoreCache.js
+++ b/app/assets/javascripts/utilities/browserStoreCache.js
@@ -12,7 +12,7 @@ function browserStoreCache(action, userData) {
         localStorage.removeItem('current_user');
         break;
       default:
-        localStorage.getItem('current_user');
+        return localStorage.getItem('current_user');
     }
   } catch (err) {
     if (navigator.cookieEnabled) {


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Bug Fix

## Description
If cookie is disabled, our use of localStorage will break the page.
## Related Tickets & Documents
Resolves https://github.com/thepracticaldev/dev.to/issues/3298
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
With cookies disabled 
![Screen Shot 2019-06-27 at 4 45 21 PM](https://user-images.githubusercontent.com/15793250/60299569-046d5c80-98fb-11e9-8a1e-d2458d4aa172.png)

## Added to documentation?

- [x] no documentation needed