### PR TITLE
Add no-readme option to GitHub tag

### DIFF
--- a/app/liquid_tags/github_tag/github_readme_tag.rb
+++ b/app/liquid_tags/github_tag/github_readme_tag.rb
@@ -6,6 +6,7 @@ class GithubTag
 
     def initialize(link)
       @link = parse_link(link)
+      @options = parse_options(link)
       @content = get_content(@link)
     end
 
@@ -14,14 +15,15 @@ class GithubTag
         partial: PARTIAL,
         locals: {
           content: @content,
+          show_readme: show_readme?,
           updated_html: @updated_html
         },
       )
     end
 
     def parse_link(link)
-      link = ActionController::Base.helpers.strip_tags(link)
-      link.gsub(/.*github\.com\//, "").delete(" ")
+      link = sanitize_link(link)
+      link.split(" ").first.delete(" ")
     end
 
     def get_content(link)
@@ -36,7 +38,30 @@ class GithubTag
       client.repository(user_name + "/" + repo_name)
     end
 
+    def valid_option(option)
+      option.match(/no-readme/)
+    end
+
+    def parse_options(link)
+      opts = sanitize_link(link)
+      _, *options = opts.split(" ")
+
+      validated_options = options.map { |option| valid_option(option) }.reject(&:nil?)
+      raise StandardError, "Invalid Options" unless options.empty? || !validated_options.empty?
+
+      options
+    end
+
+    def show_readme?
+      @options.none? "no-readme"
+    end
+
     private
+
+    def sanitize_link(link)
+      link = ActionController::Base.helpers.strip_tags(link)
+      link.gsub(/.*github\.com\//, "")
+    end
 
     def raise_error
       raise StandardError, "Invalid Github Repo link"

--- a/app/liquid_tags/github_tag/github_readme_tag.rb
+++ b/app/liquid_tags/github_tag/github_readme_tag.rb
@@ -47,7 +47,7 @@ class GithubTag
       _, *options = opts.split(" ")
 
       validated_options = options.map { |option| valid_option(option) }.reject(&:nil?)
-      raise StandardError, "Invalid Options" unless options.empty? || validated_options.any?
+      raise StandardError, "GitHub tag: `#{link}`: Invalid option - did you mean `no-readme`?" unless options.empty? || validated_options.any?
 
       options
     end

--- a/app/liquid_tags/github_tag/github_readme_tag.rb
+++ b/app/liquid_tags/github_tag/github_readme_tag.rb
@@ -47,7 +47,7 @@ class GithubTag
       _, *options = opts.split(" ")
 
       validated_options = options.map { |option| valid_option(option) }.reject(&:nil?)
-      raise StandardError, "Invalid Options" unless options.empty? || !validated_options.empty?
+      raise StandardError, "Invalid Options" unless options.empty? || validated_options.any?
 
       options
     end

--- a/app/views/liquids/_github_readme.html.erb
+++ b/app/views/liquids/_github_readme.html.erb
@@ -12,8 +12,10 @@
       <%= content.description %>
     </h3>
   </div>
+  <% if show_readme %>
   <div class="ltag-github-body">
     <p><%= (HTML_Truncator.truncate updated_html, 150).html_safe %></p>
   </div>
   <div class="gh-btn-container"><a class="gh-btn" href="<%= content.html_url %>">View on GitHub</a></div>
+  <% end %>
 </div>

--- a/app/views/pages/_editor_guide_text.html.erb
+++ b/app/views/pages/_editor_guide_text.html.erb
@@ -124,6 +124,13 @@
     <h3><strong>GitHub Repo Embed</strong></h3>
     <p>All you need is the GitHub username and repo:</p>
     <code>{% github thepracticaldev/dev.to %}</code>
+    <dl>
+      <dt><code>no-readme</code></dt>
+      <dd>
+        You can add a no-readme option to your GitHub tag to hide the readme file from the preview.<br>
+        <code>{% github thepracticaldev/dev.to no-readme %}</code>
+      </dd>
+    </dl>
     <h3><strong>GitHub Issue, Pull request or Comment Embed</strong></h3>
     <p>All you need is the GitHub issue, PR or comment URL:</p>
     <code>{% github https://github.com/thepracticaldev/dev.to/issues/9 %}</code>

--- a/spec/liquid_tags/github_tag/github_readme_tag_spec.rb
+++ b/spec/liquid_tags/github_tag/github_readme_tag_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe GithubTag::GithubReadmeTag, vcr: vcr_option do
 
     setup { Liquid::Template.register_tag("github", GithubTag) }
 
-    def generate_github_readme(path)
-      Liquid::Template.parse("{% github #{path} %}")
+    def generate_github_readme(path, options = "")
+      Liquid::Template.parse("{% github #{path} #{options} %}")
     end
 
     it "accepts proper github link" do
@@ -36,6 +36,12 @@ RSpec.describe GithubTag::GithubReadmeTag, vcr: vcr_option do
       expect do
         generate_github_readme("/hello/hey/hey/hey")
       end.to raise_error(StandardError)
+    end
+
+    it "handles 'no-readme' option" do
+      template = generate_github_readme(path, "no-readme").render
+      readme_class = "ltag-github-body"
+      expect(template).not_to include(readme_class)
     end
   end
 end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

Add option ``no-readme`` to GitHub liquid tag that hides the readme file from the preview.

## Related Tickets & Documents

Closes #4029 

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
