### PR TITLE
Webhooks: API fixes and docs

### DIFF
--- a/app/controllers/api/v0/webhooks_controller.rb
+++ b/app/controllers/api/v0/webhooks_controller.rb
@@ -12,7 +12,7 @@ module Api
       end
 
       def show
-        @webhook = Webhook::Endpoint.includes(:user).find(params[:id])
+        @webhook = @user.webhook_endpoints.find(params[:id])
       end
 
       def destroy

--- a/app/controllers/api/v0/webhooks_controller.rb
+++ b/app/controllers/api/v0/webhooks_controller.rb
@@ -17,8 +17,8 @@ module Api
 
       def destroy
         webhook = @user.webhook_endpoints.find(params[:id])
-        webhook.destroy
-        render json: { success: webhook.destroyed? }
+        webhook.destroy!
+        head :no_content
       end
 
       private

--- a/app/controllers/api/v0/webhooks_controller.rb
+++ b/app/controllers/api/v0/webhooks_controller.rb
@@ -4,8 +4,10 @@ module Api
       respond_to :json
       before_action :authenticate!
 
+      skip_before_action :verify_authenticity_token, only: %w[create destroy]
+
       def create
-        @webhook = current_user.webhook_endpoints.create!(webhook_params)
+        @webhook = @user.webhook_endpoints.create!(webhook_params)
         render "show", status: :created
       end
 
@@ -14,7 +16,7 @@ module Api
       end
 
       def destroy
-        webhook = current_user.webhook_endpoints.find(params[:id])
+        webhook = @user.webhook_endpoints.find(params[:id])
         webhook.destroy
         render json: { success: webhook.destroyed? }
       end

--- a/app/models/webhook/endpoint.rb
+++ b/app/models/webhook/endpoint.rb
@@ -2,8 +2,8 @@ module Webhook
   class Endpoint < ApplicationRecord
     belongs_to :user, inverse_of: :webhook_endpoints
 
-    validates :target_url, uniqueness: true, url: { schemes: %w[https] }
-    validates :events, presence: true
+    validates :target_url, presence: true, uniqueness: true, url: { schemes: %w[https] }
+    validates :source, :events, presence: true
 
     attribute :events, :string, array: true, default: []
 

--- a/app/views/api/v0/webhooks/show.json.jbuilder
+++ b/app/views/api/v0/webhooks/show.json.jbuilder
@@ -1,6 +1,5 @@
-json.type_of            "webhook_endpoint"
-json.events             @webhook.events
-json.target_url         @webhook.target_url
-json.source             @webhook.source
+json.type_of "webhook_endpoint"
+
+json.call(@webhook, :id, :source, :target_url, :events, :created_at)
 
 json.partial! "api/v0/articles/user", user: @webhook.user

--- a/docs/api_v0.yml
+++ b/docs/api_v0.yml
@@ -1074,3 +1074,60 @@ paths:
               -H "api-key: ACCESS_TOKEN" \
               -d '{"webhook_endpoint":{"target_url":"https://example.org/webhooks/webhook1","source":"DEV","events":["article_created"]}}' \
               https://dev.to/api/webhooks
+
+  /webhooks/{id}:
+    get:
+      summary: A webhook endpoint
+      description: |
+        This endpoint allows the client to retrieve a single
+        webhook given its `id`.
+      tags:
+        - webhooks
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Id of the webhook
+          schema:
+            type: integer
+            format: int32
+          example: 123
+      responses:
+        200:
+          description: A webhook endpoint
+          content:
+            application/json:
+              schema:
+                type: object
+                $ref: "#/components/schemas/WebhookShow"
+              examples:
+                webhook-success:
+                  $ref: "#/components/examples/WebhookShow"
+        401:
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                $ref: "#/components/schemas/APIError"
+              examples:
+                article-unauthorized:
+                  $ref: "#/components/examples/ErrorUnauthorized"
+        404:
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                type: object
+                $ref: "#/components/schemas/APIError"
+              examples:
+                article-not-found:
+                  $ref: "#/components/examples/ErrorNotFound"
+      security:
+        - api_key: []
+        - oauth2: []
+      x-code-samples: # https://github.com/Redocly/redoc/blob/master/docs/redoc-vendor-extensions.md#x-code-samples
+        - lang: Shell
+          label: curl
+          source: |
+            curl https://dev.to/api/webhooks/123

