### PR TITLE
Update notifications reply form to use theme colors

### DIFF
--- a/app/assets/stylesheets/notifications.scss
+++ b/app/assets/stylesheets/notifications.scss
@@ -327,6 +327,11 @@
           text-align: right;
           display: none;
           margin-top: 4px;
+          @include themeable(
+            background,
+            theme-container-accent-background,
+            $light-gray
+          );
           &.showing {
             display: block;
           }
@@ -346,7 +351,11 @@
             width: 100%;
             margin-left: 0%;
             border-radius: 3px;
-            border: 1px solid $light-medium-gray;
+            @include themeable(
+              border,
+              theme-container-border,
+              1px solid rgb(232, 229, 229)
+            );
           }
 
           .field {
@@ -358,12 +367,18 @@
             display: block;
             resize: none;
             border-radius: 3px;
-            border: 1px solid rgb(232, 229, 229);
             height: 55px;
             font-size: 16px;
             padding: 6px;
             transition: height 0.3s ease;
             height: calc(2vw + 120px);
+            @include themeable(
+              border,
+              theme-container-background,
+              1px solid rgb(232, 229, 229)
+            );
+            @include themeable(background, theme-container-background, #fff);
+            @include themeable(color, theme-color, $black)
           }
           input[type='submit'] {
             margin-right: 15px;


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

I noticed the colors didn't match up here.

This CSS is complicated and new to me, so please let me know if there is a better pattern for how this is done throughout the app!

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Before:
![Screenshot_2019-09-01 Notifications - dev to(1)](https://user-images.githubusercontent.com/11466782/64082813-c580cc00-ccda-11e9-8941-5d0868ef31a8.png)

After:
![Screenshot_2019-09-01 Notifications - dev to(2)](https://user-images.githubusercontent.com/11466782/64082815-cb76ad00-ccda-11e9-837d-aa9821e1904b.png)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![a pig painting, yes seriously](https://proxy.duckduckgo.com/iu/?u=https%3A%2F%2Fmedia.giphy.com%2Fmedia%2FscEmJ6yaTmhrO%2Fgiphy.gif&f=1)
