### PR TITLE
Fix stale fuzzy timestamps on notifications

### DIFF
--- a/app/views/notifications/_article.html.erb
+++ b/app/views/notifications/_article.html.erb
@@ -32,9 +32,9 @@
       <% end %>
       <div>
         <% if json_data["article"]["published_at"] %>
-          <span class="time-ago-indicator-initial-placeholder" data-seconds="<%= json_data["article"]["published_at"].to_time.to_i %>">
+          <span class="time-ago-indicator-initial-placeholder" data-seconds="<%= json_data["article"]["published_at"].to_time.to_i %>"></span>
         <% else %>
-          <span class="time-ago-indicator-initial-placeholder" data-seconds="<%= notification.notifiable.published_at.to_i %>">
+          <span class="time-ago-indicator-initial-placeholder" data-seconds="<%= notification.notifiable.published_at.to_i %>"></span>
         <% end %>
       </div>
       <a href="<%= json_data["article"]["path"] %>">

--- a/app/views/notifications/_article.html.erb
+++ b/app/views/notifications/_article.html.erb
@@ -32,9 +32,9 @@
       <% end %>
       <div>
         <% if json_data["article"]["published_at"] %>
-          <small><%= time_ago_in_words json_data["article"]["published_at"] %> ago</small>
+          <span class="time-ago-indicator-initial-placeholder" data-seconds="<%= json_data["article"]["published_at"].to_time.to_i %>">
         <% else %>
-          <small><%= time_ago_in_words notification.notifiable.published_at %> ago</small>
+          <span class="time-ago-indicator-initial-placeholder" data-seconds="<%= notification.notifiable.published_at.to_i %>">
         <% end %>
       </div>
       <a href="<%= json_data["article"]["path"] %>">

--- a/app/views/notifications/_comment.html.erb
+++ b/app/views/notifications/_comment.html.erb
@@ -21,7 +21,7 @@
         <%= h(json_data["comment"]["commentable"]["title"]) %>
       </a>
       <div>
-        <span class="time-ago-indicator-initial-placeholder" data-seconds="<%= notification.notifiable.created_at.to_i %>">
+        <span class="time-ago-indicator-initial-placeholder" data-seconds="<%= notification.notifiable.created_at.to_i %>"></span>
       </div>
       <%= render "notifications/shared/comment_box", json_data: json_data, notification: notification, context: "default" %>
     <% elsif notification.action == "Moderation" %>
@@ -42,7 +42,7 @@
         <%= h(json_data["comment"]["commentable"]["title"]) %>
       </a>
       <div>
-        <span><span class="time-ago-indicator-initial-placeholder" data-seconds="<%= notification.created_at.to_i %>"></span>
+        <span class="time-ago-indicator-initial-placeholder" data-seconds="<%= notification.created_at.to_i %>"></span>
       </div>
       <%= render "notifications/shared/comment_box", activity: activity, context: "moderation" %>
       Give them their first reply! 🎉

--- a/app/views/notifications/_comment.html.erb
+++ b/app/views/notifications/_comment.html.erb
@@ -21,7 +21,7 @@
         <%= h(json_data["comment"]["commentable"]["title"]) %>
       </a>
       <div>
-        <small><%= time_ago_in_words notification.notifiable.created_at %> ago</small>
+        <span class="time-ago-indicator-initial-placeholder" data-seconds="<%= notification.notifiable.created_at.to_i %>">
       </div>
       <%= render "notifications/shared/comment_box", json_data: json_data, notification: notification, context: "default" %>
     <% elsif notification.action == "Moderation" %>
@@ -42,7 +42,7 @@
         <%= h(json_data["comment"]["commentable"]["title"]) %>
       </a>
       <div>
-        <small><%= time_ago_in_words notification.created_at %> ago</small>
+        <span><span class="time-ago-indicator-initial-placeholder" data-seconds="<%= notification.created_at.to_i %>"></span>
       </div>
       <%= render "notifications/shared/comment_box", activity: activity, context: "moderation" %>
       Give them their first reply! 🎉

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -336,10 +336,6 @@ RSpec.describe "NotificationsIndex", type: :request do
       it "does not render the reaction as reacted if it was not reacted on" do
         expect(response.body).not_to include "reaction-button reacted"
       end
-
-      it "renders the article's published at" do
-        expect(response.body).to include time_ago_in_words(article.published_at)
-      end
     end
   end
 end

