### PR TITLE
Allow admins to undo a tag adjustment

### DIFF
--- a/app/controllers/tag_adjustments_controller.rb
+++ b/app/controllers/tag_adjustments_controller.rb
@@ -12,4 +12,13 @@ class TagAdjustmentsController < ApplicationController
     @article = Article.find(params[:tag_adjustment][:article_id])
     redirect_to "#{@article.path}/mod"
   end
+
+  def destroy
+    authorize User, :moderation_routes?
+    tag_adjustment = TagAdjustment.find(params[:id])
+    tag_adjustment.destroy
+    @article = Article.find(tag_adjustment.article_id)
+    @article.update!(tag_list: @article.tag_list.add(tag_adjustment.tag_name))
+    redirect_to "#{@article.path}/mod"
+  end
 end

--- a/app/models/tag_adjustment.rb
+++ b/app/models/tag_adjustment.rb
@@ -6,7 +6,8 @@ class TagAdjustment < ApplicationRecord
   validates :reason_for_adjustment, presence: true
   validates :adjustment_type, inclusion: { in: %w[removal addition] }, presence: true
   validates :status, inclusion: { in: %w[committed pending committed_and_resolvable resolved] }, presence: true
-  validate  :user_permissions
+  has_many :notifications, as: :notifiable, inverse_of: :notifiable, dependent: :delete_all
+  validate :user_permissions
 
   belongs_to :user
   belongs_to :tag

--- a/app/views/moderations/mod.html.erb
+++ b/app/views/moderations/mod.html.erb
@@ -145,7 +145,7 @@
         <b>Removed tags: </b>
         <% adjustments.each do |adjustment| %>
           <% if current_user.any_admin? %>
-              <%= form_for(adjustment, url: "/tag_adjustments/#{adjustment.id}", html: { method: :delete, onsubmit: "return confirm('Are you sure you want to undo the removal of #{adjustment.tag_name}?)" }) do |f| %>
+              <%= form_for(adjustment, url: "/tag_adjustments/#{adjustment.id}", html: { method: :delete, onsubmit: "return confirm('Are you sure you want to undo the removal of the #{adjustment.tag_name} tag?')" }) do |f| %>
                 <%= adjustment.tag_name %>
                 <%= f.submit "X", id: "undo" %>
               <% end %>

--- a/app/views/moderations/mod.html.erb
+++ b/app/views/moderations/mod.html.erb
@@ -57,6 +57,15 @@
     display: block;
   }
 
+  #undo {
+    background: #ff0000;
+    width: 2rem;
+    height: 2rem;
+    font-size: small;
+    display: inline-block;
+    padding-bottom: 2em;
+  }
+
   .tag-mod-form form textarea {
     width: 100%;
     padding: 5px;
@@ -76,6 +85,10 @@
 
   .level-rating-button.selected {
     background: #9bebff;
+  }
+
+  input.undo {
+    background: #ff0000; /* $red */
   }
 </style>
 
@@ -125,13 +138,18 @@
         <%= f.text_field :tag_name, placeholder: "Tag Name" %>
         <%= f.text_area :reason_for_adjustment, placeholder: "Reason for Removal (Be super kind) - Only the reason is needed, the notification will take care of the rest." %>
         <%= f.submit "Remove Tag" %>
-        <% adjustments = TagAdjustment.where(article_id: @moderatable.id, adjustment_type: "removal") %>
-        <% if adjustments.any? %>
-          <br /><br />
-          <b>Removed tags: </b>
-          <% adjustments.each do |adjustment| %>
-            <%= adjustment.tag_name %>
-          <% end %>
+      <% end %>
+      <% adjustments = TagAdjustment.where(article_id: @moderatable.id, adjustment_type: "removal") %>
+      <% if adjustments.any? %>
+        <br /><br />
+        <b>Removed tags: </b>
+        <% adjustments.each do |adjustment| %>
+          <% if current_user.any_admin? %>
+              <%= form_for(adjustment, url: "/tag_adjustments/#{adjustment.id}", html: { method: :delete, onsubmit: "return confirm('Are you sure you want to undo the removal of #{adjustment.tag_name}?)" }) do |f| %>
+                <%= adjustment.tag_name %>
+                <%= f.submit "X", id: "undo" %>
+              <% end %>
+            <% end %>
         <% end %>
       <% end %>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -148,7 +148,7 @@ Rails.application.routes.draw do
   resources :html_variant_trials, only: [:create]
   resources :html_variant_successes, only: [:create]
   resources :push_notification_subscriptions, only: [:create]
-  resources :tag_adjustments, only: [:create]
+  resources :tag_adjustments, only: %i[create destroy]
   resources :rating_votes, only: [:create]
   resources :page_views, only: %i[create update]
   resources :classified_listings, path: :listings, only: %i[index new create edit update delete dashboard]

--- a/spec/models/tag_adjustment_spec.rb
+++ b/spec/models/tag_adjustment_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe TagAdjustment, type: :model do
   it { is_expected.to validate_presence_of(:tag_name) }
   it { is_expected.to validate_presence_of(:adjustment_type) }
   it { is_expected.to validate_presence_of(:status) }
+  it { is_expected.to have_many(:notifications).dependent(:delete_all) }
 
   describe "privileges" do
     it "allows tag mods to create for their tags" do

--- a/spec/requests/tag_adjustments_spec.rb
+++ b/spec/requests/tag_adjustments_spec.rb
@@ -47,4 +47,37 @@ RSpec.describe "TagAdjustments", type: :request do
       end
     end
   end
+
+  describe "DELETE /tag_adjustments/:id" do
+    let(:tag_adjustment) { create(:tag_adjustment, article_id: article.id, user: user, tag: tag) }
+
+    before do
+      user.add_role(:admin)
+      user.add_role(:trusted)
+      tag_adjustment
+      sign_in user
+    end
+
+    context "when an article doesn't use front matter" do
+      let(:article) { Article.create(user: user, title: "something", body_markdown: "blah blah #{rand(100)}", tag_list: "#{tag.name}, yoyo, bobo", published: true) }
+
+      it "adds the tag back in" do
+        delete "/tag_adjustments/#{tag_adjustment.id}", params: {
+          id: tag_adjustment.id
+        }
+        expect(article.tag_list).to include tag.name
+      end
+    end
+
+    context "when an article uses front matter" do
+      let(:article) { create(:article, user: user, body_markdown: "---\ntitle: Hellohnnnn#{rand(1000)}\npublished: true\ntags: heyheyhey,#{tag.name}\n---\n\nHello") }
+
+      it "adds the tag back in" do
+        delete "/tag_adjustments/#{tag_adjustment.id}", params: {
+          id: tag_adjustment.id
+        }
+        expect(article.tag_list).to include tag.name
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
This allows admins to easily undo a tag adjustment. This will remove the tag adjustment by `destroying` it, and therefore `deleting_all` the other notifications related to it.

![Screen Shot 2019-08-07 at 12 57 00 PM](https://user-images.githubusercontent.com/17884966/62642037-e429b800-b912-11e9-8441-7e63c7fec51f.png)

At first I wanted to preserve the history of the actions, where undoing a tag adjustment would be a new instance of `TagAdjustment` and it wouldn't destroy the tag removal. Removing a tag doesn't happen much though so I think for now we can go with this implementation instead.

