### PR TITLE
Allow CodePen usernames to be up to 30 characters long

### DIFF
--- a/app/liquid_tags/codepen_tag.rb
+++ b/app/liquid_tags/codepen_tag.rb
@@ -47,7 +47,7 @@ class CodepenTag < LiquidTagBase
   def valid_link?(link)
     link_no_space = link.delete(" ")
     (link_no_space =~
-      /^(http|https):\/\/(codepen\.io|codepen\.io\/team)\/[a-zA-Z0-9_\-]{1,20}\/pen\/([a-zA-Z]{5,7})\/{0,1}\z/)&.zero?
+      /^(http|https):\/\/(codepen\.io|codepen\.io\/team)\/[a-zA-Z0-9_\-]{1,30}\/pen\/([a-zA-Z]{5,7})\/{0,1}\z/)&.zero?
   end
 
   def raise_error

--- a/spec/liquid_tags/codepen_tag_spec.rb
+++ b/spec/liquid_tags/codepen_tag_spec.rb
@@ -50,6 +50,13 @@ RSpec.describe CodepenTag, type: :liquid_template do
       end.to raise_error(StandardError)
     end
 
+    it "rejects codepen link with more than 30 characters in the username" do
+      codepen_link = "https://codepen.io/t_white96_this_is_31_characters/pen/XKqrJX/"
+      expect do
+        generate_new_liquid(codepen_link)
+      end.to raise_error(StandardError)
+    end
+
     it "accepts codepen link with a default-tab parameter" do
       expect do
         generate_new_liquid(codepen_link_with_default_tab)


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
Change CodePen usernames regex to allow up to 30 characters.  ~~I didn't see that character limit was explicitly tested in `codepen_tag_spec.rb` so I'm assuming it's fine to leave it that way.~~ 

## Related Tickets & Documents
Fixes #3487

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [ ] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/IzWnTWABjsbfm5Gv6e/giphy.gif)
My first open source commit! 