--- a/docs/api_v0.yml
+++ b/docs/api_v0.yml
@@ -507,17 +507,23 @@ components:
       properties:
         type_of:
           type: string
+        id:
+          type: integer
+          format: int64
+        source:
+          description: The name of the requester, eg. "DEV"
+          type: string
+        target_url:
+          type: string
+          format: url
         events:
           description: An array of events identifiers
           type: array
           items:
             type: string
-        target_url:
+        created_at:
           type: string
-          format: url
-        source:
-          description: The name of the requester, eg. "DEV"
-          type: string
+          format: date-time
         user:
           type: object
           $ref: "#/components/schemas/ArticleUser"
@@ -622,10 +628,12 @@ components:
     WebhookShow:
       value:
         type_of: webhook_endpoint
+        id: 1
+        source: DEV
+        target_url: https://example.com/webhooks/webhook1
         events:
           - article_created
-        target_url: https://example.com/webhooks/webhook1
-        source: DEV
+        created_at: "2019-09-02T09:47:39.230Z"
         user:
           name: bob
           username: bob
@@ -1131,3 +1139,52 @@ paths:
           label: curl
           source: |
             curl https://dev.to/api/webhooks/123
+    delete:
+      summary: A webhook endpoint
+      description: |
+        This endpoint allows the client to delete a single
+        webhook given its `id`.
+      tags:
+        - webhooks
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Id of the webhook
+          schema:
+            type: integer
+            format: int32
+          example: 123
+      responses:
+        204:
+          description: A successful deletion
+        401:
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                $ref: "#/components/schemas/APIError"
+              examples:
+                article-unauthorized:
+                  $ref: "#/components/examples/ErrorUnauthorized"
+        404:
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                type: object
+                $ref: "#/components/schemas/APIError"
+              examples:
+                article-not-found:
+                  $ref: "#/components/examples/ErrorNotFound"
+      security:
+        - api_key: []
+        - oauth2: []
+      x-code-samples: # https://github.com/Redocly/redoc/blob/master/docs/redoc-vendor-extensions.md#x-code-samples
+        - lang: Shell
+          label: curl
+          source: |
+            curl -X DELETE \
+              -H "api-key: ACCESS_TOKEN" \
+              https://dev.to/api/webhooks/1

--- a/docs/api_v0.yml
+++ b/docs/api_v0.yml
@@ -1,8 +1,8 @@
-openapi: '3.0.2'
+openapi: "3.0.2"
 info:
   title: DEV API
   description: Access DEV articles, comments and other resources via API
-  version: '0.5.1'
+  version: "0.5.3"
   termsOfService: https://dev.to/terms
   contact:
     name: DEV Team
@@ -125,13 +125,13 @@ components:
           format: date-time
         user:
           type: object
-          $ref: '#/components/schemas/ArticleUser'
+          $ref: "#/components/schemas/ArticleUser"
         organization:
           type: object
-          $ref: '#/components/schemas/ArticleOrganization'
+          $ref: "#/components/schemas/ArticleOrganization"
         flare_tag:
           type: object
-          $ref: '#/components/schemas/ArticleFlareTag'
+          $ref: "#/components/schemas/ArticleFlareTag"
     ArticleShow:
       type: object
       required:
@@ -220,7 +220,7 @@ components:
           type: string
         user:
           type: object
-          $ref: '#/components/schemas/ArticleUser'
+          $ref: "#/components/schemas/ArticleUser"
     ArticleCreate:
       type: object
       properties:
@@ -416,13 +416,13 @@ components:
           format: date-time
         user:
           type: object
-          $ref: '#/components/schemas/ArticleUser'
+          $ref: "#/components/schemas/ArticleUser"
         organization:
           type: object
-          $ref: '#/components/schemas/ArticleOrganization'
+          $ref: "#/components/schemas/ArticleOrganization"
         flare_tag:
           type: object
-          $ref: '#/components/schemas/ArticleFlareTag'
+          $ref: "#/components/schemas/ArticleFlareTag"
 
     ArticleUser:
       description: The article's creator
@@ -478,6 +478,50 @@ components:
           description: Text color (hexadecimal)
           type: string
 
