### PR TITLE
Remove double string escape by removing stip_tags from title

### DIFF
--- a/app/liquid_tags/link_tag.rb
+++ b/app/liquid_tags/link_tag.rb
@@ -4,7 +4,7 @@ class LinkTag < LiquidTagBase
 
   def initialize(_tag_name, slug_or_path_or_url, _tokens)
     @article = get_article(slug_or_path_or_url)
-    @title = strip_tags(@article.title)
+    @title = @article.title
   end
 
   def render(_context)

--- a/spec/liquid_tags/link_tag_spec.rb
+++ b/spec/liquid_tags/link_tag_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe LinkTag, type: :liquid_template do
         </a>
         <a href='#{article.path}' class='ltag__link__link'>
           <div class='ltag__link__content'>
-            <h2>#{ActionController::Base.helpers.sanitize(article.title)}</h2>
+            <h2>#{"".html_safe+article.title}</h2>
             <h3>#{article.user.name} ・ #{article.readable_publish_date} ・ #{article.reading_time} min read</h3>
             <div class='ltag__link__taglist'>
               #{tags}

--- a/spec/liquid_tags/link_tag_spec.rb
+++ b/spec/liquid_tags/link_tag_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe LinkTag, type: :liquid_template do
            organization_id: org.id)
   end
   let(:escaped_article) do
-      create(:article, user_id: user.id, title: "Hello & Hi <3", tags: "tag")
+      create(:article, user_id: user.id, title: "Hello & Hi <3 <script>", tags: "tag")
   end
 
   def generate_new_liquid(slug)
@@ -97,6 +97,6 @@ RSpec.describe LinkTag, type: :liquid_template do
   it "escapes title" do
     liquid = generate_new_liquid("/#{user.username}/#{escaped_article.slug}/")
     render = liquid.render
-    expect(render).to include("Hello &amp; Hi &lt;")
+    expect(render).to include("Hello &amp; Hi &lt; &lt;script&gt;")
   end
 end

--- a/spec/liquid_tags/link_tag_spec.rb
+++ b/spec/liquid_tags/link_tag_spec.rb
@@ -96,7 +96,6 @@ RSpec.describe LinkTag, type: :liquid_template do
 
   it "escapes title" do
     liquid = generate_new_liquid("/#{user.username}/#{escaped_article.slug}/")
-    render = liquid.render
-    expect(render).to include("Hello &amp; Hi &lt; &lt;script&gt;")
+    expect(liquid.render).to eq(correct_link_html(escaped_article))
   end
 end

--- a/spec/liquid_tags/link_tag_spec.rb
+++ b/spec/liquid_tags/link_tag_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe LinkTag, type: :liquid_template do
         </a>
         <a href='#{article.path}' class='ltag__link__link'>
           <div class='ltag__link__content'>
-            <h2>#{"".html_safe+article.title}</h2>
+            <h2>#{CGI.escapeHTML(article.title)}</h2>
             <h3>#{article.user.name} ・ #{article.readable_publish_date} ・ #{article.reading_time} min read</h3>
             <div class='ltag__link__taglist'>
               #{tags}

--- a/spec/liquid_tags/link_tag_spec.rb
+++ b/spec/liquid_tags/link_tag_spec.rb
@@ -9,7 +9,10 @@ RSpec.describe LinkTag, type: :liquid_template do
   let(:org_user) { create(:user, organization_id: org.id) }
   let(:org_article) do
     create(:article, user_id: org_user.id, title: "test this please", tags: "tag1 tag2 tag3",
-                     organization_id: org.id)
+           organization_id: org.id)
+  end
+  let(:escaped_article) do
+      create(:article, user_id: user.id, title: "Hello & Hi <3", tags: "tag")
   end
 
   def generate_new_liquid(slug)
@@ -17,7 +20,7 @@ RSpec.describe LinkTag, type: :liquid_template do
     Liquid::Template.parse("{% link #{slug} %}")
   end
 
-  def correct_link_html(article)
+  def correct_link_html(article) # Note: strip_tags also escapes '&'
     tags = article.tag_list.map { |t| "<span class='ltag__link__tag'>##{t}</span>" }.reverse.join
     <<~HTML
       <div class='ltag__link'>
@@ -28,7 +31,7 @@ RSpec.describe LinkTag, type: :liquid_template do
         </a>
         <a href='#{article.path}' class='ltag__link__link'>
           <div class='ltag__link__content'>
-            <h2>#{ActionController::Base.helpers.strip_tags(article.title)}</h2>
+            <h2>#{ActionController::Base.helpers.sanitize(article.title)}</h2>
             <h3>#{article.user.name} ・ #{article.readable_publish_date} ・ #{article.reading_time} min read</h3>
             <div class='ltag__link__taglist'>
               #{tags}
@@ -89,5 +92,11 @@ RSpec.describe LinkTag, type: :liquid_template do
   it "renders with a full link with a trailing slash" do
     liquid = generate_new_liquid("https://dev.to/#{user.username}/#{article.slug}/")
     expect(liquid.render).to eq(correct_link_html(article))
+  end
+
+  it "escapes title and tags" do
+    liquid = generate_new_liquid("/#{user.username}/#{escaped_article.slug}/")
+    render = liquid.render
+    expect(render).to include("Hello &amp; Hi &lt;")
   end
 end

--- a/spec/liquid_tags/link_tag_spec.rb
+++ b/spec/liquid_tags/link_tag_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe LinkTag, type: :liquid_template do
     Liquid::Template.parse("{% link #{slug} %}")
   end
 
-  def correct_link_html(article) # Note: strip_tags also escapes '&'
+  def correct_link_html(article)
     tags = article.tag_list.map { |t| "<span class='ltag__link__tag'>##{t}</span>" }.reverse.join
     <<~HTML
       <div class='ltag__link'>
@@ -94,7 +94,7 @@ RSpec.describe LinkTag, type: :liquid_template do
     expect(liquid.render).to eq(correct_link_html(article))
   end
 
-  it "escapes title and tags" do
+  it "escapes title" do
     liquid = generate_new_liquid("/#{user.username}/#{escaped_article.slug}/")
     render = liquid.render
     expect(render).to include("Hello &amp; Hi &lt;")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Documentation Update

## Description

Remove the call to strip_tags on the title of the article, because the string gets escaped a second time in `/app/views/articles/_liquid.html.erb`.

## Related Tickets & Documents

Fixes #3508

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed
