### PR TITLE
Remove columns that don't existing from schema.rb

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -936,7 +936,6 @@ ActiveRecord::Schema.define(version: 2019_07_23_094834) do
     t.text "base_cover_letter"
     t.string "behance_url"
     t.string "bg_color_hex"
-    t.text "cached_chat_channel_memberships"
     t.boolean "checked_code_of_conduct", default: false
     t.boolean "checked_terms_and_conditions", default: false
     t.integer "comments_count", default: 0, null: false
@@ -1058,7 +1057,6 @@ ActiveRecord::Schema.define(version: 2019_07_23_094834) do
     t.string "stackoverflow_url"
     t.string "stripe_id_code"
     t.text "summary"
-    t.text "summary_html"
     t.string "tabs_or_spaces"
     t.string "text_color_hex"
     t.string "text_only_name"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

The columns `users.cached_chat_channel_memberships` and `users.summary_html` do not exist in the current version of master. They were wrongly added in #3269 

See https://github.com/thepracticaldev/dev.to/pull/3269/files#diff-1acd2e7e27a227829d5d14a91c863bb6R898 and https://github.com/thepracticaldev/dev.to/pull/3269/files#diff-1acd2e7e27a227829d5d14a91c863bb6R1015

@bolariin noticed this problem while working on https://github.com/thepracticaldev/dev.to/pull/2873 and I've personally tried to reset the DB to the current master and then run the migration in #2873 with no avail since the `summary_html` column is present, the migration then fails locally

They should be safe for removal. They are not part of any existing migration

They shouldn't be present in the production DB for obvious reason (it's not populated by the schema file) but please double check.

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
