### PR TITLE
Define Doorkeeper::Application association on webhook_endpoints

### DIFF
--- a/app/models/webhook/endpoint.rb
+++ b/app/models/webhook/endpoint.rb
@@ -1,11 +1,10 @@
 module Webhook
   class Endpoint < ApplicationRecord
     belongs_to :user, inverse_of: :webhook_endpoints
-    # rubocop:disable Rails/InverseOf
     belongs_to :oauth_application, optional: true,
                                    class_name: "Doorkeeper::Application",
-                                   foreign_key: :oauth_application_id
-    # rubocop:enable Rails/InverseOf
+                                   foreign_key: :oauth_application_id,
+                                   inverse_of: :webhook_endpoints
 
     validates :target_url, presence: true, uniqueness: true, url: { schemes: %w[https] }
     validates :source, :events, presence: true

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -331,3 +331,4 @@ end
 
 Doorkeeper::AccessGrant.belongs_to :resource_owner, class_name: "User"
 Doorkeeper::AccessToken.belongs_to :resource_owner, class_name: "User"
+Doorkeeper::Application.has_many :webhook_endpoints, class_name: "Webhook::Endpoint", inverse_of: :oauth_application

--- a/spec/models/webhook/endpoint_spec.rb
+++ b/spec/models/webhook/endpoint_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Webhook::Endpoint, type: :model do
 
   describe "validations" do
     it { is_expected.to belong_to(:user).inverse_of(:webhook_endpoints) }
+    it { is_expected.to belong_to(:oauth_application).inverse_of(:webhook_endpoints).optional }
     it { is_expected.to validate_presence_of(:target_url) }
     it { is_expected.to validate_presence_of(:source) }
     it { is_expected.to validate_presence_of(:events) }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
Defined association on `Doorkeeper::Application` to `Webhook::Endpoint` to be able to specify `inverse_of` on the `Webhook::Endpoint`

## Related Tickets & Documents
#3715