### PR TITLE
Update to Chromedriver 76

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ rvm:
   - 2.6.3
 addons:
   postgresql: '9.6'
+  chrome: 'stable'
 env:
   global:
     - RAILS_ENV=test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: https://github.com/thepracticaldev/acts_as_follower.git
+  remote: git://github.com/thepracticaldev/acts_as_follower.git
   revision: 288690cd99bc470eaee493fce5bfa9fe23157692
   branch: master
   specs:
@@ -7,7 +7,7 @@ GIT
       activerecord (>= 4.0)
 
 GIT
-  remote: https://github.com/thepracticaldev/foreman.git
+  remote: git://github.com/thepracticaldev/foreman.git
   revision: b64e4019a8ed3cfae7216c3219dc91833845d9c7
   ref: b64e401
   specs:

--- a/spec/support/initializers/capybara.rb
+++ b/spec/support/initializers/capybara.rb
@@ -2,7 +2,7 @@ require "capybara/rails"
 require "capybara/rspec"
 require "webdrivers/chromedriver"
 
-Webdrivers::Chromedriver.required_version = "73.0.3683.68"
+Webdrivers::Chromedriver.required_version = "76.0.3809.68"
 Webdrivers.cache_time = 86_400
 
 Capybara.default_max_wait_time = 5

--- a/spec/support/initializers/capybara.rb
+++ b/spec/support/initializers/capybara.rb
@@ -9,16 +9,15 @@ Capybara.default_max_wait_time = 5
 
 Capybara.register_driver :headless_chrome do |app|
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    chromeOptions: { args: %w[headless disable-gpu no-sandbox window-size=1400,2000] },
+    chromeOptions: {
+      args: %w[
+        headless disable-gpu no-sandbox
+        --window-size=1980,1080 --enable-features=NetworkService,NetworkServiceInProcess
+      ]
+    },
   )
-  Capybara::Selenium::Driver.new(app, browser: :chrome, desired_capabilities: capabilities)
-end
 
-Capybara.register_driver :chrome do |app|
-  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    chromeOptions: { args: %w[no-sandbox window-size=1400,2000] },
-  )
-  Capybara::Selenium::Driver.new(app, browser: :chrome, desired_capabilities: capabilities)
+  Capybara::Selenium::Driver.new app, browser: :chrome, desired_capabilities: capabilities
 end
 
 RSpec.configure do |config|

--- a/spec/support/initializers/capybara.rb
+++ b/spec/support/initializers/capybara.rb
@@ -8,16 +8,12 @@ Webdrivers.cache_time = 86_400
 Capybara.default_max_wait_time = 5
 
 Capybara.register_driver :headless_chrome do |app|
-  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    chromeOptions: {
-      args: %w[
-        headless disable-gpu no-sandbox
-        --window-size=1980,1080 --enable-features=NetworkService,NetworkServiceInProcess
-      ]
-    },
+  options = Selenium::WebDriver::Chrome::Options.new(
+    args: %w[no-sandbox headless disable-gpu window-size=1920,1080 --enable-features=NetworkService,NetworkServiceInProcess],
+    log_level: :error,
   )
 
-  Capybara::Selenium::Driver.new app, browser: :chrome, desired_capabilities: capabilities
+  Capybara::Selenium::Driver.new app, browser: :chrome, options: options
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description
I thought it was alright to downgrade Chromedriver to 73 but that ends up being incompatible with my local machine's Chrome 76, hence this update. Capybara's config also need to be updated or else headless does not work.

## Related Tickets & Documents
n/a
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
n/a
## Added to documentation?
- [x] no documentation needed

