### PR TITLE
Podcast ownership

### DIFF
--- a/app/controllers/internal/podcasts_controller.rb
+++ b/app/controllers/internal/podcasts_controller.rb
@@ -1,0 +1,40 @@
+class Internal::PodcastsController < Internal::ApplicationController
+  layout "internal"
+
+  def index
+    @podcasts = Podcast.order("created_at DESC").page(params[:page]).per(50)
+    @podcasts = @podcasts.where("podcasts.title ILIKE :search", search: "%#{params[:search]}%") if params[:search].present?
+  end
+
+  def edit
+    @podcast = Podcast.find(params[:id])
+  end
+
+  def update
+    @podcast = Podcast.find(params[:id])
+    if @podcast.update(podcast_params)
+      redirect_to internal_podcast_path(@podcast), notice: "Всё супер-ок"
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  # TODO: implement
+  def remove_admin
+    # user.remove_role(:podcast_admin, podcast)
+  end
+
+  # TODO: implement
+  def add_admin
+    # user.add_role(:podcast_admin, podcast)
+  end
+
+  def podcast_params
+    allowed_params = %i[
+      title feed_url
+    ]
+    params.require(:podcast).permit(allowed_params)
+  end
+end

--- a/app/controllers/internal/podcasts_controller.rb
+++ b/app/controllers/internal/podcasts_controller.rb
@@ -16,7 +16,7 @@ class Internal::PodcastsController < Internal::ApplicationController
 
   def update
     if @podcast.update(podcast_params)
-      redirect_to internal_podcast_path(@podcast), notice: "Всё супер-ок"
+      redirect_to internal_podcasts_path, notice: "Podcast updated"
     else
       render :edit
     end

--- a/app/controllers/internal/podcasts_controller.rb
+++ b/app/controllers/internal/podcasts_controller.rb
@@ -1,17 +1,16 @@
 class Internal::PodcastsController < Internal::ApplicationController
   layout "internal"
 
+  before_action :find_podcast, only: %i[edit update remove_admin add_admin]
+
   def index
     @podcasts = Podcast.order("created_at DESC").page(params[:page]).per(50)
     @podcasts = @podcasts.where("podcasts.title ILIKE :search", search: "%#{params[:search]}%") if params[:search].present?
   end
 
-  def edit
-    @podcast = Podcast.find(params[:id])
-  end
+  def edit; end
 
   def update
-    @podcast = Podcast.find(params[:id])
     if @podcast.update(podcast_params)
       redirect_to internal_podcast_path(@podcast), notice: "Всё супер-ок"
     else
@@ -19,16 +18,38 @@ class Internal::PodcastsController < Internal::ApplicationController
     end
   end
 
-  private
-
-  # TODO: implement
   def remove_admin
-    # user.remove_role(:podcast_admin, podcast)
+    user = User.find_by(id: params[:podcast][:user_id])
+    unless user
+      redirect_to edit_internal_podcast_path(@podcast), notice: "No such user"
+      return
+    end
+    removed_roles = user.remove_role(:podcast_admin, @podcast)
+    if removed_roles.empty?
+      redirect_to internal_podcast_path(@podcast), notice: "Error"
+    else
+      redirect_to internal_podcasts_path, notice: "Removed roles"
+    end
   end
 
-  # TODO: implement
   def add_admin
-    # user.add_role(:podcast_admin, podcast)
+    user = User.find_by(id: params[:user_id])
+    unless user
+      redirect_to edit_internal_podcast_path(@podcast), notice: "No such user"
+      return
+    end
+    role = user.add_role(:podcast_admin, @podcast)
+    if role.persisted?
+      redirect_to internal_podcasts_path, notice: "Added role"
+    else
+      redirect_to internal_podcast_path(@podcast), notice: "Error"
+    end
+  end
+
+  private
+
+  def find_podcast
+    @podcast = Podcast.find(params[:id])
   end
 
   def podcast_params

--- a/app/models/podcast.rb
+++ b/app/models/podcast.rb
@@ -1,4 +1,6 @@
 class Podcast < ApplicationRecord
+  resourcify
+
   has_many :podcast_episodes
 
   mount_uploader :image, ProfileImageUploader
