### PR TITLE
Moderators audit logs

### DIFF
--- a/app/controllers/concerns/audit_instrumentation.rb
+++ b/app/controllers/concerns/audit_instrumentation.rb
@@ -7,6 +7,9 @@ module AuditInstrumentation
         payload.user_id = user.id
         payload.roles = user.roles.pluck(:name)
         payload.slug = slug
+        if block_given?
+          payload.data = yield
+        end
       end
     end
   end

--- a/app/controllers/concerns/audit_instrumentation.rb
+++ b/app/controllers/concerns/audit_instrumentation.rb
@@ -1,0 +1,13 @@
+module AuditInstrumentation
+  extend ActiveSupport::Concern
+
+  included do
+    def notify(listener, user, slug)
+      Audit::Notification.notify(listener) do |payload|
+        payload.user_id = user.id
+        payload.roles = user.roles.pluck(:name)
+        payload.slug = slug
+      end
+    end
+  end
+end

--- a/app/controllers/internal/tags_controller.rb
+++ b/app/controllers/internal/tags_controller.rb
@@ -35,15 +35,11 @@ class Internal::TagsController < Internal::ApplicationController
     user = User.find(@remove_user_id)
     user.update(email_tag_mod_newsletter: false)
     AssignTagModerator.remove_tag_moderator(user, @tag)
-
-    notify(:internal, current_user, __method__) { tag_params.dup }
   end
 
   def add_moderator
     User.find(@add_user_id).update(email_tag_mod_newsletter: true)
     AssignTagModerator.add_tag_moderators([@add_user_id], [@tag.id])
-
-    notify(:internal, current_user, __method__) { tag_params.dup }
   end
 
   def tag_params

--- a/app/controllers/internal/tags_controller.rb
+++ b/app/controllers/internal/tags_controller.rb
@@ -1,4 +1,5 @@
 class Internal::TagsController < Internal::ApplicationController
+  include AuditInstrumentation
   layout "internal"
 
   def index
@@ -32,11 +33,15 @@ class Internal::TagsController < Internal::ApplicationController
     user = User.find(@remove_user_id)
     user.update(email_tag_mod_newsletter: false)
     AssignTagModerator.remove_tag_moderator(user, @tag)
+
+    notify(:internal, current_user, __method__)
   end
 
   def add_moderator
     User.find(@add_user_id).update(email_tag_mod_newsletter: true)
     AssignTagModerator.add_tag_moderators([@add_user_id], [@tag.id])
+
+    notify(:internal, current_user, __method__)
   end
 
   def tag_params

--- a/app/controllers/internal/tags_controller.rb
+++ b/app/controllers/internal/tags_controller.rb
@@ -24,6 +24,8 @@ class Internal::TagsController < Internal::ApplicationController
     add_moderator if @add_user_id
     remove_moderator if @remove_user_id
     @tag.update!(tag_params)
+
+    notify(:internal, current_user, __method__) { tag_params.dup }
     redirect_to "/internal/tags/#{params[:id]}"
   end
 
@@ -34,14 +36,14 @@ class Internal::TagsController < Internal::ApplicationController
     user.update(email_tag_mod_newsletter: false)
     AssignTagModerator.remove_tag_moderator(user, @tag)
 
-    notify(:internal, current_user, __method__)
+    notify(:internal, current_user, __method__) { tag_params.dup }
   end
 
   def add_moderator
     User.find(@add_user_id).update(email_tag_mod_newsletter: true)
     AssignTagModerator.add_tag_moderators([@add_user_id], [@tag.id])
 
-    notify(:internal, current_user, __method__)
+    notify(:internal, current_user, __method__) { tag_params.dup }
   end
 
   def tag_params

--- a/app/jobs/audit/save_to_persistent_storage_job.rb
+++ b/app/jobs/audit/save_to_persistent_storage_job.rb
@@ -10,9 +10,9 @@ module Audit
 
     def build_params(event)
       {
-        user_id: event.dig(:payload, :user_id),
-        roles: event.dig(:payload, :roles),
-        slug: event.dig(:payload, :slug),
+        user_id: event.payload[:user_id],
+        roles: event.payload[:roles],
+        slug: event.payload[:slug],
         category: event.name
       }
     end

