### PR TITLE
Mitigate CVE 2015-9284

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ script:
   - './cc-test-reporter format-coverage -t lcov -o coverage/codeclimate.lcov.json'
   - './cc-test-reporter sum-coverage coverage/codeclimate.*.json'
   - './cc-test-reporter upload-coverage'
-  - 'bundle exec bundle-audit check --update'
+  - 'bundle exec bundle-audit check --update --ignore CVE-2015-9284'
   - yarn build-storybook
 deploy:
   provider: heroku

--- a/app/views/articles/_sidebar_additional.html.erb
+++ b/app/views/articles/_sidebar_additional.html.erb
@@ -8,12 +8,8 @@
         </header>
         <div class="widget-body">
           <center style="margin-bottom: 2px;">
-            <a href="/users/auth/twitter?callback_url=<%= ApplicationConfig["APP_PROTOCOL"] %><%= ApplicationConfig["APP_DOMAIN"] %>/users/auth/twitter/callback" class="cta cta-button login-cta-button" data-no-instant>
-              Sign In With Twitter
-            </a>
-            <a href="/users/auth/github?state=navbar_basic" class="cta cta-button login-cta-button" data-no-instant>
-              Sign In With GitHub
-            </a>
+            <%= render "shared/twitter_sign_in_button" %>
+            <%= render "shared/github_sign_in_button", state: :navbar_basic %>
           </center>
         </div>
       </div>

--- a/app/views/devise/registrations/_registration_form.html.erb
+++ b/app/views/devise/registrations/_registration_form.html.erb
@@ -74,12 +74,26 @@
     <h1>Great to have you</h1>
   <% end %>
   <div class="links">
-    <a href="/users/auth/twitter?callback_url=<%= ApplicationConfig["APP_PROTOCOL"] %><%= ApplicationConfig["APP_DOMAIN"] %>/users/auth/twitter/callback" class="sign-up-link" data-no-instant>
+    <%= link_to(
+          user_twitter_omniauth_authorize_path(
+            callback_url: user_twitter_omniauth_callback_url(host: "#{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}"),
+          ),
+          method: :post,
+          class: "sign-up-link",
+          data: { "no-instant": true },
+        ) do %>
       <%= inline_svg("twitter-logo.svg", class: "icon-img", aria: true, title: "twitter logo") %> Sign In with Twitter
-    </a>
-    <a href="/users/auth/github?state=join-club-page_basic" class="sign-up-link" data-no-instant>
-      <%= inline_svg("github-logo.svg", class: "icon-img", aria: true, title: "github logo") %> Sign In with GitHub
-    </a>
+    <% end %>
+
+    <%= link_to(
+          user_github_omniauth_authorize_path(state: "join-club-page_basic"),
+          method: :post,
+          class: "sign-up-link",
+          data: { "no-instant": true },
+        ) do %>
+        <%= inline_svg("github-logo.svg", class: "icon-img", aria: true, title: "github logo") %> Sign In with GitHub
+    <% end %>
+
     <p><em>We require social login to prevent abuse.</em></p>
   </div>
   <p>Open Source 😇</p>

--- a/app/views/layouts/_nav_menu.html.erb
+++ b/app/views/layouts/_nav_menu.html.erb
@@ -43,16 +43,28 @@
         Sign In/Up
       </div>
     </a>
-    <a href="/users/auth/twitter?callback_url=<%= ApplicationConfig["APP_PROTOCOL"] %><%= ApplicationConfig["APP_DOMAIN"] %>/users/auth/twitter/callback" data-no-instant>
-      <div class="option">
-        Via Twitter
-      </div>
-    </a>
-    <a href="/users/auth/github?state=navbar_basic" data-no-instant id="second-last-nav-link">
-      <div class="option">
-        Via GitHub
-      </div>
-    </a>
+    <%= link_to(
+          user_twitter_omniauth_authorize_path(
+            callback_url: user_twitter_omniauth_callback_url(host: "#{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}"),
+          ),
+          method: :post,
+          data: { "no-instant": true },
+        ) do %>
+        <div class="option">
+          Via Twitter
+        </div>
+    <% end %>
+
+    <%= link_to(
+          user_github_omniauth_authorize_path(state: :navbar_basic),
+          method: :post,
+          data: { "no-instant": true },
+        ) do %>
+        <div class="option">
+          Via GitHub
+        </div>
+    <% end %>
+
     <a href="/p/information" id="last-nav-link">
       <div class="option">
         All about dev.to

