### PR TITLE
Allow emoji in pinned repo description

### DIFF
--- a/app/views/users/_sidebar_additional.html.erb
+++ b/app/views/users/_sidebar_additional.html.erb
@@ -7,7 +7,7 @@
           <h4><span class="emoji"><img src="<%= asset_path("github-logo.svg") %>" alt="github logo"></span><%= repo.name %></h4>
         </header>
         <div class="widget-body">
-          <%= repo.description %>
+          <%= repo.description.present? ? EmojiConverter.call(repo.description) : repo.description %>
           <div class="widget-footer">
             <% if repo.fork %>
               <span class="widget-accent">fork</span>

--- a/app/views/users/_sidebar_additional.html.erb
+++ b/app/views/users/_sidebar_additional.html.erb
@@ -7,7 +7,9 @@
           <h4><span class="emoji"><img src="<%= asset_path("github-logo.svg") %>" alt="github logo"></span><%= repo.name %></h4>
         </header>
         <div class="widget-body">
-          <%= repo.description.present? ? EmojiConverter.call(repo.description) : repo.description %>
+          <% if repo.description.present? %>
+            <%= EmojiConverter.call(repo.description) %>
+          <% end %>
           <div class="widget-footer">
             <% if repo.fork %>
               <span class="widget-accent">fork</span>

--- a/spec/requests/user_profile_spec.rb
+++ b/spec/requests/user_profile_spec.rb
@@ -62,6 +62,23 @@ RSpec.describe "UserProfiles", type: :request do
         expect(response.body).to include "Gold Community Sponsor"
       end
     end
+
+    context "when github repo" do
+      before do
+        repo = build(:github_repo, user: user)
+        params = { name: Faker::Book.title, user_id: user.id, github_id_code: repo.github_id_code,
+                   url: Faker::Internet.url, description: "A book bot :robot:", featured: true,
+                   stargazers_count: 1 }
+        updated_repo = GithubRepo.find_or_create(params)
+
+        user.github_repos = [updated_repo]
+      end
+
+      it "renders emoji in description of pinned github repo" do
+        get "/#{user.username}"
+        expect(response.body).to include "A book bot 🤖"
+      end
+    end
   end
 
   describe "GET /user" do


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Allow emoji in the description for GitHub repos pinned on a user's profile.

## Related Tickets & Documents
Resolves #238 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![repo with emoji](https://user-images.githubusercontent.com/24629960/62761370-80a7a380-ba54-11e9-872d-4caf75936312.png)

## Added to documentation?
- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed