### PR TITLE
Add comment markdown to warned_user_ping

### DIFF
--- a/app/observers/application_observer.rb
+++ b/app/observers/application_observer.rb
@@ -2,9 +2,18 @@ class ApplicationObserver < ActiveRecord::Observer
   def warned_user_ping(activity)
     return unless activity.user.warned == true
 
-    SlackBotPingJob.perform_later message: "Activity: https://dev.to#{activity.path}\nManage @#{activity.user.username}: https://dev.to/internal/users/#{activity.user.id}",
+    SlackBotPingJob.perform_later message: message,
                                   channel: "warned-user-comments",
                                   username: "sloan_watch_bot",
                                   icon_emoji: ":sloan:"
+  end
+
+  def message(activity)
+    <<~HEREDOC
+      Activity: https://dev.to#{activity.path}
+      #{'Comment text: ' + activity.body_markdown.truncate(300) if activity.class.name == 'Comment'}
+      ---
+      Manage commenter - @#{activity.user.username}: https://dev.to/internal/users/#{activity.user.id},
+    HEREDOC
   end
 end

--- a/app/observers/application_observer.rb
+++ b/app/observers/application_observer.rb
@@ -2,7 +2,7 @@ class ApplicationObserver < ActiveRecord::Observer
   def warned_user_ping(activity)
     return unless activity.user.warned == true
 
-    SlackBotPingJob.perform_later message: message,
+    SlackBotPingJob.perform_later message: message(activity),
                                   channel: "warned-user-comments",
                                   username: "sloan_watch_bot",
                                   icon_emoji: ":sloan:"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
This adds a truncated version of a comment's `body_markdown` for the warned user alert. I went with `body_markdown` and not `processed_html` since markdown is _somewhat_ compatible with Slack's messaging system already.