### PR TITLE
Fix mention's inconsistent hyperlink

### DIFF
--- a/app/labor/markdown_parser.rb
+++ b/app/labor/markdown_parser.rb
@@ -203,23 +203,22 @@ class MarkdownParser
 
   def wrap_mentions_with_links!(html)
     html_doc = Nokogiri::HTML(html)
-    # looks for node that isn't <code>, <a>, and contains "@"
-    html_doc.xpath('//*[not (self::code) and not(self::a) and contains(text(), "@")]').each do |node|
-      # if the target node is a <p>, <ul>, or <li>, it will have more than 1 child
-      # otherwise inner_html can be use when there's only 1 child
-      if node.children.count > 1
-        # only focus on portion of text with "@"
-        node.xpath("text()[contains(.,'@')]").each do |el|
-          el.replace(el.text.gsub(/\B@[a-z0-9_-]+/i) do |text|
-            user_link_if_exists(text)
-          end)
-        end
-      else
-        # with only 1 child, inner_html can be used update the content
-        node.inner_html = node.inner_html.gsub(/\B@[a-z0-9_-]+/i) do |text|
-          user_link_if_exists(text)
-        end
+
+    # looks for nodes that isn't <code>, <a>, and contains "@"
+    targets = html_doc.xpath('//html/body/*[not (self::code) and not(self::a) and contains(., "@")]').to_a
+
+    # A Queue system to look for and replace possible usernames
+    until targets.empty?
+      node = targets.shift
+
+      # only focus on portion of text with "@"
+      node.xpath("text()[contains(.,'@')]").each do |el|
+        el.replace(el.text.gsub(/\B@[a-z0-9_-]+/i) { |text| user_link_if_exists(text) })
       end
+
+      # enqueue children that has @ in it's text
+      children = node.xpath('*[not(self::code) and not(self::a) and contains(., "@")]').to_a
+      targets.concat(children)
     end
 
     if html_doc.at_css("body")

--- a/spec/labor/markdown_parser_spec.rb
+++ b/spec/labor/markdown_parser_spec.rb
@@ -81,11 +81,26 @@ RSpec.describe MarkdownParser do
       expect(result).to include "<a", "<em"
     end
 
+    it "works in ul/li tag" do
+      mention = <<~DOC
+        `@#{user.username}` one two, @#{user.username} three four:
+          - `@#{user.username}`
+      DOC
+      result = generate_and_parse_markdown(mention)
+      expect(result).to eq("<p><code>@#{user.username}</code> one two, <a class=\"comment-mentioned-user\" href=\"http://localhost:3000/#{user.username}\">@#{user.username}</a>\n three four:</p>\n\n<ul>\n<li><code>@#{user.username}</code></li>\n</ul>\n\n")
+    end
+
     it "will not work in code tag" do
       mention = "this is a chunk of text `@#{user.username}`"
       result = generate_and_parse_markdown(mention)
       expect(result).to include "<code"
       expect(result).not_to include "<a"
+    end
+
+    it "works with markdown heavy contents" do
+      mention = "test **[link?](https://dev.to/ben/)** thread, @#{user.username} talks :"
+      result = generate_and_parse_markdown(mention)
+      expect(result).to include "\"http://localhost:3000/#{user.username}\">"
     end
   end
 

--- a/spec/labor/markdown_parser_spec.rb
+++ b/spec/labor/markdown_parser_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe MarkdownParser do
           - `@#{user.username}`
       DOC
       result = generate_and_parse_markdown(mention)
-      expect(result).to eq("<p><code>@#{user.username}</code> one two, <a class=\"comment-mentioned-user\" href=\"http://localhost:3000/#{user.username}\">@#{user.username}</a>\n three four:</p>\n\n<ul>\n<li><code>@#{user.username}</code></li>\n</ul>\n\n")
+      expect(result).to eq("<p><code>@#{user.username}</code> one two, <a class=\"comment-mentioned-user\" href=\"#{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}/#{user.username}\">@#{user.username}</a>\n three four:</p>\n\n<ul>\n<li><code>@#{user.username}</code></li>\n</ul>\n\n")
     end
 
     it "will not work in code tag" do
@@ -100,7 +100,7 @@ RSpec.describe MarkdownParser do
     it "works with markdown heavy contents" do
       mention = "test **[link?](https://dev.to/ben/)** thread, @#{user.username} talks :"
       result = generate_and_parse_markdown(mention)
-      expect(result).to include "\"http://localhost:3000/#{user.username}\">"
+      expect(result).to include "<a class=\"comment-mentioned-user\""
     end
   end
 


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description
The current bug https://github.com/thepracticaldev/dev.to/issues/4050 is explained in [this stack overflow answer](https://stackoverflow.com/a/27208749/5494108). We used `//div[contains(text, "some text")]` instead of `//div[contains(., "some text")]`, which limits the texts that we can search for.

On top of that fix, in order to avoid recursively searching for text containing "@" within a node's child, I used a queue system. Let me know if this is a bad idea.
## Related Tickets & Documents
Resolves https://github.com/thepracticaldev/dev.to/issues/4050

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?
- [x] no documentation needed