--- a/app/jobs/audit/save_to_persistent_storage_job.rb
+++ b/app/jobs/audit/save_to_persistent_storage_job.rb
@@ -3,9 +3,18 @@ module Audit
     queue_as :audit_logs
 
     def perform(event_string)
-      event = Audit::Event::Util.deserialize(event_string)
+      Audit::Event::Util.deserialize(event_string).
+        then { |event| build_params(event) }.
+        then { |params| AuditLog.create!(params) }
+    end
 
-      AuditLog.create!(user_id: event.dig(:payload, :user_id), roles: event.dig(:payload, :roles))
+    def build_params(event)
+      {
+        user_id: event.dig(:payload, :user_id),
+        roles: event.dig(:payload, :roles),
+        slug: event.dig(:payload, :slug),
+        category: event.name
+      }
     end
   end
 end

--- a/app/jobs/audit/save_to_persistent_storage_job.rb
+++ b/app/jobs/audit/save_to_persistent_storage_job.rb
@@ -1,0 +1,11 @@
+module Audit
+  class SaveToPersistentStorageJob < ApplicationJob
+    queue_as :audit_logs
+
+    def perform(event_string)
+      event = Audit::Event::Util.deserialize(event_string)
+
+      AuditLog.create!(user_id: event.dig(:payload, :user_id), roles: event.dig(:payload, :roles))
+    end
+  end
+end

--- a/app/jobs/audit/save_to_persistent_storage_job.rb
+++ b/app/jobs/audit/save_to_persistent_storage_job.rb
@@ -13,7 +13,8 @@ module Audit
         user_id: event.payload[:user_id],
         roles: event.payload[:roles],
         slug: event.payload[:slug],
-        category: event.name
+        category: event.name,
+        data: event.payload[:data]
       }
     end
   end

--- a/app/models/audit_log.rb
+++ b/app/models/audit_log.rb
@@ -1,0 +1,5 @@
+class AuditLog < ApplicationRecord
+  belongs_to :user
+
+  validates :user_id, presence: true
+end

--- a/app/services/audit/event/payload.rb
+++ b/app/services/audit/event/payload.rb
@@ -5,7 +5,7 @@ module Audit
       # Definition of Event payload.
       #
       # New instance object is used as block parameter in Audit::Notification.notify method.
-      attr_accessor :user_id, :roles
+      attr_accessor :user_id, :roles, :slug
 
       ##
       # Use the initializer to define default values for the payload.
@@ -14,6 +14,7 @@ module Audit
 
         @user_id = data[:user_id]
         @roles = data[:roles] || []
+        @slug = data[:slug] || :undefined
       end
 
       class << self

--- a/app/services/audit/event/payload.rb
+++ b/app/services/audit/event/payload.rb
@@ -9,18 +9,12 @@ module Audit
 
       ##
       # Use the initializer to define default values for the payload.
-      def initialize(data = {})
-        data.to_options!
 
-        @user_id = data[:user_id]
-        @roles = data[:roles] || []
-        @slug = data[:slug] || :undefined
-      end
+      def initialize
+        @roles = []
+        @slug = :undefined
 
-      class << self
-        def empty
-          Payload.new
-        end
+        yield(self)
       end
     end
   end

--- a/app/services/audit/event/payload.rb
+++ b/app/services/audit/event/payload.rb
@@ -1,0 +1,26 @@
+module Audit
+  module Event
+    class Payload
+      ##
+      # Definition of Event payload.
+      #
+      # New instance object is used as block parameter in Audit::Notification.notify method.
+      attr_accessor :user_id, :roles
+
+      ##
+      # Use the initializer to define default values for the payload.
+      def initialize(data = {})
+        data.to_options!
+
+        @user_id = data[:user_id]
+        @roles = data[:roles] || []
+      end
+
+      class << self
+        def empty
+          Payload.new
+        end
+      end
+    end
+  end
+end

--- a/app/services/audit/event/payload.rb
+++ b/app/services/audit/event/payload.rb
@@ -5,7 +5,7 @@ module Audit
       # Definition of Event payload.
       #
       # New instance object is used as block parameter in Audit::Notification.notify method.
