### PR TITLE
Paginate notifications

### DIFF
--- a/app/assets/javascripts/initializers/initNotifications.js
+++ b/app/assets/javascripts/initializers/initNotifications.js
@@ -159,35 +159,40 @@ function initPagination() {
   // paginators appear at the end of each block of HTML notifications sent by
   // the server, each time we paginate we're only interested in the last one
   const paginators = document.getElementsByClassName('notifications-paginator');
-  const paginator = paginators[paginators.length - 1];
+  if (paginators && paginators.length > 0) {
+    const paginator = paginators[paginators.length - 1];
 
-  if (paginator) {
-    window
-      .fetch(paginator.dataset.paginationPath, {
-        method: 'GET',
-        credentials: 'same-origin',
-      })
-      .then(function(response) {
-        if (response.status === 200) {
-          response.text().then(function(html) {
-            const notificationsList = html.trim();
-            console.log(notificationsList);
+    if (paginator) {
+      window
+        .fetch(paginator.dataset.paginationPath, {
+          method: 'GET',
+          credentials: 'same-origin',
+        })
+        .then(function(response) {
+          if (response.status === 200) {
+            response.text().then(function(html) {
+              const notificationsList = html.trim();
 
-            if (notificationsList) {
-              paginator.innerHTML = notificationsList;
-              initReactions();
-            } else {
-              // no more notifications to load, we hide the load more wrapper
-              const button = document.getElementById('load-more-button');
-              button.style.display = 'none';
-            }
-          });
-        }
-      });
+              if (notificationsList) {
+                paginator.innerHTML = notificationsList;
+                initReactions();
+              } else {
+                // no more notifications to load, we hide the load more wrapper
+                const button = document.getElementById('load-more-button');
+                if (button) {
+                  button.style.display = 'none';
+                }
+              }
+            });
+          }
+        });
+    }
   }
 }
 
 function initLoadMoreButton() {
   const button = document.getElementById('load-more-button');
-  button.addEventListener('click', initPagination);
+  if (button) {
+    button.addEventListener('click', initPagination);
+  }
 }

--- a/app/assets/javascripts/initializers/initNotifications.js
+++ b/app/assets/javascripts/initializers/initNotifications.js
@@ -4,28 +4,35 @@ function initNotifications() {
   initReactions();
   listenForNotificationsBellClick();
   initPagination();
+  initLoadMoreButton();
 }
 
 function markNotificationsAsRead() {
-  setTimeout(function () {
+  setTimeout(function() {
     if (document.getElementById('notifications-container')) {
       var xmlhttp;
-      var locationAsArray = window.location.pathname.split("/");
+      var locationAsArray = window.location.pathname.split('/');
       // Use regex to ensure only numbers in the original string are converted to integers
-      var parsedLastParam = parseInt(locationAsArray[locationAsArray.length - 1].replace(/[^0-9]/g, ''), 10);
+      var parsedLastParam = parseInt(
+        locationAsArray[locationAsArray.length - 1].replace(/[^0-9]/g, ''),
+        10,
+      );
 
       if (window.XMLHttpRequest) {
         xmlhttp = new XMLHttpRequest();
       } else {
         xmlhttp = new ActiveXObject('Microsoft.XMLHTTP');
       }
-      xmlhttp.onreadystatechange = function () {
-      };
+      xmlhttp.onreadystatechange = function() {};
 
       var csrfToken = document.querySelector("meta[name='csrf-token']").content;
 
-      if(Number.isInteger(parsedLastParam)) {
-        xmlhttp.open('Post', '/notifications/reads?org_id=' + parsedLastParam, true);
+      if (Number.isInteger(parsedLastParam)) {
+        xmlhttp.open(
+          'Post',
+          '/notifications/reads?org_id=' + parsedLastParam,
+          true,
+        );
       } else {
         xmlhttp.open('Post', '/notifications/reads', true);
       }
@@ -36,29 +43,42 @@ function markNotificationsAsRead() {
 }
 
 function fetchNotificationsCount() {
-  if (document.getElementById('notifications-container') == null && checkUserLoggedIn()) {
+  if (
+    document.getElementById('notifications-container') == null &&
+    checkUserLoggedIn()
+  ) {
     var xmlhttp;
     if (window.XMLHttpRequest) {
       xmlhttp = new XMLHttpRequest();
     } else {
       xmlhttp = new ActiveXObject('Microsoft.XMLHTTP');
     }
-    xmlhttp.onreadystatechange = function () {
+    xmlhttp.onreadystatechange = function() {
       if (xmlhttp.readyState == XMLHttpRequest.DONE) {
         var count = xmlhttp.response;
         if (isNaN(count)) {
-          document.getElementById('notifications-number').classList.remove('showing');
-        } else if (count != '0' && count != undefined && count != "") {
-          document.getElementById('notifications-number').innerHTML = xmlhttp.response;
-          document.getElementById('notifications-number').classList.add('showing');
-          if(instantClick){
-            InstantClick.removeExpiredKeys("force");
-            setTimeout(function(){
-              InstantClick.preload(document.getElementById("notifications-link").href, "force");
-            },30)
+          document
+            .getElementById('notifications-number')
+            .classList.remove('showing');
+        } else if (count != '0' && count != undefined && count != '') {
+          document.getElementById('notifications-number').innerHTML =
+            xmlhttp.response;
+          document
+            .getElementById('notifications-number')
+            .classList.add('showing');
+          if (instantClick) {
+            InstantClick.removeExpiredKeys('force');
+            setTimeout(function() {
+              InstantClick.preload(
+                document.getElementById('notifications-link').href,
+                'force',
+              );
+            }, 30);
           }
         } else {
-          document.getElementById('notifications-number').classList.remove('showing');
+          document
+            .getElementById('notifications-number')
+            .classList.remove('showing');
         }
       }
     };
@@ -69,12 +89,12 @@ function fetchNotificationsCount() {
 }
 
 function initReactions() {
-  setTimeout(function () {
+  setTimeout(function() {
     if (document.getElementById('notifications-container')) {
       var butts = document.getElementsByClassName('reaction-button');
       for (var i = 0; i < butts.length; i++) {
         var butt = butts[i];
-        butt.onclick = function (event) {
+        butt.onclick = function(event) {
           event.preventDefault();
           sendHapticMessage('medium');
           var thisButt = this;
@@ -95,7 +115,7 @@ function initReactions() {
 
           getCsrfToken()
             .then(sendFetch('reaction-creation', formData))
-            .then(function (response) {
+            .then(function(response) {
               if (response.status === 200) {
                 response.json().then(successCb);
               }
@@ -105,13 +125,19 @@ function initReactions() {
       var butts = document.getElementsByClassName('toggle-reply-form');
       for (var i = 0; i < butts.length; i++) {
         var butt = butts[i];
-        butt.onclick = function (event) {
+        butt.onclick = function(event) {
           event.preventDefault();
           var thisButt = this;
-          document.getElementById('comment-form-for-' + thisButt.dataset.reactableId).classList.add('showing');
+          document
+            .getElementById('comment-form-for-' + thisButt.dataset.reactableId)
+            .classList.add('showing');
           thisButt.innerHTML = '';
-          setTimeout(function () {
-            document.getElementById('comment-textarea-for-' + thisButt.dataset.reactableId).focus();
+          setTimeout(function() {
+            document
+              .getElementById(
+                'comment-textarea-for-' + thisButt.dataset.reactableId,
+              )
+              .focus();
           }, 30);
         };
       }
@@ -120,26 +146,48 @@ function initReactions() {
 }
 
 function listenForNotificationsBellClick() {
-  setTimeout(function () {
-    document.getElementById('notifications-link').onclick = function () {
-      document.getElementById('notifications-number').classList.remove('showing');
+  setTimeout(function() {
+    document.getElementById('notifications-link').onclick = function() {
+      document
+        .getElementById('notifications-number')
+        .classList.remove('showing');
     };
   }, 180);
 }
 
 function initPagination() {
-  var el = document.getElementById("notifications-pagination")
-  if (el) {
-    window.fetch(el.dataset.paginationPath, {
-      method: 'GET',
-      credentials: 'same-origin'
-    }).then(function (response) {
-      if (response.status === 200) {
-        response.text().then(function(html){
-          el.innerHTML = html
-          initReactions();
-        });
-      }
-    });
+  // paginators appear at the end of each block of HTML notifications sent by
+  // the server, each time we paginate we're only interested in the last one
+  const paginators = document.getElementsByClassName('notifications-paginator');
+  const paginator = paginators[paginators.length - 1];
+
+  if (paginator) {
+    window
+      .fetch(paginator.dataset.paginationPath, {
+        method: 'GET',
+        credentials: 'same-origin',
+      })
+      .then(function(response) {
+        if (response.status === 200) {
+          response.text().then(function(html) {
+            const notificationsList = html.trim();
+            console.log(notificationsList);
+
+            if (notificationsList) {
+              paginator.innerHTML = notificationsList;
+              initReactions();
+            } else {
+              // no more notifications to load, we hide the load more wrapper
+              const button = document.getElementById('load-more-button');
+              button.style.display = 'none';
+            }
+          });
+        }
+      });
   }
+}
+
+function initLoadMoreButton() {
+  const button = document.getElementById('load-more-button');
+  button.addEventListener('click', initPagination);
 }

--- a/app/assets/javascripts/initializers/initNotifications.js
+++ b/app/assets/javascripts/initializers/initNotifications.js
@@ -1,14 +1,19 @@
-'use strict';
-
-/* global checkUserLoggedIn, instantClick, InstantClick, sendHapticMessage */
+function initNotifications() {
+  fetchNotificationsCount();
+  markNotificationsAsRead();
+  initReactions();
+  listenForNotificationsBellClick();
+  initPagination();
+  initLoadMoreButton();
+}
 
 function markNotificationsAsRead() {
   setTimeout(function() {
     if (document.getElementById('notifications-container')) {
-      let xmlhttp;
-      const locationAsArray = window.location.pathname.split('/');
+      var xmlhttp;
+      var locationAsArray = window.location.pathname.split('/');
       // Use regex to ensure only numbers in the original string are converted to integers
-      const parsedLastParam = parseInt(
+      var parsedLastParam = parseInt(
         locationAsArray[locationAsArray.length - 1].replace(/[^0-9]/g, ''),
         10,
       );
@@ -20,8 +25,7 @@ function markNotificationsAsRead() {
       }
       xmlhttp.onreadystatechange = function() {};
 
-      const csrfToken = document.querySelector("meta[name='csrf-token']")
-        .content;
+      var csrfToken = document.querySelector("meta[name='csrf-token']").content;
 
       if (Number.isInteger(parsedLastParam)) {
         xmlhttp.open(
@@ -43,25 +47,25 @@ function fetchNotificationsCount() {
     document.getElementById('notifications-container') == null &&
     checkUserLoggedIn()
   ) {
-    let xmlhttp;
+    var xmlhttp;
     if (window.XMLHttpRequest) {
       xmlhttp = new XMLHttpRequest();
     } else {
       xmlhttp = new ActiveXObject('Microsoft.XMLHTTP');
     }
     xmlhttp.onreadystatechange = function() {
-      if (xmlhttp.readyState === XMLHttpRequest.DONE) {
-        const count = xmlhttp.response;
-        const notificationsNumber = document.getElementById(
-          'notifications-number',
-        );
-
-        if (Number.isNaN(count)) {
-          notificationsNumber.classList.remove('showing');
-        } else if (count !== '0' && count !== undefined && count !== '') {
-          notificationsNumber.innerHTML = xmlhttp.response;
-          notificationsNumber.classList.add('showing');
-
+      if (xmlhttp.readyState == XMLHttpRequest.DONE) {
+        var count = xmlhttp.response;
+        if (isNaN(count)) {
+          document
+            .getElementById('notifications-number')
+            .classList.remove('showing');
+        } else if (count != '0' && count != undefined && count != '') {
+          document.getElementById('notifications-number').innerHTML =
+            xmlhttp.response;
+          document
+            .getElementById('notifications-number')
+            .classList.add('showing');
           if (instantClick) {
             InstantClick.removeExpiredKeys('force');
             setTimeout(function() {
@@ -72,7 +76,9 @@ function fetchNotificationsCount() {
             }, 30);
           }
         } else {
-          notificationsNumber.classList.remove('showing');
+          document
+            .getElementById('notifications-number')
+            .classList.remove('showing');
         }
       }
     };
@@ -85,13 +91,10 @@ function fetchNotificationsCount() {
 function initReactions() {
   setTimeout(function() {
     if (document.getElementById('notifications-container')) {
-      const reactionButtons = document.getElementsByClassName(
-        'reaction-button',
-      );
-      for (const i = 0; i < reactionButtons.length; i += 1) {
-        const butt = reactionButtons[i];
-
-        butt.addEventListener('click', function(event) {
+      var butts = document.getElementsByClassName('reaction-button');
+      for (var i = 0; i < butts.length; i++) {
+        var butt = butts[i];
+        butt.onclick = function(event) {
           event.preventDefault();
           sendHapticMessage('medium');
           var thisButt = this;
@@ -117,13 +120,12 @@ function initReactions() {
                 response.json().then(successCb);
               }
             });
-        });
+        };
       }
-
-      const replyButtons = document.getElementsByClassName('toggle-reply-form');
-      for (const i = 0; i < replyButtons.length; i += 1) {
-        const butt = replyButtons[i];
-        butt.addEventListener('click', function(event) {
+      var butts = document.getElementsByClassName('toggle-reply-form');
+      for (var i = 0; i < butts.length; i++) {
+        var butt = butts[i];
+        butt.onclick = function(event) {
           event.preventDefault();
           var thisButt = this;
           document
@@ -137,7 +139,7 @@ function initReactions() {
               )
               .focus();
           }, 30);
-        });
+        };
       }
     }
   }, 180);
@@ -169,6 +171,7 @@ function initPagination() {
         if (response.status === 200) {
           response.text().then(function(html) {
             const notificationsList = html.trim();
+            console.log(notificationsList);
 
             if (notificationsList) {
               paginator.innerHTML = notificationsList;
@@ -187,13 +190,4 @@ function initPagination() {
 function initLoadMoreButton() {
   const button = document.getElementById('load-more-button');
   button.addEventListener('click', initPagination);
-}
-
-function initNotifications() {
-  fetchNotificationsCount();
-  markNotificationsAsRead();
-  initReactions();
-  listenForNotificationsBellClick();
-  initPagination();
-  initLoadMoreButton();
 }

--- a/app/assets/javascripts/initializers/initNotifications.js
+++ b/app/assets/javascripts/initializers/initNotifications.js
@@ -1,19 +1,14 @@
-function initNotifications() {
-  fetchNotificationsCount();
-  markNotificationsAsRead();
-  initReactions();
-  listenForNotificationsBellClick();
-  initPagination();
-  initLoadMoreButton();
-}
+'use strict';
+
+/* global checkUserLoggedIn, instantClick, InstantClick, sendHapticMessage */
 
 function markNotificationsAsRead() {
   setTimeout(function() {
     if (document.getElementById('notifications-container')) {
-      var xmlhttp;
-      var locationAsArray = window.location.pathname.split('/');
+      let xmlhttp;
+      const locationAsArray = window.location.pathname.split('/');
       // Use regex to ensure only numbers in the original string are converted to integers
-      var parsedLastParam = parseInt(
+      const parsedLastParam = parseInt(
         locationAsArray[locationAsArray.length - 1].replace(/[^0-9]/g, ''),
         10,
       );
@@ -25,7 +20,8 @@ function markNotificationsAsRead() {
       }
       xmlhttp.onreadystatechange = function() {};
 
-      var csrfToken = document.querySelector("meta[name='csrf-token']").content;
+      const csrfToken = document.querySelector("meta[name='csrf-token']")
+        .content;
 
       if (Number.isInteger(parsedLastParam)) {
         xmlhttp.open(
@@ -47,25 +43,25 @@ function fetchNotificationsCount() {
     document.getElementById('notifications-container') == null &&
     checkUserLoggedIn()
   ) {
-    var xmlhttp;
+    let xmlhttp;
     if (window.XMLHttpRequest) {
       xmlhttp = new XMLHttpRequest();
     } else {
       xmlhttp = new ActiveXObject('Microsoft.XMLHTTP');
     }
     xmlhttp.onreadystatechange = function() {
-      if (xmlhttp.readyState == XMLHttpRequest.DONE) {
-        var count = xmlhttp.response;
-        if (isNaN(count)) {
-          document
-            .getElementById('notifications-number')
-            .classList.remove('showing');
-        } else if (count != '0' && count != undefined && count != '') {
-          document.getElementById('notifications-number').innerHTML =
-            xmlhttp.response;
-          document
-            .getElementById('notifications-number')
-            .classList.add('showing');
+      if (xmlhttp.readyState === XMLHttpRequest.DONE) {
+        const count = xmlhttp.response;
+        const notificationsNumber = document.getElementById(
+          'notifications-number',
+        );
+
+        if (Number.isNaN(count)) {
+          notificationsNumber.classList.remove('showing');
+        } else if (count !== '0' && count !== undefined && count !== '') {
+          notificationsNumber.innerHTML = xmlhttp.response;
+          notificationsNumber.classList.add('showing');
+
           if (instantClick) {
             InstantClick.removeExpiredKeys('force');
             setTimeout(function() {
@@ -76,9 +72,7 @@ function fetchNotificationsCount() {
             }, 30);
           }
         } else {
-          document
-            .getElementById('notifications-number')
-            .classList.remove('showing');
+          notificationsNumber.classList.remove('showing');
         }
       }
     };
@@ -91,10 +85,13 @@ function fetchNotificationsCount() {
 function initReactions() {
   setTimeout(function() {
     if (document.getElementById('notifications-container')) {
-      var butts = document.getElementsByClassName('reaction-button');
-      for (var i = 0; i < butts.length; i++) {
-        var butt = butts[i];
-        butt.onclick = function(event) {
+      const reactionButtons = document.getElementsByClassName(
+        'reaction-button',
+      );
+      for (const i = 0; i < reactionButtons.length; i += 1) {
+        const butt = reactionButtons[i];
+
+        butt.addEventListener('click', function(event) {
           event.preventDefault();
           sendHapticMessage('medium');
           var thisButt = this;
@@ -120,12 +117,13 @@ function initReactions() {
                 response.json().then(successCb);
               }
             });
-        };
+        });
       }
-      var butts = document.getElementsByClassName('toggle-reply-form');
-      for (var i = 0; i < butts.length; i++) {
-        var butt = butts[i];
-        butt.onclick = function(event) {
+
+      const replyButtons = document.getElementsByClassName('toggle-reply-form');
+      for (const i = 0; i < replyButtons.length; i += 1) {
+        const butt = replyButtons[i];
+        butt.addEventListener('click', function(event) {
           event.preventDefault();
           var thisButt = this;
           document
@@ -139,7 +137,7 @@ function initReactions() {
               )
               .focus();
           }, 30);
-        };
+        });
       }
     }
   }, 180);
@@ -171,7 +169,6 @@ function initPagination() {
         if (response.status === 200) {
           response.text().then(function(html) {
             const notificationsList = html.trim();
-            console.log(notificationsList);
 
             if (notificationsList) {
               paginator.innerHTML = notificationsList;
@@ -190,4 +187,13 @@ function initPagination() {
 function initLoadMoreButton() {
   const button = document.getElementById('load-more-button');
   button.addEventListener('click', initPagination);
+}
+
+function initNotifications() {
+  fetchNotificationsCount();
+  markNotificationsAsRead();
+  initReactions();
+  listenForNotificationsBellClick();
+  initPagination();
+  initLoadMoreButton();
 }

--- a/app/assets/stylesheets/_mixins.scss
+++ b/app/assets/stylesheets/_mixins.scss
@@ -25,3 +25,21 @@
   #{$property}: #{$fallback} !important;
   #{$property}: var(--#{$cssVariable}, #{$fallback}) !important;
 }
+
+
+/* Mixin for a load more wrapper, made by a container div and child button */
+@mixin load-more() {
+  text-align: center;
+
+  button {
+    background: transparent;
+    @include themeable(border, theme-border, 1px solid $light-medium-gray);
+    font-size: 17px;
+    padding: 14px 5px;
+    margin: 40px auto 70px;
+    width: 320px;
+    max-width: 80%;
+    border-radius: 100px;
+    font-weight: bold;
+  }
+}

--- a/app/assets/stylesheets/item-list.scss
+++ b/app/assets/stylesheets/item-list.scss
@@ -198,19 +198,7 @@
     }
 
     .load-more-wrapper {
-      text-align: center;
-
-      button {
-        background: transparent;
-        @include themeable(border, theme-border, 1px solid $light-medium-gray);
-        font-size: 17px;
-        padding: 14px 5px;
-        margin: 40px auto 70px;
-        width: 320px;
-        max-width: 80%;
-        border-radius: 100px;
-        font-weight: bold;
-      }
+      @include load-more;
     }
   }
 }

--- a/app/assets/stylesheets/notifications.scss
+++ b/app/assets/stylesheets/notifications.scss
@@ -2,6 +2,7 @@
 @import 'mixins';
 .notifications-index {
   @include themeable(background, theme-background, $lightest-gray);
+
   .home {
     .articles-list {
       .signup-cue {
@@ -405,5 +406,9 @@
         );
       }
     }
+  }
+
+  .load-more-wrapper {
+    @include load-more;
   }
 }

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,8 +1,8 @@
 class NotificationsController < ApplicationController
-  before_action :authenticate_user!
-
   # No authorization required because we provide authentication on notifications page
   def index
+    return unless user_signed_in?
+
     @notifications_index = true
     @user = user_to_view
 

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,16 +1,21 @@
 class NotificationsController < ApplicationController
+  before_action :authenticate_user!
+
   # No authorization required because we provide authentication on notifications page
   def index
-    return unless user_signed_in?
-
     @notifications_index = true
     @user = user_to_view
-    if params[:page]
-      num = 45
-      notified_at_offset = Notification.find(params[:page])&.notified_at
+
+    # NOTE: this controller is using offset based pagination by assuming that
+    # the id of the last notification also corresponds to the newest `notified_at`
+    # this might not be forever true but it's good enough for now
+    if params[:offset]
+      num = 30
+      notified_at_offset = Notification.find(params[:offset])&.notified_at
     else
-      num = 8
+      num = 3
     end
+
     @notifications = if (params[:org_id].present? || params[:filter] == "org") && allowed_user?
                        organization_notifications
                      elsif params[:org_id].blank? && params[:filter].present?
@@ -18,11 +23,21 @@ class NotificationsController < ApplicationController
                      else
                        Notification.where(user_id: @user.id).order("notified_at DESC")
                      end
+
+    # if offset based pagination is invoked by the frontend code, we filter out all earlier ones
+    @notifications = @notifications.where("notified_at < ?", notified_at_offset) if notified_at_offset
+
+    @notifications = NotificationDecorator.decorate_collection(@notifications.limit(num))
+
     @last_user_reaction = @user.reactions.last&.id
     @last_user_comment = @user.comments.last&.id
-    @notifications = @notifications.where("notified_at < ?", notified_at_offset) if notified_at_offset
-    @notifications = NotificationDecorator.decorate_collection(@notifications.limit(num))
+
     @organizations = @user.member_organizations if @user.organizations
+
+    # The first call, the one coming from the browser URL bar will render the "index" view, which renders
+    # the first few notifications. After that the JS frontend code (see `initNotification.js`)
+    # will call this action again by sending the offset id for the last known notifications, the result
+    # will be the partial rendering of only the list of notifications that will be attached to the DOM by JS
     render partial: "notifications_list" if notified_at_offset
   end
 

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -13,7 +13,7 @@ class NotificationsController < ApplicationController
       num = 30
       notified_at_offset = Notification.find(params[:offset])&.notified_at
     else
-      num = 3
+      num = 8
     end
 
     @notifications = if (params[:org_id].present? || params[:filter] == "org") && allowed_user?

--- a/app/views/notifications/_comment.html.erb
+++ b/app/views/notifications/_comment.html.erb
@@ -25,9 +25,7 @@
       </div>
       <%= render "notifications/shared/comment_box", json_data: json_data, notification: notification, context: "default" %>
     <% elsif notification.action == "Moderation" %>
-      Hey there! <%= image_tag("emoji/apple-hugging-face.png", class: "reaction-image", alt: "Hugging face emoji") %><br /><br />
       <a href="/<%= json_data["comment"]["path"].split("/")[1] %>">@<%= json_data["comment"]["path"].split("/")[1] %></a> just left a comment. Since they are new to the community, could you leave a nice reply to help them feel welcome?
-      <br /><br />
       <b>Thank you!</b>
       <br /><br />
       <em style="font-size: 0.9em">Alternatively, if this comment violates the code of conduct, please downvote/report as appropriate.</em>
@@ -38,7 +36,7 @@
         </a></b>
       <%= render "notifications/shared/comment_box", json_data: json_data, notification: notification, context: "moderation" %>
       <br>
-      <div class="footnote">All negative reactions are 100% private. Thank you for being a trusted <%= ApplicationConfig["COMMUNITY_NAME"] %> member.</div>
+      <div class="footnote">All negative reactions are 100% private.</div>
     <% elsif notification.action == "First" %>
       <a href="<%= json_data["user"]["path"] %>"><%= json_data["user"]["name"] %></a>
       wrote their first comment on:

--- a/app/views/notifications/_notifications_list.html.erb
+++ b/app/views/notifications/_notifications_list.html.erb
@@ -1,7 +1,7 @@
-<% notification_count = 0 %>
-<% @notifications.each do |notification| %>
+<% num_notifications = @notifications.size %>
+
+<% @notifications.each_with_index do |notification, index| %>
   <% next if notification.notified_at < 24.hours.ago && notification.aggregated? %>
-  <% notification_count += 1 %>
 
   <div
     class="single-article single-article-small-pic single-notification <%= "unseen" unless notification.read? %>"
@@ -9,8 +9,17 @@
     <%= render notification.notifiable_type.downcase.to_s, notification: notification %>
   </div>
 
+  <%# Since pagination is offset based, the fastest way to retrieve the last known notification id is to %>
+  <%# ask Ruby when it is at the end of the loop %>
+  <% if index == num_notifications - 1 %>
+    <% sub_path = params[:org_id].present? ? "#{params[:filter]}/#{params[:org_id]}" : params[:filter].to_s %>
+    <div
+      class="notifications-paginator"
+      data-pagination-path="/notifications/<%= sub_path %>?offset=<%= notification.id %>"></div>
+  <% end %>
 <% rescue => e %>
   <% logger.error("Notification error - #{e.message} - #{notification.id}") %>
+
   <div class="small-pic">
     <img src="https://res.cloudinary.com/practicaldev/image/fetch/s--LnVw15KE--/c_fill,f_auto,fl_progressive,h_90,q_auto,w_90/https://thepracticaldev.s3.amazonaws.com/uploads/user/profile_image/31047/af153cd6-9994-4a68-83f4-8ddf3e13f0bf.jpg"
          alt="Sloan, the sloth mascot">

--- a/app/views/notifications/_notifications_list.html.erb
+++ b/app/views/notifications/_notifications_list.html.erb
@@ -2,11 +2,15 @@
 <% @notifications.each do |notification| %>
   <% next if notification.notified_at < 24.hours.ago && notification.aggregated? %>
   <% notification_count += 1 %>
-  <div class="single-article single-article-small-pic single-notification <%= "unseen" unless notification.read? %>" data-notification-id="<%= notification.id %>">
+
+  <div
+    class="single-article single-article-small-pic single-notification <%= "unseen" unless notification.read? %>"
+    data-notification-id="<%= notification.id %>">
     <%= render notification.notifiable_type.downcase.to_s, notification: notification %>
   </div>
+
 <% rescue => e %>
-  <% logger.error("Notifification error - #{e.message} - #{notification.id}") %>
+  <% logger.error("Notification error - #{e.message} - #{notification.id}") %>
   <div class="small-pic">
     <img src="https://res.cloudinary.com/practicaldev/image/fetch/s--LnVw15KE--/c_fill,f_auto,fl_progressive,h_90,q_auto,w_90/https://thepracticaldev.s3.amazonaws.com/uploads/user/profile_image/31047/af153cd6-9994-4a68-83f4-8ddf3e13f0bf.jpg"
          alt="Sloan, the sloth mascot">

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -62,9 +62,16 @@
           </div>
         <% end %>
       <% end %>
-      <%= render "notifications_list" %>
-      <% if @notifications.any? %>
-        <div id="notifications-pagination" data-pagination-path="/notifications/<%= params[:org_id].present? ? "#{params[:filter]}/#{params[:org_id]}" : params[:filter].to_s %>?offset=<%= @notifications.last.id %>"></div>
+
+      <%= render "notifications_list", params: params %>
+
+      <%# not using "any?"" here because "notifications_list" already asks for ".size", a little optimization :) %>
+      <% if @notifications.size.positive? %>
+      <div class="load-more-wrapper">
+        <button id="load-more-button" type="button">
+          Load More
+        </button>
+      </div>
       <% end %>
     </div>
     <div class="side-bar sidebar-additional"></div>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -66,12 +66,12 @@
       <%= render "notifications_list", params: params %>
 
       <%# not using "any?"" here because "notifications_list" already asks for ".size", a little optimization :) %>
-      <% if @notifications.size.positive? %>
-      <div class="load-more-wrapper">
-        <button id="load-more-button" type="button">
-          Load More
-        </button>
-      </div>
+      <% if @notifications.size > 7 %>
+        <div class="load-more-wrapper">
+          <button id="load-more-button" type="button">
+            Load More
+          </button>
+        </div>
       <% end %>
     </div>
     <div class="side-bar sidebar-additional"></div>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -64,7 +64,7 @@
       <% end %>
       <%= render "notifications_list" %>
       <% if @notifications.any? %>
-        <div id="notifications-pagination" data-pagination-path="/notifications/<%= params[:org_id].present? ? "#{params[:filter]}/#{params[:org_id]}" : params[:filter].to_s %>?page=<%= @notifications.last.id %>"></div>
+        <div id="notifications-pagination" data-pagination-path="/notifications/<%= params[:org_id].present? ? "#{params[:filter]}/#{params[:org_id]}" : params[:filter].to_s %>?offset=<%= @notifications.last.id %>"></div>
       <% end %>
     </div>
     <div class="side-bar sidebar-additional"></div>

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -393,7 +393,20 @@ RSpec.describe "NotificationsIndex", type: :request do
     end
 
     context "when a user is an admin" do
-      it "can view other people's notifications"
+      let(:admin) { create(:user, :super_admin) }
+      let(:user2)    { create(:user) }
+      let(:article)  { create(:article, user_id: user.id) }
+
+      before do
+        user2.follow(user)
+        Notification.send_to_followers_without_delay(article, "Published")
+        sign_in admin
+      end
+
+      it "can view other people's notifications" do
+        get "/notifications?username=#{user2.username}"
+        expect(response.body).to include "made a new post:"
+      end
     end
   end
 end

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -391,5 +391,9 @@ RSpec.describe "NotificationsIndex", type: :request do
         expect(response.body).to include time_ago_in_words(article.published_at)
       end
     end
+
+    context "when a user is an admin" do
+      it "can view other people's notifications"
+    end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

This PR adds pagination to the notification page, while keeping the offset based pagination already in place.

The load more button looks like the one we have in the reading list and pro history pages.

I've added a bunch of documentation, both in the controller and in the views to explain how all of this currently works. I didn't change the offset based pagination, I just built the feature on top of it.

The only drawback of this approach is that it requires one extra click when you're at the end of the notifications list so that the client knows they are done paginating.

I also lowered the amount of notifications from 48 to 30 but maybe we can raise that.

I had 88 notifications last weekend and I only could read the last 48 so I decided to fix that :D

## Related Tickets & Documents

Closes https://github.com/thepracticaldev/dev.to/issues/3259

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![notifications-pagination](https://user-images.githubusercontent.com/146201/64347474-49e19080-cff4-11e9-8fc1-7117c41abdfa.gif)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
