### PR TITLE
User profile: hide report abuse link if visiting yourself

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -145,14 +145,16 @@
       </div>
     </div>
     <%= render "articles/user_metadata", context: "profile" %>
-    <div class="profile-dropdown">
-      <button id="user-profile-dropdown">
-        <%= image_tag("three-dots.svg", class: "dropdown-icon", alt: "Toggle dropdown menu") %>
-      </button>
-      <div id="user-profile-dropdownmenu" class="profile-dropdownmenu">
-        <a href="/report-abuse?url=https://dev.to/<%= @user.username %>">Report Abuse</a>
+    <% unless @user == current_user %>
+      <div class="profile-dropdown">
+        <button id="user-profile-dropdown">
+          <%= image_tag("three-dots.svg", class: "dropdown-icon", alt: "Toggle dropdown menu") %>
+        </button>
+        <div id="user-profile-dropdownmenu" class="profile-dropdownmenu">
+          <a href="/report-abuse?url=https://<%= ApplicationConfig["APP_DOMAIN"] %>/<%= @user.username %>">Report Abuse</a>
+        </div>
       </div>
-    </div>
+    <% end %>
   </div>
 <% end %>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -145,6 +145,7 @@
       </div>
     </div>
     <%= render "articles/user_metadata", context: "profile" %>
+    <%# TODO: move the following condition down to the "Report Abuse" link if other options are added to the menu %>
     <% unless @user == current_user %>
       <div class="profile-dropdown">
         <button id="user-profile-dropdown">

--- a/spec/requests/user_profile_spec.rb
+++ b/spec/requests/user_profile_spec.rb
@@ -81,14 +81,6 @@ RSpec.describe "UserProfiles", type: :request do
     end
   end
 
-  describe "GET /user" do
-    it "renders to appropriate page" do
-      user = create(:user)
-      get "/#{user.username}"
-      expect(response.body).to include CGI.escapeHTML(user.name)
-    end
-  end
-
   describe "redirect to moderation" do
     it "redirects to admin" do
       user = create(:user)

--- a/spec/system/user/view_user_index_spec.rb
+++ b/spec/system/user/view_user_index_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "User index", type: :system do
 
   context "when user is unauthorized" do
     context "when 1 article" do
-      before { visit "/user3000" }
+      before { visit "/#{user.username}" }
 
       it "shows the header", js: true do
         within("h1") { expect(page).to have_content(user.name) }
@@ -56,13 +56,19 @@ RSpec.describe "User index", type: :system do
           expect(page).to have_selector(timestamp_selector)
         end
       end
+
+      it "renders the report abuse link" do
+        within(".profile-dropdown") do
+          expect(page).to have_link("Report Abuse")
+        end
+      end
     end
   end
 
   context "when visiting own profile" do
     before do
       sign_in user
-      visit "/user3000"
+      visit "/#{user.username}"
     end
 
     it "shows the header", js: true do
@@ -84,6 +90,10 @@ RSpec.describe "User index", type: :system do
         expect(page).to have_content("Recent Comments")
         expect(page).to have_link(nil, href: comment.path)
       end
+    end
+
+    it "renders the report abuse link" do
+      expect(page).not_to have_link("Report Abuse")
     end
   end
 end

--- a/spec/system/user/view_user_index_spec.rb
+++ b/spec/system/user/view_user_index_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe "User index", type: :system do
       end
     end
 
-    it "renders the report abuse link" do
+    it "does not render the report abuse link" do
       expect(page).not_to have_link("Report Abuse")
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

I was thinking we might want to hide the dropdown for now since it only includes "report abuse" if a user is looking at their own profile

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