-      attr_accessor :user_id, :roles, :slug
+      attr_accessor :user_id, :roles, :slug, :data
 
       ##
       # Use the initializer to define default values for the payload.
@@ -13,6 +13,7 @@ module Audit
       def initialize
         @roles = []
         @slug = :undefined
+        @data = {}
 
         yield(self)
       end

--- a/app/services/audit/event/util.rb
+++ b/app/services/audit/event/util.rb
@@ -1,0 +1,48 @@
+module Audit
+  module Event
+    class Util
+      class << self
+        ##
+        # These class methods are only used to serialize the object send toward
+        # ActiveJob. Up until Rails 6, Rails cannot serialize Time objects,
+        # therefore we need custom serialization.
+        #
+        # Additional method is used as Warning, which helps to notify when it is
+        # save to remove this custom serialization for ActiveSupport::Notifications::Event object
+        # more at: https://edgeapi.rubyonrails.org/classes/ActiveJob/Serializers/ObjectSerializer.html
+        # and https://edgeapi.rubyonrails.org/classes/ActiveJob/SerializationError.html
+        # for supported class instances
+
+        def deserialize(string)
+          obsolete_usage_warn
+
+          ActiveSupport::JSON.decode(string).deep_symbolize_keys.tap do |h|
+            h[:time] = Time.zone.iso8601(h[:time])
+            h[:end] = Time.zone.iso8601(h[:end])
+          end.deep_symbolize_keys!
+        end
+
+        def serialize(event)
+          obsolete_usage_warn
+
+          ActiveSupport::JSON.encode event
+        end
+
+        private
+
+        def obsolete_usage_warn
+          warn_message = <<-WARN.strip_heredoc
+            This Util class becomes obsolete from Rails 6.
+            Rails 6 adds out of the box, support for Active Job message serialization
+            for class like Time.
+
+            You can save delete this Util class and remove the usage from
+            Audit::Notification.listen method, or in any other places
+          WARN
+
+          Rails.logger.warn(warn_message) if Rails.version.match?(/\A6.\d.\w+/)
+        end
+      end
+    end
+  end
+end

--- a/app/services/audit/helper.rb
+++ b/app/services/audit/helper.rb
@@ -1,0 +1,9 @@
+module Audit
+  module Helper
+    NOTIFICATION_SUFFIX = ".audit.log".freeze
+
+    def instrument_name(name)
+      "#{name}#{NOTIFICATION_SUFFIX}"
+    end
+  end
+end

--- a/app/services/audit/notification.rb
+++ b/app/services/audit/notification.rb
@@ -21,14 +21,12 @@ module Audit
       # Audit::Notification.notify('listener_name') do |payload|
       #   payload.user_id = current_user.id
       #   payload.roles = current_user.roles.pluck(:name)
-
-      #   payload
       # end
 
-      def notify(listener)
+      def notify(listener, &block)
         return unless block_given?
 
-        ActiveSupport::Notifications.instrument(instrument_name(listener), yield(Audit::Event::Payload.empty))
+        ActiveSupport::Notifications.instrument(instrument_name(listener), Audit::Event::Payload.new(&block))
       end
 
       ##

--- a/app/services/audit/notification.rb
+++ b/app/services/audit/notification.rb
@@ -1,0 +1,45 @@
+module Audit
+  class Notification
+    ##
+    # Main class for wrapping ActiveSupport Instrumentation API.
+    #
+    # This class represent main entry point for receiving and notifying custom
+    # events, implemented according to
+    # https://guides.rubyonrails.org/active_support_instrumentation.html#creating-custom-events
+
+    class << self
+      include Audit::Helper
+
+      ##
+      # Audit::Notification.notify method, receives listener name, which is registered through
+      # Audit::Notification.listen and the event payload, passed as a block.
+      #
+      # Object of Audit::Event::Payload is send to the block as argument. This way,
+      # the payload object follows the rules defined in Audit::Event::Payload
+      #
+      # Example:
+      # Audit::Notification.notify('listener_name') do |payload|
+      #   payload.user_id = current_user.id
+      #   payload.roles = current_user.roles.pluck(:name)
+
+      #   payload
+      # end
+
+      def notify(listener)
+        return unless block_given?
+
+        ActiveSupport::Notifications.instrument(instrument_name(listener), yield(Audit::Event::Payload.empty))
+      end
+
+      ##
+      # Audit::Notification.listen receives Events sent from ActiveSupport Instrumentation API.
+      # Then, this event is serialized and send to background job.
+
+      def listen(*args)
+        ActiveSupport::Notifications::Event.new(*args).
+          then { |event| Audit::Event::Util.serialize(event) }.
+          then { |event_job| Audit::SaveToPersistentStorageJob.perform_later(event_job) }
+      end
+    end
+  end
+end

