### PR TITLE
Rename uncommunicative variables

### DIFF
--- a/app/labor/badge_rewarder.rb
+++ b/app/labor/badge_rewarder.rb
@@ -65,7 +65,7 @@ module BadgeRewarder
     badge = Badge.find_by(slug: "dev-contributor")
     ["thepracticaldev/dev.to", "thepracticaldev/DEV-ios", "thepracticaldev/DEV-Android"].each do |repo|
       commits = client.commits repo, since: since.iso8601
-      authors_uids = commits.map { |c| c.author.id }
+      authors_uids = commits.map { |commit| commit.author.id }
       Identity.where(provider: "github", uid: authors_uids).find_each do |i|
         BadgeAchievement.where(user_id: i.user_id, badge_id: badge.id).first_or_create(
           rewarding_context_message_markdown: message_markdown,

--- a/app/labor/bufferizer.rb
+++ b/app/labor/bufferizer.rb
@@ -45,7 +45,7 @@ class Bufferizer
 
   def social_tags
     # for linkedin's followable tags
-    " #programming #softwareengineering " + (@article.tag_list.map { |t| "#" + t }).join(" ")
+    " #programming #softwareengineering " + (@article.tag_list.map { |tag| "#" + tag }).join(" ")
   end
 
   def listings_twitter_text

--- a/app/labor/cache_buster.rb
+++ b/app/labor/cache_buster.rb
@@ -25,9 +25,9 @@ class CacheBuster
     commentable.touch(:last_comment_at)
     bust("#{commentable.path}/comments/")
     bust(commentable.path.to_s)
-    commentable.comments.includes(:user).find_each do |c|
-      bust(c.path)
-      bust(c.path + "?i=i")
+    commentable.comments.includes(:user).find_each do |comment|
+      bust(comment.path)
+      bust(comment.path + "?i=i")
     end
     bust("#{commentable.path}/comments/*")
   end
@@ -47,8 +47,8 @@ class CacheBuster
     bust("/api/articles/#{article.id}")
     return unless article.collection_id
 
-    article.collection&.articles&.find_each do |a|
-      bust(a.path)
+    article.collection&.articles&.find_each do |collection_article|
+      bust(collection_article.path)
     end
   end
 

--- a/app/labor/flare_tag.rb
+++ b/app/labor/flare_tag.rb
@@ -1,16 +1,16 @@
 class FlareTag
-  FLARES = %w[explainlikeimfive
-              jokes
-              watercooler
-              ama
-              techtalks
-              help
-              news
-              healthydebate
-              showdev
-              challenge
-              anonymous
-              discuss].freeze
+  FLARE_TAGS = %w[explainlikeimfive
+                  jokes
+                  watercooler
+                  ama
+                  techtalks
+                  help
+                  news
+                  healthydebate
+                  showdev
+                  challenge
+                  anonymous
+                  discuss].freeze
 
   def initialize(article, except_tag = nil)
     @article = article.decorate
@@ -19,7 +19,7 @@ class FlareTag
 
   def tag
     @tag ||= Rails.cache.fetch("article_flare_tag-#{article.id}-#{article.updated_at}", expires_in: 12.hours) do
-      flare = FLARES.detect { |f| article.cached_tag_list_array.include?(f) }
+      flare = FLARE_TAGS.detect { |tag| article.cached_tag_list_array.include?(tag) }
       flare && flare != except_tag ? Tag.select(%i[name bg_color_hex text_color_hex]).find_by(name: flare) : nil
     end
   end

--- a/app/labor/html_cleaner.rb
+++ b/app/labor/html_cleaner.rb
@@ -6,8 +6,8 @@ class HtmlCleaner
       img.remove if img.attr("src") && (img.attr("src").include? "medium.com/_/stat")
     end
     # Remove Medium catch phrase
-    doc.css("p").each do |p|
-      p.remove if p.text.include? "where people are continuing the conversation by highlighting"
+    doc.css("p").each do |paragraph|
+      paragraph.remove if paragraph.text.include? "where people are continuing the conversation by highlighting"
     end
 
     doc.css("figure").each do |el|

--- a/app/labor/mailchimp_bot.rb
+++ b/app/labor/mailchimp_bot.rb
@@ -76,7 +76,7 @@ class MailchimpBot
     return false unless user.tag_moderator?
 
     success = false
-    tags = user.roles.where(name: "tag_moderator").map { |t| Tag.find(t.resource_id).name }
+    tags = user.roles.where(name: "tag_moderator").map { |tag| Tag.find(tag.resource_id).name }
     status = user.email_tag_mod_newsletter ? "subscribed" : "unsubscribed"
     begin
       gibbon.lists(ApplicationConfig["MAILCHIMP_TAG_MODERATORS_ID"]).members(target_md5_email).upsert(

--- a/app/labor/markdown_fixer.rb
+++ b/app/labor/markdown_fixer.rb
@@ -32,7 +32,7 @@ class MarkdownFixer
     # because --- messes with front matter
     def modify_hr_tags(markdown)
       markdown.gsub(/-{3}.*?-{3}/m) do |front_matter|
-        front_matter.gsub(/^---/).with_index { |m, i| i > 1 ? "#{m}-----" : m }
+        front_matter.gsub(/^---/).with_index { |match, i| i > 1 ? "#{match}-----" : match }
       end
     end
 

--- a/app/labor/markdown_parser.rb
+++ b/app/labor/markdown_parser.rb
@@ -181,8 +181,8 @@ class MarkdownParser
     html_doc.xpath("//body/*[not (@class='highlight')]").each do |el|
       el.children.each do |child|
         if child.text?
-          new_child = child.text.gsub(/\B@[a-z0-9_-]+/i) do |s|
-            user_link_if_exists(s)
+          new_child = child.text.gsub(/\B@[a-z0-9_-]+/i) do |text|
+            user_link_if_exists(text)
           end
           child.replace(new_child) if new_child != child.text
         end
@@ -224,21 +224,21 @@ class MarkdownParser
 
   def wrap_all_images_in_links(html)
     doc = Nokogiri::HTML.fragment(html)
-    doc.search("p img").each do |i|
-      i.swap("<a href='#{i.attr('src')}' class='article-body-image-wrapper'>#{i}</a>") unless i.parent.name == "a"
+    doc.search("p img").each do |image|
+      image.swap("<a href='#{image.attr('src')}' class='article-body-image-wrapper'>#{image}</a>") unless image.parent.name == "a"
     end
     doc.to_html
   end
 
   def remove_empty_paragraphs(html)
     doc = Nokogiri::HTML.fragment(html)
-    doc.css("p").select { |p| all_children_are_blank?(p) }.each(&:remove)
+    doc.css("p").select { |paragraph| all_children_are_blank?(paragraph) }.each(&:remove)
     doc.to_html
   end
 
   def wrap_all_tables(html)
     doc = Nokogiri::HTML.fragment(html)
-    doc.search("table").each { |i| i.swap("<div class='table-wrapper-paragraph'>#{i}</div>") }
+    doc.search("table").each { |table| table.swap("<div class='table-wrapper-paragraph'>#{table}</div>") }
     doc.to_html
   end
 

--- a/app/labor/markdown_parser.rb
+++ b/app/labor/markdown_parser.rb
@@ -169,10 +169,6 @@ class MarkdownParser
       else
         "{% raw %}" + codeblock + "{% endraw %}"
       end
-      # Below is the old implementation that replaces all liquid tag.
-      # codeblock.gsub(/{%.{1,}[^}]{2}%}/) do |liquid_tag|
-      #   liquid_tag.gsub(/{%/, '{{ "{%').gsub(/%}/, '" }}%}')
-      # end
     end
   end
 

--- a/app/liquid_tags/codepen_tag.rb
+++ b/app/liquid_tags/codepen_tag.rb
@@ -29,7 +29,7 @@ class CodepenTag < LiquidTagBase
     _, *options = stripped_link.split(" ")
 
     # Validation
-    validated_options = options.map { |o| valid_option(o) }.reject(&:nil?)
+    validated_options = options.map { |option| valid_option(option) }.reject(&:nil?)
     raise StandardError, "Invalid Options" unless options.empty? || !validated_options.empty?
 
     option = validated_options.join("&")

--- a/app/liquid_tags/codesandbox_tag.rb
+++ b/app/liquid_tags/codesandbox_tag.rb
@@ -33,7 +33,7 @@ class CodesandboxTag < LiquidTagBase
   def parse_options(input)
     _, *options = input.split(" ")
 
-    options.map { |o| valid_option(o) }.reject(&:nil?)
+    options.map { |option| valid_option(option) }.reject(&:nil?)
 
     query = options.join("&")
 

--- a/app/liquid_tags/glitch_tag.rb
+++ b/app/liquid_tags/glitch_tag.rb
@@ -54,10 +54,10 @@ class GlitchTag < LiquidTagBase
 
   def build_options(options)
     # Convert options to query param pairs
-    params = options.map { |x| option_to_query_pair(x) }.compact
+    params = options.map { |option| option_to_query_pair(option) }.compact
 
     # Deal with the file option if present or use default
-    file_option = options.detect { |x| x.start_with?("file=") }
+    file_option = options.detect { |option| option.start_with?("file=") }
     path = file_option ? (file_option.sub! "file=", "") : "index.html"
     params.push ["path", path]
 
@@ -72,7 +72,7 @@ class GlitchTag < LiquidTagBase
     options -= %w[app code] if (options & %w[app code]) == %w[app code]
 
     # Validation
-    validated_options = options.map { |o| valid_option(o) }.reject(&:nil?)
+    validated_options = options.map { |option| valid_option(option) }.reject(&:nil?)
     raise StandardError, "Invalid Options" unless options.empty? || !validated_options.empty?
 
     build_options(options)

--- a/app/liquid_tags/jsfiddle_tag.rb
+++ b/app/liquid_tags/jsfiddle_tag.rb
@@ -29,7 +29,7 @@ class JSFiddleTag < LiquidTagBase
     _, *options = stripped_link.split(" ")
 
     # Validation
-    validated_options = options.map { |o| valid_option(o) }.reject(&:nil?)
+    validated_options = options.map { |option| valid_option(option) }.reject(&:nil?)
     raise StandardError, "Invalid Options" unless options.empty? || !validated_options.empty?
 
     validated_options.length.zero? ? "" : validated_options.join(",").concat("/")

--- a/app/liquid_tags/stackblitz_tag.rb
+++ b/app/liquid_tags/stackblitz_tag.rb
@@ -35,10 +35,10 @@ class StackblitzTag < LiquidTagBase
   end
 
   def parse_input(input, validator)
-    input_split = input.split(" ")
+    inputs = input.split(" ")
 
     # Validation
-    validated_views = input_split.map { |o| validator.call(o) }.reject(&:nil?)
+    validated_views = inputs.map { |input_option| validator.call(input_option) }.reject(&:nil?)
     raise StandardError, "Invalid Options" unless validated_views.length.between?(0, 1)
 
     validated_views.length.zero? ? "" : validated_views.join("").to_s

--- a/app/models/chat_channel.rb
+++ b/app/models/chat_channel.rb
@@ -129,8 +129,8 @@ class ChatChannel < ApplicationRecord
 
   def channel_human_names
     active_memberships.
-      order("last_opened_at DESC").limit(5).includes(:user).map do |m|
-        m.user.name
+      order("last_opened_at DESC").limit(5).includes(:user).map do |membership|
+        membership.user.name
       end
   end
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -227,14 +227,14 @@ class Comment < ApplicationRecord
   def wrap_timestamps_if_video_present!
     return unless commentable_type != "PodcastEpisode" && commentable.video.present?
 
-    self.processed_html = processed_html.gsub(/(([0-9]:)?)(([0-5][0-9]|[0-9])?):[0-5][0-9]/) { |s| "<a href='#{commentable.path}?t=#{s}'>#{s}</a>" }
+    self.processed_html = processed_html.gsub(/(([0-9]:)?)(([0-5][0-9]|[0-9])?):[0-5][0-9]/) { |string| "<a href='#{commentable.path}?t=#{string}'>#{string}</a>" }
   end
 
   def shorten_urls!
     doc = Nokogiri::HTML.parse(processed_html)
-    doc.css("a").each do |a|
-      unless a.to_s.include?("<img") || a.attr("class")&.include?("ltag")
-        a.content = strip_url(a.content) unless a.to_s.include?("<img")
+    doc.css("a").each do |anchor|
+      unless anchor.to_s.include?("<img") || anchor.attr("class")&.include?("ltag")
+        anchor.content = strip_url(anchor.content) unless anchor.to_s.include?("<img")
       end
     end
     self.processed_html = doc.to_html.html_safe

--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -2,8 +2,8 @@ class Identity < ApplicationRecord
   belongs_to :user
   has_many  :backup_data, as: :instance, class_name: "BackupData", dependent: :destroy
   validates :uid, :provider, presence: true
-  validates :uid, uniqueness: { scope: :provider }, if: proc { |i| i.uid_changed? || i.provider_changed? }
-  validates :user_id, uniqueness: { scope: :provider }, if: proc { |i| i.user_id_changed? || i.provider_changed? }
+  validates :uid, uniqueness: { scope: :provider }, if: proc { |identity| identity.uid_changed? || identity.provider_changed? }
+  validates :user_id, uniqueness: { scope: :provider }, if: proc { |identity| identity.user_id_changed? || identity.provider_changed? }
   validates :provider, inclusion: { in: %w[github twitter] }
 
   serialize :auth_data_dump

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -58,8 +58,8 @@ class Message < ApplicationRecord
   def append_rich_links(html)
     doc = Nokogiri::HTML(html)
     rich_style = "border: 1px solid #0a0a0a; border-radius: 3px; padding: 8px;"
-    doc.css("a").each do |a|
-      if (article = rich_link_article(a))
+    doc.css("a").each do |anchor|
+      if (article = rich_link_article(anchor))
         html += "<a style='color: #0a0a0a' href='#{article.path}'
           target='_blank' data-content='articles/#{article.id}'>
           <h1 style='#{rich_style}'  data-content='articles/#{article.id}'>

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -3,8 +3,8 @@ class Notification < ApplicationRecord
   belongs_to :user, optional: true
   belongs_to :organization, optional: true
 
-  validates :user_id, presence: true, if: proc { |n| n.organization_id.nil? }
-  validates :organization_id, presence: true, if: proc { |n| n.user_id.nil? }
+  validates :user_id, presence: true, if: proc { |notifcation| notifcation.organization_id.nil? }
+  validates :organization_id, presence: true, if: proc { |notifcation| notifcation.user_id.nil? }
 
   before_create :mark_notified_at_time
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -69,7 +69,7 @@ class Organization < ApplicationRecord
 
     self.old_old_slug = old_slug
     self.old_slug = slug_was
-    articles.find_each { |a| a.update(path: a.path.gsub(slug_was, slug)) }
+    articles.find_each { |article| article.update(path: article.path.gsub(slug_was, slug)) }
   end
 
   def path

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -71,8 +71,8 @@ class Tag < ActsAsTaggableOn::Tag
   def calculate_hotness_score
     self.hotness_score = Article.tagged_with(name).
       where("articles.featured_number > ?", 7.days.ago.to_i).
-      map do |a|
-        (a.comments_count * 14) + (a.reactions_count * 4) + rand(6) + ((taggings_count + 1) / 2)
+      map do |article|
+        (article.comments_count * 14) + (article.reactions_count * 4) + rand(6) + ((taggings_count + 1) / 2)
       end.
       sum
   end

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -58,9 +58,9 @@ class Tweet < ApplicationRecord
 
   class << self
     def try_to_get_tweet(twitter_id_code)
-      c = TwitterBot.new(random_identity).client
-      t = c.status(twitter_id_code, tweet_mode: "extended")
-      make_tweet_from_api_object(t)
+      client = TwitterBot.new(random_identity).client
+      tweet = client.status(twitter_id_code, tweet_mode: "extended")
+      make_tweet_from_api_object(tweet)
     end
 
     def make_tweet_from_api_object(tweeted)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -504,13 +504,13 @@ class User < ApplicationRecord
 
     self.old_old_username = old_username
     self.old_username = username_was
-    chat_channels.find_each do |c|
-      c.slug = c.slug.gsub(username_was, username)
-      c.save
+    chat_channels.find_each do |channel|
+      channel.slug = channel.slug.gsub(username_was, username)
+      channel.save
     end
-    articles.find_each do |a|
-      a.path = a.path.gsub(username_was, username)
-      a.save
+    articles.find_each do |article|
+      article.path = article.path.gsub(username_was, username)
+      article.save
     end
   end
 

--- a/app/services/credits/ledger.rb
+++ b/app/services/credits/ledger.rb
@@ -52,9 +52,9 @@ module Credits
         purchase_types = credits_purchases_with_purchase.map(&:purchase_type).uniq.compact
         purchase_types.each do |purchase_type|
           credits_purchases_by_type = credits_purchases_with_purchase.select { |row| row.purchase_type == purchase_type }
-          purchases = purchase_type.constantize.where(id: credits_purchases_by_type.map(&:purchase_id))
+          purchase_set = purchase_type.constantize.where(id: credits_purchases_by_type.map(&:purchase_id))
           credits_purchases_by_type.each do |credit_purchase|
-            purchase = purchases.detect { |p| p.id == credit_purchase.purchase_id }
+            purchase = purchase_set.detect { |set| set.id == credit_purchase.purchase_id }
             items << Item.new(
               purchase: purchase,
               cost: credit_purchase.cost.to_i,

--- a/app/services/notifications/new_follower/send.rb
+++ b/app/services/notifications/new_follower/send.rb
@@ -32,7 +32,7 @@ module Notifications
         end
 
         followers = User.where(id: recent_follows.select(:follower_id))
-        aggregated_siblings = followers.map { |f| user_data(f) }
+        aggregated_siblings = followers.map { |follower| user_data(follower) }
         if aggregated_siblings.size.zero?
           notification = Notification.find_by(notification_params)&.destroy
         else

--- a/app/services/notifications/reactions/send.rb
+++ b/app/services/notifications/reactions/send.rb
@@ -27,7 +27,7 @@ module Notifications
           includes(:reactable).
           order("created_at DESC")
 
-        aggregated_reaction_siblings = reaction_siblings.map { |r| { category: r.category, created_at: r.created_at, user: user_data(r.user) } }
+        aggregated_reaction_siblings = reaction_siblings.map { |reaction| { category: reaction.category, created_at: reaction.created_at, user: user_data(reaction.user) } }
 
         notification_params = {
           notifiable_type: reaction.reactable_type,


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
This PR renames a significant number of the single letter variables, which is pretty much just my opinion, but I don't see much benefit to having shorter variable names.

Secondarily, it also removes some commented code from two years ago.

```
Clarify uncommunicative variables in labor classes

Single letter variable names are largely a question of preference, in
some cases I think that convention mitigates the opaque nature of single
letter variable names (e.g., e for error, i for index, etc).

However, in some cases they can be unclear and there isn't much reason
to use single letter variables unless for some reason character length is
really important.

In this case, I would prefer clarity in variable names over brevity of
code so I've used Reek to identify short variable names and I'm changing
them.

It's pretty boring, but hopefully incremental code love changes like
this one add up and improve readability and accessibility for those
interested in reading this codebase.
```
## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![Yeah? Well that's just like your opinion man.](https://proxy.duckduckgo.com/iu/?u=https%3A%2F%2Fmedia1.tenor.com%2Fimages%2Fbc7d998ddd37ece9696185b2b4c51fcd%2Ftenor.gif%3Fitemid%3D10470601&f=1)
