### PR TITLE
Fix out of place clipboard-copy icon

### DIFF
--- a/app/assets/stylesheets/article-show.scss
+++ b/app/assets/stylesheets/article-show.scss
@@ -1189,6 +1189,7 @@ article {
           box-shadow: $shadow;
           left: auto;
           bottom: 48px;
+          min-width: 312px;
           padding-bottom: 6px;
           padding-top: 6px;
         }


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
The clipboard copy icon in the dropdown share menu was out of place on Chrome. I adjusted the min-width and this looked to resolve the issue.

## Related Tickets & Documents
Resolves #2982

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
* On Chrome
![clipboard-copy chrome](https://user-images.githubusercontent.com/24629960/62000887-bc378a80-b0b0-11e9-8728-a38ec966599e.png)

* On Firefox
![clipboard-copy firefox](https://user-images.githubusercontent.com/24629960/62000888-bc378a80-b0b0-11e9-8120-bccf41295f08.png)

## Added to documentation?
- [x] no documentation needed