### PR TITLE
Fix comment deletion bug(deleted comment still appears in profile)

### DIFF
--- a/app/jobs/comments/bust_cache_job.rb
+++ b/app/jobs/comments/bust_cache_job.rb
@@ -6,7 +6,7 @@ module Comments
       comment = Comment.find_by(id: comment_id)
       return unless comment&.commentable
 
-      service.call(comment.commentable, comment.user.username)
+      service.call(comment.commentable)
     end
   end
 end

--- a/app/jobs/users/bust_cache_job.rb
+++ b/app/jobs/users/bust_cache_job.rb
@@ -5,11 +5,7 @@ module Users
     def perform(user_id, cache_buster = CacheBuster.new)
       user = User.find_by(id: user_id)
 
-      cache_buster.bust("/#{user.username}") if user
-      cache_buster.bust("/#{user.username}?i=i") if user
-      cache_buster.bust("/live/#{user.username}") if user
-      cache_buster.bust("/live/#{user.username}?i=i") if user
-      cache_buster.bust("/feed/#{user.username}") if user
+      cache_buster.bust_user(user) if user
     end
   end
 end

--- a/app/labor/cache_buster.rb
+++ b/app/labor/cache_buster.rb
@@ -12,32 +12,24 @@ class CacheBuster
                   headers: { "Fastly-Key" => ApplicationConfig["FASTLY_API_KEY"] })
   end
 
-  def bust_comment(commentable, username)
-    if commentable
-      bust("/") if Article.published.order("hotness_score DESC").limit(3).pluck(:id).include?(commentable.id)
-      if commentable.decorate.cached_tag_list_array.include?("discuss") &&
-          commentable.featured_number.to_i > 35.hours.ago.to_i
-        bust("/")
-        bust("/?i=i")
-        bust("?i=i")
-      end
-      commentable.touch(:last_comment_at)
-      bust("#{commentable.path}/comments/")
-      bust(commentable.path.to_s)
-      commentable.comments.includes(:user).find_each do |c|
-        bust(c.path)
-        bust(c.path + "?i=i")
-      end
-      bust("#{commentable.path}/comments/*")
+  def bust_comment(commentable)
+    return unless commentable
+
+    bust("/") if Article.published.order("hotness_score DESC").limit(3).pluck(:id).include?(commentable.id)
+    if commentable.decorate.cached_tag_list_array.include?("discuss") &&
+        commentable.featured_number.to_i > 35.hours.ago.to_i
+      bust("/")
+      bust("/?i=i")
+      bust("?i=i")
     end
-
-    return unless username
-
-    paths = [
-      "/#{username}", "/#{username}/comments",
-      "/#{username}/comments?i=i", "/#{username}/comments/?i=i"
-    ]
-    paths.each { |path| bust(path) }
+    commentable.touch(:last_comment_at)
+    bust("#{commentable.path}/comments/")
+    bust(commentable.path.to_s)
+    commentable.comments.includes(:user).find_each do |c|
+      bust(c.path)
+      bust(c.path + "?i=i")
+    end
+    bust("#{commentable.path}/comments/*")
   end
 
   def bust_article(article)
@@ -168,5 +160,17 @@ class CacheBuster
     bust("/listings/#{classified_listing.category}/#{classified_listing.slug}")
     bust("/listings/#{classified_listing.category}/#{classified_listing.slug}?i=i")
     bust("/listings/#{classified_listing.category}")
+  end
+
+  def bust_user(user)
+    username = user.username
+    paths = [
+      "/#{username}", "/#{username}?i=i",
+      "/#{username}/comments",
+      "/#{username}/comments?i=i", "/#{username}/comments/?i=i",
+      "/live/#{username}", "/live/#{username}?i=i",
+      "/feed/#{username}"
+    ]
+    paths.each { |path| bust(path) }
   end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -23,6 +23,7 @@ class Comment < ApplicationRecord
   after_save     :calculate_score
   after_save     :bust_cache
   after_save     :synchronous_bust
