### PR TITLE
Fix Video Duration to include hours

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -429,7 +429,10 @@ class Article < ApplicationRecord
     minutes = (video_duration_in_seconds.to_i / 60) % 60
     seconds = video_duration_in_seconds.to_i % 60
     seconds = "0#{seconds}" if seconds.to_s.size == 1
-    "#{minutes}:#{seconds}"
+
+    hours = (video_duration_in_seconds.to_i / 3600)
+    minutes = "0#{minutes}" if hours.positive? && minutes < 10
+    hours < 1 ? "#{minutes}:#{seconds}" : "#{hours}:#{minutes}:#{seconds}"
   end
 
   def fetch_video_duration

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -251,6 +251,16 @@ RSpec.describe Article, type: :model do
       article.video_duration_in_seconds = 1161
       expect(article.video_duration_in_minutes).to eq("19:21")
     end
+
+    it "has video_duration_in_minutes display hour when video is an hour or longer" do
+      article.video_duration_in_seconds = 3600
+      expect(article.video_duration_in_minutes).to eq("1:00:00")
+    end
+
+    it "has correctly non-padded minutes with hour in video_duration_in_minutes" do
+      article.video_duration_in_seconds = 5000
+      expect(article.video_duration_in_minutes).to eq("1:23:20")
+    end
   end
 
   describe ".seo_boostable" do


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
The video duration on DEV videos posts cut off any hours. I added the option of hours to display if a video is long enough. For testing, I added test cases to verify if it converted the given seconds to expected time format with hours.

## Related Tickets & Documents
Resolves #3375 

## Added to documentation?
- [x] no documentation needed