### PR TITLE
Fix instagram URL validation rule

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -93,7 +93,7 @@ class User < ApplicationRecord
             format: /\A(http(s)?:\/\/)?(www.gitlab.com|gitlab.com)\/.*\Z/
   validates :instagram_url,
             allow_blank: true,
-            format: /\A(http(s)?:\/\/)?(www.instagram.com|instagram.com)\/[a-z\d_]{1,30}\Z/
+            format: /\A(http(s)?:\/\/)?(?:www.)?instagram.com\/(?=.{1,30}\/?$)([a-zA-Z\d_]\.?)*[a-zA-Z\d_]+\/?\Z/
   validates :twitch_url,
             allow_blank: true,
             format: /\A(http(s)?:\/\/)?(www.twitch.tv|twitch.tv)\/.*\Z/

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -263,7 +263,7 @@ RSpec.describe User, type: :model do
     end
 
     it "accepts valid instagram url" do
-      %w[jess je_ss].each do |username|
+      %w[jess je_ss je_ss.tt A.z.E.r.T.y].each do |username|
         user.instagram_url = "https://instagram.com/#{username}"
         expect(user).to be_valid
       end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
The current rule does not consider 2 scenarios:
1- Instagram adds a tailing slash to the URL, users who copy paste their URL will be confused when they get "URL not valid error".
2 - Instagram allows no consecutive periods between the characters, also uppercase letters.

Example of profile that won't pass the current implementation
- https://www.instagram.com/dr.Cocktail/
- https://www.instagram.com/mr.america/

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed