### PR TITLE
Adds border-right to the menu for displays with min-width 1250 or higher

### DIFF
--- a/app/assets/stylesheets/top-bar.scss
+++ b/app/assets/stylesheets/top-bar.scss
@@ -300,6 +300,8 @@
       }
       @media screen and (min-width: 1250px) {
         position: absolute;
+        border-right: 1px solid rgb(219, 222, 225);
+        border-bottom-right-radius: 5px;
         right: 4px;
       }
       .header {


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
Modifies top-bar.scss to add 'border-right' and 'border-bottom-right-raidus' property
for '.menu' in media query 'mind-width: 1250px' to get even menu appearance on desktop
screens.

It adds border radius of 5px throughout the bottom-end of the menu and has the border running back all the way up on the right side on wide-enough(>=1250px) displays.

## Related Tickets & Documents
Issue #3726 
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
- night theme desktop
![night-theme-desktop](https://user-images.githubusercontent.com/22113778/63223168-27b3da00-c1cf-11e9-9bca-d6ee3db62963.png)
- night theme mobile
![night-theme-mobile](https://user-images.githubusercontent.com/22113778/63223169-27b3da00-c1cf-11e9-83b3-827d80064db4.png)
- pink theme desktop
![pink-theme-desktop](https://user-images.githubusercontent.com/22113778/63223170-27b3da00-c1cf-11e9-859a-cb8502619a9b.png)
- night theme mobile
![pink-theme-mobile](https://user-images.githubusercontent.com/22113778/63223171-27b3da00-c1cf-11e9-84d7-16b5791d3768.png)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![I did it!](https://user-images.githubusercontent.com/22113778/63223238-364ec100-c1d0-11e9-86c5-557e252a6ea9.gif)