+  after_destroy  :after_destroy_actions
   before_destroy :before_destroy_actions
   after_create   :send_email_notification, if: :should_send_email_notification?
   after_create   :create_first_reaction
@@ -264,6 +265,11 @@ class Comment < ApplicationRecord
     Comments::CreateFirstReactionJob.perform_later(id)
   end
 
+  def after_destroy_actions
+    Users::BustCacheJob.perform_now(user_id)
+    user&.touch(:last_comment_at)
+  end
+
   def before_destroy_actions
     commentable.touch(:last_comment_at) if commentable.respond_to?(:last_comment_at)
     ancestors.update_all(updated_at: Time.current)
@@ -282,6 +288,7 @@ class Comment < ApplicationRecord
 
   def synchronous_bust
     commentable.touch(:last_comment_at) if commentable.respond_to?(:last_comment_at)
+    user&.touch(:last_comment_at)
     cache_buster = CacheBuster.new
     cache_buster.bust(commentable.path.to_s) if commentable
     expire_root_fragment

--- a/app/services/edge_cache/commentable/bust.rb
+++ b/app/services/edge_cache/commentable/bust.rb
@@ -1,9 +1,8 @@
 module EdgeCache
   module Commentable
     class Bust
-      def initialize(commentable, username, cache_buster = CacheBuster.new)
+      def initialize(commentable, cache_buster = CacheBuster.new)
         @commentable = commentable
-        @username = username
         @cache_buster = cache_buster
       end
 
@@ -12,14 +11,14 @@ module EdgeCache
       end
 
       def call
-        cache_buster.bust_comment(commentable, username)
+        cache_buster.bust_comment(commentable)
         cache_buster.bust("#{commentable.path}/comments")
         commentable.index!
       end
 
       private
 
-      attr_reader :commentable, :username, :cache_buster
+      attr_reader :commentable, :cache_buster
     end
   end
 end

--- a/app/services/moderator/manage_activity_and_roles.rb
+++ b/app/services/moderator/manage_activity_and_roles.rb
@@ -18,10 +18,11 @@ module Moderator
       cachebuster = CacheBuster.new
       user.comments.find_each do |comment|
         comment.reactions.delete_all
-        cachebuster.bust_comment(comment.commentable, user.username)
+        cachebuster.bust_comment(comment.commentable)
         comment.delete
         comment.remove_notifications
       end
+      cachebuster.bust_user(user)
     end
 
     def delete_articles
@@ -33,7 +34,8 @@ module Moderator
         article.reactions.delete_all
         article.comments.includes(:user).find_each do |comment|
           comment.reactions.delete_all
-          cachebuster.bust_comment(comment.commentable, comment.user.username)
+          cachebuster.bust_comment(comment.commentable)
+          cachebuster.bust_user(comment.user)
           comment.delete
         end
         article.remove_algolia_index

--- a/spec/jobs/comments/bust_cache_job_spec.rb
+++ b/spec/jobs/comments/bust_cache_job_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Comments::BustCacheJob, type: :job do
     it "calls the service" do
       described_class.perform_now(comment.id, edge_cache_commentable_bust_service)
       expect(edge_cache_commentable_bust_service).to have_received(:call).
-        with(comment.commentable, comment.user.username).once
+        with(comment.commentable).once
     end
 
     it "doesn't call the service with a non existent comment" do

--- a/spec/jobs/users/bust_cache_job_spec.rb
+++ b/spec/jobs/users/bust_cache_job_spec.rb
@@ -7,14 +7,11 @@ RSpec.describe Users::BustCacheJob, type: :job do
     let(:user) { FactoryBot.create(:user) }
 
     it "busts cache" do
-      path = user.path
-
       cache_buster = double
