### PR TITLE
Add random variants to onboarding for a/b testing

### DIFF
--- a/app/controllers/async_info_controller.rb
+++ b/app/controllers/async_info_controller.rb
@@ -52,6 +52,7 @@ class AsyncInfoController < ApplicationController
         experience_level: @user.experience_level,
         preferred_languages_array: @user.preferred_languages_array,
         config_body_class: @user.config_body_class,
+        onboarding_variant_version: @user.onboarding_variant_version,
         pro: @user.pro?
       }
     end

--- a/app/dashboards/display_ad_dashboard.rb
+++ b/app/dashboards/display_ad_dashboard.rb
@@ -17,6 +17,7 @@ class DisplayAdDashboard < Administrate::BaseDashboard
     cost_per_click: Field::Number.with_options(decimals: 2),
     impressions_count: Field::Number,
     clicks_count: Field::Number,
+    success_rate: Field::Number,
     published: Field::Boolean,
     approved: Field::Boolean,
     created_at: Field::DateTime,
@@ -33,6 +34,9 @@ class DisplayAdDashboard < Administrate::BaseDashboard
     id
     placement_area
     body_markdown
+    published
+    approved
+    success_rate
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
@@ -47,6 +51,7 @@ class DisplayAdDashboard < Administrate::BaseDashboard
     cost_per_click
     impressions_count
     clicks_count
+    success_rate
     published
     approved
     created_at

--- a/app/dashboards/html_variant_dashboard.rb
+++ b/app/dashboards/html_variant_dashboard.rb
@@ -32,6 +32,7 @@ class HtmlVariantDashboard < Administrate::BaseDashboard
     user
     html_variant_trials
     html_variant_successes
+    success_rate
     id
   ].freeze
 

--- a/app/javascript/listings/__tests__/__snapshots__/listingDashboard.test.jsx.snap
+++ b/app/javascript/listings/__tests__/__snapshots__/listingDashboard.test.jsx.snap
@@ -84,30 +84,18 @@ preact-render-spy (1 nodes)
   </div>
   <div class="dashboard-listings-view">
     <div class="dashboard-listing-row expired">
-      <a href="cfp/asdfasdf-2ea8">
-        <h2>asdfasdf (expired)</h2>
+      <span class="listing-org">Infotrode</span>
+      <a href="cfp/hehhehe-5hld">
+        <h2>hehhehe (expired)</h2>
       </a>
       <span class="dashboard-listing-date">Jun 11</span>
       <span class="dashboard-listing-category">
         <a href="/listings/cfp/">cfp</a>
       </span>
-      <span class="dashboard-listing-tags">
-        <a
-          href="/listings?t=computerscience"
-          data-no-instant={true}
-        >
-          #computerscience 
-        </a>
-        <a
-          href="/listings?t=career"
-          data-no-instant={true}
-        >
-          #career 
-        </a>
-      </span>
+      <span class="dashboard-listing-tags"></span>
       <div class="listing-row-actions">
         <a
-          href="/listings/23/edit"
+          href="/listings/25/edit"
           class="dashboard-listing-edit-button cta pill green"
         >
           EDIT
@@ -153,18 +141,30 @@ preact-render-spy (1 nodes)
       </div>
     </div>
     <div class="dashboard-listing-row expired">
-      <span class="listing-org">Infotrode</span>
-      <a href="cfp/hehhehe-5hld">
-        <h2>hehhehe (expired)</h2>
+      <a href="cfp/asdfasdf-2ea8">
+        <h2>asdfasdf (expired)</h2>
       </a>
       <span class="dashboard-listing-date">Jun 11</span>
       <span class="dashboard-listing-category">
         <a href="/listings/cfp/">cfp</a>
       </span>
-      <span class="dashboard-listing-tags"></span>
+      <span class="dashboard-listing-tags">
+        <a
+          href="/listings?t=computerscience"
+          data-no-instant={true}
+        >
+          #computerscience 
+        </a>
+        <a
+          href="/listings?t=career"
+          data-no-instant={true}
+        >
+          #career 
+        </a>
+      </span>
       <div class="listing-row-actions">
         <a
-          href="/listings/25/edit"
+          href="/listings/23/edit"
           class="dashboard-listing-edit-button cta pill green"
         >
           EDIT

