### PR TITLE
Switch to internally built color picker

### DIFF
--- a/app/assets/stylesheets/color-picker.scss
+++ b/app/assets/stylesheets/color-picker.scss
@@ -1,0 +1,1 @@
+.color-palette{height:100px;width:100px;background:red;display:none}.color-palette{margin-top:5px;width:270px;height:220px;background:#efefef;border:1px solid #bcbcbc;border-radius:1px;display:none;padding:1px;position:absolute;z-index:1000}.color-option{width:18px;height:18px;margin:3px;cursor:pointer;float:left}#colorPicker{border-right:10px solid #003cb3}

--- a/app/assets/stylesheets/minimal.scss
+++ b/app/assets/stylesheets/minimal.scss
@@ -30,6 +30,7 @@
 @import 'classified_listings';
 @import 'credits';
 @import 'item-list';
+@import 'color-picker';
 
 @import 'ltags/LiquidTags';
 

--- a/app/javascript/packs/colorPicker.js
+++ b/app/javascript/packs/colorPicker.js
@@ -1,0 +1,66 @@
+function makeColorPickerGo(colorInput, colorPalette) {
+
+  colorInput.addEventListener("click", showColorPalette);
+  colorInput.addEventListener("focusout", hideColorPalette);
+  colorPalette.mouseIsOver = false;
+  colorInput.style.border =  `2px solid ${colorInput.value}`;
+
+  colorPalette.onmouseover = () => {
+    colorPalette.mouseIsOver = true;
+  };
+  colorPalette.onmouseout = () => {
+    colorPalette.mouseIsOver = false;
+  }
+
+  function hideColorPalette() {
+    if(colorPalette.mouseIsOver === false) {
+      colorPalette.style.display = 'none';
+      colorInput.style.border =  `2px solid ${colorInput.value}`;
+    }
+  }
+
+  function chooseColor(e) {
+    let color = rgbToHex(e.target.style.backgroundColor);
+    colorInput.value = color;
+    colorInput.style.border =  `2px solid ${color}`;
+    colorPalette.style.display = 'none';
+  }
+
+  function componentToHex(c) {
+    var hex = c.toString(16);
+    return hex.length == 1 ? "0" + hex : hex;
+  }
+
+  function rgbToHex(color) {
+    var arr = color.replace('rgb', '').replace('(', '').replace(')', '').split(',');
+    return "#" + componentToHex(Number(arr[0])) + componentToHex(Number(arr[1])) + componentToHex(Number(arr[2]));
+  }
+
+  function showColorPalette() {
+    console.log('show')
+    colorPalette.style.display = 'block';
+    var newDiv = '<div class="color-option" style="background-color:#000000"></div><div class="color-option" style="background-color:#191919"></div><div class="color-option" style="background-color:#323232"></div><div class="color-option" style="background-color:#4b4b4b"></div><div class="color-option" style="background-color:#646464"></div><div class="color-option" style="background-color:#7d7d7d"></div><div class="color-option" style="background-color:#969696"></div><div class="color-option" style="background-color:#afafaf"></div><div class="color-option" style="background-color:#c8c8c8"></div><div class="color-option" style="background-color:#e1e1e1"></div><div class="color-option" style="background-color:#ffffff"></div><div class="color-option" style="background-color:#820000"></div><div class="color-option" style="background-color:#9b0000"></div><div class="color-option" style="background-color:#b40000"></div><div class="color-option" style="background-color:#cd0000"></div><div class="color-option" style="background-color:#e60000"></div><div class="color-option" style="background-color:#ff0000"></div><div class="color-option" style="background-color:#ff1919"></div><div class="color-option" style="background-color:#ff3232"></div><div class="color-option" style="background-color:#ff4b4b"></div><div class="color-option" style="background-color:#ff6464"></div><div class="color-option" style="background-color:#ff7d7d"></div><div class="color-option" style="background-color:#823400"></div><div class="color-option" style="background-color:#9b3e00"></div><div class="color-option" style="background-color:#b44800"></div><div class="color-option" style="background-color:#cd5200"></div><div class="color-option" style="background-color:#e65c00"></div><div class="color-option" style="background-color:#ff6600"></div><div class="color-option" style="background-color:#ff7519"></div><div class="color-option" style="background-color:#ff8532"></div><div class="color-option" style="background-color:#ff944b"></div><div class="color-option" style="background-color:#ffa364"></div><div class="color-option" style="background-color:#ffb27d"></div><div class="color-option" style="background-color:#828200"></div><div class="color-option" style="background-color:#9b9b00"></div><div class="color-option" style="background-color:#b4b400"></div><div class="color-option" style="background-color:#cdcd00"></div><div class="color-option" style="background-color:#e6e600"></div><div class="color-option" style="background-color:#ffff00"></div><div class="color-option" style="background-color:#ffff19"></div><div class="color-option" style="background-color:#ffff32"></div><div class="color-option" style="background-color:#ffff4b"></div><div class="color-option" style="background-color:#ffff64"></div><div class="color-option" style="background-color:#ffff7d"></div><div class="color-option" style="background-color:#003300"></div><div class="color-option" style="background-color:#004d00"></div><div class="color-option" style="background-color:#008000"></div><div class="color-option" style="background-color:#00b300"></div><div class="color-option" style="background-color:#00cc00"></div><div class="color-option" style="background-color:#00e600"></div><div class="color-option" style="background-color:#1aff1a"></div><div class="color-option" style="background-color:#4dff4d"></div><div class="color-option" style="background-color:#66ff66"></div><div class="color-option" style="background-color:#80ff80"></div><div class="color-option" style="background-color:#b3ffb3"></div><div class="color-option" style="background-color:#001a4d"></div><div class="color-option" style="background-color:#002b80"></div><div class="color-option" style="background-color:#003cb3"></div><div class="color-option" style="background-color:#004de6"></div><div class="color-option" style="background-color:#0000ff"></div><div class="color-option" style="background-color:#0055ff"></div><div class="color-option" style="background-color:#3377ff"></div><div class="color-option" style="background-color:#4d88ff"></div><div class="color-option" style="background-color:#6699ff"></div><div class="color-option" style="background-color:#80b3ff"></div><div class="color-option" style="background-color:#b3d1ff"></div><div class="color-option" style="background-color:#003333"></div><div class="color-option" style="background-color:#004d4d"></div><div class="color-option" style="background-color:#006666"></div><div class="color-option" style="background-color:#009999"></div><div class="color-option" style="background-color:#00cccc"></div><div class="color-option" style="background-color:#00ffff"></div><div class="color-option" style="background-color:#1affff"></div><div class="color-option" style="background-color:#33ffff"></div><div class="color-option" style="background-color:#4dffff"></div><div class="color-option" style="background-color:#80ffff"></div><div class="color-option" style="background-color:#b3ffff"></div><div class="color-option" style="background-color:#4d004d"></div><div class="color-option" style="background-color:#602060"></div><div class="color-option" style="background-color:#660066"></div><div class="color-option" style="background-color:#993399"></div><div class="color-option" style="background-color:#ac39ac"></div><div class="color-option" style="background-color:#bf40bf"></div><div class="color-option" style="background-color:#c653c6"></div><div class="color-option" style="background-color:#cc66cc"></div><div class="color-option" style="background-color:#d279d2"></div><div class="color-option" style="background-color:#d98cd9"></div><div class="color-option" style="background-color:#df9fdf"></div><div class="color-option" style="background-color:#660029"></div><div class="color-option" style="background-color:#800033"></div><div class="color-option" style="background-color:#b30047"></div><div class="color-option" style="background-color:#cc0052"></div><div class="color-option" style="background-color:#e6005c"></div><div class="color-option" style="background-color:#ff0066"></div><div class="color-option" style="background-color:#ff1a75"></div><div class="color-option" style="background-color:#ff3385"></div><div class="color-option" style="background-color:#ff4d94"></div><div class="color-option" style="background-color:#ff66a3"></div><div class="color-option" style="background-color:#ff99c2"></div>';
+    colorPalette.innerHTML = newDiv;
+    var options = document.getElementsByClassName('color-option')
+    for (var i = 0; i < options.length; i++) {
+      options[i].onclick = function(event) {chooseColor(event)}
+    }
+  }
+
+}
+
+var colorInputs = document.getElementsByClassName('color-picker');
+var colorPalettes = document.getElementsByClassName('color-palette');
+
+for (var i = 0; i < colorInputs.length; i++) {
+  makeColorPickerGo(colorInputs[i], colorPalettes[i]);
+}
+
+window.InstantClick.on('change', () => {
+  var colorInputs = document.getElementsByClassName('color-picker');
+  var colorPalettes = document.getElementsByClassName('color-palette');
+
+  for (var i = 0; i < colorInputs.length; i++) {
+    makeColorPickerGo(colorInputs[i], colorPalettes[i]);
+  }
+});

--- a/app/views/internal/tags/index.html.erb
+++ b/app/views/internal/tags/index.html.erb
@@ -1,5 +1,3 @@
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jscolor/2.0.4/jscolor.min.js"
-  integrity="sha256-CJWfUCeP3jLdUMVNUll6yQx37gh9AKmXTRxvRf7jzro=" crossorigin="anonymous"></script>
 <style>
   textarea {
     height: 140px;

--- a/app/views/internal/tags/show.html.erb
+++ b/app/views/internal/tags/show.html.erb
@@ -64,11 +64,11 @@
   </div>
   <div>
     <%= f.label :bg_color_hex %>
-    <%= f.text_field :bg_color_hex, class: "jscolor {hash:true}", required: true %>
+    <%= f.text_field :bg_color_hex, class: "color-picker", required: true %>
   </div>
   <div>
     <%= f.label :text_color_hex %>
-    <%= f.text_field :text_color_hex, class: "jscolor {hash:true}", required: true %>
+    <%= f.text_field :text_color_hex, class: "color-picker", required: true %>
   </div>
   <div>
     <%= f.submit %>

--- a/app/views/partnerships/index.html.erb
+++ b/app/views/partnerships/index.html.erb
@@ -117,6 +117,6 @@
     </div>
   </div>
   <div style="text-align: center;">
-    <h2>Questions about anything?<br /><br />Email <a href="mailto:partners@dev.to">partners@dev.to</a></h1>
+    <h2>Questions about anything?<br /><br />Email <a href="mailto:partners@dev.to">partners@dev.to</a></h2>
   </div>
 </div>

--- a/app/views/tags/edit.html.erb
+++ b/app/views/tags/edit.html.erb
@@ -1,7 +1,6 @@
 <% title "Edit #{@tag.name}" %>
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jscolor/2.0.4/jscolor.min.js"
-  integrity="sha256-CJWfUCeP3jLdUMVNUll6yQx37gh9AKmXTRxvRf7jzro=" crossorigin="anonymous"></script>
+<%= javascript_pack_tag "colorPicker", defer: true %>
 
 <style>
   .widget header {
@@ -58,12 +57,15 @@
     <div class="tag-form-field">
       <%= label_tag :bg_color_hex %>
       <br>
-      <%= text_field_tag "tag[bg_color_hex]", @tag.bg_color_hex, placeholder: "Click for color picker", class: "tag-form-text-field jscolor {hash:true, required:false}" %>
+      <%= text_field_tag "tag[bg_color_hex]", @tag.bg_color_hex, placeholder: "Click for color picker", class: "tag-form-text-field color-picker" %>
+      <div class="color-palette"></div>
+
     </div>
     <div class="tag-form-field">
       <%= label_tag :text_color_hex %>
       <br>
-      <%= text_field_tag "tag[text_color_hex]", @tag.text_color_hex, placeholder: "Click for color picker", class: "tag-form-text-field jscolor {hash:true, required:false}" %>
+      <%= text_field_tag "tag[text_color_hex]", @tag.text_color_hex, placeholder: "Click for color picker", class: "tag-form-text-field color-picker" %>
+      <div class="color-palette"></div>
     </div>
     <div class="tag-form-field">
       <%= label_tag :short_summary %>
@@ -89,8 +91,8 @@
 <% if current_user.has_role?(:super_admin) || current_user.has_role?(:admin) %>
   <center>
     <h1><a href="/internal/tags/<%= @tag.id %>" data-no-instant><%= @tag.name %> admin</a></h1>
-    <br/>
-    <br/>
-    <br/>
+    <br />
+    <br />
+    <br />
   </center>
 <% end %>

--- a/app/views/users/_org_admin.html.erb
+++ b/app/views/users/_org_admin.html.erb
@@ -1,5 +1,4 @@
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jscolor/2.0.4/jscolor.min.js"
-  integrity="sha256-CJWfUCeP3jLdUMVNUll6yQx37gh9AKmXTRxvRf7jzro=" crossorigin="anonymous"></script>
+<%= javascript_pack_tag "colorPicker", defer: true %>
 
 <%= javascript_include_tag "https://unpkg.com/@webcomponents/webcomponentsjs@2.2.10/webcomponents-loader.js", defer: true %>
 <%= javascript_pack_tag "clipboardCopy", defer: true %>
@@ -105,11 +104,13 @@
   </div>
   <div class="field">
     <%= f.label :text_color_hex, "Text color (hex)" %>
-    <%= f.text_field :text_color_hex, placeholder: "#ffffff", class: "jscolor {hash:true, required:false}" %>
+    <%= f.text_field :text_color_hex, placeholder: "#ffffff", class: "color-picker" %>
+    <div class="color-palette"></div>
   </div>
   <div class="field">
     <%= f.label :bg_color_hex, "Background color (hex)" %>
-    <%= f.text_field :bg_color_hex, placeholder: "#000000", class: "jscolor {hash:true, required:false}" %>
+    <%= f.text_field :bg_color_hex, placeholder: "#000000", class: "color-picker" %>
+    <div class="color-palette"></div>
   </div>
   <div class="field">
     <%= f.label :url, "Site url" %>

--- a/app/views/users/_org_non_member.html.erb
+++ b/app/views/users/_org_non_member.html.erb
@@ -1,5 +1,4 @@
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jscolor/2.0.4/jscolor.min.js"
-  integrity="sha256-CJWfUCeP3jLdUMVNUll6yQx37gh9AKmXTRxvRf7jzro=" crossorigin="anonymous"></script>
+<%= javascript_pack_tag "colorPicker", defer: true %>
 
 <h3>Join An Organization</h3>
 <h5>Do you have the secret code?</h5>
@@ -42,11 +41,13 @@
   </div>
   <div class="field">
     <%= f.label :text_color_hex, "Text color (hex)" %>
-    <%= text_field_tag "organization[text_color_hex]", "#000000", placeholder: "Click for color picker", class: "jscolor {hash:true, required:false}" %>
+    <%= text_field_tag "organization[text_color_hex]", "#000000", placeholder: "Click for color picker", class: "color-picker" %>
+    <div class="color-palette"></div>
   </div>
   <div class="field">
     <%= f.label :bg_color_hex, "Background color (hex)" %>
-    <%= text_field_tag "organization[bg_color_hex]", "#FFFFFF", placeholder: "Click for color picker", class: "jscolor {hash:true, required:false}" %>
+    <%= text_field_tag "organization[bg_color_hex]", "#FFFFFF", placeholder: "Click for color picker", class: "color-picker" %>
+    <div class="color-palette"></div>
   </div>
   <div class="field">
     <%= f.label :url, "Website url *" %>

--- a/app/views/users/_profile.html.erb
+++ b/app/views/users/_profile.html.erb
@@ -1,5 +1,4 @@
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jscolor/2.0.4/jscolor.min.js"
-  integrity="sha256-CJWfUCeP3jLdUMVNUll6yQx37gh9AKmXTRxvRf7jzro=" crossorigin="anonymous"></script>
+<%= javascript_pack_tag "colorPicker", defer: true %>
 
 <% unless @user.identities.exists?(provider: 'github') %>
   <div class="field">
@@ -75,12 +74,14 @@
   <div class="field">
     <% @user.bg_color_hex = user_colors(@user)[:bg] if @user.bg_color_hex.blank? %>
     <%= f.label :bg_color_hex, "background color" %>
-    <%= f.text_field :bg_color_hex, placeholder: "#000000", class: "jscolor {hash:true}" %>
+    <%= f.text_field :bg_color_hex, placeholder: "#000000", class: "color-picker" %>
+    <div class="color-palette"></div>
   </div>
   <div class="field">
     <% @user.bg_color_hex = user_colors(@user)[:text] if @user.text_color_hex.blank? %>
     <%= f.label :text_color_hex, "text color" %>
-    <%= f.text_field :text_color_hex, placeholder: "#ffffff", class: "jscolor {hash:true}" %>
+    <%= f.text_field :text_color_hex, placeholder: "#ffffff", class: "color-picker" %>
+    <div class="color-palette"></div>
   </div>
   <div class="field">
     <%= f.label :location %>


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
This feature moves us away from a pretty hacky use of an external color picker via CDN and into a color picker written in our own code.

I followed along with some example color picker code on the web, so the new stuff is not entirely "not" hacky, but it's a cleaner platform for us to work from if we want to make further changes. I kept old style JS so I wouldn't have to think about the implementation, but this can be fixed later.

Overall way fewer bytes, and one less lightly needed external script.

The functionality is and design is modified to look like this:

![](https://cl.ly/caf143c8931d/Image%202019-08-13%20at%206.12.43%20PM.png)