### PR TITLE
Fix ampersand not being escaped in Twitter share from the hamburger menu

### DIFF
--- a/app/views/articles/_actions.html.erb
+++ b/app/views/articles/_actions.html.erb
@@ -59,7 +59,8 @@
         </div>
         <web-share-wrapper shareurl="https://dev.to<%= @article.path %>" sharetext="<%= @article.title %>" template="web-share-button">
           <div class="dropdown-link-row">
-            <a target="_blank" href='https://twitter.com/intent/tweet?text="<%= @article.title %>" by <%= @article.user.twitter_username ? "@" + @article.user.twitter_username : @article.user.name %> %23DEVcommunity https://dev.to<%= @article.path %>'>
+            <a target="_blank"
+               href='https://twitter.com/intent/tweet?text="<%= u @article.title.strip %>" by <%= @article.user.twitter_username ? "@" + @article.user.twitter_username : @article.user.name %> %23DEVcommunity https://dev.to<%= @article.path %>'>
               Share to Twitter
             </a>
           </div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Ampersand is not escaped on Twitter share from the hamburger menu.

## Related Tickets & Documents
Resolves #3451

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
N/A

## Added to documentation?
- [x] no documentation needed
