### PR TITLE
API: Remove /api/articles/onboarding

### DIFF
--- a/app/controllers/api/v0/articles_controller.rb
+++ b/app/controllers/api/v0/articles_controller.rb
@@ -34,22 +34,6 @@ module Api
         @article = Article.published.includes(:user).find(params[:id]).decorate
       end
 
-      def onboarding
-        tag_list = if params[:tag_list].present?
-                     params[:tag_list].split(",")
-                   else
-                     %w[career discuss productivity]
-                   end
-        @articles = Array.new(4) { Suggester::Articles::Classic.new.get(tag_list) }
-        Article.tagged_with(tag_list, any: true).
-          order("published_at DESC").
-          where("positive_reactions_count > ? OR comments_count > ? AND published = ?", 10, 3, true).
-          limit(15).each do |article|
-            @articles << article
-          end
-        @articles = @articles.uniq.sample(6)
-      end
-
       def create
         @article = ArticleCreationService.new(@user, article_params).create!
         render "show", status: :created, location: @article.url

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,7 +77,6 @@ Rails.application.routes.draw do
           constraints: ApiConstraints.new(version: 0, default: true) do
       resources :articles, only: %i[index show create update] do
         collection do
-          get "/onboarding", to: "articles#onboarding"
           get :me
         end
       end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

The endpoint `/api/articles/onboarding` is never used by the frontend, it's likely a leftover from a previous onboarding experience.

It's also not tested anywhere

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
