### PR TITLE
A temp rake task to update podcast statuses

### DIFF
--- a/lib/tasks/temporary/podcasts.rake
+++ b/lib/tasks/temporary/podcasts.rake
@@ -1,7 +1,7 @@
 desc "A task to check potentially unplayable podcasts and update their and their episodes' statuses if needed"
 
 task update_podcasts_statuses: :environment do
-  Podcast.where("status_notice ilike %may not be playable%").pluck(:id).find_each do |podcast_id|
-    Podcasts::GetEpisodesJob.new(podcast_id: podcast_id, limit: 1000, force_update: true).perform_later
+  Podcast.where("status_notice ILIKE ?", "%may not be playable%").pluck(:id).each do |podcast_id|
+    Podcasts::GetEpisodesJob.perform_later(podcast_id: podcast_id, limit: 1000, force_update: true)
   end
 end

--- a/lib/tasks/temporary/podcasts.rake
+++ b/lib/tasks/temporary/podcasts.rake
@@ -1,0 +1,7 @@
+desc "A task to check potentially unplayable podcasts and update their and their episodes' statuses if needed"
+
+task update_podcasts_statuses: :environment do
+  Podcast.where("status_notice ilike %may not be playable%").pluck(:id).find_each do |podcast_id|
+    Podcasts::GetEpisodesJob.new(podcast_id: podcast_id, limit: 1000, force_update: true).perform_later
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
We need to re-check the podcasts' availability and set the episodes' and podcasts' statuses accordingly. The task goes through the podcasts that were marked as possibly unplayable before and schedules jobs to re-check them.
The task needs to be run once.

## Related Tickets & Documents
#2952 
