### PR TITLE
Added association between webhook_endpoints and oauth apps

### DIFF
--- a/app/controllers/api/v0/webhooks_controller.rb
+++ b/app/controllers/api/v0/webhooks_controller.rb
@@ -7,7 +7,7 @@ module Api
       skip_before_action :verify_authenticity_token, only: %w[create destroy]
 
       def index
-        @webhooks = @user.webhook_endpoints.order(:id)
+        @webhooks = webhooks_scope.order(:id)
       end
 
       def create
@@ -18,16 +18,24 @@ module Api
       end
 
       def show
-        @webhook = @user.webhook_endpoints.find(params[:id])
+        @webhook = webhooks_scope.find(params[:id])
       end
 
       def destroy
-        webhook = @user.webhook_endpoints.find(params[:id])
+        webhook = webhooks_scope.find(params[:id])
         webhook.destroy!
         head :no_content
       end
 
       private
+
+      def webhooks_scope
+        if doorkeeper_token
+          @user.webhook_endpoints.for_app(doorkeeper_token.application_id)
+        else
+          @user.webhook_endpoints
+        end
+      end
 
       def webhook_params
         params.require(:webhook_endpoint).permit(:target_url, :source, events: [])

--- a/app/controllers/api/v0/webhooks_controller.rb
+++ b/app/controllers/api/v0/webhooks_controller.rb
@@ -11,7 +11,9 @@ module Api
       end
 
       def create
-        @webhook = @user.webhook_endpoints.create!(webhook_params)
+        @webhook = @user.webhook_endpoints.new(webhook_params)
+        @webhook.oauth_application_id = doorkeeper_token.application_id if doorkeeper_token
+        @webhook.save!
         render "show", status: :created
       end
 

--- a/app/models/webhook/endpoint.rb
+++ b/app/models/webhook/endpoint.rb
@@ -1,6 +1,11 @@
 module Webhook
   class Endpoint < ApplicationRecord
     belongs_to :user, inverse_of: :webhook_endpoints
+    # rubocop:disable Rails/InverseOf
+    belongs_to :oauth_application, optional: true,
+                                   class_name: "Doorkeeper::Application",
+                                   foreign_key: :oauth_application_id
+    # rubocop:enable Rails/InverseOf
 
     validates :target_url, presence: true, uniqueness: true, url: { schemes: %w[https] }
     validates :source, :events, presence: true

--- a/app/models/webhook/endpoint.rb
+++ b/app/models/webhook/endpoint.rb
@@ -13,6 +13,7 @@ module Webhook
     attribute :events, :string, array: true, default: []
 
     scope :for_events, ->(events) { where("events @> ARRAY[?]::varchar[]", Array(events)) }
+    scope :for_app, ->(app_id) { where(oauth_application_id: app_id) }
 
     def self.table_name_prefix
       "webhook_"

--- a/db/migrate/20190918104106_add_oauth_application_id_to_webhook_endpoints.rb
+++ b/db/migrate/20190918104106_add_oauth_application_id_to_webhook_endpoints.rb
@@ -1,0 +1,7 @@
+class AddOauthApplicationIdToWebhookEndpoints < ActiveRecord::Migration[5.2]
+  def change
+    change_table :webhook_endpoints do |t|
+      t.references :oauth_application, foreign_key: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_10_153845) do
+ActiveRecord::Schema.define(version: 2019_09_18_104106) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -1153,11 +1153,13 @@ ActiveRecord::Schema.define(version: 2019_09_10_153845) do
   create_table "webhook_endpoints", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "events", null: false, array: true
+    t.bigint "oauth_application_id"
     t.string "source"
     t.string "target_url", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.index ["events"], name: "index_webhook_endpoints_on_events"
+    t.index ["oauth_application_id"], name: "index_webhook_endpoints_on_oauth_application_id"
     t.index ["user_id"], name: "index_webhook_endpoints_on_user_id"
   end
 
@@ -1174,5 +1176,6 @@ ActiveRecord::Schema.define(version: 2019_09_10_153845) do
   add_foreign_key "push_notification_subscriptions", "users"
   add_foreign_key "sponsorships", "organizations"
   add_foreign_key "sponsorships", "users"
+  add_foreign_key "webhook_endpoints", "oauth_applications"
   add_foreign_key "webhook_endpoints", "users"
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
- added `Webhook::Endpoint` `belongs_to` `oauth_application` so that we could remove the corresponding webhooks when the oauth app access is revoked
- added specs to check that the `oauth_application_id` is set properly
- added tests for the webhooks API auth by the doorkeeper token
- limited access to the webhooks if the user is authorized by the doorkeeper token.

## Related Tickets & Documents
#3715 