--- a/app/javascript/listings/__tests__/__snapshots__/listingDashboard.test.jsx.snap
+++ b/app/javascript/listings/__tests__/__snapshots__/listingDashboard.test.jsx.snap
@@ -84,18 +84,30 @@ preact-render-spy (1 nodes)
   </div>
   <div class="dashboard-listings-view">
     <div class="dashboard-listing-row expired">
-      <span class="listing-org">Infotrode</span>
-      <a href="cfp/hehhehe-5hld">
-        <h2>hehhehe (expired)</h2>
+      <a href="cfp/asdfasdf-2ea8">
+        <h2>asdfasdf (expired)</h2>
       </a>
       <span class="dashboard-listing-date">Jun 11</span>
       <span class="dashboard-listing-category">
         <a href="/listings/cfp/">cfp</a>
       </span>
-      <span class="dashboard-listing-tags"></span>
+      <span class="dashboard-listing-tags">
+        <a
+          href="/listings?t=computerscience"
+          data-no-instant={true}
+        >
+          #computerscience 
+        </a>
+        <a
+          href="/listings?t=career"
+          data-no-instant={true}
+        >
+          #career 
+        </a>
+      </span>
       <div class="listing-row-actions">
         <a
-          href="/listings/25/edit"
+          href="/listings/23/edit"
           class="dashboard-listing-edit-button cta pill green"
         >
           EDIT
@@ -141,30 +153,18 @@ preact-render-spy (1 nodes)
       </div>
     </div>
     <div class="dashboard-listing-row expired">
-      <a href="cfp/asdfasdf-2ea8">
-        <h2>asdfasdf (expired)</h2>
+      <span class="listing-org">Infotrode</span>
+      <a href="cfp/hehhehe-5hld">
+        <h2>hehhehe (expired)</h2>
       </a>
       <span class="dashboard-listing-date">Jun 11</span>
       <span class="dashboard-listing-category">
         <a href="/listings/cfp/">cfp</a>
       </span>
-      <span class="dashboard-listing-tags">
-        <a
-          href="/listings?t=computerscience"
-          data-no-instant={true}
-        >
-          #computerscience 
-        </a>
-        <a
-          href="/listings?t=career"
-          data-no-instant={true}
-        >
-          #career 
-        </a>
-      </span>
+      <span class="dashboard-listing-tags"></span>
       <div class="listing-row-actions">
         <a
-          href="/listings/23/edit"
+          href="/listings/25/edit"
           class="dashboard-listing-edit-button cta pill green"
         >
           EDIT

--- a/app/javascript/onboarding/Onboarding.jsx
+++ b/app/javascript/onboarding/Onboarding.jsx
@@ -9,14 +9,30 @@ import FollowTags from './components/FollowTags';
 import FollowUsers from './components/FollowUsers';
 import BioForm from './components/BioForm';
 
