### PR TITLE
Use maskable icons

### DIFF
--- a/app/assets/javascripts/manifest.json.erb
+++ b/app/assets/javascripts/manifest.json.erb
@@ -14,10 +14,12 @@
   }, {
     "src": "<%= image_path "devlogo-pwa-128.png" %>",
     "sizes": "128x128",
-    "type": "image/png"
+    "type": "image/png",
+    "purpose": "any maskable"
   }, {
     "src": "<%= image_path "devlogo-pwa-512.png" %>",
     "sizes": "512x512",
-    "type": "image/png"
+    "type": "image/png",
+    "purpose": "any maskable"
   }]
 }


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

This PR changes how the dev.to PWA appears on Android. Previously the home screen icon had a white background. Soon, browsers will let you specify an icon to fill the entire space. Since the dev.to icon is already a black square, you can just adjust the `"purpose"` field in the web app manifest!

[Icon preview](https://maskable.app/?demo=https://raw.githubusercontent.com/thepracticaldev/dev.to/master/app/assets/images/devlogo-pwa-512.png)

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
