### PR TITLE
Remove unnecessary `pluck` calls

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -164,7 +164,7 @@ class StoriesController < ApplicationController
       return
     end
     assign_user_comments
-    @pinned_stories = Article.published.where(id: @user.profile_pins.pluck(:pinnable_id)).
+    @pinned_stories = Article.published.where(id: @user.profile_pins.select(:pinnable_id)).
       limited_column_select.
       order("published_at DESC").decorate
     @stories = ArticleDecorator.decorate_collection(@user.articles.published.

--- a/app/services/messages/send_push.rb
+++ b/app/services/messages/send_push.rb
@@ -11,10 +11,8 @@ module Messages
     end
 
     def call
-      receiver_ids = chat_channel.chat_channel_memberships.
-        where.not(user_id: user.id).pluck(:user_id)
-
-      PushNotificationSubscription.where(user_id: receiver_ids).find_each do |sub|
+      receivers = chat_channel.chat_channel_memberships.where.not(user_id: user.id).select(:user_id)
+      PushNotificationSubscription.where(user_id: receivers).find_each do |sub|
         break if no_push_necessary?(sub)
 
         Webpush.payload_send(

--- a/app/services/notifications/new_follower/send.rb
+++ b/app/services/notifications/new_follower/send.rb
@@ -31,7 +31,7 @@ module Notifications
           notification_params[:organization_id] = followable_id
         end
 
-        followers = User.where(id: recent_follows.pluck(:follower_id))
+        followers = User.where(id: recent_follows.select(:follower_id))
         aggregated_siblings = followers.map { |f| user_data(f) }
         if aggregated_siblings.size.zero?
           notification = Notification.find_by(notification_params)&.destroy

--- a/app/services/suggester/users/sidebar.rb
+++ b/app/services/suggester/users/sidebar.rb
@@ -14,7 +14,7 @@ module Suggester
             where("positive_reactions_count > ?", reaction_count).
             where("published_at > ?", 4.months.ago).
             where("user_id != ?", user.id).
-            where.not(user_id: user.following_by_type("User").pluck(:id)).
+            where.not(user_id: user.following_by_type("User")).
             pluck(:user_id)
           group_one = User.select(:id, :name, :username, :profile_image, :summary).
             where(id: user_ids).

--- a/spec/services/messages/send_push_spec.rb
+++ b/spec/services/messages/send_push_spec.rb
@@ -8,7 +8,12 @@ RSpec.describe Messages::SendPush do
 
   before do
     create(:chat_channel_membership, user_id: user2.id, chat_channel_id: chat_channel.id)
-    PushNotificationSubscription.create(user_id: user2.id, endpoint: "http://nowhere.togo", p256dh_key: "BBoN_OkTfE_0uObue", auth_key: "aW1hcm    thcmF", notification_type: "browser")
+    PushNotificationSubscription.create(
+      user_id: user2.id,
+      endpoint: "http://nowhere.togo", p256dh_key: "BBoN_OkTfE_0uObue",
+      auth_key: "aW1hcm    thcmF",
+      notification_type: "browser"
+    )
     allow(Webpush).to receive(:payload_send).and_return(true)
   end
 
@@ -21,7 +26,8 @@ RSpec.describe Messages::SendPush do
 
   context "when push is not necessary" do
     before do
-      PushNotificationSubscription.last.user.chat_channel_memberships.order("last_opened_at DESC").first.update(last_opened_at: 3.seconds.ago)
+      membership = PushNotificationSubscription.last.user.chat_channel_memberships.order("last_opened_at DESC").first
+      membership.update(last_opened_at: 3.seconds.ago)
     end
 
     it "does not push subscription message" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

`pluck` is very useful to load in memory a list of IDs, without building AR objects in the process.

However, in the case of `WHERE id IN ()` statements, AR, combining lazy loading and magic, will build the correct subquery instead of loading AR objects, effectively using 1 instead of 2 queries (the one to select the IDs and the one to filter the other set).

Hence, if those IDs are not needed for other purposes, `pluck` has no real advantage.

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
