### PR TITLE
Dispatch events only to the corresponding user endpoints

### DIFF
--- a/app/services/webhook/dispatch_event.rb
+++ b/app/services/webhook/dispatch_event.rb
@@ -10,7 +10,7 @@ module Webhook
     end
 
     def call
-      endpoint_urls = Endpoint.for_events([event_type]).pluck(:target_url)
+      endpoint_urls = Endpoint.for_events([event_type]).where(user_id: record.user_id).pluck(:target_url)
       return if endpoint_urls.empty?
 
       event_json = Event.new(event_type: event_type, payload: PayloadAdapter.new(record).hash).to_json

--- a/spec/requests/articles/articles_create_spec.rb
+++ b/spec/requests/articles/articles_create_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "ArticlesCreate", type: :request do
     end
 
     before do
-      create(:webhook_endpoint, events: %w[article_created article_updated], target_url: url)
+      create(:webhook_endpoint, events: %w[article_created article_updated], target_url: url, user: user)
     end
 
     it "schedules a dispatching event job" do

--- a/spec/requests/articles/articles_update_spec.rb
+++ b/spec/requests/articles/articles_update_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe "ArticlesUpdate", type: :request do
   end
 
   it "schedules a dispatching event job" do
-    create(:webhook_endpoint, events: %w[article_created article_updated])
+    create(:webhook_endpoint, events: %w[article_created article_updated], user: user)
     expect do
       put "/articles/#{article.id}", params: {
         article: { title: "new_title", body_markdown: "Yo ho ho#{rand(100)}", tag_list: "yo" }

--- a/spec/services/webhook/dispatch_event_spec.rb
+++ b/spec/services/webhook/dispatch_event_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Webhook::DispatchEvent, type: :service do
   let!(:article) { create(:article, user: user) }
 
   it "does nothing if there are no corresponding endpoints" do
-    create(:webhook_endpoint, events: %w[article_created])
+    create(:webhook_endpoint, events: %w[article_created], user: user)
     expect do
       described_class.call("article_destroyed", article)
     end.not_to have_enqueued_job(Webhook::DispatchEventJob)

--- a/spec/services/webhook/dispatch_event_spec.rb
+++ b/spec/services/webhook/dispatch_event_spec.rb
@@ -1,7 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Webhook::DispatchEvent, type: :service do
-  let!(:article) { create(:article) }
+  let!(:user) { create(:user) }
+  let!(:article) { create(:article, user: user) }
 
   it "does nothing if there are no corresponding endpoints" do
     create(:webhook_endpoint, events: %w[article_created])
@@ -11,11 +12,19 @@ RSpec.describe Webhook::DispatchEvent, type: :service do
   end
 
   it "schedules jobs" do
-    create(:webhook_endpoint, events: %w[article_created], target_url: "https://create-webhooks.example.com/accept")
-    create(:webhook_endpoint, events: %w[article_created article_updated article_destroyed], target_url: "https://all-webhooks.example.com/accept")
-    create(:webhook_endpoint, events: %w[article_destroyed], target_url: "https://destroy-webhooks.example.com/accept")
+    create(:webhook_endpoint, events: %w[article_created], user: user, target_url: "https://create-webhooks.example.com/accept")
+    create(:webhook_endpoint, events: %w[article_created article_updated article_destroyed], user: user, target_url: "https://all-webhooks.example.com/accept")
+    create(:webhook_endpoint, events: %w[article_destroyed], user: user, target_url: "https://destroy-webhooks.example.com/accept")
     expect do
       described_class.call("article_created", article)
     end.to have_enqueued_job(Webhook::DispatchEventJob).twice
+  end
+
+  it "doesn't schedule jobs if the endpoints belong to another user" do
+    user2 = create(:user)
+    create(:webhook_endpoint, events: %w[article_created], user: user2, target_url: "https://create-webhooks.example.com/accept")
+    expect do
+      described_class.call("article_created", article)
+    end.not_to have_enqueued_job(Webhook::DispatchEventJob)
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
My previous solution for events dispatching sends all the articles creates/updates/destroys to all the endpoints, not only the corresponding users' ones. This pr fixes it.

## Related Tickets & Documents
#3715 
