### PR TITLE
Improve Error Message for malformed Github Repo Links

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -465,6 +465,8 @@ class Article < ApplicationRecord
 
   def liquid_tags_used
     MarkdownParser.new(body_markdown.to_s + comments_blob.to_s).tags_used
+  rescue StandardError
+    []
   end
 
   private

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -308,6 +308,14 @@ RSpec.describe Article, type: :model do
     expect(article.decorate.liquid_tags_used).to eq([])
   end
 
+  it "returns error message with malformed liquid tags" do
+    body = "{% github /thepracticaldev/dev.to %}"
+    article = build(:article, body_markdown: body, title: "Hello")
+    article.save
+    expect(article.persisted?).to eq(false)
+    expect(article.errors[:base]).to eq(["Invalid Github Repo link"])
+  end
+
   it "returns article title length classification" do
     article.title = "0" * 106
     expect(article.decorate.title_length_classification).to eq("longest")


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
It looks the problem was from `article.save` in `article_creation_service`. https://github.com/thepracticaldev/dev.to/blob/4689cdd266e7e678511e733d24c719d9f89948cd/app/services/article_creation_service.rb#L24

This was because of `tags_used` in `MarkdownParser` would raise an error which was not properly handled. 
https://github.com/thepracticaldev/dev.to/blob/4689cdd266e7e678511e733d24c719d9f89948cd/app/labor/markdown_parser.rb#L87-L96

It looks like this error affected other liquid tags.

## Related Tickets & Documents
Resolves #3511

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![improved error message](https://user-images.githubusercontent.com/24629960/62392134-a9033f80-b534-11e9-8020-8e944a33b2f8.gif)

## Added to documentation?
- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed