### PR TITLE
Use a clearer method name to render chat channel

### DIFF
--- a/app/controllers/chat_channels_controller.rb
+++ b/app/controllers/chat_channels_controller.rb
@@ -21,12 +21,12 @@ class ChatChannelsController < ApplicationController
   def create
     authorize ChatChannel
     @chat_channel = ChatChannelCreationService.new(current_user, params[:chat_channel]).create
-    chat_channel_valid?
+    render_chat_channel
   end
 
   def update
     ChatChannelUpdateService.new(@chat_channel, chat_channel_params).update
-    chat_channel_valid?
+    render_chat_channel
   end
 
   def open
@@ -163,7 +163,7 @@ class ChatChannelsController < ApplicationController
     end
   end
 
-  def chat_channel_valid?
+  def render_chat_channel
     if @chat_channel.valid?
       render json: { status: "success",
                      chat_channel: @chat_channel.to_json(only: %i[channel_name slug]) },


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

`chat_channel_valid?` is not the real purpose of this method, the goal
here is to properly render a chat channel in case it's valid or not.

Hence, I renamed the method to make it clearer, hopefully :)