@@ -27,6 +29,10 @@ class Podcast < ApplicationRecord
       or(PodcastEpisode.where(guid: item.guid.to_s)).presence
     episode ||= PodcastEpisode.where(website_url: item.link).presence if unique_website_url?
     episode.to_a.first
+  end
+
+  def admins
+    User.with_role(:podcast_admin, self)
   end
 
   private

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -27,6 +27,7 @@ class Role < ApplicationRecord
                 chatroom_beta_tester
                 comment_banned
                 pro
+                podcast_admin
               ]
             }
   scopify

--- a/app/views/internal/podcasts/edit.html.erb
+++ b/app/views/internal/podcasts/edit.html.erb
@@ -1,0 +1,43 @@
+<h1>
+  <%= link_to @podcast.title, "/#{@podcast.slug}" %>
+</h1>
+<% if @podcast.admins.any? %>
+  <p><strong>Admins: </strong></p>
+  <ul>
+    <% @podcast.admins.each do |admin| %>
+      <%= form_for @podcast, url: remove_admin_internal_podcast_path(@podcast.id), html: { method: :delete } do |f| %>
+        <li>
+          <%= link_to "@#{admin.username}", "/#{admin.username}" %>
+          <%= f.hidden_field :user_id, value: admin.id %>
+          <%= f.submit "Remove" %>
+        </li>
+        <br>
+      <% end %>
+    <% end %>
+  </ul>
+<% else %>
+  <p>There are no admins for this podcast.</p>
+<% end %>
+
+<%= form_tag add_admin_internal_podcast_path(@podcast.id) do %>
+  <div>
+    <%= label_tag "Add Admin (by user_id) " %>
+    <%= text_field_tag :user_id %>
+    <%= submit_tag "Add Admin" %>
+  </div>
+<% end %>
+
+<%= form_for [:internal, @podcast] do |f| %>
+  <hr>
+  <div>
+    <%= f.label :title %>
+    <%= f.text_field :title %>
+  </div>
+  <div>
+    <%= f.label :feed_url %>
+    <%= f.text_field :feed_url %>
+  </div>
+  <div>
+    <%= f.submit %>
+  </div>
+<% end %>

--- a/app/views/internal/podcasts/edit.html.erb
+++ b/app/views/internal/podcasts/edit.html.erb
@@ -19,11 +19,11 @@
   <p>There are no admins for this podcast.</p>
 <% end %>
 
-<%= form_tag add_admin_internal_podcast_path(@podcast.id) do %>
+<%= form_for @podcast, url: add_admin_internal_podcast_path(@podcast.id), html: { method: :post } do |f| %>
   <div>
-    <%= label_tag "Add Admin (by user_id) " %>
-    <%= text_field_tag :user_id %>
-    <%= submit_tag "Add Admin" %>
+    <%= f.label "Add Admin (by user_id) " %>
+    <%= f.text_field :user_id %>
+    <%= f.submit "Add Admin" %>
   </div>
 <% end %>
 

--- a/app/views/internal/podcasts/edit.html.erb
+++ b/app/views/internal/podcasts/edit.html.erb
@@ -22,7 +22,7 @@
 <%= form_for @podcast, url: add_admin_internal_podcast_path(@podcast.id), html: { method: :post } do |f| %>
   <div>
     <%= f.label "Add Admin (by user_id) " %>
-    <%= f.text_field :user_id %>
+    <%= f.text_field :user_id, value: "" %>
     <%= f.submit "Add Admin" %>
   </div>
 <% end %>

--- a/app/views/internal/podcasts/index.html.erb
+++ b/app/views/internal/podcasts/index.html.erb
@@ -14,7 +14,7 @@
 
 <%= paginate @podcasts %>
 <br>
-<div style="font-weight: 600; border-bottom: 2px solid black; display: grid; grid-template-columns: 5% 15% 25% 10% 10% 20% 15%;">
+<div class="wrapper-7" style="font-weight: 600; border-bottom: 2px solid black;">
   <div>ID</div>
   <div>Title</div>
   <div>Feed URL</div>
