### PR TITLE
Update Bundler to 2.0.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,6 @@
 source "https://rubygems.org"
 ruby "2.6.3"
 
-# Enforce git to transmitted via https.
-# workaround until bundler 2.0 is released.
-git_source(:github) do |repo_name|
-  repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
-  "https://github.com/#{repo_name}.git"
-end
-
 group :production do
   gem "nakayoshi_fork", "~> 0.0.4" # solves CoW friendly problem on MRI 2.2 and later
   gem "rack-host-redirect", "~> 1.3" # Lean and simple host redirection via Rack middleware

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -974,4 +974,4 @@ RUBY VERSION
    ruby 2.6.3p62
 
 BUNDLED WITH
-   1.17.3
+   2.0.2


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

Bundler is at 2.0.2 which is supported by Heroku and doesn't need the HTTPS hack.

If you're using a custom buildpack set on an older version of Bundler please ignore and close this.

## Related Tickets & Documents

1. [Heroku - Ruby apps with Bundler 2.x now receive version 2.0.2](https://devcenter.heroku.com/changelog-items/1656)
2. [Heroku - Bundler version](https://devcenter.heroku.com/articles/bundler-version)
