### PR TITLE
Exclude AWS Cloud9 user config directory and resolve AWS install error "role ec2-user does not exist" in FAQ (v2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ _docker-storage/
 docs/.static/ruby-doc/
 # ReDoc generated API doc (in the Gitdocs folder)
 docs/.static/api/
+
+# AWS Cloud9 specific folder for user settings
+.c9/

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -12,3 +12,17 @@ make ruby-doc
 ```
 
 Then open `.static/ruby-doc/index.html` in the `docs` directory and browse the Ruby documentation
+
+## How do I fix the Error `role "ec2-user" does not exist` on an AWS instance?
+
+After installing and configuring PostgreSQL on an AWS EC2 (or AWS Cloud9) instance and running `bin/setup`, this error could occur.
+
+To fix it, run the following two commands in a terminal (assuming your PostgreSQL user is named **postgres**):
+
+```
+sudo -u postgres createuser -s ec2-user
+sudo -u postgres createdb ec2-user
+```
+
+The first command creates the user **ec2-user** and the second one creates the database for this user, because every user needs its database.
+Even if the first command fails, run the second command to create the missing database.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [x] Documentation Update

## Description
#### AWS Cloud9 config folder
When dev.to is set up on an AWS Cloud9 instance, there is a folder `.c9` automatically created by AWS C9 for storing user specific settings (themes, keybindings of the IDE etc.).
I added this folder to the .gitignore file because it could include sensitive information.

#### Update FAQ with fix for AWS PostgreSQL error
After setting up PostgreSQL on the AWS Cloud9 instance and running `bin/setup` for the new dev.to instance, the error `role "ec2-user" does not exist` occured. I added the fix for this one to the **faqs.md** file in case someone else has this issue.

## Added to documentation?

- [x] docs.dev.to
- [ ] readme
- [ ] no documentation needed

*Note:*
The pre commit linting messed up the previous PR so I started from fresh with a new one only including the required changes now.