+    WebhookCreate:
+      description: Webhook creation payload
+      type: object
+      properties:
+        webhook_endpoint:
+          type: object
+          required:
+            - source
+            - target_url
+            - events
+          properties:
+            source:
+              description: The name of the requester, eg. "DEV"
+              type: string
+            target_url:
+              type: string
+              format: url
+            events:
+              description: An array of events identifiers
+              type: array
+              items:
+                type: string
+
+    WebhookShow:
+      description: Webhook
+      type: object
+      properties:
+        type_of:
+          type: string
+        events:
+          description: An array of events identifiers
+          type: array
+          items:
+            type: string
+        target_url:
+          type: string
+          format: url
+        source:
+          description: The name of the requester, eg. "DEV"
+          type: string
+        user:
+          type: object
+          $ref: "#/components/schemas/ArticleUser"
+
   examples:
     ErrorNotFound:
       value:
@@ -491,34 +535,36 @@ components:
       value:
         type_of: article
         id: 150589
-        title: 'Byte Sized Episode 2: The Creation of Graph Theory '
-        description: The full story of Leonhard Euler and the creation of this fundamental
+        title: "Byte Sized Episode 2: The Creation of Graph Theory "
+        description:
+          The full story of Leonhard Euler and the creation of this fundamental
           computer science principle, delivered in a few minutes.
         cover_image: https://res.cloudinary.com/practicaldev/image/fetch/s--qgutBUrH--/c_imagga_scale,f_auto,fl_progressive,h_420,q_auto,w_1000/https://thepracticaldev.s3.amazonaws.com/i/88e62fzblbluz1dm7xjf.png
         readable_publish_date: Aug  1
         social_image: https://res.cloudinary.com/practicaldev/image/fetch/s--6wSHHfwd--/c_imagga_scale,f_auto,fl_progressive,h_500,q_auto,w_1000/https://thepracticaldev.s3.amazonaws.com/i/88e62fzblbluz1dm7xjf.png
         tag_list: computerscience, graphtheory, bytesized, history
         tags:
-        - computerscience
-        - graphtheory
-        - bytesized
-        - history
+          - computerscience
+          - graphtheory
+          - bytesized
+          - history
         slug: byte-sized-episode-2-the-creation-of-graph-theory-34g1
         path: "/bytesized/byte-sized-episode-2-the-creation-of-graph-theory-34g1"
         url: https://dev.to/bytesized/byte-sized-episode-2-the-creation-of-graph-theory-34g1
         canonical_url: https://dev.to/bytesized/byte-sized-episode-2-the-creation-of-graph-theory-34g1
         comments_count: 19
         positive_reactions_count: 276
-        created_at: '2019-07-31T11:15:06Z'
+        created_at: "2019-07-31T11:15:06Z"
         edited_at:
         crossposted_at:
-        published_at: '2019-08-01T15:47:54Z'
-        last_comment_at: '2019-08-06T09:12:45Z'
+        published_at: "2019-08-01T15:47:54Z"
+        last_comment_at: "2019-08-06T09:12:45Z"
         body_html: |+
           <p>Today's episode of Byte Sized is about Leonhard Euler and the creation of <a href="https://en.wikipedia.org/wiki/Graph_theory">Graph Theory</a>.</p>
 
           <p>For more about how Graph Theory works, check out this video from BaseCS!</p>...
-        body_markdown: "---\r\ntitle: Byte Sized Episode 2: The Creation of Graph Theory \r\npublished:
+        body_markdown:
+          "---\r\ntitle: Byte Sized Episode 2: The Creation of Graph Theory \r\npublished:
           true\r\ndescription: The full story of Leonhard Euler and the creation of this fundamental
           computer science principle, delivered in a few minutes.\r\ntags: computerscience,
           graphtheory, bytesized, history\r\ncover_image: https://thepracticaldev.s3.amazonaws.com/i/88e62fzblbluz1dm7xjf.png\r\nseries:
@@ -566,7 +612,28 @@ components:
           series: Hello series
           canonical_url: https://example.com/blog/hello
           organization_id: 1234
-
+    WebhookCreate:
+      value:
+        webhook_endpoint:
+          target_url: https://example.com/webhooks/webhook1
+          source: DEV
+          events:
+            - article_created
+    WebhookShow:
+      value:
+        type_of: webhook_endpoint
+        events:
+          - article_created
+        target_url: https://example.com/webhooks/webhook1
+        source: DEV
+        user:
+          name: bob
+          username: bob
+          twitter_username:
+          github_username: bob
+          website_url:
+          profile_image: "..."
+          profile_image_90: "..."
 
 paths:
   /articles:
