### PR TITLE
Cache bust the article's path and add minor improvement for banishing

### DIFF
--- a/app/labor/cache_buster.rb
+++ b/app/labor/cache_buster.rb
@@ -42,6 +42,7 @@ class CacheBuster
 
   def bust_article(article)
     bust("/" + article.user.username)
+    bust(article.path)
     bust(article.path + "/")
     bust(article.path + "?i=i")
     bust(article.path + "/?i=i")

--- a/app/services/moderator/manage_activity_and_roles.rb
+++ b/app/services/moderator/manage_activity_and_roles.rb
@@ -38,6 +38,7 @@ module Moderator
         end
         article.remove_algolia_index
         article.delete
+        article.purge
       end
       virtual_articles.each do |article|
         cachebuster.bust_article(article)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
TLDR; this fixes a bug where articles that were cleared with the `CacheBuster.bust_article` method did not have it's direct path `article.path` cleared.

Along with the fix above, I wanted to test out a new method of clearing caches -- credit to @maestromac for thinking of this. We rely on "manual cache clearing", which basically means we clear caches by URL directly. Fastly has a gem that's fairly old, but does a lot of cache clearing under the hood.

Anyway, it has a `purge` method which clears/purges the cache for you, theoretically. I think it's fairly safe to use it, but figured we should test it out in the banisher first. If we agree that it's a good way of clearing caches, I think we should move our from direct URL cache clearing to this, or use a combination of both.

## How does the PR make me feel?
![A man crosses his fingers and looks into the camera like, "Please, this is it, right?"](https://media.giphy.com/media/2AM7sPypVqsfTIemSa/giphy-downsized.gif)