### PR TITLE
Fix failing algolia jobs

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -96,9 +96,10 @@ class Comment < ApplicationRecord
   end
 
   def self.trigger_index(record, remove)
-    if remove
-      AlgoliaSearch::AlgoliaJob.perform_later(record, "remove_from_index!")
-    elsif record.deleted == false
+    # record is removed from index synchronously in before_destroy_actions
+    return if remove
+
+    if record.deleted == false
       AlgoliaSearch::AlgoliaJob.perform_later(record, "index!")
     else
       AlgoliaSearch::AlgoliaJob.perform_later(record, "remove_algolia_index")

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -157,7 +157,7 @@ class User < ApplicationRecord
   before_destroy :destroy_follows
   before_destroy :unsubscribe_from_newsletters
 
-  algoliasearch per_environment: true, enqueue: true do
+  algoliasearch per_environment: true, enqueue: :trigger_delayed_index do
     attribute :name
     add_index "searchables",
               id: :index_id,
@@ -187,6 +187,12 @@ class User < ApplicationRecord
 
   def estimated_default_language
     language_settings["estimated_default_language"]
+  end
+
+  def self.trigger_delayed_index(record, remove)
+    return if remove
+
+    AlgoliaSearch::AlgoliaJob.perform_later(record, "index!")
   end
 
   def tag_line

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -260,24 +260,30 @@ RSpec.describe Comment, type: :model do
   end
 
   describe "when algolia auto-indexing/removal is triggered" do
+    context "when destroying" do
+      it "doesn't schedule an ActiveJob on destroy" do
+        comment = create(:comment, commentable: article)
+        expect do
+          comment.destroy
+        end.not_to have_enqueued_job.on_queue("algoliasearch")
+      end
+    end
+
     context "when record.deleted == false" do
       it "checks auto-indexing" do
-        expect { build(:comment, user_id: user2.id, commentable_id: article.id).save }.to have_enqueued_job.with(kind_of(Comment), "index!").on_queue("algoliasearch")
+        expect do
+          create(:comment, user_id: user2.id, commentable_id: article.id)
+        end.to have_enqueued_job.with(kind_of(Comment), "index!").on_queue("algoliasearch")
       end
     end
 
     context "when record.deleted == true" do
-      before do
-        comment.deleted = true
-      end
-
       it "checks auto-indexing" do
-        expect { comment.save! }.to have_enqueued_job.with(kind_of(Comment), "remove_algolia_index").on_queue("algoliasearch")
+        comment.deleted = true
+        expect do
+          comment.save!
+        end.to have_enqueued_job.with(kind_of(Comment), "remove_algolia_index").on_queue("algoliasearch")
       end
-    end
-
-    it "checks auto-removing background process" do
-      expect { comment.destroy }.to have_enqueued_job.with({ "_aj_globalid" => "gid://practical-developer/Comment/#{comment.id}" }, "remove_from_index!").on_queue("algoliasearch")
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -655,11 +655,11 @@ RSpec.describe User, type: :model do
 
   describe "when agolia auto-indexing/removal is triggered" do
     it "process background auto-indexing when user is saved" do
-      expect { user.save }.to have_enqueued_job.with(kind_of(User), "algolia_index!").on_queue("algoliasearch")
+      expect { user.save }.to have_enqueued_job.with(user, "index!").on_queue("algoliasearch")
     end
 
-    it "process background auto-removal on deletion" do
-      expect { user.destroy }.to have_enqueued_job.with({ "_aj_globalid" => "gid://practical-developer/User/#{user.id}" }, "algolia_remove_from_index!").on_queue("algoliasearch")
+    it "doesn't schedule a job on destroy" do
+      expect { user.destroy }.not_to have_enqueued_job.on_queue("algoliasearch")
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Fixed ActiveJob `DeserializationError`s which appeared after merging #3486
Actually, on `User` and `Comment` destroy, records are removed from the index `synchronously` in `before_destroy` callbacks, so there's no need to do anything in `trigger_index` or `trigger_delayed_index` when `remove` is `true`.



