### PR TITLE
Updates Possible error messages under windows installation docs

### DIFF
--- a/docs/installation/windows.md
+++ b/docs/installation/windows.md
@@ -131,4 +131,17 @@ Pay attention to the username and password you setup during installation of Post
 sudo apt-get install libpq-dev
 ```
 
+3. If the command `bin/setup` fails at installing `cld-0.8.0` with the warnings `'aclocal-1.10' is missing on your system` and `'automake-1.10' is missing on your system`. Please install `automake-1.10` using the commands below.
+
+```shell
+cd
+sudo apt-get update
+sudo apt-get install autoconf
+wget https://ftp.gnu.org/gnu/automake/automake-1.10.tar.gz
+tar xf automake-1.10.tar.gz
+cd automake-1.10/
+./configure --prefix=/usr/local
+make
+```
+
 > If you encountered any errors that you subsequently resolved, **please consider updating this section** with your errors and their solutions.


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Documentation Update

## Description
Adds solution for the command 'bin/setup' failing while trying to install
'cld-0.8.0' due to absence of 'aclocal-1.10' and 'automake-1.10'. Provides
commands to install 'automake-1.10' from 'ftp.gnu.org' which fixes the problem.
## Related Tickets & Documents
#3740 
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
- Desktop
![image](https://user-images.githubusercontent.com/22113778/63536009-5cf25c00-c530-11e9-8b55-512ed56e0a55.png)
- Mobile
![image](https://user-images.githubusercontent.com/22113778/63536237-cd997880-c530-11e9-823a-792bf452c461.png)

## Added to documentation?

- [x] docs.dev.to
- [ ] readme
- [ ] no documentation needed

