### PR TITLE
Fixes encoding of special characters in org (#3779)

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -70,7 +70,7 @@ class OrganizationsController < ApplicationController
     params.require(:organization).permit(permitted_params).
       transform_values do |value|
         if value.class.name == "String"
-          ActionController::Base.helpers.strip_tags(value)
+          Loofah.scrub_fragment(value, :prune).text(encode_special_chars: false)
         else
           value
         end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

According to [issue 28060 on the rails project](https://github.com/rails/rails/issues/28060), ``strip_tags`` since v1.0.3 encodes special html characters (&, <, > ...) by default. To restore its previous behaviour, I'm using Loofah directly, which is what ``strip_tags`` uses behind the scene. 

This solution does **NOT** fix existing organizations, they will need to be updated replacing ``&amp;`` with ``&``. I chose this solution over fixing how we show the ``&amp;`` in the view, because:

1. [Storing HTML encoded characters in the database might be a problem if we decide to display the data in a non-HTML format](https://stackoverflow.com/questions/4598802/should-we-html-encode-special-characters-before-storing-them-in-the-database/20700136)
2. This bug was present in all text fields that accepted & (not only the name of the organization)

## Related Tickets & Documents

Fixes #3779

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

No UI changes.

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