@@ -655,30 +722,31 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ArticleIndex'
+                  $ref: "#/components/schemas/ArticleIndex"
               examples:
                 articles-success:
                   summary: Successful response
                   value:
                     - type_of: article
                       id: 150589
-                      title: 'Byte Sized Episode 2: The Creation of Graph Theory'
-                      description: The full story of Leonhard Euler and the creation of this fundamental
+                      title: "Byte Sized Episode 2: The Creation of Graph Theory"
+                      description:
+                        The full story of Leonhard Euler and the creation of this fundamental
                         computer science principle, delivered in a few minutes.
                       cover_image: https://res.cloudinary.com/practicaldev/image/fetch/s--qgutBUrH--/c_imagga_scale,f_auto,fl_progressive,h_420,q_auto,w_1000/https://thepracticaldev.s3.amazonaws.com/i/88e62fzblbluz1dm7xjf.png
-                      published_at: '2019-08-01T15:47:54.000Z'
+                      published_at: "2019-08-01T15:47:54.000Z"
                       tag_list:
-                      - computerscience
-                      - graphtheory
-                      - bytesized
-                      - history
+                        - computerscience
+                        - graphtheory
+                        - bytesized
+                        - history
                       slug: byte-sized-episode-2-the-creation-of-graph-theory-34g1
                       path: "/bytesized/byte-sized-episode-2-the-creation-of-graph-theory-34g1"
                       url: https://dev.to/bytesized/byte-sized-episode-2-the-creation-of-graph-theory-34g1
                       canonical_url: https://dev.to/bytesized/byte-sized-episode-2-the-creation-of-graph-theory-34g1
                       comments_count: 15
                       positive_reactions_count: 210
-                      published_timestamp: '2019-08-01T15:47:54Z'
+                      published_timestamp: "2019-08-01T15:47:54Z"
                       user:
                         name: Vaidehi Joshi
                         username: vaidehijoshi
@@ -725,14 +793,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ArticleCreate'
+              $ref: "#/components/schemas/ArticleCreate"
             examples:
               article-create-title-body:
-                $ref: '#/components/examples/ArticleCreateTitleBody'
+                $ref: "#/components/examples/ArticleCreateTitleBody"
               article-create-front-matter:
-                $ref: '#/components/examples/ArticleCreateFrontMatter'
+                $ref: "#/components/examples/ArticleCreateFrontMatter"
               article-create-organization:
-                $ref: '#/components/examples/ArticleCreateOrganization'
+                $ref: "#/components/examples/ArticleCreateOrganization"
 
       responses:
         201:
@@ -741,10 +809,10 @@ paths:
             application/json:
               schema:
                 type: object
-                $ref: '#/components/schemas/ArticleShow'
+                $ref: "#/components/schemas/ArticleShow"
               examples:
                 article-success:
-                  $ref: '#/components/examples/ArticleShow'
+                  $ref: "#/components/examples/ArticleShow"
           headers:
             Location:
               description: The URL of the new article
@@ -757,10 +825,10 @@ paths:
             application/json:
               schema:
                 type: object
-                $ref: '#/components/schemas/APIError'
+                $ref: "#/components/schemas/APIError"
               examples:
                 article-unauthorized:
-                  $ref: '#/components/examples/ErrorUnauthorized'
+                  $ref: "#/components/examples/ErrorUnauthorized"
       security:
         - api_key: []
         - oauth2: []
@@ -806,20 +874,20 @@ paths:
             application/json:
               schema:
                 type: object
-                $ref: '#/components/schemas/ArticleShow'
+                $ref: "#/components/schemas/ArticleShow"
               examples:
                 article-success:
-                  $ref: '#/components/examples/ArticleShow'
+                  $ref: "#/components/examples/ArticleShow"
         404:
           description: Resource not found
           content:
             application/json:
               schema:
                 type: object
-                $ref: '#/components/schemas/APIError'
+                $ref: "#/components/schemas/APIError"
               examples:
                 article-not-found:
-                  $ref: '#/components/examples/ErrorNotFound'
+                  $ref: "#/components/examples/ErrorNotFound"
       x-code-samples: # https://github.com/Redocly/redoc/blob/master/docs/redoc-vendor-extensions.md#x-code-samples
         - lang: Shell
           label: curl
@@ -863,14 +931,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ArticleUpdate'
+              $ref: "#/components/schemas/ArticleUpdate"
             examples:
               article-update-title-body:
