### PR TITLE
Make unsure specs more confident about time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ branches:
   only:
     - master
 before_install:
-  - date
+  - date --rfc-3339=seconds
   - nvm install
 install:
   - bundle install --path vendor/bundle

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ branches:
   only:
     - master
 before_install:
+  - date
   - nvm install
 install:
   - bundle install --path vendor/bundle

--- a/spec/services/analytics_service_spec.rb
+++ b/spec/services/analytics_service_spec.rb
@@ -5,7 +5,18 @@ RSpec.describe AnalyticsService, type: :service do
   let(:organization) { create(:organization) }
   let(:article) { create(:article, user: user, published: true) }
 
-  before { Timecop.freeze(Time.current.utc) }
+  before do
+    # We use Zonebie to fortify the code and spot time zone related problems but in this
+    # particular case it can make these tests fail because,
+    # for example, "2019-07-21T23:57:12-12:00" is the 22th in UTC, and since
+    # the code delegates to DATE() in PostgreSQL which runs on UTC without time zone
+    # info, there's no easy way for these tests to work correctly in a time zone on
+    # the day line like "International Date Line West".
+    # For this reason data created on "2019-07-21T23:57:12-12:00" will appear on the 22nd in the DB
+    # and hence never be selected by the Analytics engine
+    # In the meantime for a lack of a better solution, we force this tests to run at midday in UTC
+    Timecop.freeze("2019-04-01T12:00:00Z")
+  end
 
   after { Timecop.return }
 

--- a/spec/services/credits/ledger_spec.rb
+++ b/spec/services/credits/ledger_spec.rb
@@ -20,16 +20,18 @@ RSpec.describe Credits::Ledger do
   end
 
   it "returns a list of user purchases with their costs" do
-    start = Time.current
-    buy(user, user_listing, 3)
+    Timecop.freeze(Time.current) do
+      start = Time.current
+      buy(user, user_listing, 3)
 
-    items = described_class.call(user)[[User.name, user.id]]
-    expect(items.length).to be(1)
+      items = described_class.call(user)[[User.name, user.id]]
+      expect(items.length).to be(1)
 
-    item = items.first
-    expect(item.purchase.is_a?(ClassifiedListing)).to be(true)
-    expect(item.cost).to eq(3)
-    expect(item.purchased_at >= start).to eq(true)
+      item = items.first
+      expect(item.purchase.is_a?(ClassifiedListing)).to be(true)
+      expect(item.cost).to eq(3)
+      expect(item.purchased_at.to_i >= start.to_i).to eq(true)
+    end
   end
 
   it "returns a list of purchases for the org the user is an admin for" do

--- a/spec/services/notifications/reactions/send_spec.rb
+++ b/spec/services/notifications/reactions/send_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Notifications::Reactions::Send, type: :service do
 
   context "when a reaction is persisted and has siblings" do
     before do
-      create(:reaction, reactable: article, user: user3)
+      create(:reaction, reactable: article, user: user3, created_at: Time.current - 1.day)
     end
 
     it "creates a notification" do
@@ -87,10 +87,10 @@ RSpec.describe Notifications::Reactions::Send, type: :service do
       end
 
       it "updates the notification" do
-        now = Time.current
+        old_notified_at = old_notification.notified_at
         described_class.call(reaction_data(article_reaction), user)
         old_notification.reload
-        expect(old_notification.notified_at).to be > now
+        expect(old_notification.notified_at).to be > old_notified_at
       end
 
       it "updates the notification json" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
We faced a problem in the #3449 pr build. Some of the tests related to time checking fail on Travis.
You can reproduce the problem by checking out the branch and running all the service specs:
```
bundle exec rspec spec/services
```
Fixes
- made notifications reactions tests more "confident" about the time
- use `Timecop.freeze` to avoid timezone issues
- compare time in seconds for credits ledger spec
- `date` in `before_install` to see in which moment in time the CI build has run



## Related Tickets & Documents
#3449 