### PR TITLE
[WIP] Turn off notifications for posts' reactions

### DIFF
--- a/app/jobs/notifications/new_reaction_job.rb
+++ b/app/jobs/notifications/new_reaction_job.rb
@@ -14,7 +14,11 @@ module Notifications
       return unless %w[User Organization].include?(receiver_klass)
 
       receiver = receiver_klass.constantize.find_by(id: receiver_data.fetch(:id))
-      service.call(reaction_data, receiver) if receiver
+      service.call(reaction_data, receiver) if shoud_send_reaction_notification?(receiver, receiver_data)
+    end
+
+    def shoud_send_reaction_notification?(receiver, receiver_data)
+      receiver && receiver_data.fetch(:post_reaction_notifications, true)
     end
   end
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -74,6 +74,7 @@ class UserPolicy < ApplicationPolicy
        editor_version
        email_unread_notifications
        mobile_comment_notifications
+       post_reaction_notifications
        employer_name
        employer_url
        employment_title

--- a/app/views/users/_notifications.html.erb
+++ b/app/views/users/_notifications.html.erb
@@ -1,5 +1,12 @@
-<h3>Email Notification Settings</h3>
 <%= form_for(@user) do |f| %>
+  <h3>Notifications</h3>
+  <div class="checkbox-field">
+    <div class="sub-field">
+      <%= f.check_box :post_reaction_notifications %>
+      <%= f.label :post_reaction_notifications, "Notify me when someone reacts to my posts" %>
+    </div>
+  </div>
+  <h3>Email Notification Settings</h3>
   <div class="checkbox-field">
     <div class="sub-field">
       <%= f.check_box :email_newsletter %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -970,6 +970,7 @@ ActiveRecord::Schema.define(version: 2019_06_28_123548) do
     t.string "medium_url"
     t.datetime "membership_started_at"
     t.boolean "mobile_comment_notifications", default: true
+    t.boolean "post_reaction_notifications", default: true
     t.integer "monthly_dues", default: 0
     t.string "mostly_work_with"
     t.string "name"


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
This PR adds the feature of disabling notifications for post reactions.

## Related Tickets & Documents
Feature request here: https://github.com/thepracticaldev/dev.to/issues/3244

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![demo](https://user-images.githubusercontent.com/8633440/60762637-941db400-a03b-11e9-86bc-f8afc660f826.gif)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