--- a/app/services/audit/subscribe.rb
+++ b/app/services/audit/subscribe.rb
@@ -1,0 +1,19 @@
+module Audit
+  class Subscribe
+    class << self
+      include Audit::Helper
+
+      def listen(*listeners)
+        listeners.each do |listener|
+          ActiveSupport::Notifications.subscribe(instrument_name(listener)) do |*args|
+            Audit::Notification.listen(*args)
+          end
+        end
+      end
+
+      def forget(*listeners)
+        listeners.each { |listener| ActiveSupport::Notifications.unsubscribe(instrument_name(listener)) }
+      end
+    end
+  end
+end

--- a/config/initializers/audit_events.rb
+++ b/config/initializers/audit_events.rb
@@ -6,4 +6,4 @@
 # Example:
 # Audit::Subscribe.listen :admin, :quest_user
 
-Audit::Subscribe.listen :moderator unless Rails.env.test?
+Audit::Subscribe.listen(:moderator, :internal) unless Rails.env.test?

--- a/config/initializers/audit_events.rb
+++ b/config/initializers/audit_events.rb
@@ -1,0 +1,9 @@
+##
+# Custom Audit Instrumentation
+#
+# Put here all custom listener names, for later usage in Audit Instrumentation
+#
+# Example:
+# Audit::Subscribe.listen :admin, :quest_user
+
+Audit::Subscribe.listen :moderator unless Rails.env.test?

--- a/db/migrate/20190708105607_create_audit_logs.rb
+++ b/db/migrate/20190708105607_create_audit_logs.rb
@@ -1,0 +1,10 @@
+class CreateAuditLogs < ActiveRecord::Migration[5.2]
+  def change
+    create_table :audit_logs do |t|
+      t.references :user, foreign_key: true
+      t.string :roles, array: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190801132654_add_additional_columns_to_audit_log.rb
+++ b/db/migrate/20190801132654_add_additional_columns_to_audit_log.rb
@@ -1,0 +1,6 @@
+class AddAdditionalColumnsToAuditLog < ActiveRecord::Migration[5.2]
+  def change
+    add_column(:audit_logs, :slug, :string)
+    add_column(:audit_logs, :category, :string)
+  end
+end

--- a/db/migrate/20190906193806_add_jsonb_data_column_to_audit_logs.rb
+++ b/db/migrate/20190906193806_add_jsonb_data_column_to_audit_logs.rb
@@ -1,0 +1,6 @@
+class AddJsonbDataColumnToAuditLogs < ActiveRecord::Migration[5.2]
+  def change
+    add_column :audit_logs, :data, :jsonb, null: false, default: {}
+    add_index :audit_logs, :data, using: :gin
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -146,8 +146,10 @@ ActiveRecord::Schema.define(version: 2019_09_18_104106) do
   end
 
   create_table "audit_logs", force: :cascade do |t|
+    t.string "category"
     t.datetime "created_at", null: false
     t.string "roles", array: true
+    t.string "slug"
     t.datetime "updated_at", null: false
     t.bigint "user_id"
     t.index ["user_id"], name: "index_audit_logs_on_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -145,6 +145,14 @@ ActiveRecord::Schema.define(version: 2019_09_18_104106) do
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 
+  create_table "audit_logs", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "roles", array: true
+    t.datetime "updated_at", null: false
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_audit_logs_on_user_id"
+  end
+
   create_table "backup_data", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.bigint "instance_id", null: false
