### PR TITLE
Rescue InvalidURIError when busting cache

### DIFF
--- a/app/labor/cache_buster.rb
+++ b/app/labor/cache_buster.rb
@@ -10,6 +10,8 @@ class CacheBuster
                   headers: { "Fastly-Key" => ApplicationConfig["FASTLY_API_KEY"] })
     HTTParty.post("https://api.fastly.com/purge/https://dev.to#{path}?i=i",
                   headers: { "Fastly-Key" => ApplicationConfig["FASTLY_API_KEY"] })
+  rescue URI::InvalidURIError => e
+    Rails.logger.error("Trying to bust cache of an invalid uri: #{e}")
   end
 
   def bust_comment(commentable)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
I see a decent amount of `InvalidURIError`s on busting cache jobs related to the #2934 issue (invalid tags containing blanks). These jobs keep retrying and wasting resources.
This pr is a quick solution for this problem, the proper solutions are described in #2934
I thought about checking tags for blanks explicitly because we would like to know if we try to bust cache of an invalid url in other cases, but the `CacheBuster` approach seems to be more like "catch the errors" plus we don't want to waste resources in other cases as well.

## Related Tickets & Documents
#2934
