### PR TITLE
Report Abuse button on Feed

### DIFF
--- a/app/assets/stylesheets/articles.scss
+++ b/app/assets/stylesheets/articles.scss
@@ -727,7 +727,7 @@
     .article-reading-time {
       position: absolute;
       right: 82px;
-      bottom: 12px;
+      bottom: 20px;
       font-size: 13px;
       padding: 6px 0px;
       font-weight: 600;
@@ -738,6 +738,23 @@
         darken($medium-gray, 5%)
       );
     }
+
+    .article-report {
+      position: absolute;
+      right: 82px;
+      bottom: 4px;
+      font-size: 13px;
+      padding: 6px 0px;
+      font-weight: 600;
+      z-index: 8;
+      text-decoration: underline;
+      @include themeable(
+        color,
+        theme-secondary-color,
+        darken($medium-gray, 5%)
+      );
+    }
+
     .article-engagement-count {
       font-size: 13px;
       font-weight: bold;

--- a/app/views/articles/_single_story.html.erb
+++ b/app/views/articles/_single_story.html.erb
@@ -63,4 +63,9 @@
     <span class="bm-initial">SAVE</span>
     <span class="bm-success">SAVED</span>
   </button>
+  <a
+    href="/report-abuse?url=<%= story.url %>"
+    class="article-report">
+    Report Abuse
+  </a>
 </div>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -141,6 +141,11 @@
               <span class="bm-initial">SAVE</span>
               <span class="bm-success">SAVED</span>
             </button>
+            <a
+            href="/report-abuse?url=<%= @featured_story.url %>"
+            class="article-report">
+            Report Abuse
+            </a>
           </div>
         </a>
       <% end %>


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
This PR solves #3329. It adds a `Report Abuse` button to the Feed page, aiming to report Articles without the need to access them.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![Screen Shot 2019-06-30 at 19 56 35](https://user-images.githubusercontent.com/27960597/60404766-4bb94e80-9b82-11e9-85d6-63b4b06507e4.png)
![Screen Shot 2019-06-30 at 22 00 19](https://user-images.githubusercontent.com/27960597/60404823-cedaa480-9b82-11e9-9517-a2d7d8548540.png)
![Screen Shot 2019-06-30 at 22 00 30](https://user-images.githubusercontent.com/27960597/60404787-8fac5380-9b82-11e9-8f1a-fde04e38d8dd.png)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [ ] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
