### PR TITLE
Fix flaky listings specs

### DIFF
--- a/spec/liquid_tags/classified_listing_tag_spec.rb
+++ b/spec/liquid_tags/classified_listing_tag_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe ClassifiedListingTag, type: :liquid_template do
     )
   end
   let(:expired_listing) do
+    datetime = 40.days.ago
     create(
       :classified_listing,
       user_id: user.id,
@@ -24,9 +25,9 @@ RSpec.describe ClassifiedListingTag, type: :liquid_template do
       category: "cfp",
       tag_list: %w[x y z],
       organization_id: nil,
-      bumped_at: Time.zone.today - 40,
-      created_at: Time.zone.today - 40,
-      updated_at: Time.zone.today - 40,
+      bumped_at: datetime,
+      created_at: datetime,
+      updated_at: datetime,
     )
   end
   let(:org) { create(:organization) }
@@ -60,7 +61,7 @@ RSpec.describe ClassifiedListingTag, type: :liquid_template do
         <div class="ltag__listing-content">
           <h3>
             <a href="/listings/#{listing.category}/#{listing.slug}">
-              #{listing.title}
+              #{CGI.escapeHTML(listing.title)}
             </a>
           </h3>
           <div class="ltag__listing-body">

--- a/spec/requests/classified_listings_spec.rb
+++ b/spec/requests/classified_listings_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "ClassifiedListings", type: :request do
     context "when the user has category and slug params for active listing" do
       it "shows that direct listing" do
         get "/listings", params: { category: `#{listing.category}`, slug: `#{listing.slug}` }
-        expect(response.body).to include(listing.title)
+        expect(response.body).to include(CGI.escapeHTML(listing.title))
       end
     end
 
@@ -60,7 +60,7 @@ RSpec.describe "ClassifiedListings", type: :request do
         expired_listing.published = false
         expired_listing.save
         get "/listings", params: { category: `#{expired_listing.category}`, slug: `#{expired_listing.slug}` }
-        expect(response.body).not_to include(expired_listing.title)
+        expect(response.body).not_to include(CGI.escapeHTML(expired_listing.title))
       end
     end
   end
@@ -396,7 +396,9 @@ RSpec.describe "ClassifiedListings", type: :request do
     let!(:listing_draft) { create(:classified_listing, user: user, bumped_at: nil, published: false) }
     let(:organization) { create(:organization) }
     let!(:org_listing) { create(:classified_listing, user: user, organization: organization) }
-    let!(:org_listing_draft) { create(:classified_listing, user: user, organization: organization, bumped_at: nil, published: false) }
+    let!(:org_listing_draft) do
+      create(:classified_listing, user: user, organization: organization, bumped_at: nil, published: false)
+    end
 
     before do
       sign_in user


### PR DESCRIPTION
##  What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

While examining PR https://github.com/thepracticaldev/dev.to/pull/3892 I noticed that `spec/requests/classified_listings_spec.rb` could fail due to missing escaping of auto generated text.

