### PR TITLE
Add markdown to article api response

### DIFF
--- a/app/views/api/v0/articles/show.json.jbuilder
+++ b/app/views/api/v0/articles/show.json.jbuilder
@@ -21,6 +21,7 @@ json.published_at       @article.published_at&.utc&.iso8601
 json.last_comment_at    @article.last_comment_at&.utc&.iso8601
 
 json.body_html @article.processed_html
+json.body_markdown @article.body_markdown
 json.ltag_style(@article.liquid_tags_used.map { |ltag| Rails.application.assets["ltags/#{ltag}.css"].to_s.html_safe })
 json.ltag_script(@article.liquid_tags_used.map { |ltag| ltag.script.html_safe })
 

--- a/spec/requests/api/v0/articles_spec.rb
+++ b/spec/requests/api/v0/articles_spec.rb
@@ -83,6 +83,11 @@ RSpec.describe "Api::V0::Articles", type: :request do
       get "/api/articles/#{article.id}"
       expect(json_response["title"]).to eq(article.title)
     end
+    
+    it "contains article markdown content" do
+      get "/api/articles/#{article.id}"
+      expect(json_response["body_markdown"]).to eq(article.body_markdown)
+    end
 
     it "fails with an unpublished article" do
       article.update_columns(published: false)


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
When creating an article with the v0 API the article is defined in markdown, however when retrieving that article the markdown is not available, which makes it difficult for consumers of the API that need to read the frontmatter.

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/102h4wsmCG2s12/giphy.gif)