--- a/app/views/layouts/_signup_modal.html.erb
+++ b/app/views/layouts/_signup_modal.html.erb
@@ -17,12 +17,26 @@
     <p>
       We're a place where coders share, stay up-to-date and grow their careers.
     </p>
-    <a href="/users/auth/twitter?callback_url=<%= ApplicationConfig["APP_PROTOCOL"] %><%= ApplicationConfig["APP_DOMAIN"] %>/users/auth/twitter/callback" class="sign-up-link cta" data-no-instant>
+    <%= link_to(
+          user_twitter_omniauth_authorize_path(
+            callback_url: user_twitter_omniauth_callback_url(host: "#{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}"),
+          ),
+          method: :post,
+          class: "sign-up-link cta",
+          data: { "no-instant": true },
+        ) do %>
       <img src="<%= asset_path("twitter-logo.svg") %>" class="icon-img" alt="Twitter logo" /> Auth With Twitter
-    </a>
-    <a href="/users/auth/github?state=signup-modal" class="sign-up-link cta" data-no-instant>
+    <% end %>
+
+    <%= link_to(
+          user_github_omniauth_authorize_path(state: "signup-modal"),
+          ),
+          method: :post,
+          class: "sign-up-link cta",
+          data: { "no-instant": true },
+        ) do %>
       <img src="<%= asset_path("github-logo.svg") %>" class="icon-img" alt="GitHub logo" /> Auth With GitHub
-    </a>
+    <% end %>
     <p>
       <em>We strive for transparency and don't collect excess data.</em>
     </p>

--- a/app/views/layouts/_signup_modal.html.erb
+++ b/app/views/layouts/_signup_modal.html.erb
@@ -30,7 +30,6 @@
 
     <%= link_to(
           user_github_omniauth_authorize_path(state: "signup-modal"),
-          ),
           method: :post,
           class: "sign-up-link cta",
           data: { "no-instant": true },

--- a/app/views/shared/_github_sign_in_button.html.erb
+++ b/app/views/shared/_github_sign_in_button.html.erb
@@ -1,0 +1,7 @@
+<%= link_to(
+      "Sign In With GitHub",
+      user_github_omniauth_authorize_path(state: state),
+      method: :post,
+      class: "cta cta-button login-cta-button",
+      data: { "no-instant": true },
+    ) %>

--- a/app/views/shared/_twitter_sign_in_button.html.erb
+++ b/app/views/shared/_twitter_sign_in_button.html.erb
@@ -1,0 +1,10 @@
+<%= link_to(
+      "Sign In With Twitter",
+      user_twitter_omniauth_authorize_path(
+        callback_url: user_twitter_omniauth_callback_url(host: "#{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}"),
+      ),
+      method: :post,
+      class: "cta cta-button login-cta-button",
+      data: { "no-instant": true },
+    )
+%>

--- a/app/views/stories/_sign_in_invitation.html.erb
+++ b/app/views/stories/_sign_in_invitation.html.erb
@@ -1,6 +1,6 @@
 <div class="single-article single-article-small-pic feed-cta" id="in-feed-cta">
   <div class="cta-container" id="cta-content">
-    <img class="rainbowdevimage" src="<%= asset_path "rainbowdev.svg" %>" /> 
+    <img class="rainbowdevimage" src="<%= asset_path "rainbowdev.svg" %>" />
     <h2>
       <a href="/">DEV</a> is a community of <br /><%= number_with_delimiter User.count %> amazing humans who code.
     </h2>
@@ -8,12 +8,9 @@
       Create your profile to customize your experience and get involved.
     </h3>
     <div class="button-container">
-      <a href="/users/auth/twitter?callback_url=<%= ApplicationConfig["APP_PROTOCOL"] %><%= ApplicationConfig["APP_DOMAIN"] %>/users/auth/twitter/callback" class="cta cta-button" aria-label="Sign in with Twitter." data-no-instant>
-        Sign In with Twitter 
-      </a>
-      <a href="/users/auth/github?state=in-feed-cta" class="cta cta-button" aria-label="Sign in with GitHub." data-no-instant>
-        Sign In with GitHub
-      </a>
+      <%= render "shared/twitter_sign_in_button" %>
+      <%= render "shared/github_sign_in_button", state: "in-feed-cta" %>
+
       <div class="feed-cta-sub">
         <em>We require social login to prevent abuse.</em>
       </div>

