### PR TITLE
[WIP] feat(Article): Add body_markdown_digest to article

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,3 +1,5 @@
+require "digest"
+
 class Article < ApplicationRecord
   include CloudinaryHelper
   include ActionView::Helpers
@@ -62,6 +64,7 @@ class Article < ApplicationRecord
   before_save       :set_caches
   before_save       :fetch_video_duration
   before_save       :clean_data
+  before_save       :compute_digest
   after_save        :async_score_calc, if: :published
   after_save        :bust_cache
   after_save        :update_main_image_background_hex
@@ -625,5 +628,9 @@ class Article < ApplicationRecord
 
   def async_bust
     Articles::BustCacheJob.perform_later(id)
+  end
+
+  def compute_digest
+    self.body_markdown_digest = Digest::SHA1.hexdigest body_markdown
   end
 end

--- a/app/views/api/v0/articles/index.json.jbuilder
+++ b/app/views/api/v0/articles/index.json.jbuilder
@@ -1,18 +1,19 @@
 json.array! @articles do |article|
-  json.type_of            "article"
-  json.id                 article.id
-  json.title              article.title
-  json.description        article.description
-  json.cover_image        cloud_cover_url(article.main_image)
-  json.published_at       article.published_at
-  json.tag_list           article.cached_tag_list_array
-  json.slug               article.slug
-  json.path               article.path
-  json.url                article.url
-  json.canonical_url      article.processed_canonical_url
-  json.comments_count     article.comments_count
+  json.type_of                  "article"
+  json.id                       article.id
+  json.body_markdown_digest     article.body_markdown_digest
+  json.title                    article.title
+  json.description              article.description
+  json.cover_image              cloud_cover_url(article.main_image)
+  json.published_at             article.published_at
+  json.tag_list                 article.cached_tag_list_array
+  json.slug                     article.slug
+  json.path                     article.path
+  json.url                      article.url
+  json.canonical_url            article.processed_canonical_url
+  json.comments_count           article.comments_count
   json.positive_reactions_count article.positive_reactions_count
-  json.published_timestamp article.published_timestamp
+  json.published_timestamp      article.published_timestamp
 
   json.user do
     json.name             article.user.name

--- a/app/views/api/v0/articles/show.json.jbuilder
+++ b/app/views/api/v0/articles/show.json.jbuilder
@@ -22,6 +22,7 @@ json.last_comment_at    @article.last_comment_at&.utc&.iso8601
 
 json.body_html @article.processed_html
 json.body_markdown @article.body_markdown
+json.body_markdown_digest @article.body_markdown_digest
 json.ltag_style(@article.liquid_tags_used.map { |ltag| Rails.application.assets["ltags/#{ltag}.css"].to_s.html_safe })
 json.ltag_script(@article.liquid_tags_used.map { |ltag| ltag.script.html_safe })
 

--- a/db/migrate/20190709225714_add_body_markdown_digest_to_articles.rb
+++ b/db/migrate/20190709225714_add_body_markdown_digest_to_articles.rb
@@ -1,0 +1,9 @@
+class AddBodyMarkdownDigestToArticles < ActiveRecord::Migration[5.2]
+  def change
+    add_column :articles, :body_markdown_digest, :string, limit: 40, null: false
+
+    Article.find_each(:batch_size => 1000) do |article|
+      article.save!
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_09_192214) do
+ActiveRecord::Schema.define(version: 2019_07_09_225714) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -58,6 +58,7 @@ ActiveRecord::Schema.define(version: 2019_07_09_192214) do
     t.boolean "automatically_renew", default: false
     t.text "body_html"
     t.text "body_markdown"
+    t.string "body_markdown_digest", limit: 40, null: false
     t.jsonb "boost_states", default: {}, null: false
     t.text "cached_organization"
     t.string "cached_tag_list"

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -544,5 +544,21 @@ RSpec.describe Article, type: :model do
     end
   end
 
+  describe "body_markdown_digest" do
+    let(:article) { build(:article) }
+
+    it "returns the empty sha1sum when article is new" do
+      article.save
+      expect(article.body_markdown_digest).to eq("da39a3ee5e6b4b0d3255bfef95601890afd80709")
+    end
+
+    it "returns the sha1sum of the article body_markdown" do
+      body = "Hey hey Ho Ho"
+      article.body_markdown = body
+      article.save
+      expect(article.body_markdown_digest).to eq("2d6a066ef31b3328048bdd25ec896665a6bea972")
+    end
+  end
+
   include_examples "#sync_reactions_count", :article
 end

--- a/spec/requests/api/v0/articles_spec.rb
+++ b/spec/requests/api/v0/articles_spec.rb
@@ -74,6 +74,13 @@ RSpec.describe "Api::V0::Articles", type: :request do
       get "/api/articles?tag=#{tag.name}"
       expect(JSON.parse(response.body).size).to eq(0)
     end
+
+    it "returns body_markdown_digest in response" do
+      create(:article)
+      create(:article, featured: true)
+      get "/api/articles"
+      expect(JSON.parse(response.body)[0]["body_markdown_digest"]).to eq("da39a3ee5e6b4b0d3255bfef95601890afd80709")
+    end
   end
 
   describe "GET /api/articles/:id" do
@@ -83,10 +90,15 @@ RSpec.describe "Api::V0::Articles", type: :request do
       get "/api/articles/#{article.id}"
       expect(json_response["title"]).to eq(article.title)
     end
-    
+
     it "contains article markdown content" do
       get "/api/articles/#{article.id}"
       expect(json_response["body_markdown"]).to eq(article.body_markdown)
+    end
+
+    it "contains article body_markdown_digest" do
+      get "/api/articles/#{article.id}"
+      expect(json_response["body_markdown_digest"]).to eq(article.body_markdown_digest)
     end
 
     it "fails with an unpublished article" do


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
When developing a client that uses the dev.to API it is often necessary to determine if the articles on the local client need to be synchronised with the API. Currently the only way to do this is to iterate through the articles comparing the full text markdown which is inefficient. Instead by computing a sha1sum when saving the article, this can be computed by clients and compared with the API value. If it matches, no update is needed.

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/l46C6sdSa5DVSJnLG/giphy.gif)
