### PR TITLE
Hide scrollbars in the editor textarea

### DIFF
--- a/app/assets/stylesheets/preact/article-form.scss
+++ b/app/assets/stylesheets/preact/article-form.scss
@@ -362,7 +362,7 @@
   resize: none;
   padding: 20px 6px;
   font-family: $monospace;
-  // overflow: initial;
+  overflow: hidden;
   background: white;
   background: var(--theme-container-background, white);
   color: $black;

--- a/app/assets/stylesheets/preact/article-form.scss
+++ b/app/assets/stylesheets/preact/article-form.scss
@@ -362,6 +362,8 @@
   resize: none;
   padding: 20px 6px;
   font-family: $monospace;
+  // scrollbars not needed because the preact-textarea-autosize package
+  // automatically resizes the article form
   overflow: hidden;
   background: white;
   background: var(--theme-container-background, white);


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Documentation Update

## Description
There is no need for scrollbars in the textarea given the scrollbar at the edge of the browser and that `preact-textarea-autosize` used for the textarea automatically increases the height of the textarea when needed. 

## Related Tickets & Documents

Closes #3898, closes #2939, closes #3330

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
Nothing of significance changed besides the bugs not appearing anymore.

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed
- [X] code

## [optional] What gif best describes this PR or how it makes you feel?

![woman spinning in joy](https://user-images.githubusercontent.com/13080965/64088531-bd368a00-ccf6-11e9-9098-c7313c60b142.gif)

