### PR TITLE
Fixes encoding of special characters on organization page rendering

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -70,7 +70,7 @@ class OrganizationsController < ApplicationController
     params.require(:organization).permit(permitted_params).
       transform_values do |value|
         if value.class.name == "String"
-          Loofah.scrub_fragment(value, :prune).text(encode_special_chars: false)
+          ActionController::Base.helpers.strip_tags(value)
         else
           value
         end

--- a/app/views/articles/_user_metadata.html.erb
+++ b/app/views/articles/_user_metadata.html.erb
@@ -13,7 +13,7 @@
             headquarters
           </div>
           <div class="value">
-            <%= @organization.location %>
+            <%= sanitize @organization.location %>
           </div>
         </div>
       <% end %>
@@ -33,7 +33,7 @@
             support_email
           </div>
           <div class="value">
-            <a href="mailto:<%= @organization.email %>"><%= @organization.email %></a>
+            <a href="mailto:<%= sanitize @organization.email %>"><%= sanitize @organization.email %></a>
           </div>
         </div>
       <% end %>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -1,4 +1,4 @@
-<% title sanitize @organization.name %>
+<% title sanitize(@organization.name) %>
 
 <%= content_for :page_meta do %>
   <%= render "users/meta" %>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -1,4 +1,4 @@
-<% title @organization.name %>
+<% title sanitize @organization.name %>
 
 <%= content_for :page_meta do %>
   <%= render "users/meta" %>

--- a/app/views/users/_profile_header.html.erb
+++ b/app/views/users/_profile_header.html.erb
@@ -24,7 +24,7 @@
         </span>
       </h1>
       <p class="profile-description" itemprop="description">
-        <%= sanitize @user.summary.presence || ["404 bio not found"].sample %>
+        <%= sanitize(@user.summary.presence || "404 bio not found") %>
       </p>
       <style>
         .profile-details .social .icon-img path {

--- a/app/views/users/_profile_header.html.erb
+++ b/app/views/users/_profile_header.html.erb
@@ -18,13 +18,13 @@
     </div>
     <div class="profile-details">
       <h1 style="color:<%= HexComparer.new([user_colors(@user)[:bg], user_colors(@user)[:text]]).brightness(0.78) %>">
-        <span itemprop="name"><%= @user.name %></span>
+        <span itemprop="name"><%= sanitize @user.name %></span>
         <span class="user-profile-follow-button-wrapper">
           <button id="user-follow-butt" class="cta follow-action-button user-profile-follow-button" style="color:<%= user_colors(@user)[:text] %>;background-color:<%= user_colors(@user)[:bg] %>" data-info='{"id":<%= @user.id %>,"className":"<%= @user.class.name %>"}'>&nbsp;</button>
         </span>
       </h1>
       <p class="profile-description" itemprop="description">
-        <%= @user.summary.presence || ["404 bio not found"].sample %>
+        <%= sanitize @user.summary.presence || ["404 bio not found"].sample %>
       </p>
       <style>
         .profile-details .social .icon-img path {

--- a/spec/requests/user_profile_spec.rb
+++ b/spec/requests/user_profile_spec.rb
@@ -61,6 +61,30 @@ RSpec.describe "UserProfiles", type: :request do
         get organization.path
         expect(response.body).to include "Gold Community Sponsor"
       end
+
+      it "renders organization name properly encoded" do
+        organization.update(name: "Org & < ' \" 1")
+        get organization.path
+        expect(response.body).to include(ActionController::Base.helpers.sanitize(organization.name))
+      end
+
+      it "renders organization email properly encoded" do
+        organization.update(email: "t&st&mail@dev.to")
+        get organization.path
+        expect(response.body).to include(ActionController::Base.helpers.sanitize(organization.email))
+      end
+
+      it "renders organization summary properly encoded" do
+        organization.update(summary: "Org & < ' \" &quot; 1")
+        get organization.path
+        expect(response.body).to include(ActionController::Base.helpers.sanitize(organization.summary))
+      end
+
+      it "renders organization location properly encoded" do
+        organization.update(location: "123, ave dev & < ' \" &quot; to")
+        get organization.path
+        expect(response.body).to include(ActionController::Base.helpers.sanitize(organization.location))
+      end
     end
 
     context "when github repo" do


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

@rhymes as we discussed on PR #3817 I brought back the old code (``strip_tags``) and sanitized the parameters that accept special characters on page rendering. I used ``sanitize`` instead of ``raw`` because the rails docs said it's safer. 

You mentioned some testing, but because I wasn't 100% sure you meant automated tests I didn't write any. I can update my PR with any tests you think it'd be cool to have. 

## Related Tickets & Documents

#3799 and #3817 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

No UI changes

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
