### PR TITLE
Add a /quickin route for development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -116,6 +116,7 @@ group :development do
   gem "yard", "~> 0.9.20" # YARD is a documentation generation tool for the Ruby programming language
   gem "yard-activerecord", "~> 0.0.16" # YARD extension that handles and interprets methods used when developing applications with ActiveRecord
   gem "yard-activesupport-concern", "~> 0.0.1" # YARD extension that brings support for modules making use of ActiveSupport::Concern
+  gem 'quickin', path: 'lib/quickin' # Allow developers to skip auth https://github.com/thepracticaldev/dev.to/pull/3893
 end
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -112,11 +112,11 @@ group :development do
   gem "memory_profiler", "~> 0.9", require: false # Memory profiling routines for Ruby 2.3+
   gem "pry", "~> 0.12" # An IRB alternative and runtime developer console
   gem "pry-rails", "~> 0.3" # Use Pry as your rails console
+  gem "quickin", path: "lib/quickin" # Allow developers to skip auth https://github.com/thepracticaldev/dev.to/pull/3893
   gem "web-console", "~> 3.7" # Rails Console on the Browser
   gem "yard", "~> 0.9.20" # YARD is a documentation generation tool for the Ruby programming language
   gem "yard-activerecord", "~> 0.0.16" # YARD extension that handles and interprets methods used when developing applications with ActiveRecord
   gem "yard-activesupport-concern", "~> 0.0.1" # YARD extension that brings support for modules making use of ActiveSupport::Concern
-  gem 'quickin', path: 'lib/quickin' # Allow developers to skip auth https://github.com/thepracticaldev/dev.to/pull/3893
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,12 @@ GIT
     foreman (0.85.0)
       thor (>= 0.19, < 0.21)
 
+PATH
+  remote: lib/quickin
+  specs:
+    quickin (0.1.0)
+      rails (~> 5.2.3)
+
 GEM
   remote: https://rubygems.org/
   remote: https://rails-assets.org/
@@ -924,6 +930,7 @@ DEPENDENCIES
   pundit-matchers (~> 1.6)
   pusher (~> 1.3)
   pusher-push-notifications (~> 1.1)
+  quickin!
   rack-host-redirect (~> 1.3)
   rack-timeout (~> 0.5)
   rails (~> 5.2, >= 5.2.3)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,12 @@ Rails.application.routes.draw do
     get "/enter" => "registrations#new", as: :sign_up
   end
 
+  if Rails.env.development?
+    # This should only be available in a development environment, it allows
+    # a developer to circumvent the auth process.
+    mount Quickin::Engine, at: "/quickin"
+  end
+
   namespace :admin do
     # Check administrate gem docs
     DashboardManifest::DASHBOARDS.each do |dashboard_resource|

