### PR TITLE
Changed podcast liquid tag color on default theme

### DIFF
--- a/app/assets/stylesheets/ltags/PodcastTag.scss
+++ b/app/assets/stylesheets/ltags/PodcastTag.scss
@@ -61,10 +61,11 @@
       display: flex;
       flex-direction: row;
       font-size: 14px;
+
       a {
         margin-right: 10px;
         background-color: #292e34;
-        color: white;
+        color: var(--theme-color, white);
         border-radius: 3px;
         font-size: 13px;
         font-weight: 400;
@@ -80,15 +81,15 @@
 
         img {
           display: inline;
-          width: 16px;
-          height: 16px;
           left: 0;
           margin-right: 5px;
           vertical-align: middle;
         }
+
         .service-name{
           display:none;
         }
+
         @media screen and (min-width: 630px) {
           .service-name{
             display:inline-block;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Documentation Update

## Description
Text within the renderen Podcast Liquid Element was white on white background on Light theme.
Also removed width and height from an `display:inline`element and added white-space around some css selectors.

## Related Tickets & Documents
Relates to #3588 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
**Before:**
![Screenshot 2019-08-02 at 23 48 54](https://user-images.githubusercontent.com/24296556/62400699-70895300-b580-11e9-8c3e-ea73b3e21ea5.png)

**After:**
![Screenshot 2019-08-02 at 23 50 02](https://user-images.githubusercontent.com/24296556/62400705-7a12bb00-b580-11e9-9c4b-f1d19cc647da.png)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed

## What gif best describes this PR or how it makes you feel?

![That's all?](https://media.giphy.com/media/raLs6VW04mYDe/giphy.gif)
