### PR TITLE
add ids to terms page so each clause can be linked to directly

### DIFF
--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -29,7 +29,7 @@
     </h1>
   </div>
   <div class="body">
-    <h3>
+    <h3 id="terms">
       1. Terms
     </h3>
 
@@ -43,7 +43,7 @@
       protected by applicable copyright and trade mark law.
     </p>
 
-    <h3>
+    <h3 id="use-licence">
       2. Use License
     </h3>
 
@@ -67,7 +67,7 @@
       </li>
     </ol>
 
-    <h3>
+    <h3 id="disclaimer">
       3. Disclaimer
     </h3>
 
@@ -77,7 +77,7 @@
       </li>
     </ol>
 
-    <h3>
+    <h3 id="limitations">
       4. Limitations
     </h3>
 
@@ -85,7 +85,7 @@
       In no event shall DEV or its suppliers be liable for any damages (including, without limitation, damages for loss of data or profit, or due to business interruption,) arising out of the use or inability to use the materials on DEV's Internet site, even if DEV or an authorized representative has been notified orally or in writing of the possibility of such damage. Because some jurisdictions do not allow limitations on implied warranties, or limitations of liability for consequential or incidental damages, these limitations may not apply to you.
     </p>
 
-    <h3>
+    <h3 id="revisions-and-errata">
       5. Revisions and Errata
     </h3>
 
@@ -93,7 +93,7 @@
       The materials appearing on DEV's web site could include technical, typographical, or photographic errors. DEV does not warrant that any of the materials on its web site are accurate, complete, or current. DEV may make changes to the materials contained on its web site at any time without notice. DEV does not, however, make any commitment to update the materials.
     </p>
 
-    <h3>
+    <h3 id="links">
       6. Links
     </h3>
 
@@ -101,7 +101,7 @@
       DEV has not reviewed all of the sites linked to its Internet web site and is not responsible for the contents of any such linked site. The inclusion of any link does not imply endorsement by DEV of the site. Use of any such linked web site is at the user's own risk.
     </p>
 
-    <h3>
+    <h3 id="copyright-takedown">
       7. Copyright / Takedown
     </h3>
 
@@ -110,7 +110,7 @@
       <a href="mailto:yo@dev.to">yo@dev.to</a>. DEV may remove any content users post for any reason.
     </p>
 
-    <h3>
+    <h3 id="site-terms-of-use-modifications">
       8. Site Terms of Use Modifications
     </h3>
 
@@ -118,7 +118,7 @@
       DEV may revise these terms of use for its web site at any time without notice. By using this web site you are agreeing to be bound by the then current version of these Terms and Conditions of Use.
     </p>
 
-    <h3>
+    <h3 id="dev-trademarks-and-logo-policy">
       9. DEV Trademarks and Logos Policy
     </h3>
 
@@ -126,7 +126,7 @@
       All uses of the DEV logo, DEV badges, brand slogans, iconography, and the like, may only be used with express permission from DEV. DEV reserves all rights, even if certain assets are included in DEV open source projects. Please contact yo@dev.to with any questions or to request permission.
     </p>
 
-    <h3>
+    <h3 id="reserved-names">
       10. Reserved Names
     </h3>
 
@@ -138,7 +138,7 @@
       Additionally, DEV reserves the right to change any already-claimed name at its sole discretion. In such cases, DEV will make reasonable effort to find a suitable alternative and assist with any transition-related concerns.
     </p>
 
-    <h3>
+    <h3 id="content-policy">
       11. Content Policy
     </h3>
 
@@ -150,7 +150,7 @@
       DEV reserves the right to remove any content that it deems to be in violation of this policy at its sole discretion. Additionally, DEV reserves the right to restrict any user’s ability to participate on the platform at its sole discretion.
     </p>
 
-    <h3>
+    <h3 id="governing-law">
       12. Governing Law
     </h3>
 


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

This PR adds IDs to all of the Header tags (<h3>) on the terms page so it makes it easier to link someone to a particular section of the terms (i.e. the content policy)

## Related Tickets & Documents
n/a

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
n/a

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## What gif best describes this PR or how it makes you feel?

![pointing at a place in a book](https://media.giphy.com/media/10fnAMC2KdYbxC/giphy.gif)
