### PR TITLE
Add place holder alt text to markdown link

### DIFF
--- a/app/javascript/article-form/elements/imageManagement.jsx
+++ b/app/javascript/article-form/elements/imageManagement.jsx
@@ -131,7 +131,7 @@ export default class ImageManagement extends Component {
             <input
               id="image-markdown-copy-link-input"
               type="text"
-              value={`![](${insertionImageUrl})`}
+              value={`![Alt Text](${insertionImageUrl})`}
             />
             <img
               id="image-markdown-copy-icon"


### PR DESCRIPTION
This change will hopefully encourage article authors to include alt text
when they add images to their articles.
