### PR TITLE
Add inverted styling for social links in night mode on 'Key Links' page

### DIFF
--- a/app/views/pages/information.html.erb
+++ b/app/views/pages/information.html.erb
@@ -27,6 +27,8 @@
   .social-links {
     text-align: center;
     padding: 40px 0px;
+    filter: invert(0);
+	  filter: var(--theme-social-icon-invert, invert(0));
   }
 
   .social-links img {


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
Fixes #3456.

Styling applied to social links is based on the solution from PR #2209.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
Before:
![before](https://user-images.githubusercontent.com/35671299/61095239-ece1b800-a452-11e9-9c37-8f4c161d2f36.png)

After:
![after](https://user-images.githubusercontent.com/35671299/61095244-f1a66c00-a452-11e9-9669-bb36b7546fb8.png)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
