### PR TITLE
Generate HTTPS urls with Rails url helpers

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -126,4 +126,4 @@ Rails.application.configure do
                         "practicaldev.herokuapp.com" => "dev.to"
 end
 
-Rails.application.routes.default_url_options = { host: Rails.application.config.app_domain }
+Rails.application.routes.default_url_options = { host: Rails.application.config.app_domain, protocol: :https }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

Apparently we're generating HTTP URLs when using Rails URL helpers, like `user_social_preview_url(user, format: :png)`. By default Rails generates HTTP urls unless told so.

This forces the routes helpers to generate HTTPS URLs.

The redirect works correctly.

See https://github.com/thepracticaldev/dev.to/issues/4055#issuecomment-532582952 for why this is happening

## Related Tickets & Documents

Closes #4055

