### PR TITLE
Documentation update for Admin panel, on Backend instructions

### DIFF
--- a/docs/backend/admin.md
+++ b/docs/backend/admin.md
@@ -21,7 +21,7 @@ rails console
 ```ruby
 Loading development environment (Rails 5.2.3)
 [1] pry(main)> user = User.find_by(username: "bob")
-[2] pry(main)> user.add_role(:admin)
+[2] pry(main)> user.add_role(:super_admin)
 [3] pry(main)> user.save!
 ```
 


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Documentation Update

## Description
According to the Admin Policy, user can see `/admin` page only if `ApplicationPolicy#user_admin?` is `true`. And the [definition](https://github.com/thepracticaldev/dev.to/blob/7ee0350ac525ede462d98d5af7d27b55246f0c50/app/policies/application_policy.rb#L67) of this method, requires for user to have `:super_admin` role, and not :admin role as stand in the documentation

## Related Tickets & Documents
Related [document](https://docs.dev.to/backend/admin/)

## Added to documentation?

- [x] docs.dev.to
- [ ] readme
- [ ] no documentation needed
