### PR TITLE
Escape comment.title to fix failing spec

### DIFF
--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe "NotificationsIndex", type: :request do
       end
 
       it "contextualize comment title properly" do
-        expect(response.body).to include "re: #{comment.title}"
+        expect(response.body).to include CGI.escapeHTML("re: #{comment.title}")
       end
     end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Escape `comment.title` to fix failing spec in the master build:
![изображение](https://user-images.githubusercontent.com/30115/60711819-5aa35680-9f1e-11e9-805e-328c0261f3af.png)