### PR TITLE
Clear previous ClassifiedListings in Algolia during DB Seed

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -246,6 +246,7 @@ Rails.logger.info "12. Creating Classified listings"
 users = User.order(Arel.sql("RANDOM()")).to_a
 users.each { |user| Credit.add_to(user, rand(100)) }
 
+ClassifiedListing.clear_index!
 listings_categories = ClassifiedListing.categories_available.keys
 listings_categories.each_with_index do |category, index|
   # rotate users if they are less than the categories


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
When you create new listings locally and then re run DEV, during the setup process, listings 1-22 are recreated, but other listings persist in Algolia (but are not in the db anymore). 

The `listings` page then shows old listings that don't exist anymore because they are still in Algolia.

## Related Tickets & Documents
N/A

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
N/A

## Added to documentation?
- [x] no documentation needed