-                $ref: '#/components/examples/ArticleCreateTitleBody'
+                $ref: "#/components/examples/ArticleCreateTitleBody"
               article-update-front-matter:
-                $ref: '#/components/examples/ArticleCreateFrontMatter'
+                $ref: "#/components/examples/ArticleCreateFrontMatter"
               article-update-organization:
-                $ref: '#/components/examples/ArticleCreateOrganization'
+                $ref: "#/components/examples/ArticleCreateOrganization"
       responses:
         200:
           description: The updated article
@@ -878,20 +946,20 @@ paths:
             application/json:
               schema:
                 type: object
-                $ref: '#/components/schemas/ArticleShow'
+                $ref: "#/components/schemas/ArticleShow"
               examples:
                 article-success:
-                  $ref: '#/components/examples/ArticleShow'
+                  $ref: "#/components/examples/ArticleShow"
         401:
           description: Unauthorized
           content:
             application/json:
               schema:
                 type: object
-                $ref: '#/components/schemas/APIError'
+                $ref: "#/components/schemas/APIError"
               examples:
                 article-unauthorized:
-                  $ref: '#/components/examples/ErrorUnauthorized'
+                  $ref: "#/components/examples/ErrorUnauthorized"
       security:
         - api_key: []
         - oauth2: []
@@ -944,7 +1012,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ArticleMe'
+                  $ref: "#/components/schemas/ArticleMe"
       security:
         - api_key: []
         - oauth2: []
@@ -953,3 +1021,56 @@ paths:
           label: curl
           source: |
             curl https://dev.to/api/articles/me
+
+  /webhooks:
+    post:
+      summary: Create a new webhook
+      description: |
+        This endpoint allows the client to create a new webhook.
+
+        "Webhooks" are used to register HTTP endpoints that will be called once a relevant event is
+        triggered inside the web application, events like `article_created`, `article_updated`.
+      tags:
+        - webhooks
+      requestBody:
+        description: Webhook to create
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WebhookCreate"
+            examples:
+              webhook-create:
+                $ref: "#/components/examples/WebhookCreate"
+
+      responses:
+        201:
+          description: A newly created webhook
+          content:
+            application/json:
+              schema:
+                type: object
+                $ref: "#/components/schemas/WebhookShow"
+              examples:
+                webhook-success:
+                  $ref: "#/components/examples/WebhookShow"
+        401:
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                $ref: "#/components/schemas/APIError"
+              examples:
+                article-unauthorized:
+                  $ref: "#/components/examples/ErrorUnauthorized"
+      security:
+        - api_key: []
+        - oauth2: []
+      x-code-samples: # https://github.com/Redocly/redoc/blob/master/docs/redoc-vendor-extensions.md#x-code-samples
+        - lang: Shell
+          label: curl
+          source: |
+            curl -X POST -H "Content-Type: application/json" \
+              -H "api-key: ACCESS_TOKEN" \
+              -d '{"webhook_endpoint":{"target_url":"https://example.org/webhooks/webhook1","source":"DEV","events":["article_created"]}}' \
+              https://dev.to/api/webhooks

--- a/spec/factories/webhook_endpoints.rb
+++ b/spec/factories/webhook_endpoints.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :webhook_endpoint, class: Webhook::Endpoint do
     target_url { Faker::Internet.url(scheme: "https") }
-    events { %w[article_created article_updated article_destroyed] }
+    events { Webhook::Event::EVENT_TYPES }
     user
     source { "stackbit" }
   end

--- a/spec/models/webhook/endpoint_spec.rb
+++ b/spec/models/webhook/endpoint_spec.rb
@@ -1,15 +1,31 @@
 require "rails_helper"
 
 RSpec.describe Webhook::Endpoint, type: :model do
-  let!(:endpoint) { create(:webhook_endpoint, user: user, events: %w[article_created article_updated article_destroyed]) }
+  let!(:endpoint) do
+    create(
+      :webhook_endpoint, user: user, events: %w[article_created article_updated article_destroyed]
+    )
+  end
   let(:user) { create(:user) }
+
+  describe "validations" do
+    it { is_expected.to belong_to(:user).inverse_of(:webhook_endpoints) }
+    it { is_expected.to validate_presence_of(:target_url) }
+    it { is_expected.to validate_presence_of(:source) }
+    it { is_expected.to validate_presence_of(:events) }
+    it { is_expected.to validate_uniqueness_of(:target_url) }
+    it { is_expected.to allow_value("https://foo.com").for(:target_url) }
+    it { is_expected.not_to allow_value("http://foo.com").for(:target_url) }
+  end
 
   it "is valid" do
     expect(endpoint).to be_valid
   end
 
   it "sets events according to the list" do