@@ -1178,6 +1186,7 @@ ActiveRecord::Schema.define(version: 2019_09_18_104106) do
     t.index ["user_id"], name: "index_webhook_endpoints_on_user_id"
   end
 
+  add_foreign_key "audit_logs", "users"
   add_foreign_key "badge_achievements", "badges"
   add_foreign_key "badge_achievements", "users"
   add_foreign_key "chat_channel_memberships", "chat_channels"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -148,10 +148,12 @@ ActiveRecord::Schema.define(version: 2019_09_18_104106) do
   create_table "audit_logs", force: :cascade do |t|
     t.string "category"
     t.datetime "created_at", null: false
+    t.jsonb "data", default: {}, null: false
     t.string "roles", array: true
     t.string "slug"
     t.datetime "updated_at", null: false
     t.bigint "user_id"
+    t.index ["data"], name: "index_audit_logs_on_data", using: :gin
     t.index ["user_id"], name: "index_audit_logs_on_user_id"
   end
 

--- a/spec/factories/activesupport_events.rb
+++ b/spec/factories/activesupport_events.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :activesupport_event, class: ActiveSupport::Notifications::Event do
+    name { "audit.log" }
+    time { Timecop.freeze(Time.zone.now) }
+    ending { time + 10.seconds }
+    transaction_id { Faker::Crypto.md5 }
+    payload { {} }
+
+    initialize_with { new(name, time, ending, transaction_id, payload) }
+  end
+end

--- a/spec/factories/audit_logs.rb
+++ b/spec/factories/audit_logs.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :audit_log do
+  end
+end

--- a/spec/models/audit_log_spec.rb
+++ b/spec/models/audit_log_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe AuditLog, type: :model do
+  let(:user) { create(:user) }
+  let(:audit_log) { create(:audit_log, user_id: user.id) }
+
+  it { is_expected.to belong_to(:user) }
+  it { is_expected.to validate_presence_of(:user_id) }
+end

--- a/spec/requests/internal/moderator_logs_spec.rb
+++ b/spec/requests/internal/moderator_logs_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe "/internal/tags", type: :request do
+  let(:super_admin) { create(:user, :super_admin) }
+  let(:tag_moderator) { create(:user) }
+  let(:tag) { create(:tag) }
+  let(:listener) { :internal }
+
+  before do
+    tag
+    sign_in super_admin
+    Audit::Subscribe.listen listener
+  end
+
+  after do
+    Audit::Subscribe.forget listener
+  end
+
+  describe "POST /internal/tag/:id" do
+    [
+      {
+        tag_key: :tag_moderator_id,
+        name: :add_moderator
+      },
+      {
+        tag_key: :remove_moderator_id,
+        name: :remove_moderator
+      },
+      {
+        tag_key: :short_summary,
+        name: :update
+      },
+    ].each do |action|
+      it "creates entry for #{action[:name]} action" do
+        params = {
+          tag: Hash[action[:tag_key], tag_moderator.id.to_s]
+        }
+
+        allow(AssignTagModerator).to receive(:add_tag_moderators)
+
+        perform_enqueued_jobs do
+          put "/internal/tags/#{tag.id}", params: params
+          log = AuditLog.find_by(user_id: super_admin.id, slug: action[:name])
+          expect(log.data.symbolize_keys).to eq(params[:tag])
+        end
+      end
+    end
+  end
+end

--- a/spec/services/audit/event/util_spec.rb
+++ b/spec/services/audit/event/util_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe Audit::Event::Util, type: :service do
+  let(:utils) { described_class }
+  let!(:event) { build(:activesupport_event) }
+
+  describe "Serialization" do
+    it "evaluates to same object" do
+      event_dup = event.dup
+      compare_to = utils.deserialize(utils.serialize(event))
+
+      expect(event_dup.time.iso8601.in_time_zone).to eq(compare_to[:time].iso8601)
+      expect(event_dup.end.iso8601.in_time_zone).to eq(compare_to[:end].iso8601)
+    end
+  end
+end

--- a/spec/services/audit/event/util_spec.rb
+++ b/spec/services/audit/event/util_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe Audit::Event::Util, type: :service do
 
   describe "Serialization" do
     it "evaluates to same object" do
-      event_dup = event.dup
       compare_to = utils.deserialize(utils.serialize(event))
 