@@ -25,14 +25,18 @@
 </div>
 
 <% @podcasts.each do |podcast| %>
-  <div style="border-bottom: 1px solid grey; padding: 10px; display: grid; grid-template-columns: 5% 15% 25% 10% 10% 20% 15%;">
+  <div class="wrapper-7" style="border-bottom: 1px solid grey; padding: 10px;">
     <div class="grid-item"><%= podcast.id %></div>
     <div class="grid-item"><a href="<%= edit_internal_podcast_path(podcast) %>"><%= podcast.title %></a></div>
     <div class="grid-item"><a href="<%= podcast.feed_url %>"><%= podcast.feed_url %></a></div>
     <div class="grid-item"><%= podcast.podcast_episodes.count %></div>
     <div class="grid-item"><%= podcast.reachable %></div>
     <div class="grid-item"><%= podcast.status_notice %></div>
-    <div class="grid-item"><%= podcast.admins.pluck(:id) %></div>
+    <div class="grid-item">
+      <% podcast.admins.pluck(:username).each do |username| %>
+        <%= link_to "@#{username}", "/#{username}" %>
+      <% end %>
+    </div>
   </div>
 <% end %>
 <%= paginate @podcasts %>

--- a/app/views/internal/podcasts/index.html.erb
+++ b/app/views/internal/podcasts/index.html.erb
@@ -27,7 +27,7 @@
 <% @podcasts.each do |podcast| %>
   <div style="border-bottom: 1px solid grey; padding: 10px; display: grid; grid-template-columns: 5% 15% 25% 10% 10% 20% 15%;">
     <div class="grid-item"><%= podcast.id %></div>
-    <div class="grid-item"><a href="<%= internal_podcast_path(podcast) %>"><%= podcast.title %></a></div>
+    <div class="grid-item"><a href="<%= edit_internal_podcast_path(podcast) %>"><%= podcast.title %></a></div>
     <div class="grid-item"><a href="<%= podcast.feed_url %>"><%= podcast.feed_url %></a></div>
     <div class="grid-item"><%= podcast.podcast_episodes.count %></div>
     <div class="grid-item"><%= podcast.reachable %></div>

--- a/app/views/internal/podcasts/index.html.erb
+++ b/app/views/internal/podcasts/index.html.erb
@@ -1,0 +1,38 @@
+<style>
+  .alert {
+    border: 2px red solid;
+  }
+</style>
+
+<h1>Podcasts</h1>
+
+<%= form_tag("/internal/podcasts", method: "get") do %>
+  <%= label_tag(:search, "Find by title:") %>
+  <%= text_field_tag(:search, params[:search]) %>
+  <%= submit_tag("Search") %>
+<% end %>
+
+<%= paginate @podcasts %>
+<br>
+<div style="font-weight: 600; border-bottom: 2px solid black; display: grid; grid-template-columns: 5% 15% 25% 10% 10% 20% 15%;">
+  <div>ID</div>
+  <div>Title</div>
+  <div>Feed URL</div>
+  <div>Episodes</div>
+  <div>Reachable</div>
+  <div>Status Notice</div>
+  <div>Admins</div>
+</div>
+
+<% @podcasts.each do |podcast| %>
+  <div style="border-bottom: 1px solid grey; padding: 10px; display: grid; grid-template-columns: 5% 15% 25% 10% 10% 20% 15%;">
+    <div class="grid-item"><%= podcast.id %></div>
+    <div class="grid-item"><a href="<%= internal_podcast_path(podcast) %>"><%= podcast.title %></a></div>
+    <div class="grid-item"><a href="<%= podcast.feed_url %>"><%= podcast.feed_url %></a></div>
+    <div class="grid-item"><%= podcast.podcast_episodes.count %></div>
+    <div class="grid-item"><%= podcast.reachable %></div>
+    <div class="grid-item"><%= podcast.status_notice %></div>
+    <div class="grid-item"><%= podcast.admins.pluck(:id) %></div>
+  </div>
+<% end %>
+<%= paginate @podcasts %>

--- a/app/views/layouts/internal.html.erb
+++ b/app/views/layouts/internal.html.erb
@@ -42,6 +42,12 @@
     padding: 2px;
   }
 
