### PR TITLE
API: /api/articles/me defaults to published articles

### DIFF
--- a/app/controllers/api/v0/articles_controller.rb
+++ b/app/controllers/api/v0/articles_controller.rb
@@ -47,7 +47,14 @@ module Api
       def me
         per_page = (params[:per_page] || 30).to_i
         num = [per_page, 1000].min
-        @articles = @user.articles.
+
+        @articles = @user.articles.published # defaults to only published articles
+
+        @articles = @user.articles.published if params[:status] == "published"
+        @articles = @user.articles.unpublished if params[:status] == "unpublished"
+        @articles = @user.articles if params[:status] == "all"
+
+        @articles = @articles.
           includes(:organization).
           order(published_at: :desc, created_at: :desc).
           page(params[:page]).

--- a/app/controllers/api/v0/articles_controller.rb
+++ b/app/controllers/api/v0/articles_controller.rb
@@ -48,11 +48,16 @@ module Api
         per_page = (params[:per_page] || 30).to_i
         num = [per_page, 1000].min
 
-        @articles = @user.articles.published # defaults to only published articles
-
-        @articles = @user.articles.published if params[:status] == "published"
-        @articles = @user.articles.unpublished if params[:status] == "unpublished"
-        @articles = @user.articles if params[:status] == "all"
+        @articles = case params[:status]
+                    when "published"
+                      @user.articles.published
+                    when "unpublished"
+                      @user.articles.unpublished
+                    when "all"
+                      @user.articles
+                    else
+                      @user.articles.published
+                    end
 
         @articles = @articles.
           includes(:organization).

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -75,6 +75,7 @@ class Article < ApplicationRecord
   serialize :cached_organization
 
   scope :published, -> { where(published: true) }
+  scope :unpublished, -> { where(published: false) }
 
   scope :cached_tagged_with, ->(tag) { where("cached_tag_list ~* ?", "^#{tag},| #{tag},|, #{tag}$|^#{tag}$") }
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,7 +79,7 @@ Rails.application.routes.draw do
           constraints: ApiConstraints.new(version: 0, default: true) do
       resources :articles, only: %i[index show create update] do
         collection do
-          get :me
+          get "me(/:status)", to: "articles#me", as: :me, constraints: { status: /published|unpublished|all/ }
         end
       end
       resources :comments, only: %i[index show]

--- a/docs/api_v0.yml
+++ b/docs/api_v0.yml
@@ -2,7 +2,7 @@ openapi: "3.0.2"
 info:
   title: DEV API
   description: Access DEV articles, comments and other resources via API
-  version: "0.5.3"
+  version: "0.5.4"
   termsOfService: https://dev.to/terms
   contact:
     name: DEV Team
@@ -984,14 +984,162 @@ paths:
     get:
       summary: Authenticated user's articles
       description: |
