### PR TITLE
Add button to copy org secret to clipboard

### DIFF
--- a/app/assets/stylesheets/settings.scss
+++ b/app/assets/stylesheets/settings.scss
@@ -572,6 +572,7 @@
     width: 100%;
     border-radius: 3px;
     font-size: 1.1em;
+    cursor: pointer;
   }
   .settings-generate-new-secret {
     margin-top: 10px;
@@ -584,6 +585,23 @@
     cursor: pointer;
     &:hover {
       background: lighten($black, 14%);
+    }
+  }
+  clipboard-copy {
+    cursor: pointer;
+    display: flex;
+    img {
+      max-width: 26px;
+      margin-left: 8px;
+    }
+
+  }
+  .copy-text-announcer {
+    display: block;
+    text-align: center;
+    padding-top: 10px;
+    &[hidden] {
+      display: none;
     }
   }
 }

--- a/app/views/users/_org_admin.html.erb
+++ b/app/views/users/_org_admin.html.erb
@@ -1,6 +1,9 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jscolor/2.0.4/jscolor.min.js"
   integrity="sha256-CJWfUCeP3jLdUMVNUll6yQx37gh9AKmXTRxvRf7jzro=" crossorigin="anonymous"></script>
 
+<%= javascript_include_tag "https://unpkg.com/@webcomponents/webcomponentsjs@2.2.10/webcomponents-loader.js", defer: true %>
+<%= javascript_pack_tag "clipboardCopy", defer: true %>
+
 <style>
   .primary-sticky-nav-author, .primary-sticky-nav-author-element {
     border: 1px solid <%= HexComparer.new([user_colors(@organization)[:bg], user_colors(@organization)[:text]]).brightness(0.88) %> !important;
@@ -57,7 +60,13 @@
     <li>Paste the secret code below and click <b>Join Organization</b></li>
   </ol>
   <h5>Your secret: (You should rotate this regularly)</h5>
-  <input type="text" class="settings-org-secret" id="settings-org-secret" value="<%= @organization.secret %>" readonly aria-label="Organization secret (to be rotated regularly)">
+  <clipboard-copy for="settings-org-secret" onclick="nextElementSibling.hidden = false">
+    <input type="text" class="settings-org-secret" id="settings-org-secret" value="<%= @organization.secret %>" readonly aria-label="Organization secret (to be rotated regularly)">
+    <%= image_tag "content-copy.svg", alt: "Copy to clipboard" %>
+  </clipboard-copy>
+  <span class="copy-text-announcer" id="copy-text-announcer" role="alert" hidden>
+    Copied to clipboard!
+  </span>
   <%= form_tag "/organizations/generate_new_secret", onsubmit: "return confirm('Are you sure you want to generate a new secret? All outstanding secrets will be invalid.');" do %>
     <%= hidden_field_tag "organization[id]", @organization.id %>
     <button class="settings-generate-new-secret">Generate New Secret</button>


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
In order to improve the copy of the organization secret in desktop and mobile devices, a button is being added besides the secret field to copy them to the clipboard. If you prefer you can just click on the secret to copy them automatically.

I could not login with GitHub account from my iPhone on safari to test the feature, so if someone can test or help me to login on an iPhone I appreciate.

## Related Tickets & Documents
Fixes #3568 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
#### Chrome
![deepin-screen-recorder_Select area_20190804011816](https://user-images.githubusercontent.com/24780712/62419416-ed3a3100-b655-11e9-84ea-ca5922bb6316.gif)

#### Firefox
![deepin-screen-recorder_Select area_20190804013020](https://user-images.githubusercontent.com/24780712/62419477-8a499980-b657-11e9-8dd2-4e0ff6df0fb5.gif)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![copy that](https://media.giphy.com/media/ilwSzqi91BZjG/giphy.gif)
