### PR TITLE
Internal Listings Management: Fill Tweet Text

### DIFF
--- a/app/views/internal/classified_listings/index.html.erb
+++ b/app/views/internal/classified_listings/index.html.erb
@@ -44,7 +44,7 @@
           <%= form_tag "/internal/buffer_updates" do %>
             <input type="hidden" name="social_channel" value="listings_twitter" />
             <input type="hidden" name="listing_id" value="<%= listing.id %>" />
-            <textarea cols="37" rows="8" wrap="hard" name="tweet" maxlength="255"><% if User.find(listing.user_id).twitter_username.present? %>📋 New DEV Listing!&#013&#013Category: <%= listing.category %>&#013&#013<%= listing.title %>&#013&#013Posted by @<%= User.find(listing.user_id).twitter_username %><% end %></textarea>
+            <textarea cols="37" rows="8" wrap="hard" name="tweet" maxlength="255">📋 New DEV Listing!&#013&#013Category: <%= listing.category %>&#013&#013<%= listing.title %>&#013&#013<% if User.find(listing.user_id).twitter_username.present? %>Posted by @<%= User.find(listing.user_id).twitter_username %><% end %></textarea>
             <br>
             <button class="btn-info tweet-listing">🐦 Tweet 🐦</button>
           <% end %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Buffer tweet prefills for listings from users without twitter handles.

## Related Tickets & Documents
N/A

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
### First listing is from user without associated twitter account 
![Screen Shot 2019-09-09 at 15 31 19](https://user-images.githubusercontent.com/13403332/64560659-e8ccfc00-d316-11e9-8540-893252e0f097.png)

## Added to documentation?
- [x] no documentation needed