-    webhook = create(:webhook_endpoint, events: %w[article_updated other_updated cool article_created])
+    webhook = create(
+      :webhook_endpoint, events: %w[article_updated other_updated cool article_created]
+    )
     webhook.reload
     expect(webhook.events.sort).to eq(%w[article_created article_updated])
   end

--- a/spec/requests/api/v0/webhooks_spec.rb
+++ b/spec/requests/api/v0/webhooks_spec.rb
@@ -14,6 +14,11 @@ RSpec.describe "Api::V0::Webhooks", type: :request do
       expect(response).to have_http_status(:ok)
     end
 
+    it "returns 404 if the webhook does not exist" do
+      get "/api/webhooks/9999"
+      expect(response).to have_http_status(:not_found)
+    end
+
     it "returns json on success" do
       get "/api/webhooks/#{webhook.id}"
       json = JSON.parse(response.body)

--- a/spec/requests/api/v0/webhooks_spec.rb
+++ b/spec/requests/api/v0/webhooks_spec.rb
@@ -19,6 +19,12 @@ RSpec.describe "Api::V0::Webhooks", type: :request do
       expect(response).to have_http_status(:not_found)
     end
 
+    it "returns 404 if another user webhook is accessed" do
+      other_webhook = create(:webhook_endpoint, user: create(:user))
+      get "/api/webhooks/#{other_webhook.id}"
+      expect(response).to have_http_status(:not_found)
+    end
+
     it "returns json on success" do
       get "/api/webhooks/#{webhook.id}"
       json = JSON.parse(response.body)
@@ -75,8 +81,13 @@ RSpec.describe "Api::V0::Webhooks", type: :request do
       other_webhook = create(:webhook_endpoint, user: create(:user))
       expect do
         delete "/api/webhooks/#{other_webhook.id}"
-        expect(response).to have_http_status(:not_found)
       end.not_to change(Webhook::Endpoint, :count)
+    end
+
+    it "returns 404 if another user webhook is accessed" do
+      other_webhook = create(:webhook_endpoint, user: create(:user))
+      delete "/api/webhooks/#{other_webhook.id}"
+      expect(response).to have_http_status(:not_found)
     end
   end
 end

--- a/spec/requests/api/v0/webhooks_spec.rb
+++ b/spec/requests/api/v0/webhooks_spec.rb
@@ -66,18 +66,16 @@ RSpec.describe "Api::V0::Webhooks", type: :request do
       end.to change(Webhook::Endpoint, :count).by(-1)
     end
 
-    it "returns 200 on success" do
+    it "returns 204 on success" do
       delete "/api/webhooks/#{webhook.id}"
-      expect(response).to have_http_status(:ok)
-      expect(response.content_type).to eq("application/json")
-      json = JSON.parse(response.body)
-      expect(json["success"]).to be true
+      expect(response).to have_http_status(:no_content)
     end
 
     it "doesn't allow to destroy other user webhook" do
       other_webhook = create(:webhook_endpoint, user: create(:user))
       expect do
         delete "/api/webhooks/#{other_webhook.id}"
+        expect(response).to have_http_status(:not_found)
       end.not_to change(Webhook::Endpoint, :count)
     end
   end

--- a/spec/requests/api/v0/webhooks_spec.rb
+++ b/spec/requests/api/v0/webhooks_spec.rb
@@ -24,7 +24,11 @@ RSpec.describe "Api::V0::Webhooks", type: :request do
 
   describe "POST /api/v0/webhooks" do
     let(:webhook_params) do
-      { source: "stackbit", target_url: Faker::Internet.url(scheme: "https"), events: %w[article_created article_updated article_destroyed] }
+      {
+        source: "stackbit",
+        target_url: Faker::Internet.url(scheme: "https"),
+        events: %w[article_created article_updated article_destroyed]
+      }
     end
 
     it "creates a webhook" do


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [x] Documentation Update

## Description

I've fixed a few details about the API that prevented it to be used by a third party client, and also removed the HTTP DELETE body which is useless in this case.

## Related Tickets & Documents

See #3715 and #3783 

## Added to documentation?

- [x] docs.dev.to
- [ ] readme
- [ ] no documentation needed