--- a/spec/system/notifications/user_visits_notifications_spec.rb
+++ b/spec/system/notifications/user_visits_notifications_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe "Visiting notifications", type: :system do
+  let_it_be(:user) { create(:user) }
+  let_it_be(:other_user) { create(:user) }
+
+  before do
+    user.follow(other_user)
+    sign_in user
+    Timecop.travel(10.minutes.ago)
+  end
+
+  after do
+    Timecop.return
+  end
+
+  context "when visiting post notifications" do
+    let(:article) { create(:article, :with_notification_subscription, user: other_user) }
+
+    before do
+      Notification.send_to_followers_without_delay(article, "Published")
+      visit "/notifications/posts"
+    end
+
+    it "shows the timestamp in a human readable format", js: true do
+      expect(page).to have_selector(".time-ago-indicator", text: "(10 mins ago)")
+    end
+  end
+
+  context "when visiting comment notifications" do
+    let(:article) { create(:article, :with_notification_subscription, user: user) }
+    let(:comment) { create(:comment, commentable: article, user: other_user) }
+
+    before do
+      Notification.send_new_comment_notifications_without_delay(comment)
+      visit "/notifications/comments"
+    end
+
+    it "shows the timestamp in a human readable format", js: true do
+      expect(page).to have_selector(".time-ago-indicator", text: "(10 mins ago)")
+    end
+  end
+end

--- a/spec/system/notifications/user_visits_notifications_spec.rb
+++ b/spec/system/notifications/user_visits_notifications_spec.rb
@@ -1,42 +1,37 @@
 require "rails_helper"
 
-RSpec.describe "Visiting notifications", type: :system do
-  let_it_be(:user) { create(:user) }
-  let_it_be(:other_user) { create(:user) }
+RSpec.describe "User visits notifications", type: :system do
+  let(:reader) { create(:user) }
+  let(:author) { create(:user) }
+  let(:article) { create(:article, :with_notification_subscription, user: author) }
+  let(:comment) { create(:comment, commentable: article, user: reader) }
 
   before do
-    user.follow(other_user)
-    sign_in user
-    Timecop.travel(10.minutes.ago)
+    reader.follow(author)
+    article.update_column(:published_at, 10.minutes.ago)
+    comment.update_column(:created_at, 10.minutes.ago)
   end
 
-  after do
-    Timecop.return
-  end
-
-  context "when visiting post notifications" do
-    let(:article) { create(:article, :with_notification_subscription, user: other_user) }
-
+  context "when viewing post notifications" do
     before do
       Notification.send_to_followers_without_delay(article, "Published")
+      sign_in reader
       visit "/notifications/posts"
     end
 
-    it "shows the timestamp in a human readable format", js: true do
+    it "shows the timestamp in a human-readable format", js: true do
       expect(page).to have_selector(".time-ago-indicator", text: "(10 mins ago)")
     end
   end
 
-  context "when visiting comment notifications" do
-    let(:article) { create(:article, :with_notification_subscription, user: user) }
-    let(:comment) { create(:comment, commentable: article, user: other_user) }
-
+  context "when viewing comment notifications" do
     before do
       Notification.send_new_comment_notifications_without_delay(comment)
+      sign_in author
       visit "/notifications/comments"
     end
 
-    it "shows the timestamp in a human readable format", js: true do
+    it "shows the timestamp in a human-readable format", js: true do
       expect(page).to have_selector(".time-ago-indicator", text: "(10 mins ago)")
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
Fuzzy timestamps on cached notifications are now being displayed correctly.

**Implementation details:**

Instead of using the `time_ago_in_words` Rails helper, timestamps are now being rendered dynamically with JavaScript.

Timestamps are stored in a `data` attribute on the element. When paired with the `time-ago-indicator-initial-placeholder` class it works as an anchor for the `insertTimes()` JavaScript helper. It replaces the element with a fuzzy timestamp generated by `timeAgo()`.

**This fix changes the existing implementation in a couple of ways:**
* The styling is a bit different now due to the nature of the `insertTimes()` helper. It replaces the element (originally a `<small>` element) with a `<span>` element.
(_see screenshots below_)
* Comment notifications aren't cached at the moment, but since post and comment notifications can be viewed alongside each other on the "ALL" menu option, I replaced them as well for consistency.
* The `timeAgo()` helper doesn't render timestamps older than 24 hours by default.
(_see screenshots below_)

Let me know if these issues need to be dealt with in some way ✌️ 

## Related Tickets & Documents
Fixes issue #3548

Other related issues: #2997 and #3183 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
### Style changes
_Before_
![timeago_before](https://user-images.githubusercontent.com/18333420/62384455-c0512580-b552-11e9-9bf3-bd665e705dc9.png)
_After_
![timeago_after](https://user-images.githubusercontent.com/18333420/62384451-bf1ff880-b552-11e9-8296-a8fcc48c6ebd.png)

### Notifications older than 24 hours
_Before_
![24_hours_before](https://user-images.githubusercontent.com/18333420/62384461-c6470680-b552-11e9-8e3a-d5eeb664849c.png)
_After_
![24_hours_after](https://user-images.githubusercontent.com/18333420/62384460-c5ae7000-b552-11e9-935e-c7add37f46f7.png)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed