### PR TITLE
Fix podcasts episodes surrogate key and add "/podcasts"

### DIFF
--- a/app/controllers/podcast_episodes_controller.rb
+++ b/app/controllers/podcast_episodes_controller.rb
@@ -4,15 +4,21 @@ class PodcastEpisodesController < ApplicationController
 
   def index
     @podcast_index = true
+
     @podcasts = Podcast.available.order("title asc")
-    @podcast_episodes = PodcastEpisode.available.order("published_at desc").first(20)
+    @podcast_episodes = PodcastEpisode.
+      available.
+      includes(:podcast).order("published_at desc").first(20)
+
     if params[:q].blank?
-      set_surrogate_key_header("podcast_episodes_all " + params[:q].to_s,
-                               @podcast_episodes.map { |e| e["record_key"] })
+      surrogate_keys = ["podcast_episodes_all"] + @podcast_episodes.map(&:record_key)
+      set_surrogate_key_header(surrogate_keys)
     end
+
     @featured_story = Article.new
     @article_index = true
     @list_of = "podcast-episodes"
+
     render template: "podcast_episodes/index"
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -315,8 +315,8 @@ Rails.application.routes.draw do
   get "/new" => "articles#new"
   get "/new/:template" => "articles#new"
 
-  get "/pod" => "podcast_episodes#index"
-  get "/podcasts" => "podcast_episodes#index"
+  get "/pod", to: "podcast_episodes#index"
+  get "/podcasts", to: redirect("pod")
   get "/readinglist" => "reading_list_items#index"
   get "/readinglist/:view" => "reading_list_items#index", constraints: { view: /archive/ }
   get "/history", to: "history#index", as: :history

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -316,6 +316,7 @@ Rails.application.routes.draw do
   get "/new/:template" => "articles#new"
 
   get "/pod" => "podcast_episodes#index"
+  get "/podcasts" => "podcast_episodes#index"
   get "/readinglist" => "reading_list_items#index"
   get "/readinglist/:view" => "reading_list_items#index", constraints: { view: /archive/ }
   get "/history", to: "history#index", as: :history

--- a/spec/requests/podcasts/podcast_episodes_index_spec.rb
+++ b/spec/requests/podcasts/podcast_episodes_index_spec.rb
@@ -21,9 +21,9 @@ RSpec.describe "PodcastEpisodesSpec", type: :request do
       expect(response.headers["Surrogate-Key"]).to eq("podcast_episodes_all podcast_episodes/#{pe.id}")
     end
 
-    it "renders page using /podcasts" do
+    it "redirects /podcasts to /pod" do
       get "/podcasts"
-      expect(response.body).to include("If you know of a great dev podcast")
+      expect(response.body).to redirect_to(pod_path)
     end
   end
 end

--- a/spec/requests/podcasts/podcast_episodes_index_spec.rb
+++ b/spec/requests/podcasts/podcast_episodes_index_spec.rb
@@ -14,5 +14,16 @@ RSpec.describe "PodcastEpisodesSpec", type: :request do
       expect(response.body).to include("SuperMario")
       expect(response.body).not_to include("unreachable")
     end
+
+    it "sets proper surrogate key" do
+      pe = create(:podcast_episode)
+      get "/pod"
+      expect(response.headers["Surrogate-Key"]).to eq("podcast_episodes_all podcast_episodes/#{pe.id}")
+    end
+
+    it "renders page using /podcasts" do
+      get "/podcasts"
+      expect(response.body).to include("If you know of a great dev podcast")
+    end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

Surrogate keys right now contain a bunch of nil, because `record_key` is an attribute.

I've also loaded podcasts to avoid N+1 and added /podcasts to the website, since right now leads to a 404 page.