--- a/docs/backend/commandeering-users.md
+++ b/docs/backend/commandeering-users.md
@@ -1,0 +1,22 @@
+---
+title: Commandeering Users
+---
+
+#  Commandeering Users
+
+During development, it will inevitably become necessary to control multiple users.
+
+Obviously, you shouldn't create an infinite amout of GitHub or Twitter accounts to generate test users (seriously, please don't do this).
+
+Instead, you can take advantage of a small hack that is exposed when the application runs in development mode. There is a gem in the lib directory called [quickin](https://github.com/thepracticaldev/dev.to/pull/3893), which exists to solve this problem for Dev.to contributors.
+
+The quickin gem exposes the `/quickin` route, which will allow you to grab a currently existing user and skip the authentication process. For obvious reasons, this route is not exposed when the application runs in production.
+
+To log in as the first user in the database, all you have to do is navigate to `localhost:3000/quickin`. You can also specify which user you'd like to take over by including the user's `id` as a parameter:
+
+```
+# Login as the user with an id of 4
+localhost:3000/quickin?id=4
+```
+
+Please be careful with this functionality; it's pretty hacky. As every Tobey Maguire fan knows, "With great power comes great responsibility."

--- a/docs/backend/readme.md
+++ b/docs/backend/readme.md
@@ -5,6 +5,7 @@ items:
   - auth-twitter.md
   - auth-github.md
   - authorization.md
+  - commandeering-users.md
   - roles.md
   - algolia.md
   - pusher.md

--- a/lib/quickin/Gemfile
+++ b/lib/quickin/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 # Declare your gem's dependencies in quickin.gemspec.

--- a/lib/quickin/Gemfile
+++ b/lib/quickin/Gemfile
@@ -1,0 +1,15 @@
+source 'https://rubygems.org'
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+
+# Declare your gem's dependencies in quickin.gemspec.
+# Bundler will treat runtime dependencies like base dependencies, and
+# development dependencies will be added by default to the :development group.
+gemspec
+
+# Declare any dependencies that are still in development here instead of in
+# your gemspec. These might include edge Rails or gems from your path or
+# Git. Remember to move these dependencies to your gemspec before releasing
+# your gem to rubygems.org.
+
+# To use a debugger
+# gem 'byebug', group: [:development, :test]

--- a/lib/quickin/MIT-LICENSE
+++ b/lib/quickin/MIT-LICENSE
@@ -1,0 +1,20 @@
+Copyright 2019 jacobherrington
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/lib/quickin/README.md
+++ b/lib/quickin/README.md
@@ -1,0 +1,22 @@
+# Quickin
+This is a [Rails Engine](https://guides.rubyonrails.org/engines.html) that
+intentionally isolates some dangerous code.
+
+In this application, if you are in the development environment, this gem will
+allow you to quickly login as a user by hitting the `/quickin` route.
+
+You can pass an ID parameter to the route if you want to get a user by ID:
+
+```
+localhost:3000/quickin?id=4 # Login as the user with an id of 4
+```
+
+This should probably not be used at all outside of the dev.to application,
+it's generally pretty hacky, but is useful due to the unique nature of the
+auth system used by Dev.to.
+
+Ideally, it can be replaced easily by a development-only masquerade feature.
+
+## License
+The gem is available as open source under the terms of the
+[MIT License](https://opensource.org/licenses/MIT).

--- a/lib/quickin/app/controllers/user_controller_decorator.rb
+++ b/lib/quickin/app/controllers/user_controller_decorator.rb
@@ -1,0 +1,25 @@
+module UserControllerDecorator
+  def self.prepended(base)
+    base.skip_after_action :verify_authorized, only: :quickin
+  end
+
+  # Double check the environment at runtime!
+  if Rails.env.development?
+    # This method allows you to quickly login as another user for testing
+    # purposes in an development environment. Use it by accessing the
+    # `/quickin` route.
+
+    def quickin
+      logger.warn "Using the quickin workaround, this should never happen in production!"
+      @user =
+        if params[:id]
+          User.find(params[:id])
+        else
+          User.first
+        end
+      sign_in_and_redirect @user, event: :authentication
+    end
+  end
+
+  UsersController.prepend self
+end

--- a/lib/quickin/bin/rails
+++ b/lib/quickin/bin/rails
@@ -2,13 +2,13 @@
 # This command will automatically be run when you run "rails" with Rails gems
 # installed from the root of your application.
 
-ENGINE_ROOT = File.expand_path('..', __dir__)
-ENGINE_PATH = File.expand_path('../lib/quickin/engine', __dir__)
-APP_PATH = File.expand_path('../test/dummy/config/application', __dir__)
+ENGINE_ROOT = File.expand_path("..", __dir__)
+ENGINE_PATH = File.expand_path("../lib/quickin/engine", __dir__)
+APP_PATH = File.expand_path("../test/dummy/config/application", __dir__)
 
 # Set up gems listed in the Gemfile.
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
-require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
+require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
 
-require 'rails/all'
-require 'rails/engine/commands'
+require "rails/all"
+require "rails/engine/commands"

--- a/lib/quickin/bin/rails
+++ b/lib/quickin/bin/rails
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+# This command will automatically be run when you run "rails" with Rails gems
+# installed from the root of your application.
+
+ENGINE_ROOT = File.expand_path('..', __dir__)
+ENGINE_PATH = File.expand_path('../lib/quickin/engine', __dir__)
+APP_PATH = File.expand_path('../test/dummy/config/application', __dir__)
+
+# Set up gems listed in the Gemfile.
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
+require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
+
+require 'rails/all'
+require 'rails/engine/commands'

--- a/lib/quickin/config/routes.rb
+++ b/lib/quickin/config/routes.rb
@@ -1,0 +1,6 @@
+Quickin::Engine.routes.draw do
+  # This should only be available in a development environment, it allows
+  # a developer to circumvent the auth process. See
+  # lib/quickin/app/controllers/user_controller_decorator.rb for more.
+  get "/" => "users#quickin"
+end

--- a/lib/quickin/lib/quickin.rb
+++ b/lib/quickin/lib/quickin.rb
@@ -1,0 +1,1 @@
+require "quickin/engine"

--- a/lib/quickin/lib/quickin/engine.rb
+++ b/lib/quickin/lib/quickin/engine.rb
@@ -1,0 +1,10 @@
+module Quickin
+  class Engine < ::Rails::Engine
+    def self.activate
+      Dir.glob(File.join(File.dirname(__FILE__), "../../app/**/*_decorator*.rb")) do |c|
+        require_dependency(c)
+      end
+    end
+    config.to_prepare(&method(:activate).to_proc)
+  end
+end

--- a/lib/quickin/lib/quickin/version.rb
+++ b/lib/quickin/lib/quickin/version.rb
@@ -1,3 +1,3 @@
 module Quickin
-  VERSION = '0.1.0'
+  VERSION = "0.1.0".freeze
 end

--- a/lib/quickin/lib/quickin/version.rb
+++ b/lib/quickin/lib/quickin/version.rb
@@ -1,0 +1,3 @@
+module Quickin
+  VERSION = '0.1.0'
+end

--- a/lib/quickin/quickin.gemspec
+++ b/lib/quickin/quickin.gemspec
@@ -1,0 +1,20 @@
+$:.push File.expand_path("lib", __dir__)
+
+# Maintain your gem's version:
+require "quickin/version"
+
+# Describe your gem and declare its dependencies:
+Gem::Specification.new do |spec|
+  spec.name        = "quickin"
+  spec.version     = Quickin::VERSION
+  spec.authors     = ["jacobherrington"]
+  spec.email       = ["jacobherringtondeveloper@gmail.com"]
+  spec.homepage    = "https://github.com/thepracticaldev/dev.to/tree/master/lib/quickin"
+  spec.summary     = "Grab a user quickly!"
+  spec.description = "A hacky way to quickly grab a user."
+  spec.license     = "MIT"
+
+  spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "README.md"]
+
+  spec.add_dependency "rails", "~> 5.2.3"
+end

--- a/lib/quickin/quickin.gemspec
+++ b/lib/quickin/quickin.gemspec
@@ -1,4 +1,4 @@
-$:.push File.expand_path("lib", __dir__)
+$LOAD_PATH.push File.expand_path("lib", __dir__)
 
 # Maintain your gem's version:
 require "quickin/version"


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
**Initial Description** 
This PR adds a route to allow someone in development to grab an account easily. Sometimes you need multiple accounts to reproduce a bug, and this allows for that!

If this PR goes unmerged, this tactic should at least be documented for people wishing to contribute, that way people don't have to DM Andy 😉

```
This is a trick that Andy shared with me for grabbing a user during
local development. I totally get why this commit might be best left out
of the repository, but I think it should be fine as a workaround while
an alternative method for masquerading as users is developed.
```

**Post Feedback Description**
So I've rolled this stuff into an engine in the lib directory that is only required in the development group.

Hopefully, I've also documented that this is pretty hacky well enough.

You won't hurt my feelings if you say this is too sketchy.. it's pretty sketchy. 

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

If this is determined to be an acceptable solution, I will make a follow-up PR to document this route in both contributing.md and the development documentation site.

## [optional] What gif best describes this PR or how it makes you feel?

![Fallout lockpicking gif](https://proxy.duckduckgo.com/iu/?u=http%3A%2F%2Fi.imgur.com%2FZM0CStn.gif&f=1)
