### PR TITLE
Expired Listing 404

### DIFF
--- a/app/controllers/classified_listings_controller.rb
+++ b/app/controllers/classified_listings_controller.rb
@@ -7,7 +7,7 @@ class ClassifiedListingsController < ApplicationController
 
   def index
     published_listings = ClassifiedListing.where(published: true)
-    @displayed_classified_listing = published_listings.find_by!(slug: params[:slug]) if params[:slug]
+    @displayed_classified_listing = published_listings.find_by(slug: params[:slug]) if params[:slug]
 
     if params[:view] == "moderate"
       return redirect_to "/internal/listings/#{@displayed_classified_listing.id}/edit"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description
When you currently visit a listing that is expired, it goes to a 404 page because the controller query uses `find_by!` and doesn't allow nil assignment when searching for the expired slug.

By removing the `!`, this allows `nil` to be the `@displayed_classified_listing`, which is how we prevent viewing expired listings by direct link.

## Related Tickets & Documents
N/A

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
N/A

## Added to documentation?

- [x] no documentation needed
