### PR TITLE
Fix for multi-image upload to handle single imgs for comments

### DIFF
--- a/app/assets/javascripts/initializers/initializeCommentsPage.js.erb
+++ b/app/assets/javascripts/initializers/initializeCommentsPage.js.erb
@@ -465,7 +465,7 @@ function handleImageUpload(event, randomIdNumber) {
                 var messageContainer = document.getElementById("image-upload-file-label-" + randomIdNumber)
                 // button.style.display = "none";
                 messageContainer.style.display = "none";
-                address.value = json.link;
+                address.value = json.links[0];
                 address.classList.add("showing");
                 address.select();
 

--- a/app/assets/javascripts/utilities/buildCommentFormHTML.js.erb
+++ b/app/assets/javascripts/utilities/buildCommentFormHTML.js.erb
@@ -26,7 +26,7 @@ function buildCommentFormHTML(commentableId, commentableType, parentId) {
               <img alt="markdown guide" class="icon-image" src="<%= asset_path('info.svg') %>" />\
             </a>\
             <div class="editor-image-upload">\
-              <input type="file" multiple="" id="image-upload-' + randomIdNumber + '"  name="file" accept="image/*" style="display:none">\
+              <input type="file" id="image-upload-' + randomIdNumber + '"  name="file" accept="image/*" style="display:none">\
               <button title="Upload Image" class="image-upload-button" id="image-upload-button-' + randomIdNumber + '" onclick="handleImageUpload(event,'+ randomIdNumber + ')">\
                 <img alt="upload image" class="icon-image" src="<%= asset_path("image-upload.svg") %>" />\
               </button>\

--- a/app/assets/javascripts/utilities/buildCommentFormHTML.js.erb
+++ b/app/assets/javascripts/utilities/buildCommentFormHTML.js.erb
@@ -26,7 +26,7 @@ function buildCommentFormHTML(commentableId, commentableType, parentId) {
               <img alt="markdown guide" class="icon-image" src="<%= asset_path('info.svg') %>" />\
             </a>\
             <div class="editor-image-upload">\
-              <input type="file" id="image-upload-' + randomIdNumber + '"  name="file" accept="image/*" style="display:none">\
+              <input type="file" multiple="" id="image-upload-' + randomIdNumber + '"  name="file" accept="image/*" style="display:none">\
               <button title="Upload Image" class="image-upload-button" id="image-upload-button-' + randomIdNumber + '" onclick="handleImageUpload(event,'+ randomIdNumber + ')">\
                 <img alt="upload image" class="icon-image" src="<%= asset_path("image-upload.svg") %>" />\
               </button>\

--- a/app/controllers/image_uploads_controller.rb
+++ b/app/controllers/image_uploads_controller.rb
@@ -43,11 +43,18 @@ class ImageUploadsController < ApplicationController
   private
 
   def image_upload(images)
-    images.map do |image|
+    if images.is_a? Array
+      images.map do |image|
+        uploader = ArticleImageUploader.new
+        uploader.store!(image)
+        RateLimitChecker.new(current_user).track_image_uploads
+        uploader
+      end
+    else
       uploader = ArticleImageUploader.new
-      uploader.store!(image)
+      uploader.store!(images)
       RateLimitChecker.new(current_user).track_image_uploads
-      uploader
+      [uploader]
     end
   end
 end

--- a/spec/requests/image_uploads_spec.rb
+++ b/spec/requests/image_uploads_spec.rb
@@ -43,6 +43,12 @@ RSpec.describe "ImageUploads", type: :request do
         expect(response.body).to match("\/i\/.+\.")
       end
 
+      it "supports for uploading a single image not in an array" do
+        post "/image_uploads", headers: headers, params: { image: image }
+        expect(JSON.parse(response.body)["links"].length).to eq(1)
+        expect(response.body).to match("\/i\/.+\.")
+      end
+
       it "supports upload of more than one image at a time" do
         image2 = Rack::Test::UploadedFile.new(
           Rails.root.join("spec", "support", "fixtures", "images", "image2.jpeg"),


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This fixes an issue where the image uploads controller accepted only arrays of images, and thus broke uploading images via comments. I looked at #3599 but couldn't quickly figure out how to get the comment's image upload `<form>` working so that it automatically sends an array to the server -- like the multi-image upload for articles does -- so I went with the quickest fix I could think of.

This fix uses a simple `if else` to check if the image is an array; if it's not, then it'll upload like  multiple images would and return an array with one `uploader`.