+  .wrapper-7 {
+    display: grid;
+    grid-template-columns: 5% 15% 25% 10% 10% 20% 15%;
+    padding: 2px;
+  }
+
   .wrapper-3 {
     display: grid;
     grid-template-columns: 25% 40% 25%%;

--- a/app/views/layouts/internal.html.erb
+++ b/app/views/layouts/internal.html.erb
@@ -143,6 +143,7 @@
         <% controller_names.each do |name| %>
           <li class="<%= "active" if controller_name == name %>"><a href="/internal/<%= name %>"><%= name %></a></li>
         <% end %>
+        <li class="<%= "active" if controller_name == "podcasts" %>"><a href="/internal/podcasts">pod</a></li>
       </ul>
     </div><!--/.nav-collapse -->
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,12 @@ Rails.application.routes.draw do
     resources :feedback_messages, only: %i[index show]
     resources :listings, only: %i[index edit update destroy], controller: "classified_listings"
     resources :pages, only: %i[index new create edit update destroy]
-    resources :podcasts, only: %i[index edit update destroy]
+    resources :podcasts, only: %i[index edit update destroy] do
+      member do
+        post :add_admin
+        delete :remove_admin
+      end
+    end
     resources :reactions, only: [:update]
     resources :chat_channels, only: %i[index create update]
     resources :reports, only: %i[index show], controller: "feedback_messages" do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
     resources :feedback_messages, only: %i[index show]
     resources :listings, only: %i[index edit update destroy], controller: "classified_listings"
     resources :pages, only: %i[index new create edit update destroy]
+    resources :podcasts, only: %i[index edit update destroy]
     resources :reactions, only: [:update]
     resources :chat_channels, only: %i[index create update]
     resources :reports, only: %i[index show], controller: "feedback_messages" do

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_11_070019) do
+ActiveRecord::Schema.define(version: 2019_07_23_094834) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -667,6 +667,7 @@ ActiveRecord::Schema.define(version: 2019_07_11_070019) do
     t.string "website_url"
     t.index ["guid"], name: "index_podcast_episodes_on_guid", unique: true
     t.index ["media_url"], name: "index_podcast_episodes_on_media_url", unique: true
+    t.index ["podcast_id"], name: "index_podcast_episodes_on_podcast_id"
   end
 
   create_table "podcasts", id: :serial, force: :cascade do |t|

--- a/spec/models/podcast_spec.rb
+++ b/spec/models/podcast_spec.rb
@@ -107,4 +107,30 @@ RSpec.describe Podcast, type: :model do
       expect(podcast.existing_episode(item)).to eq(nil)
     end
   end
+
+  describe "#admins" do
+    let(:podcast) { create(:podcast) }
+    let(:podcast2) { create(:podcast) }
+    let(:podcast3) { create(:podcast) }
+    let(:user) { create(:user) }
+    let(:user2) { create(:user) }
+    let(:user3) { create(:user) }
+
+    before do
+      user.add_role(:podcast_admin, podcast)
+      user2.add_role(:podcast_admin, podcast)
+      user.add_role(:podcast_admin, podcast3)
+      user3.add_role(:podcast_admin, podcast2)
+      user3.add_role(:podcast_admin, podcast2)
+      [user, user2, user3].each(&:save)
+    end
+
+    it "returns proper admins" do
+      expect(podcast.admins.sort).to eq([user, user2].sort)
+    end
+
+    it "returns proper admins for podcast3" do
+      expect(podcast3.admins).to eq([user])
+    end
+  end
 end

