### PR TITLE
Remove channel_users from chat_channel index

### DIFF
--- a/app/models/chat_channel.rb
+++ b/app/models/chat_channel.rb
@@ -21,7 +21,7 @@ class ChatChannel < ApplicationRecord
 
   algoliasearch index_name: "SecuredChatChannel_#{Rails.env}" do
     attribute :id, :viewable_by, :slug, :channel_type,
-              :channel_name, :channel_users, :last_message_at, :status,
+              :channel_name, :last_message_at, :status,
               :messages_count, :channel_human_names, :channel_mod_ids, :pending_users_select_fields,
               :description
     searchableAttributes %i[channel_name channel_slug channel_human_names]


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
Fixes an issue where _too large_ objects stop indexing. We no longer need this field to be included.