### PR TITLE
Use each instead of find_each to keep order

### DIFF
--- a/app/views/pages/sponsors.html.erb
+++ b/app/views/pages/sponsors.html.erb
@@ -35,7 +35,7 @@
       <img src="<%= cloudinary("https://thepracticaldev.s3.amazonaws.com/i/2zmukvll98je8qsdyewq.png", 30) %>" alt="golden badge">
     </h4>
     <div id="gold-sponsors">
-      <% Sponsorship.gold.includes(:organization).order(featured_number: :asc).find_each do |sponsorship| %>
+      <% Sponsorship.gold.includes(:organization).order(featured_number: :asc).each do |sponsorship| %>
         <a href="<%= sponsorship.url %>"><img src="<%= cloudinary(sponsorship.organization.nav_image_url, 250) %>"></a>
         <p>
           <%= sponsorship.blurb_html.html_safe %>
@@ -50,7 +50,7 @@
       <img src="<%= cloudinary("https://thepracticaldev.s3.amazonaws.com/i/2zmukvll98je8qsdyewq.png", 30) %>" alt="silver badge">
     </h4>
     <div id="silver-sponsors">
-      <% Sponsorship.silver.includes(:organization).order(featured_number: :asc).find_each do |sponsorship| %>
+      <% Sponsorship.silver.includes(:organization).order(featured_number: :asc).each do |sponsorship| %>
         <a href="<%= sponsorship.url %>"><img src="<%= cloudinary(sponsorship.organization.nav_image_url, 250) %>"></a>
         <p>
           <%= sponsorship.blurb_html.html_safe %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This fixes a bug where the order of sponsors was not correct. TIL that `.find_each` nullifies some SQL queries, like `.order` and `.select`, for example.

I originally had a test to go with this but it added 9 to 13 seconds. to our CI. IMO it's just not worth it...
```ruby
describe "GET /sponsors" do
    it "shows the sponsors in order of their featured number" do
      3.times do |i|
        create(:sponsorship, level: "gold", blurb_html: "gold-sponsor-#{i + 1}", featured_number: i + 1)
      end
      get "/sponsors"
      # only check the div.body to avoid timestamps and weird SVG IDs
      html = Nokogiri::HTML(response.body).search(".body")
      Approvals.verify(html, name: "sponsors", format: :html)
    end
  end
```