### PR TITLE
Add GET /internal/tags/:id route back in

### DIFF
--- a/app/controllers/internal/tags_controller.rb
+++ b/app/controllers/internal/tags_controller.rb
@@ -16,10 +16,6 @@ class Internal::TagsController < Internal::ApplicationController
     @tag = Tag.find(params[:id])
   end
 
-  def edit
-    @tag = Tag.find(params[:id])
-  end
-
   def update
     @tag = Tag.find(params[:id])
     @add_user_id = params[:tag][:tag_moderator_id]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,7 +44,7 @@ Rails.application.routes.draw do
         post "save_status"
       end
     end
-    resources :tags, only: %i[index edit update]
+    resources :tags, only: %i[index edit update show]
     resources :users, only: %i[index show edit update] do
       member do
         post "banish"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,7 +44,7 @@ Rails.application.routes.draw do
         post "save_status"
       end
     end
-    resources :tags, only: %i[index edit update show]
+    resources :tags, only: %i[index update show]
     resources :users, only: %i[index show edit update] do
       member do
         post "banish"

--- a/spec/requests/internal/tags_spec.rb
+++ b/spec/requests/internal/tags_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe "/internal/tags", type: :request do
+  let(:super_admin) { create(:user, :super_admin) }
+  let(:tag)         { create(:tag) }
+
+  before do
+    tag
+    sign_in super_admin
+  end
+
+  describe "GET /internal/tags" do
+    it "responds with 200 OK" do
+      get "/internal/tags"
+      expect(response.status).to eq 200
+    end
+  end
+
+  describe "GET /internal/tags/:id" do
+    it "responds with 200 OK" do
+      get "/internal/tags/#{tag.id}"
+      expect(response.status).to eq 200
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This adds the `GET /internal/tags/:id` was accidentally removed. 😅 Also removes `GET /internal/tags/:id/edit` route and controller action, since there wasn't a view for it (we use the show page as the edit page).