--- a/app/views/users/_account.html.erb
+++ b/app/views/users/_account.html.erb
@@ -1,17 +1,13 @@
 <% unless @user.identities.exists?(provider: "github") %>
   <div class="field">
-    <a href="/users/auth/github" class="big-button cta" data-no-instant>
-      <img src="<%= asset_path("github-logo.svg") %>" alt="github logo"> CONNECT GITHUB ACCOUNT
-    </a>
+    <%= render "github_sign_in_button" %>
   </div>
   <hr />
 <% end %>
 
 <% unless @user.identities.exists?(provider: "twitter") %>
   <div class="field">
-    <a href="/users/auth/twitter?callback_url=<%= ApplicationConfig["APP_PROTOCOL"] %><%= ApplicationConfig["APP_DOMAIN"] %>/users/auth/twitter/callback" class="big-button cta" data-no-instant>
-      <img src="<%= asset_path("twitter-logo.svg") %> " alt="twitter logo"> CONNECT TWITTER ACCOUNT
-    </a>
+    <%= render "twitter_sign_in_button" %>
   </div>
   <hr />
 <% end %>

--- a/app/views/users/_github_sign_in_button.html.erb
+++ b/app/views/users/_github_sign_in_button.html.erb
@@ -1,0 +1,8 @@
+<%= link_to(
+      user_github_omniauth_authorize_path,
+      method: :post,
+      class: "big-button cta",
+      data: { "no-instant": true },
+    ) do %>
+  <img src="<%= asset_path("github-logo.svg") %>" alt="github logo"> CONNECT GITHUB ACCOUNT
+<% end %>

--- a/app/views/users/_profile.html.erb
+++ b/app/views/users/_profile.html.erb
@@ -3,17 +3,13 @@
 
 <% unless @user.identities.exists?(provider: 'github') %>
   <div class="field">
-    <a href="/users/auth/github" class="big-button cta" data-no-instant>
-      <img src="<%= asset_path("github-logo.svg") %>" alt="github logo" /> CONNECT GITHUB ACCOUNT
-    </a>
+    <%= render "github_sign_in_button" %>
   </div>
 <% end %>
 
 <% unless @user.identities.exists?(provider: 'twitter') %>
   <div class="field">
-    <a href="/users/auth/twitter?callback_url=<%= ApplicationConfig["APP_PROTOCOL"] %><%= ApplicationConfig["APP_DOMAIN"] %>/users/auth/twitter/callback" class="big-button cta" data-no-instant>
-      <img src="<%= asset_path("twitter-logo.svg") %>" alt="twitter logo" /> CONNECT TWITTER ACCOUNT
-    </a>
+    <%= render "twitter_sign_in_button" %>
   </div>
 <% end %>
 <h4>

--- a/app/views/users/_twitter_sign_in_button.html.erb
+++ b/app/views/users/_twitter_sign_in_button.html.erb
@@ -1,0 +1,10 @@
+<%= link_to(
+      user_twitter_omniauth_authorize_path(
+        callback_url: user_twitter_omniauth_callback_url(host: "#{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}"),
+      ),
+      method: :post,
+      class: "big-button cta",
+      data: { "no-instant": true },
+    ) do %>
+  <img src="<%= asset_path("twitter-logo.svg") %> " alt="twitter logo"> CONNECT TWITTER ACCOUNT
+<% end %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

There's an old vulnerability that has been promoted to a CVE recently, which is blocking all builds. 
Basically omniauth links with GETs are in some cases subject to CSRF attacks.
Unfortunately there's no agreed upon solution at present. There's a gem that mitigates the problem but it conflicts with a [patch in our codebase](https://github.com/thepracticaldev/dev.to/blame/master/config/initializers/persistent_csrf_token_cookie.rb), in addition to the fact that I can't verify this gem is working correctly since we don't use Omniauth directly.

My proposed solution is this PR:

- convert all sign in links to POSTs
- ignore the CVE until a more permanent solution is found, I'll keep monitoring the issue in the foreseeable future

## Related Tickets & Documents

- https://github.com/omniauth/omniauth/pull/809 and discussion
- https://github.com/rubysec/ruby-advisory-db/pull/390 and discussion
- https://github.com/cookpad/omniauth-rails_csrf_protection

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
