### PR TITLE
Remove a link to a missing section in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,6 @@
     - [Clean code with tests](#clean-code-with-tests)
     - [Create a pull request](#create-a-pull-request)
     - [Create an issue](#create-an-issue)
-  - [How to get help](#how-to-get-help)
   - [The bottom line](#the-bottom-line)
 
 ## Contributing


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [X] Documentation Update

## Description

The `How to get help` section was removed with #3659. This removes the link to it from the table of contents as well.
