### PR TITLE
Add getunopenedchatchannels to onboardingredirect

### DIFF
--- a/app/javascript/packs/onboardingRedirectCheck.jsx
+++ b/app/javascript/packs/onboardingRedirectCheck.jsx
@@ -1,4 +1,5 @@
 import { getUserDataAndCsrfToken } from '../chat/util';
+import getUnopenedChannels from '../src/utils/getUnopenedChannels';
 
 HTMLDocument.prototype.ready = new Promise(resolve => {
   if (document.readyState !== 'loading') {
@@ -28,6 +29,7 @@ document.ready.then(
     .then(({ currentUser, csrfToken }) => {
       window.currentUser = currentUser;
       window.csrfToken = csrfToken;
+      getUnopenedChannels();
 
       if (redirectableLocation() && !onboardingSkippable(currentUser)) {
         window.location = `${window.location.origin}/onboarding?referrer=${window.location}`;


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
This was another bit of functionality tacked into the `onboarding` script erroneously, and then removed when we migrated this file.

This functionality should be loaded elsewhere but for now just getting things back to the old status quo.