### PR TITLE
Redirect to actual latest published thread

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -94,7 +94,10 @@ class PagesController < ApplicationController
   private # helpers
 
   def latest_published_thread(tag_name)
-    Article.published.where(user_id: ApplicationConfig["DEVTO_USER_ID"]).tagged_with(tag_name).last
+    Article.published.
+      where(user_id: ApplicationConfig["DEVTO_USER_ID"]).
+      order("published_at ASC").
+      tagged_with(tag_name).last
   end
 
   def members_for_display

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -75,8 +75,10 @@ RSpec.describe "Pages", type: :request do
   end
 
   describe "GET /welcome" do
-    it "redirects to the first welcome thread" do
+    it "redirects to the latest welcome thread" do
       user = create(:user, id: 1)
+      earlier_welcome_thread = create(:article, user: user, tags: "welcome")
+      earlier_welcome_thread.update(published_at: Time.current - 1.week)
       latest_welcome_thread = create(:article, user: user, tags: "welcome")
       get "/welcome"
 
@@ -85,8 +87,10 @@ RSpec.describe "Pages", type: :request do
   end
 
   describe "GET /challenge" do
-    it "redirects to the first challenge thread" do
+    it "redirects to the latest challenge thread" do
       user = create(:user, id: 1)
+      earlier_challenge_thread = create(:article, user: user, tags: "challenge")
+      earlier_challenge_thread.update(published_at: Time.current - 1.week)
       latest_challenge_thread = create(:article, user: user, tags: "challenge")
       get "/challenge"
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This fixes a bug where the latest published welcome / challenge thread SQL query was pulling the last article by ID and not by publish date.

## [optional] What gif best describes this PR or how it makes you feel?

![Stephen Colbert on the Late Show taps his watch and signals, "it's looping."](https://media.giphy.com/media/1XdfVRTyn5d31Q1lG0/giphy-downsized.gif)