### PR TITLE
Make window.currentUser available globally

### DIFF
--- a/app/javascript/packs/onboardingRedirectCheck.jsx
+++ b/app/javascript/packs/onboardingRedirectCheck.jsx
@@ -25,7 +25,10 @@ function onboardingSkippable(currentUser) {
 
 document.ready.then(
   getUserDataAndCsrfToken()
-    .then(({ currentUser }) => {
+    .then(({ currentUser, csrfToken }) => {
+      window.currentUser = currentUser;
+      window.csrfToken = csrfToken;
+
       if (redirectableLocation() && !onboardingSkippable(currentUser)) {
         window.location = `${window.location.origin}/onboarding?referrer=${window.location}`;
       }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This fixes an issue where `window.currentUser` and `window.csrfToken` was no longer available on every page.

I'm not sure we need that info on every page, but this will resolve a critical bug we currently have.