### PR TITLE
Allow for the sending of arbitrary broadcasts

### DIFF
--- a/app/services/notifications/welcome_notification/send.rb
+++ b/app/services/notifications/welcome_notification/send.rb
@@ -18,6 +18,7 @@ module Notifications
         json_data = {
           user: user_data(dev_account),
           broadcast: {
+            title: welcome_broadcast.title,
             processed_html: welcome_broadcast.processed_html
           }
         }

--- a/app/views/notifications/_broadcast.html.erb
+++ b/app/views/notifications/_broadcast.html.erb
@@ -1,14 +1,12 @@
 <% json_data = notification.json_data %>
-<% if notification.action == "Onboarding" %>
-  <% user = User.find_by_id(json_data["user"]["id"]) %>
-  <% cache "broadcast-onboarding-notification" do %>
-    <a href="<%= json_data["user"]["path"] %>" class="small-pic-link-wrapper">
-      <div class="small-pic">
-        <img src="<%= ProfileImage.new(user).get %>" alt="link to <%= json_data["user"]["username"] %>'s profile">
-      </div>
-    </a>
-    <div class="content notification-content broadcast-content">
-      <%= json_data["broadcast"]["processed_html"].html_safe %>
+<% user = User.find_by(id: json_data["user"]["id"]) %>
+<% cache "broadcast-html-#{notification.json_data['broadcast']['title']}" do %>
+  <a href="<%= json_data["user"]["path"] %>" class="small-pic-link-wrapper">
+    <div class="small-pic">
+      <img src="<%= ProfileImage.new(user).get %>" alt="link to <%= json_data["user"]["username"] %>'s profile">
     </div>
-  <% end %>
+  </a>
+  <div class="content notification-content broadcast-content">
+    <%= json_data["broadcast"]["processed_html"].html_safe %>
+  </div>
 <% end %>


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
We created the "broadcast" feature with the idea of doing more than just the welcome message, but we also implemented this to only account for the welcome message to this point. This expands the behavior so that we _can_ send alternate types of welcome messages. We still don't have the rest of it in the app but we can at least experiment with this functionality manually now.

This would send any broadcast, including the welcome one if it is passed in. But we can now send other broadcasts this way. (And should likely change the name of this module if we are to keep this structure)

```ruby
Notifications::WelcomeNotification::Send.call(1, Broadcast.last)
```

I added the `title` to the JSON, which will load as `nil` for now so shouldn't break the old functionality.

The line
```
if notification.action == "Onboarding"
```

Doesn't seem necessary because the same notification HTML should work for any broadcast.

PS. I looked at the code for "broadcasts" in internal and I don't think it works as we'd expect it to but I just didn't touch it, and felt like this basic tweak was better scoped for this idea.