-      allow(cache_buster).to receive(:bust)
+      allow(cache_buster).to receive(:bust_user)
 
       described_class.perform_now(user.id, cache_buster) do
-        expect(cache_buster).to have_received(:bust).with(path)
-        expect(cache_buster).to have_received(:bust).with("/feed#{path}")
+        expect(cache_buster).to have_received(:bust_user).with(user)
       end
     end
   end

--- a/spec/labor/cache_buster_spec.rb
+++ b/spec/labor/cache_buster_spec.rb
@@ -12,15 +12,7 @@ RSpec.describe CacheBuster do
 
   describe "#bust_comment" do
     it "busts comment" do
-      cache_buster.bust_comment(comment.commentable, user.username)
-    end
-
-    it "works if commentable is missing" do
-      cache_buster.bust_comment(nil, user.username)
-    end
-
-    it "works if username is missing" do
-      cache_buster.bust_comment(comment.commentable, "")
+      cache_buster.bust_comment(comment.commentable)
     end
   end
 
@@ -92,6 +84,16 @@ RSpec.describe CacheBuster do
   describe "#bust_classified_listings" do
     it "busts classified listings" do
       cache_buster.bust_classified_listings(listing)
+    end
+  end
+
+  describe "#bust_user" do
+    it "busts a user" do
+      allow(cache_buster).to receive(:bust)
+      cache_buster.bust_user(user)
+      expect(cache_buster).to have_received(:bust).with("/" + user.username.to_s)
+      expect(cache_buster).to have_received(:bust).with("/" + user.username.to_s + "/comments?i=i")
+      expect(cache_buster).to have_received(:bust).with("/feed/" + user.username.to_s)
     end
   end
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -287,5 +287,23 @@ RSpec.describe Comment, type: :model do
     end
   end
 
+  describe "when a comment is destroyed" do
+    it "updates user last comment date" do
+      expect do
+        comment.destroy
+        user2.reload
+      end.to change(user2, :last_comment_at)
+    end
+  end
+
+  describe "when a comment is created" do
+    it "updates user last comment date" do
+      expect do
+        comment.save
+        user2.reload
+      end.to change(user2, :last_comment_at)
+    end
+  end
+
   include_examples "#sync_reactions_count", :article_comment
 end

--- a/spec/services/edge_cache/commentable/bust_spec.rb
+++ b/spec/services/edge_cache/commentable/bust_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 RSpec.describe EdgeCache::Commentable::Bust, type: :service do
   let(:commentable) { create(:article) }
-  let(:username) { create(:user).username }
   let(:cache_buster) { double }
 
   before do
@@ -11,14 +10,14 @@ RSpec.describe EdgeCache::Commentable::Bust, type: :service do
   end
 
   it "busts the cache" do
-    described_class.call(commentable, username, cache_buster)
-    expect(cache_buster).to have_received(:bust_comment).with(commentable, username).once
+    described_class.call(commentable, cache_buster)
+    expect(cache_buster).to have_received(:bust_comment).with(commentable).once
     expect(cache_buster).to have_received(:bust).with("#{commentable.path}/comments").once
   end
 
   it "indexes the commentable" do
     allow(commentable).to receive(:index!)
-    described_class.call(commentable, username, cache_buster)
+    described_class.call(commentable, cache_buster)
     expect(commentable).to have_received(:index!).once
   end
 end


### PR DESCRIPTION
  - Refactor comment bust cache to process only comment and not user anymore
  - Refactor calls accordingly
  - New method to bust user cache, based on previous comment bust cache + existing bust user cache
  - User cache busted via hooks after comment operation (and not before as previous comment bust method used to do)
  - Added user cache busting after comment busting to keep same behaviour
  - Added touch on user object to update numbers of comments/articles that are Rails cached and were not updated either on the profile page.
  - Added tests

<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
Profile recent comments not updated after deletion of a comment. 
Number of comments not updated either
## Related Tickets & Documents
#3600 
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
