### PR TITLE
Send only public events to the webhook endpoints #3715 

### DIFF
--- a/app/services/articles/creator.rb
+++ b/app/services/articles/creator.rb
@@ -18,7 +18,7 @@ module Articles
         NotificationSubscription.create(user: user, notifiable_id: article.id, notifiable_type: "Article", config: "all_comments")
         Notification.send_to_followers(article, "Published") if article.published?
 
-        dispatch_event(article) if article.published?
+        dispatch_event(article)
       end
 
       article.decorate
@@ -29,6 +29,8 @@ module Articles
     attr_reader :user, :article_params, :event_dispatcher
 
     def dispatch_event(article)
+      return unless article.published?
+
       event_dispatcher.call("article_created", article)
     end
 

--- a/app/services/articles/creator.rb
+++ b/app/services/articles/creator.rb
@@ -14,12 +14,11 @@ module Articles
       raise if RateLimitChecker.new(user).limit_by_action("published_article_creation")
 
       article = save_article
-
       if article.persisted?
         NotificationSubscription.create(user: user, notifiable_id: article.id, notifiable_type: "Article", config: "all_comments")
-        Notification.send_to_followers(article, "Published") if article.published
+        Notification.send_to_followers(article, "Published") if article.published?
 
-        dispatch_event(article)
+        dispatch_event(article) if article.published?
       end
 
       article.decorate

--- a/app/services/articles/destroyer.rb
+++ b/app/services/articles/destroyer.rb
@@ -6,7 +6,7 @@ module Articles
       article.destroy!
       Notification.remove_all_without_delay(notifiable_id: article.id, notifiable_type: "Article", action: "Published")
       Notification.remove_all(notifiable_id: article.id, notifiable_type: "Article", action: "Reaction")
-      event_dispatcher.call("article_destroyed", article)
+      event_dispatcher.call("article_destroyed", article) if article.published?
     end
   end
 end

--- a/app/services/articles/updater.rb
+++ b/app/services/articles/updater.rb
@@ -13,6 +13,7 @@ module Articles
 
     def call
       article = load_article
+      was_published = article.published
 
       # the client can change the series the article belongs to
       if article_params.key?(:series)
@@ -38,7 +39,8 @@ module Articles
       send_notification = article.published && article.saved_change_to_published_at.present?
       Notification.send_to_followers(article, "Published") if send_notification
 
-      dispatch_event(article)
+      # don't send only if article keeps being unpublished
+      dispatch_event(article) if article.published || was_published
 
       article.decorate
     end

--- a/spec/requests/articles/articles_create_spec.rb
+++ b/spec/requests/articles/articles_create_spec.rb
@@ -63,7 +63,14 @@ RSpec.describe "ArticlesCreate", type: :request do
       create(:webhook_endpoint, events: %w[article_created article_updated], target_url: url, user: user)
     end
 
-    it "schedules a dispatching event job" do
+    it "doesn't schedule a dispatching event job (unpublished)" do
+      expect do
+        post "/articles", params: article_params
+      end.not_to have_enqueued_job(Webhook::DispatchEventJob).once
+    end
+
+    it "schedules a dispatching event job (published)" do
+      article_params[:article][:body_markdown] = "---\ntitle: hey hey hahuu\npublished: true\nseries: helloyo\n---\nYo ho ho#{rand(100)}"
       expect do
         post "/articles", params: article_params
       end.to have_enqueued_job(Webhook::DispatchEventJob).once

--- a/spec/services/articles/creator_spec.rb
+++ b/spec/services/articles/creator_spec.rb
@@ -37,6 +37,14 @@ RSpec.describe Articles::Creator do
       article = described_class.call(user, valid_attributes, event_dispatcher)
       expect(event_dispatcher).to have_received(:call).with("article_created", article.object)
     end
+
+    it "doesn't call an event dispatcher when an article is unpublished" do
+      attributes = attributes_for(:article, published: false)
+      event_dispatcher = double
+      allow(event_dispatcher).to receive(:call)
+      article = described_class.call(user, attributes, event_dispatcher)
+      expect(event_dispatcher).not_to have_received(:call).with("article_created", article.object)
+    end
   end
 
   context "when valid attributes" do

--- a/spec/services/articles/destroyer_spec.rb
+++ b/spec/services/articles/destroyer_spec.rb
@@ -2,6 +2,11 @@ require "rails_helper"
 
 RSpec.describe Articles::Destroyer do
   let(:article) { create(:article) }
+  let(:event_dispatcher) { double }
+
+  before do
+    allow(event_dispatcher).to receive(:call)
+  end
 
   it "destroys an article" do
     described_class.call(article)
@@ -15,9 +20,13 @@ RSpec.describe Articles::Destroyer do
   end
 
   it "calls events dispatcher" do
-    event_dispatcher = double
-    allow(event_dispatcher).to receive(:call)
     described_class.call(article, event_dispatcher)
     expect(event_dispatcher).to have_received(:call).with("article_destroyed", article)
+  end
+
+  it "doesn't call a dispatched when a draft is destroyed" do
+    draft = create(:article, published: false)
+    described_class.call(draft, event_dispatcher)
+    expect(event_dispatcher).not_to have_received(:call)
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
- dispatch "article_create" events only when an article is published
- dispatch "article_update" events only when an article is published or is updated to be unpublished (don't send when a draft is updated w/o being published)
- dispatch "article_destroyed" events only when an article was published

## Related Tickets & Documents
#3715 