### PR TITLE
Open "buy credits" link in new tab in creating listings

### DIFF
--- a/app/views/classified_listings/_form.html.erb
+++ b/app/views/classified_listings/_form.html.erb
@@ -78,7 +78,7 @@
         <h3>Listings Require Credits</h3>
       <% end %>
       <div class="listings-current-credits-inner">
-        You have <%= pluralize @credits.size, "credit" %> available — <a target="_blank" href="/credits/purchase" data-no-instant>Buy More</a>
+        You have <%= pluralize @credits.size, "credit" %> available — <a target="_blank" rel="noopener noreferrer" href="/credits/purchase" data-no-instant>Buy More</a>
       </div>
       <% if @organizations.present? %>
         <div class="listings-current-credits-inner">
@@ -88,7 +88,7 @@
           <% end %>
         </select>
         has <span id="org-credits-number"><%= @organizations.first.unspent_credits_count %></span> credits -
-          <a id="org-credits-purchase-link" target="_blank" href="/credits/purchase?organization_id=<%= @organizations.first.id %>" data-no-instant>Buy More</a>
+          <a id="org-credits-purchase-link" target="_blank" rel="noopener noreferrer" href="/credits/purchase?organization_id=<%= @organizations.first.id %>" data-no-instant>Buy More</a>
         </div>
         <%= javascript_pack_tag "orgCreditsSelector", defer: true %>
       <% end %>

--- a/app/views/classified_listings/_form.html.erb
+++ b/app/views/classified_listings/_form.html.erb
@@ -78,7 +78,7 @@
         <h3>Listings Require Credits</h3>
       <% end %>
       <div class="listings-current-credits-inner">
-        You have <%= pluralize @credits.size, "credit" %> available — <a href="/credits/purchase" data-no-instant>Buy More</a>
+        You have <%= pluralize @credits.size, "credit" %> available — <a target="_blank" href="/credits/purchase" data-no-instant>Buy More</a>
       </div>
       <% if @organizations.present? %>
         <div class="listings-current-credits-inner">
@@ -88,7 +88,7 @@
           <% end %>
         </select>
         has <span id="org-credits-number"><%= @organizations.first.unspent_credits_count %></span> credits -
-          <a id="org-credits-purchase-link" href="/credits/purchase?organization_id=<%= @organizations.first.id %>" data-no-instant>Buy More</a>
+          <a id="org-credits-purchase-link" target="_blank" href="/credits/purchase?organization_id=<%= @organizations.first.id %>" data-no-instant>Buy More</a>
         </div>
         <%= javascript_pack_tag "orgCreditsSelector", defer: true %>
       <% end %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor

## Description
Adds target=_blank to buy credit links in create a listings page to open in new tab/window.

## Related Tickets & Documents
#3454 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
N/A

## Added to documentation?

- [x] no documentation needed

