### PR TITLE
Fix/icons in dark mode

### DIFF
--- a/app/assets/stylesheets/article-show.scss
+++ b/app/assets/stylesheets/article-show.scss
@@ -351,8 +351,11 @@ article {
       a {
         color: $black;
         padding: calc(0.3vw + 14px);
-        background: darken($lightest-gray, 12%);
-        background: var(--theme-series-article-background, darken($lightest-gray, 12%));
+        @include themeable (
+          background,
+          theme-series-article-background,
+          darken($lightest-gray, 12%)
+        );
         display: inline-block;
         position: relative;
         z-index: 4;
@@ -365,13 +368,19 @@ article {
         }
 
         &:hover {
-          background: darken($lightest-gray, 18%);
-          background: var(--theme-series-article-hover, darken($lightest-gray, 18%));
+          @include themeable (
+            background,
+            theme-series-article-hover,
+            darken($lightest-gray, 18%)
+          );
         }
 
         &.current-article {
-          background: $black;
-          background: var(--theme-current-article-background, $black);
+          @include themeable (
+            background,
+            theme-current-article-background,
+            $black
+          );
           color: white;
         }
 

--- a/app/assets/stylesheets/article-show.scss
+++ b/app/assets/stylesheets/article-show.scss
@@ -352,6 +352,7 @@ article {
         color: $black;
         padding: calc(0.3vw + 14px);
         background: darken($lightest-gray, 12%);
+        background: var(--theme-series-article-background, darken($lightest-gray, 12%));
         display: inline-block;
         position: relative;
         z-index: 4;
@@ -365,10 +366,12 @@ article {
 
         &:hover {
           background: darken($lightest-gray, 18%);
+          background: var(--theme-series-article-hover, darken($lightest-gray, 18%));
         }
 
         &.current-article {
           background: $black;
+          background: var(--theme-current-article-background, $black);
           color: white;
         }
 
@@ -1170,8 +1173,8 @@ article {
         left: 0;
         z-index: 100;
         @include themeable(
-          background, 
-          theme-top-bar-background, 
+          background,
+          theme-top-bar-background,
           $tan
         );
         font-size: 1em;
@@ -1226,8 +1229,8 @@ article {
           a {
             font-weight: bold;
             @include themeable(
-              color, 
-              theme-color, 
+              color,
+              theme-color,
               $black
             );
             padding: 12px 18px;
@@ -1236,8 +1239,8 @@ article {
             font-size: 0.8em;
             &:hover {
               @include themeable(
-                background, 
-                theme-top-bar-background-hover, 
+                background,
+                theme-top-bar-background-hover,
                 $light-gray
               );
               }
@@ -1246,8 +1249,8 @@ article {
           &.notification-subscriptions-area-row {
             padding: 0px;
             @include themeable(
-              border-bottom, 
-              theme-container-border, 
+              border-bottom,
+              theme-container-border,
               1px solid $medium-gray
             );
           }
@@ -1262,13 +1265,13 @@ article {
               border-top-left-radius: 3px;
             }
             @include themeable-important(
-              background, 
-              theme-container-background, 
+              background,
+              theme-container-background,
               darken($tan, 3%)
             );
             @include themeable-important(
-              border-bottom, 
-              theme-subtle-border, 
+              border-bottom,
+              theme-subtle-border,
               1px solid $light-medium-gray
             );
             button.notification-subscription-label {
@@ -1279,8 +1282,8 @@ article {
               float: right !important;
               padding: 4px 0px !important;
               @include themeable-important(
-                border, 
-                theme-border, 
+                border,
+                theme-border,
                 1px solid $light-medium-gray
               );
               border-radius: 100px;
@@ -1300,14 +1303,14 @@ article {
             margin: auto !important;
             cursor: pointer !important;
             @include themeable-important(
-              color, 
-              theme-color, 
+              color,
+              theme-color,
               $black
             );
             &:hover {
               @include themeable-important(
-                background, 
-                theme-top-bar-background-hover, 
+                background,
+                theme-top-bar-background-hover,
                 $light-gray
               );
             }
@@ -1323,8 +1326,8 @@ article {
                 visibility: visible;
               }
               @include themeable-important(
-                color, 
-                theme-color, 
+                color,
+                theme-color,
                 $black
               );
             }

--- a/app/views/layouts/_user_config.html.erb
+++ b/app/views/layouts/_user_config.html.erb
@@ -31,7 +31,10 @@
         --theme-container-box-shadow: none;\
         --theme-container-border: 1px solid #22303f;\
         --theme-subtle-border: 1px solid #1f2c3a;\
-        --theme-social-icon-invert: invert(100)</style>'
+        --theme-social-icon-invert: invert(100);\
+        --theme-current-article-background: #f5f6f7;\
+        --theme-series-article-background: #636363;\
+        --theme-series-article-hover: #848484;</style>'
     } else if (bodyClass.includes('pink-theme')) {
       document.getElementById('body-styles').innerHTML = '<style>\
       :root {\


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
This PR modifies the colours used in the article series circles, specifically in the night theme.
Previously they were not that accessible, and the _current article_ was very dark and hard to notice. Colours were inverted for night theme, leaving the other themes intact.

## Related Tickets & Documents
#3674 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![63062545-fda4a400-bebe-11e9-8cd2-2f89060132d8](https://user-images.githubusercontent.com/5412470/63111800-16ab6480-bf54-11e9-9472-d3f58434d715.gif)


## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![Shy](https://media.giphy.com/media/ANWIS2HYfROI8/giphy.gif)