### PR TITLE
Refactor the Spotify playlist option

### DIFF
--- a/app/liquid_tags/spotify_tag.rb
+++ b/app/liquid_tags/spotify_tag.rb
@@ -1,12 +1,13 @@
 class SpotifyTag < LiquidTagBase
   PARTIAL = "liquids/spotify".freeze
-  URI_REGEXP = /spotify:(track|artist|album|episode|show):\w{22}/.freeze
-  URI_PLAYLIST_REGEXP = /spotify:(user):([a-zA-Z0-9]+):playlist:\w{22}/.freeze
+  URI_REGEXP = /spotify:(track|artist|playlist|album|episode|show):\w{22}/.freeze
+  URI_PLAYLIST_REGEXP = /spotify:(user):([a-zA-Z0-9]+):playlist:\w{22}/.freeze # legacy support
   TYPE_HEIGHT = {
     track: 80,
     user: 380,
     artist: 380,
     album: 380,
+    playlist: 380,
     episode: 232,
     show: 232
   }.freeze

--- a/app/views/pages/api.html.erb
+++ b/app/views/pages/api.html.erb
@@ -145,10 +145,10 @@ https://dev.to/api/articles</code></pre></div>
     Create an article on behalf an organisation
   </h3>
 
-  <p>Just add <code>publish_under_org</code> as <code>true</code> to the JSON request:</p>
+  <p>Just add <code>organization_id: your_org_id</code> to the JSON request:</p>
   <div class="highlight"><pre class="highlight plaintext"><code class="language-bash">curl -X POST -H "Content-Type: application/json" \
 -H "api-key: ACCESS_TOKEN" \
--d '{"article": {"title": "Title", "body_markdown": "Body", "published": false, "publish_under_org": true}}' \
+-d '{"article": {"title": "Title", "body_markdown": "Body", "published": false, "organization_id": 99999}}' \
 https://dev.to/api/articles</code></pre></div>
   <h3>
     <a name="using-the-front-matter" href="#using-the-front-matter" class="anchor">
@@ -172,7 +172,7 @@ This is an intro about JavaScript</code></pre></div>
 
   <div class="highlight"><pre class="highlight plaintext"><code class="language-bash">curl -X POST -H "Content-Type: application/json" \
 -H "api-key: ACCESS_TOKEN" \
--d '{"article": {"body_markdown": "---\ntitle: A sample article about...\npublished: false\n...", "publish_under_org": true}}' \
+-d '{"article": {"body_markdown": "---\ntitle: A sample article about...\npublished: false\n---\n..."}}' \
 https://dev.to/api/articles</code></pre></div>
 
   <p>The front matter will take precedence on other JSON params with the same name.</p>
@@ -189,7 +189,7 @@ body_markdown: The Markdown body, with or without a front matter (string, requir
 published: True if the article should be published right away, defaults to false (boolean, optional)
 tags: A list of tags for the article (array, optional)
 series: The name of the series the article should be published within (string, optional)
-publish_under_org: True if the article should be placed under the organization belonging to the user creating the article, defaults to false (boolean, optional)
+organization_id: Your organization's ID, if you wish to create an article under an organization (string, optional)
 main_image: URL of the image to use as the cover (string, optional)
 canonical_url: canonical URL of the article (string, optional)</code></pre></div>
   <h3>
@@ -285,7 +285,7 @@ description: Description of the article (optional)
 body_markdown: The Markdown body, with or without a front matter (required)
 published: True if the article should be published right away, defaults to false (optional)
 series: The name of the series the article should be published within (optional)
-publish_under_org: True if the article should be placed under the organization belonging to the user creating the article, defaults to false (optional)
+organization_id: Your organization's ID, if you wish to create an article under an organization (string, optional)
 main_image: URL of the image to use as the cover (optional)
 canonical_url: canonical URL of the article (optional)</code></pre></div>
   <h3>

--- a/spec/liquid_tags/spotify_tag_spec.rb
+++ b/spec/liquid_tags/spotify_tag_spec.rb
@@ -3,7 +3,8 @@ require "rails_helper"
 RSpec.describe SpotifyTag, type: :liquid_template do
   describe "#link" do
     let(:valid_uri) { "spotify:track:0K1UpnetfCKtcNu37rJmCg" }
-    let(:valid_playlist_uri) { "spotify:user:spotify:playlist:37i9dQZF1E36t2Deh8frhL" }
+    let(:valid_playlist_uri) { "spotify:playlist:37i9dQZF1E36t2Deh8frhL" }
+    let(:legacy_playlist_uri) { "spotify:user:spotify:playlist:37i9dQZF1E36t2Deh8frhL" }
     let(:invalid_uri) { "asdfasdf:asdfasdf:asdfasdf" }
 
     def generate_tag(link)
@@ -36,6 +37,10 @@ RSpec.describe SpotifyTag, type: :liquid_template do
 
     it "does not raise an error if the playlist uri is valid" do
       expect { generate_tag(valid_playlist_uri) }.not_to raise_error
+    end
+
+    it "does not raise an error for a legacy playlist URI" do
+      expect { generate_tag(legacy_playlist_uri) }.not_to raise_error
     end
 
     it "raises an error if the uri is invalid" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
Currently the Spotify tag takes a playlist URI, but it's a bit cryptic and was not added to the editor guide at the time. I played around with it and it seems for whatever reason that there is now a simpler way to embed playlists.

My guess is that the previous iteration relied on Spotify's playlist URI `spotify.com/user/:username/playlist/:playlist_code` which they have now updated to something simpler: `spotify.com/playlist/:playlist_code`

Also updates the API page with the latest info on publishing under an organization.