### PR TITLE
Remove dead routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -344,8 +344,6 @@ Rails.application.routes.draw do
   get "/:timeframe" => "stories#index", constraints: { timeframe: /latest/ }
 
   # Legacy comment format (might still be floating around app, and external links)
-  get "/:username/:slug/comments/new/:parent_id_code" => "comments#new"
-  get "/:username/:slug/comments/new" => "comments#new"
   get "/:username/:slug/comments" => "comments#index"
   get "/:username/:slug/comments/:id_code" => "comments#index"
   get "/:username/:slug/comments/:id_code/edit" => "comments#edit"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
When user get '/:username/:slug/comments/new' or '/:username/:slug/comments/new/:parent_id_code', the user will see 500 Error page.
(ex in development) /ashleigh_wolff/a-farewell-to-arms-113f/comment/new

This error is caused by NoMethodError, because CommentsController don't have "new" method.
I think it should be ActiveRecord::RecordNotFound or Routing Error, and user should get 404 Error page.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
