### PR TITLE
Send JSON 404 response to API error routes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -77,4 +77,12 @@ class ApplicationController < ActionController::Base
   def touch_current_user
     current_user.touch
   end
+
+  def routing_error
+    if params[:path].start_with?("api")
+      render json: { error: "not found", status: 404 }, status: :not_found
+    else
+      render "public/404.html", status: :not_found, layout: false
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -380,6 +380,8 @@ Rails.application.routes.draw do
   get "/:username" => "stories#index"
 
   root "stories#index"
+
+  match '*path', :to => 'application#routing_error', via: [:get, :post]
 end
 
 # rubocop:enable Metrics/BlockLength

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -381,7 +381,7 @@ Rails.application.routes.draw do
 
   root "stories#index"
 
-  match '*path', :to => 'application#routing_error', via: [:get, :post]
+  match '*path', to: 'application#routing_error', via: [:get, :post]
 end
 
 # rubocop:enable Metrics/BlockLength

--- a/spec/requests/api/v0/articles_spec.rb
+++ b/spec/requests/api/v0/articles_spec.rb
@@ -188,6 +188,12 @@ RSpec.describe "Api::V0::Articles", type: :request do
         expected_order = json_response.map { |resp| resp["published"] }
         expect(expected_order).to eq([false, true])
       end
+
+      it "returns 404 JSON error for an unsupported option" do
+        get me_api_articles_path(status: :foobar), params: { access_token: access_token.token }
+        expect(response).to have_http_status(:not_found)
+        expect(json_response["error"]).to eq("not found")
+      end
     end
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

While developing #3937 I noticed how in some cases when the Rails server routes to a 404 page will return the HTML version of the page for API calls expecting JSON. 

This solves this.

We use the catch all lifeline in case the 404 wasn't handled or raised inside the controller actions. This will return the regular 404 page to everything but the API routes.

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