+        This endpoint allows the client to retrieve a list of its published articles.
+
+        "Articles" are all the posts that users create on DEV that typically
+        show up in the feed. They can be a blog post, a discussion question,
+        a help thread etc. but is referred to as article within the code.
+
+        Published articles will be in reverse chronological publication order.
+
+        It will return published articles with pagination.
+        By default a page will contain `30` articles.
+      tags:
+        - articles
+      parameters:
+        - name: page
+          in: query
+          description: Pagination page.
+          schema:
+            type: integer
+            format: int32
+          example: 1
+        - name: per_page
+          in: query
+          description: Page size (defaults to 30 with a maximum of 1000).
+          schema:
+            type: integer
+            format: int32
+          example: 30
+      responses:
+        200:
+          description: A list of published articles
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ArticleMe"
+      security:
+        - api_key: []
+        - oauth2: []
+      x-code-samples: # https://github.com/Redocly/redoc/blob/master/docs/redoc-vendor-extensions.md#x-code-samples
+        - lang: Shell
+          label: curl
+          source: |
+            curl https://dev.to/api/articles/me
+
+  /articles/me/published:
+    get:
+      summary: Authenticated user's published articles
+      description: |
+        This endpoint allows the client to retrieve a list of its published articles.
+
+        "Articles" are all the posts that users create on DEV that typically
+        show up in the feed. They can be a blog post, a discussion question,
+        a help thread etc. but is referred to as article within the code.
+
+        Published articles will be in reverse chronological publication order.
+
+        It will return published articles with pagination.
+        By default a page will contain `30` articles.
+      tags:
+        - articles
+      parameters:
+        - name: page
+          in: query
+          description: Pagination page.
+          schema:
+            type: integer
+            format: int32
+          example: 1
+        - name: per_page
+          in: query
+          description: Page size (defaults to 30 with a maximum of 1000).
+          schema:
+            type: integer
+            format: int32
+          example: 30
+      responses:
+        200:
+          description: A list of published articles
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ArticleMe"
+      security:
+        - api_key: []
+        - oauth2: []
+      x-code-samples: # https://github.com/Redocly/redoc/blob/master/docs/redoc-vendor-extensions.md#x-code-samples
+        - lang: Shell
+          label: curl
+          source: |
+            curl https://dev.to/api/articles/me/published
+
+  /articles/me/unpublished:
+    get:
+      summary: Authenticated user's unpublished articles
+      description: |
+        This endpoint allows the client to retrieve a list of its unpublished articles.
+
+        "Articles" are all the posts that users create on DEV that typically
+        show up in the feed. They can be a blog post, a discussion question,
+        a help thread etc. but is referred to as article within the code.
+
+        Unpublished articles will be in reverse chronological creation order.
+
+        It will return unpublished articles with pagination.
+        By default a page will contain `30` articles.
+      tags:
+        - articles
+      parameters:
+        - name: page
+          in: query
+          description: Pagination page.
+          schema:
+            type: integer
+            format: int32
+          example: 1
+        - name: per_page
+          in: query
+          description: Page size (defaults to 30 with a maximum of 1000).
+          schema:
+            type: integer
+            format: int32
+          example: 30
+      responses:
+        200:
+          description: A list of articles
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ArticleMe"
+      security:
+        - api_key: []
+        - oauth2: []
+      x-code-samples: # https://github.com/Redocly/redoc/blob/master/docs/redoc-vendor-extensions.md#x-code-samples
+        - lang: Shell
+          label: curl
+          source: |
+            curl https://dev.to/api/articles/me/unpublished
+
+  /articles/me/all:
+    get:
+      summary: Authenticated user's all articles
+      description: |
         This endpoint allows the client to retrieve a list of its articles.
 
         "Articles" are all the posts that users create on DEV that typically
         show up in the feed. They can be a blog post, a discussion question,
         a help thread etc. but is referred to as article within the code.
 
-        It will return both published and draft articles with pagination.
-        Draft articles will be at the top of the list in reverse chronological creation order.
+        It will return both published and unpublished articles with pagination.
+
+        Unpublished articles will be at the top of the list in reverse chronological creation order.
         Published articles will follow in reverse chronological publication order.
 
         By default a page will contain `30` articles.
@@ -1028,7 +1176,7 @@ paths:
         - lang: Shell
           label: curl
           source: |
-            curl https://dev.to/api/articles/me
+            curl https://dev.to/api/articles/me/all
 
   /webhooks:
     post:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

We want to make it explicit to retrieve unpublished articles, this change defaults `/api/articles/me` to only published articles, also adds `/api/articles/me/published`, `/api/articles/me/unpublished` and `/api/articles/me/all` to make requests more explicit.

This PR potentially breaks current usage of `/api/articles/me` by removing unpublished articles from the response.

## Related Tickets & Documents

Closes https://github.com/thepracticaldev/dev.to/issues/3928

## Added to documentation?

- [x] docs.dev.to
- [ ] readme
- [ ] no documentation needed
