### PR TITLE
Remove logic relying on old podcast status

### DIFF
--- a/app/views/podcast_episodes/show.html.erb
+++ b/app/views/podcast_episodes/show.html.erb
@@ -73,7 +73,7 @@
     </div>
   </div>
   <%# checking both podcast_episode and podcast status for now  %>
-  <% if !@episode.https? || @episode.podcast.status_notice.to_s.include?("may not be playable") %>
+  <% unless @episode.https? %>
     <center>
       <h1 style="color: #e05252;">
         <%= I18n.t "podcasts.statuses.unplayable" %>

--- a/lib/tasks/temporary/podcasts.rake
+++ b/lib/tasks/temporary/podcasts.rake
@@ -1,7 +1,0 @@
-desc "A task to check potentially unplayable podcasts and update their and their episodes' statuses if needed"
-
-task update_podcasts_statuses: :environment do
-  Podcast.where("status_notice ILIKE ?", "%may not be playable%").pluck(:id).each do |podcast_id|
-    Podcasts::GetEpisodesJob.perform_later(podcast_id: podcast_id, limit: 1000, force_update: true)
-  end
-end

--- a/spec/system/podcasts/user_visits_podcast_episode_spec.rb
+++ b/spec/system/podcasts/user_visits_podcast_episode_spec.rb
@@ -18,14 +18,6 @@ RSpec.describe "User visits podcast show page", type: :system do
   end
 
   context "when episode may not be playable" do
-    it "displays the status_notice" do
-      podcast = create(:podcast, status_notice: "This podcast may not be playable in the browser")
-      podcast_episode = create(:podcast_episode, podcast_id: podcast.id)
-      visit podcast_episode.path.to_s
-      expect(page).to have_text(I18n.t("podcasts.statuses.unplayable"))
-      expect(page).to have_text("Click here to download")
-    end
-
     it "displays status when episode is not reachable by https" do
       podcast_episode = create(:podcast_episode, https: false)
       visit podcast_episode.path.to_s


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
There are no podcasts left with the "This podcast may not be playable in the browser" status notice, so in this pr I removed the logic related to it. The new status notices are more specific about the podcast's status.
I have also removed the temporary task to update podcasts' statuses.

## Related Tickets & Documents
#2952 