+// Current Onboarding Variants
+// 0) Original intro slide: three explainer paragraphs, left adjusted.
+// 1) Modified intro slide: Cat gif, let's get started.
+// 2) Modified intro slide: Cat gif, We have a few quick questions to fill out your profile
+// 3) Modified intro slide: Skull gif, The more you get involved in community, the better developer you will be.
+// 4) Modified intro slide: Skull gif, You just made a great choice for your dev career
+// 5) No intro slide.
+// 6) Last slide challenge: Leave three constructive comments today
+
 export default class Onboarding extends Component {
   constructor(props) {
     super(props);
 
+    const url = new URL(window.location);
+    const previousLocation = url.searchParams.get('referrer');
+    let variant = '0'; 
+    if (url.searchParams.get('variant') || window.currentUser) {
+      variant = url.searchParams.get('variant') || window.currentUser.onboarding_variant_version || '0';
+    };
+
     this.nextSlide = this.nextSlide.bind(this);
     this.prevSlide = this.prevSlide.bind(this);
-
-    const slides = [
+    
+    let slides = [
       IntroSlide,
       EmailListTermsConditionsForm,
       BioForm,
@@ -26,14 +42,24 @@ export default class Onboarding extends Component {
       ClosingSlide,
     ];
 
-    const url = new URL(window.location);
-    const previousLocation = url.searchParams.get('referrer');
+    if (variant === '5') {
+      slides = [
+        EmailListTermsConditionsForm,
+        BioForm,
+        PersonalInfoForm,
+        FollowTags,
+        FollowUsers,
+        ClosingSlide,
+      ];
+    }
+
 
     this.slides = slides.map(SlideComponent => (
       <SlideComponent
         next={this.nextSlide}
         prev={this.prevSlide}
         previousLocation={previousLocation}
+        variant={variant}
       />
     ));
 

--- a/app/javascript/onboarding/__tests__/__snapshots__/Onboarding.test.jsx.snap
+++ b/app/javascript/onboarding/__tests__/__snapshots__/Onboarding.test.jsx.snap
@@ -353,17 +353,19 @@ preact-render-spy (1 nodes)
          />
         <span>community!</span>
       </h1>
-      <p>
-        DEV is where programmers share ideas and help each other grow. 🤓
-      </p>
-      <p>
-        Ask questions, leave helpful comments, encourage others, and have fun! 🙌
-      </p>
-      <p>
-        A few 
-        <strong>quick questions</strong>
-         for you before you get started...
-      </p>
+      <div>
+        <p>
+          DEV is where programmers share ideas and help each other grow. 🤓
+        </p>
+        <p>
+          Ask questions, leave helpful comments, encourage others, and have fun! 🙌
+        </p>
+        <p>
+          A few 
+          <strong>quick questions</strong>
+           for you before you get started...
+        </p>
+      </div>
     </div>
     <nav class="onboarding-navigation">
       <button

--- a/app/javascript/onboarding/components/ClosingSlide.jsx
+++ b/app/javascript/onboarding/components/ClosingSlide.jsx
@@ -19,10 +19,14 @@ class ClosingSlide extends Component {
   }
 
   render() {
-    const { previousLocation, prev, next } = this.props;
+    const { previousLocation, prev, next, variant } = this.props;
 
     const previousLocationListElement = () => {
-      if (previousLocation !== 'none' && previousLocation !== null) {
+      if (variant === '6') {
+        return (
+            <div className="onboarding-previous-location" >✨ <em>Challenge: Leave 3 constructive comments today</em> ✨</div>
+        );
+      } else if (previousLocation !== 'none' && previousLocation !== null) {
         return (
           <a className="onboarding-previous-location" href={previousLocation}>
             <div>Or go back to the page you were on before you signed up</div>
@@ -89,6 +93,7 @@ ClosingSlide.propTypes = {
   prev: PropTypes.func.isRequired,
   next: PropTypes.string.isRequired,
   previousLocation: PropTypes.string.isRequired,
+  variant: PropTypes.string.isRequired,
 };
 
 export default ClosingSlide;

--- a/app/javascript/onboarding/components/IntroSlide.jsx
+++ b/app/javascript/onboarding/components/IntroSlide.jsx
@@ -30,7 +30,51 @@ class IntroSlide extends Component {
   }
 
   render() {
-    const { prev } = this.props;
+    const { prev, variant } = this.props;
+    let onboardingBody = (
+      <div>
+        <p>
+          DEV is where programmers share ideas and help each other grow. 🤓
+        </p>
+        <p>
+          Ask questions, leave helpful comments, encourage others, and have fun! 🙌
+        </p>
+        <p>
+          A few <strong>quick questions</strong> for you before you get started...
+        </p>
+      </div>
+    )
+
+    if (variant === '1') {
+      onboardingBody = <div style={{textAlign: 'center'}}>
+          <img src='https://media.giphy.com/media/ICOgUNjpvO0PC/giphy.gif' alt='hello cat' style={{borderRadius: '8px', height: '220px'}} />
+          <br/><strong><em>Let's get started...</em></strong>
+        </div>
+    } else if ( variant === '2') {
+      onboardingBody = <div style={{textAlign: 'center'}}>
+        <img src='https://media.giphy.com/media/ICOgUNjpvO0PC/giphy.gif' alt='hello cat' style={{borderRadius: '8px', height: '140px'}} />
+        <p>We have a few quick questions to fill out your profile</p>
+        <p>
+          <strong><em>Let's get started...</em></strong>
+        </p>
+      </div>
+    } else if ( variant === '3') {
+      onboardingBody = <div style={{textAlign: 'center', fontSize: '0.9em'}}>
+        <img src='https://media.giphy.com/media/aWRWTF27ilPzy/giphy.gif' alt='hello' style={{borderRadius: '8px', height: '140px'}} />
+        <p>The more you get involved in community, the better developer you will be.</p>
+        <p>
+          <strong><em>Let's get started...</em></strong>
+        </p>
+      </div>
+    } else if ( variant === '4') {
+      onboardingBody = <div style={{textAlign: 'center', fontSize: '1.1em'}}>
+        <img src='https://media.giphy.com/media/aWRWTF27ilPzy/giphy.gif' alt='hello' style={{borderRadius: '8px', height: '140px'}} />
+        <p>You just made a great choice for your dev career.</p>
+        <p>
+          <strong><em>Let's get started...</em></strong>
+        </p>
+      </div>
+    }
     return (
       <div className="onboarding-main">
         <div className="onboarding-content">
@@ -43,11 +87,7 @@ class IntroSlide extends Component {
             />
             <span>community!</span>
           </h1>
-          <p>
-            DEV is where programmers share ideas and help each other grow. 🤓
-          </p>
-          <p>Ask questions, leave helpful comments, encourage others, and have fun! 🙌</p>
-          <p>A few <strong>quick questions</strong> for you before you get started...</p>
+          {onboardingBody}
         </div>
         <Navigation prev={prev} next={this.onSubmit} hidePrev />
       </div>
@@ -62,6 +102,7 @@ class IntroSlide extends Component {
 IntroSlide.propTypes = {
   prev: PropTypes.func.isRequired,
   next: PropTypes.string.isRequired,
+  variant: PropTypes.string.isRequired,
 };
 
 export default IntroSlide;

--- a/app/services/authorization_service.rb
+++ b/app/services/authorization_service.rb
@@ -63,6 +63,7 @@ class AuthorizationService
       add_social_identity_data(user)
       user.saw_onboarding = false
       user.editor_version = "v2"
+      user.onboarding_variant_version = %w[0 0 0 0 0 0 1 2 3 4 5 6].sample # 6/12 chance of getting version zero (current dominant)
       user.save!
     end
     user

--- a/db/migrate/20190818191954_add_onboarding_variant_to_users.rb
+++ b/db/migrate/20190818191954_add_onboarding_variant_to_users.rb
@@ -1,0 +1,5 @@
+class AddOnboardingVariantToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :onboarding_variant_version, :string, default: "0"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_01_083510) do
+ActiveRecord::Schema.define(version: 2019_08_18_191954) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -1076,6 +1076,7 @@ ActiveRecord::Schema.define(version: 2019_08_01_083510) do
     t.boolean "onboarding_package_fulfilled", default: false
     t.boolean "onboarding_package_requested", default: false
     t.boolean "onboarding_package_requested_again", default: false
+    t.string "onboarding_variant_version", default: "0"
     t.boolean "org_admin", default: false
     t.integer "organization_id"
     t.boolean "permit_adjacent_sponsors", default: true

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -111,6 +111,12 @@ RSpec.describe User, type: :model do
       user.reload
       expect(user.email).to eq("anna@example.com")
     end
+
+    it "sets onboarding_variant_version" do
+      user = create(:user, email: "anna@example.com")
+      user.reload
+      expect(%w[0 1 2 3 4 5 6]).to include(user.onboarding_variant_version)
+    end
   end
 
   describe "validations" do


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
This feature adds the field `onboarding_variant_version` which is randomly assigned to new users. These variants are then applied to onboarding and we can measure the relative effectiveness of various approaches.

For now, I added some mild copy adjustments to the first slide, alongside one variant to just skip the first slide, and one more to add a "challenge" of three constructive comments on the last slide.

All the current active variants are  to be described in comments in the code. When we add new variants we will always increment, so if we deem versions "0" and "2" are to be replaced with new variants, the available variants will be 1,3,4,5,6,7,8 now and 0 and 2 are for historical archive.

Also added `success_rate` to admin dashboard for display units as a random misc improvement for administration.