### PR TITLE
Replace "DEV access token" with "DEV API key"

### DIFF
--- a/app/controllers/api_secrets_controller.rb
+++ b/app/controllers/api_secrets_controller.rb
@@ -9,7 +9,7 @@ class ApiSecretsController < ApplicationController
     @secret.user_id = current_user.id
 
     if @secret.save
-      flash[:notice] = "Your access token has been generated: #{@secret.secret}"
+      flash[:notice] = "Your API Key has been generated: #{@secret.secret}"
     else
       flash[:error] = @secret.errors.full_messages.to_sentence
     end
@@ -21,7 +21,7 @@ class ApiSecretsController < ApplicationController
     authorize @secret
 
     if @secret.destroy
-      flash[:notice] = "Your access token has been revoked."
+      flash[:notice] = "Your API Key has been revoked."
     else
       flash[:error] = "An error occurred. Please try again or send an email to: yo@dev.to"
     end

--- a/app/views/users/_account.html.erb
+++ b/app/views/users/_account.html.erb
@@ -16,22 +16,22 @@
   <hr />
 <% end %>
 
-<h2>DEV API Access Tokens</h2>
-<p>You can generate personal access tokens to use for authentication with the DEV API. The API is still in early beta though. The <a href="/api">DEV API documentation</a> contains further information.</a></p>
-<h3>Generate an access token</h3>
+<h2>DEV API Keys</h2>
+<p>You can generate personal API keys to use for authentication with the DEV API. The API is still in early beta though. The <a href="/api">DEV API documentation</a> contains further information.</a></p>
+<h3>Generate a new Key</h3>
 <%= form_tag users_api_secrets_path, method: :post do %>
   <%= fields_for :api_secret do |api_secret| %>
     <div class="field">
-      <%= api_secret.label(:description, "Token Description") %>
-      <%= api_secret.text_field(:description, placeholder: "What's this token for?", required: true) %>
+      <%= api_secret.label(:description, "Description") %>
+      <%= api_secret.text_field(:description, placeholder: "What's this API key for?", required: true) %>
     </div>
   <% end %>
   <button class="big-action cta" id="new__api__secret__btn" type="submit">
-    Generate Token
+    Generate API Key
   </button>
 <% end %>
 
-<h3>Active access tokens (Never share these secrets!)</h3>
+<h3>Active API keys (never share these!)</h3>
 <% if @user.api_secrets.empty? %>
   <p>None yet!</p>
 <% end %>

--- a/docs/api_v0.yml
+++ b/docs/api_v0.yml
@@ -25,19 +25,19 @@ components:
         API Key authentication.
 
         Authentication for some endpoints, like write operations on the
-        Articles API require an API key (DEV API access token).
+        Articles API require a DEV API key.
 
         ### Getting an API key
 
         To obtain one, please follow these steps:
 
           - visit https://dev.to/settings/account
-          - in the "DEV API Access Tokens" section create a new token by adding a
-            description and clicking on "Generate Token"
+          - in the "DEV API Keys" section create a new key by adding a
+            description and clicking on "Generate API Key"
 
-            ![obtain a DEV API access token](https://res.cloudinary.com/practicaldev/image/fetch/s--F4Ya4WgC--/c_limit%2Cf_auto%2Cfl_progressive%2Cq_auto%2Cw_880/https://thepracticaldev.s3.amazonaws.com/i/4zm0cbutj9o9eau0jm9t.png)
-          - You'll see the newly generated token in the same view
-            ![generated DEV API access token](https://res.cloudinary.com/practicaldev/image/fetch/s--kp5L6-9G--/c_limit%2Cf_auto%2Cfl_progressive%2Cq_auto%2Cw_880/https://thepracticaldev.s3.amazonaws.com/i/ra01mo6fp1es261db2ho.png)
+            ![obtain a DEV API Key](https://user-images.githubusercontent.com/146201/64421366-af3f8b00-d0a1-11e9-8ff6-7cc0ca6e854e.png)
+          - You'll see the newly generated key in the same view
+            ![generated DEV API Key](https://user-images.githubusercontent.com/146201/64421367-af3f8b00-d0a1-11e9-9831-73d3bdfdff66.png)
       name: api-key
       in: header
     oauth2:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

Currently the API key section in the website uses the wording "DEV access token", but we call them "api keys" basically everywhere else, in the code and in the API documentation.

Additionally, the wording "access token" might collide with "OAuth access token" in the future if and when OAuth2 support is open to the public (and it's already a bit confusing in the API docs)

This PR replaces "DEV access token" with "DEV API key"

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![dev_api_keys_1](https://user-images.githubusercontent.com/146201/64421634-4efd1900-d0a2-11e9-803d-cbff95e840c0.png)
![dev_api_keys_2](https://user-images.githubusercontent.com/146201/64421638-50c6dc80-d0a2-11e9-8356-baf937ace152.png)


## Added to documentation?

- [x] docs.dev.to
- [ ] readme
- [ ] no documentation needed
