### PR TITLE
Add missing "dev-badge" class for proper night mode styling

### DIFF
--- a/app/views/pages/badges.html.erb
+++ b/app/views/pages/badges.html.erb
@@ -33,7 +33,7 @@
     <% if user_signed_in? %>
       <p>
         <a href="https://dev.to/<%= current_user.username %>">
-          <img src="https://d2fltix0v2e0sb.cloudfront.net/dev-badge.svg" alt="<%= current_user.name %>'s DEV Profile" height="30" width="30">
+          <img src="https://d2fltix0v2e0sb.cloudfront.net/dev-badge.svg" alt="<%= current_user.name %>'s DEV Profile" height="30" width="30" class="dev-badge">
         </a>
       </p>
       <p>
@@ -64,7 +64,7 @@
       </p>
     <% else %>
       <p>
-        <img src="https://d2fltix0v2e0sb.cloudfront.net/dev-badge.svg" height="30" width="30" />
+        <img src="https://d2fltix0v2e0sb.cloudfront.net/dev-badge.svg" height="30" width="30" alt="DEV badge" class="dev-badge" />
       </p>
       <h2 style="text-align:center;">
         <a href="/enter">Log in to view your custom embed code</a>

--- a/app/views/pages/badges.html.erb
+++ b/app/views/pages/badges.html.erb
@@ -64,7 +64,7 @@
       </p>
     <% else %>
       <p>
-        <img src="https://d2fltix0v2e0sb.cloudfront.net/dev-badge.svg" height="30" width="30" alt="DEV badge" class="dev-badge" />
+        <img src="https://d2fltix0v2e0sb.cloudfront.net/dev-badge.svg" height="30" width="30" alt="DEV badge" class="dev-badge">
       </p>
       <h2 style="text-align:center;">
         <a href="/enter">Log in to view your custom embed code</a>


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
Added missing `class="dev-badge"` for DEV badges on [this page](https://dev.to/p/badges). This makes the badges display correctly, in white, when night mode is enabled. See the screenshots below for reference.

I also added a missing `alt` to one of the badges, for accessibility reasons, and removed an unnecessary tag closing.

### Further thoughts
On the page, we give instructions for how users can implement the DEV badge on their own website. However, this is only for the black DEV badge, since I guess there are no actual white ones (the `class="dev-badge"` only adds a filter for night mode.

Should we somehow explain how a white badge can be achieved as well—like the one they're seeing if they're using night mode—or should we leave this for the user to figure out?

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
**Before**:
![badge before](https://user-images.githubusercontent.com/35671299/61151004-1b0fd800-a4e5-11e9-81ef-15a5f09aaee1.png)

**After**:
![badge after](https://user-images.githubusercontent.com/35671299/61151008-1c410500-a4e5-11e9-8733-0ef4615c1137.png)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![Yay, it's Friday!](https://media.giphy.com/media/NCWULdPUFIJ3y/giphy.gif)