### PR TITLE
Hash OAuth2 access tokens

### DIFF
--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -105,7 +105,7 @@ Doorkeeper.configure do
   # in your installation, they will be invalid without enabling the additional
   # setting `fallback_to_plain_secrets` below.
   #
-  # hash_token_secrets
+  hash_token_secrets
   # By default, token secrets will be hashed using the
   # +Doorkeeper::Hashing::SHA256+ strategy.
   #


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

For security purposes I'm proposing to active hashing for OAuth2 access tokens.

Even if they have a temporary validity (2 hours) and at present could seem like an unnecessary precaution, Doorkeeper allows us not to store the tokens themselves but an hash. 

Doorkeeper, in addition, allows us to store encrypted application secrets but there's currently an issue that's going to be fixed in [doorkeeper 5.2.0](https://github.com/doorkeeper-gem/doorkeeper/blob/master/CHANGELOG.md#520rc1) where the secrets are not shown during creation on the website. Once that's out I'd like to enable encryption of application secrets as well, because they are effectively passwords that are always valid, as the [Doorkeeper docs explain](https://doorkeeper.gitbook.io/guides/security/token-and-application-secrets)

Existing apps will have to reauthenticate but it's ok to do it now that we're still beta testing

## Related Tickets & Documents

- https://doorkeeper.gitbook.io/guides/security/token-and-application-secrets

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

```ruby
[13] pry(main)> token.token
=> "44egGG...."
[14] pry(main)> Doorkeeper::AccessToken.first
  Doorkeeper::AccessToken Load (4.9ms)  SELECT  "oauth_access_tokens".* FROM "oauth_access_tokens" ORDER BY "oauth_access_tokens"."id" ASC LIMIT $1  [["LIMIT", 1]]
=> #<Doorkeeper::AccessToken:0x00007f9307e18e70
 id: 1,
 resource_owner_id: 11,
 application_id: 4,
 token: "cf67bcb7d25...",
...
```

as you can see the token itself is not stored in plain text in the DB.

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