-      expect(event_dup.time.iso8601.in_time_zone).to eq(compare_to[:time].iso8601)
-      expect(event_dup.end.iso8601.in_time_zone).to eq(compare_to[:end].iso8601)
+      expect(event.class).to eq(compare_to.class)
+      expect(event.time.iso8601.in_time_zone).to eq(compare_to.time.iso8601)
+      expect(event.end.iso8601.in_time_zone).to eq(compare_to.end.iso8601)
     end
   end
 end

--- a/spec/services/audit/helper_spec.rb
+++ b/spec/services/audit/helper_spec.rb
@@ -1,0 +1,7 @@
+require "rails_helper"
+
+RSpec.describe Audit::Helper, type: :service do
+  it "has a notification suffix" do
+    expect(Audit::Helper::NOTIFICATION_SUFFIX).not_to be nil
+  end
+end

--- a/spec/services/audit/notification_spec.rb
+++ b/spec/services/audit/notification_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+RSpec.describe Audit::Notification, type: :service do
+  let!(:listener) { Faker::Alphanumeric.alpha(10) }
+  let(:user) { build(:user, :admin) }
+  let(:queue_name) { Audit::SaveToPersistentStorageJob.queue_name }
+  let(:job_class) { Audit::SaveToPersistentStorageJob }
+
+  before do
+    Audit::Subscribe.listen listener
+  end
+
+  after do
+    Audit::Subscribe.forget listener
+  end
+
+  def notify
+    described_class.notify(listener) do |payload|
+      payload.user_id = user.id
+      payload.roles = user.roles.pluck(:name)
+
+      payload
+    end
+  end
+
+  describe "Publishing and receiving events" do
+    context "when payload is missing" do
+      it "event is not created" do
+        allow(described_class).to receive(:listen)
+        described_class.notify(listener)
+
+        expect(described_class).not_to have_received(:listen)
+      end
+    end
+
+    context "when payload is present" do
+      it "receives an event" do
+        allow(described_class).to receive(:listen)
+        notify
+
+        expect(described_class).to have_received(:listen)
+      end
+    end
+  end
+
+  describe "Queueing job for saving an event" do
+    it "can enqueue job on dedicated queue name" do
+      expect { notify }.to have_enqueued_job(job_class).on_queue(queue_name.to_s)
+    end
+  end
+
+  describe "Saving to database" do
+    it "creates an AuditLog record" do
+      user.save
+      perform_enqueued_jobs do
+        notify
+      end
+
+      event_record = AuditLog.find_by(user_id: user.id)
+      expect(event_record.user).to eq(user)
+      expect(event_record.roles).to eq(user.roles.pluck(:name))
+    end
+  end
+end

--- a/spec/services/audit/notification_spec.rb
+++ b/spec/services/audit/notification_spec.rb
@@ -18,8 +18,6 @@ RSpec.describe Audit::Notification, type: :service do
     described_class.notify(listener) do |payload|
       payload.user_id = user.id
       payload.roles = user.roles.pluck(:name)
-
-      payload
     end
   end
 

--- a/spec/services/audit/subscribe_spec.rb
+++ b/spec/services/audit/subscribe_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe Audit::Subscribe, type: :service do
+  let(:notifications) { ActiveSupport::Notifications }
+  let(:listeners) { %i[moderator visitor] }
+  let(:listener_suffix) { Audit::Helper::NOTIFICATION_SUFFIX }
+
+  before do
+    listeners.each do |listener|
+      allow(notifications).to receive(:subscribe).with([listener, listener_suffix].join)
+    end
+  end
+
+  it "can subscribe to custom listeners" do
+    described_class.listen(*listeners)
+
+    listeners.each do |listener|
+      expect(notifications).to have_received(:subscribe).with([listener, listener_suffix].join)
+    end
+  end
+end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Wrapper classes are created under `Audit` namespace, which are able to use the internal Rails Instrumentation [API](https://guides.rubyonrails.org/active_support_instrumentation.html#rails)

To be done:
- [ ] Documentation
- [ ] Definition of Event payloads

## Related Tickets & Documents
Fixes #3141 

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [ ] no documentation needed