--- a/spec/requests/internal/podcasts_spec.rb
+++ b/spec/requests/internal/podcasts_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe "/internal/podcasts", type: :request do
+  describe "PUT /internal/podcasts/:id" do
+    let(:admin) { create(:user, :super_admin) }
+    let(:podcast) { create(:podcast) }
+    let(:user) { create(:user) }
+
+    before do
+      sign_in admin
+    end
+
+    it "adds an admin" do
+      expect do
+        post add_admin_internal_podcast_path(podcast.id), params: { podcast: { user_id: user.id } }
+      end.to change(Role, :count).by(1)
+      user.reload
+      expect(user.has_role?(:podcast_admin, podcast)).to be true
+    end
+
+    it "does nothing when adding an admin for non-existent user" do
+      post add_admin_internal_podcast_path(podcast.id), params: { podcast: { user_id: user.id + 1 } }
+      expect(response).to redirect_to(edit_internal_podcast_path(podcast))
+    end
+
+    it "removes an admin" do
+      user.add_role(:podcast_admin, podcast)
+      expect do
+        delete remove_admin_internal_podcast_path(podcast.id), params: { podcast: { user_id: user.id } }
+      end.to change(Role, :count).by(-1)
+      expect(user.has_role?(:podcast_admin, podcast)).to be false
+    end
+
+    it "does nothing when removing an admin for non-existent user" do
+      delete remove_admin_internal_podcast_path(podcast.id), params: { podcast: { user_id: user.id + 1 } }
+      expect(response).to redirect_to(edit_internal_podcast_path(podcast))
+    end
+  end
+end

--- a/spec/requests/internal/podcasts_spec.rb
+++ b/spec/requests/internal/podcasts_spec.rb
@@ -1,15 +1,27 @@
 require "rails_helper"
 
 RSpec.describe "/internal/podcasts", type: :request do
-  describe "PUT /internal/podcasts/:id" do
-    let(:admin) { create(:user, :super_admin) }
-    let(:podcast) { create(:podcast) }
-    let(:user) { create(:user) }
+  let(:admin) { create(:user, :super_admin) }
+  let(:podcast) { create(:podcast) }
+  let(:user) { create(:user) }
 
+  before do
+    sign_in admin
+  end
+
+  describe "GET /internal/podcasts" do
     before do
-      sign_in admin
+      create_list(:podcast, 3)
+      user.add_role(:podcast_admin, Podcast.order("random()").first)
     end
 
+    it "renders success" do
+      get internal_podcasts_path
+      expect(response).to be_success
+    end
+  end
+
+  describe "Adding admin" do
     it "adds an admin" do
       expect do
         post add_admin_internal_podcast_path(podcast.id), params: { podcast: { user_id: user.id } }
@@ -22,7 +34,9 @@ RSpec.describe "/internal/podcasts", type: :request do
       post add_admin_internal_podcast_path(podcast.id), params: { podcast: { user_id: user.id + 1 } }
       expect(response).to redirect_to(edit_internal_podcast_path(podcast))
     end
+  end
 
+  describe "Removing admin" do
     it "removes an admin" do
       user.add_role(:podcast_admin, podcast)
       expect do
@@ -34,6 +48,20 @@ RSpec.describe "/internal/podcasts", type: :request do
     it "does nothing when removing an admin for non-existent user" do
       delete remove_admin_internal_podcast_path(podcast.id), params: { podcast: { user_id: user.id + 1 } }
       expect(response).to redirect_to(edit_internal_podcast_path(podcast))
+    end
+  end
+
+  describe "Updating" do
+    it "updates" do
+      put internal_podcast_path(podcast), params: { podcast: { title: "hello", feed_url: "https://pod.example.com/rss.rss" } }
+      podcast.reload
+      expect(podcast.title).to eq("hello")
+      expect(podcast.feed_url).to eq("https://pod.example.com/rss.rss")
+    end
+
+    it "redirects after update" do
+      put internal_podcast_path(podcast), params: { podcast: { title: "hello", feed_url: "https://pod.example.com/rss.rss" } }
+      expect(response).to redirect_to(internal_podcasts_path)
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
- defined Podcast admins
- implemented basic internal podcasts section
- adding and removing podcast admins from `internal`

I implemented a basic user interface similar to adding tag moderators, it can be improved, at least adding admins by their usernames.

## Related Tickets & Documents
#3537 

## Screenshots
![изображение](https://user-images.githubusercontent.com/30115/61947764-c2454280-afae-11e9-9efa-f689c9b68bcb.png)

![изображение](https://user-images.githubusercontent.com/30115/61947911-14866380-afaf-11e9-8d67-0e46f80528e1.png)

