### PR TITLE
Rescue all Errno exceptions while fetching a podcast episode

### DIFF
--- a/app/services/podcasts/get_media_url.rb
+++ b/app/services/podcasts/get_media_url.rb
@@ -34,7 +34,7 @@ module Podcasts
 
     def url_reachable?(url)
       HTTParty.head(url).code == 200
-    rescue Net::OpenTimeout, Errno::ECONNREFUSED
+    rescue Net::OpenTimeout, SystemCallError
       false
     end
   end

--- a/spec/services/podcasts/get_media_url_spec.rb
+++ b/spec/services/podcasts/get_media_url_spec.rb
@@ -47,4 +47,13 @@ RSpec.describe Podcasts::GetMediaUrl do
     expect(result.reachable).to be false
     expect(result.url).to eq(http_url)
   end
+
+  it "http, https unreachable with other exception" do
+    allow(HTTParty).to receive(:head).with(https_url).and_raise(Errno::EINVAL)
+    allow(HTTParty).to receive(:head).with(http_url).and_raise(Errno::EINVAL)
+    result = described_class.call(http_url)
+    expect(result.https).to be false
+    expect(result.reachable).to be false
+    expect(result.url).to eq(http_url)
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
A couple of podcast episodes fetching jobs are failing with `Errno::EINVAL`, so we need to rescue more types of errors.

## Related Tickets & Documents
#2952 