### PR TITLE
Resolve error with code blocks in numbered lists

### DIFF
--- a/app/labor/markdown_parser.rb
+++ b/app/labor/markdown_parser.rb
@@ -161,8 +161,8 @@ class MarkdownParser
 
   def escape_liquid_tags_in_codeblock(content)
     # Escape codeblocks, code spans, and inline code
-    content.gsub(/`{3}.*?`{3}|`{2}.+?`{2}|`{1}.+?`{1}/m) do |codeblock|
-      if codeblock[0..2] == "```"
+    content.gsub(/[[:space:]]*`{3}.*?`{3}|`{2}.+?`{2}|`{1}.+?`{1}/m) do |codeblock|
+      if codeblock.match?(/[[:space:]]*`{3}/)
         "\n{% raw %}\n" + codeblock + "\n{% endraw %}\n"
       else
         "{% raw %}" + codeblock + "{% endraw %}"

--- a/spec/labor/markdown_parser_spec.rb
+++ b/spec/labor/markdown_parser_spec.rb
@@ -17,6 +17,18 @@ RSpec.describe MarkdownParser do
     expect(generate_and_parse_markdown(code_block)).to include("{% what %}")
   end
 
+  it "escapes codeblocks in numbered lists" do
+    code_block = "1. Define your hooks in config file `lefthook.yml`\n
+    ```yaml
+     pre-push:\n        parallel: true\n        commands:\n        rubocop:
+     run: bundle exec rspec --fail-fast\n
+    ```"
+    escaped_codeblock = generate_and_parse_markdown(code_block)
+    expect(escaped_codeblock).not_to include("```")
+    expect(escaped_codeblock).not_to include("`")
+    expect(escaped_codeblock).to include("bundle exec rspec --fail-fast")
+  end
+
   it "escapes liquid tags in code spans" do
     code_span = "``{% what %}``"
     expect(generate_and_parse_markdown(code_span)).to include("{% what %}")

--- a/spec/support/fixtures/approvals/user_preview_article_body.approved.html
+++ b/spec/support/fixtures/approvals/user_preview_article_body.approved.html
@@ -96,9 +96,7 @@ Format: <a href="cloudinary_link"></a></p>
 the present is our past.</p>
 </blockquote>
 
-<p>I think you should use an <code>&lt;addr&gt;</code> element here instead.</p>
-
-
+<p>I think you should use an <code>&lt;addr&gt;</code> element here instead.<br /></p>
 
 <div class="highlight"><pre class="highlight javascript"><code><span class="kd">function</span> <span class="nx">fancyAlert</span><span class="p">(</span><span class="nx">arg</span><span class="p">)</span> <span class="p">{</span>
   <span class="k">if</span><span class="p">(</span><span class="nx">arg</span><span class="p">)</span> <span class="p">{</span>


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
The error had to do with space and indententation matter with text inside numbered lists. Also, the backticks have to be aligned vertically. When the substitution happens with adding `{% raw %} .. {% endraw %}`, some of the space surrounding the codeblock is lost so the backticks are no longer aligned. I updated the code to preserve the any space character before the backticks.

## Related Tickets & Documents
Resolves #3437

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![visual confirmation](https://user-images.githubusercontent.com/24629960/62484552-6f2a7700-b788-11e9-9d56-70621d0a1c7d.gif)


## Added to documentation?
- [x] no documentation needed