### PR TITLE
wip: Moderators audit logs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem "delayed_job_web", "~> 1.4" # Web interface for delayed_job
 gem "devise", "~> 4.6" # Flexible authentication solution for Rails
 gem "draper", "~> 3.1" # Draper adds an object-oriented layer of presentation logic to your Rails apps
 gem "dry-struct", "~> 1.0" # Typed structs and value objects
+gem 'dry-configurable', "~> 0.8" #A simple mixin to make Ruby classes configurable
 gem "email_validator", "~> 2.0" # Email validator for Rails and ActiveModel
 gem "emoji_regex", "~> 2.0" # A pair of Ruby regular expressions for matching Unicode Emoji symbols
 gem "envied", "~> 0.9" # Ensure presence and type of your app's ENV-variables

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -890,6 +890,7 @@ DEPENDENCIES
   derailed_benchmarks (~> 1.3)
   devise (~> 4.6)
   draper (~> 3.1)
+  dry-configurable (~> 0.8)
   dry-struct (~> 1.0)
   email_validator (~> 2.0)
   emoji_regex (~> 2.0)

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -8,6 +8,7 @@ module Admin
   class ApplicationController < Administrate::ApplicationController
     include Pundit
     before_action :authorize_admin
+    after_action :moderator_audit
 
     def order
       @order ||= Administrate::Order.new(params[:order] || "id", params[:direction] || "desc")
@@ -25,6 +26,21 @@ module Admin
 
     def authorize_admin
       authorize :admin, :show?
+    end
+
+    def moderator_audit
+      payload = {
+        user: {
+          id: current_user.id,
+          roles: current_user.roles&.pluck(:name)
+        },
+        action: {
+          method: request.method,
+          path: request.original_fullpath
+        }
+      }
+
+      Moderator::Audit::Notification.new(payload).instrument
     end
   end
 end

--- a/app/services/moderator/audit/application.rb
+++ b/app/services/moderator/audit/application.rb
@@ -1,0 +1,14 @@
+module Moderator
+  module Audit
+    class Application
+      extend Dry::Configurable
+
+      ACTION_TYPES = %i[removal downvote vomit vote].freeze
+
+      # Custom instrumentation name used by ActiveSupport::Notifications
+      setting :instrumentation_name, "moderator.audit.log".freeze
+      # Action type which describe the action made by the moderator
+      setting :types, ACTION_TYPES
+    end
+  end
+end

--- a/app/services/moderator/audit/notification.rb
+++ b/app/services/moderator/audit/notification.rb
@@ -1,0 +1,24 @@
+module Moderator
+  module Audit
+    class Notification
+      AuditConfig = Moderator::Audit::Application.config
+
+      def initialize(payload)
+        @payload = payload
+      end
+
+      def instrument
+        ActiveSupport::Notifications.instrument(AuditConfig.instrumentation_name, @payload)
+      end
+
+      class << self
+        def subscribe(*_args)
+          # Save event to DB
+          # event = ActiveSupport::Notifications::Event.new(*args)
+
+          Rails.logger.info "Moderator::Audit::Notification.subscribe Event Received!"
+        end
+      end
+    end
+  end
+end

--- a/app/services/moderator/audit/subscribe.rb
+++ b/app/services/moderator/audit/subscribe.rb
@@ -1,0 +1,12 @@
+module Moderator
+  module Audit
+    class Subscribe
+      include Singleton
+      AuditConfig = Moderator::Audit::Application.config
+
+      ActiveSupport::Notifications.subscribe(AuditConfig.instrumentation_name) do |*args|
+        Moderator::Audit::Notification.subscribe(*args)
+      end
+    end
+  end
+end

--- a/config/initializers/moderator_audit_event.rb
+++ b/config/initializers/moderator_audit_event.rb
@@ -1,0 +1,2 @@
+# Initialize the custom Rails Instrumentation for Moderator
+Moderator::Audit::Subscribe.instance


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
This is a WIP

Wrapper class is created `Moderator::AuditNotification` to be able to use the internal Rails Instrumentation [API](https://guides.rubyonrails.org/active_support_instrumentation.html#rails)

Missing parts is saving to DB through ActiveJob and tests.

Please let me know if I am on the right track.

Also I am confused with the payload definition. As you can see, I've try to add some info on `:moderator_audit` on `Admin::ApplicationController#after_action` method.
 
## Related Tickets & Documents
Fixes #3141 


## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [ ] no documentation needed

