### PR TITLE
Doorkeeper default scope

### DIFF
--- a/app/controllers/api/v0/articles_controller.rb
+++ b/app/controllers/api/v0/articles_controller.rb
@@ -4,7 +4,9 @@ module Api
       respond_to :json
 
       before_action :authenticate!, only: %i[create update me]
-      before_action -> { doorkeeper_authorize! :public }, only: %w[index show me], if: -> { doorkeeper_token }
+      before_action -> { doorkeeper_authorize! :public }, only: %w[index show], if: -> { doorkeeper_token }
+      before_action -> { doorkeeper_authorize! :read_articles }, only: %w[me], if: -> { doorkeeper_token }
+
       before_action :set_cache_control_headers, only: [:index]
       caches_action :show,
                     cache_path: proc { |c| c.params.permit! },

--- a/app/controllers/api/v0/articles_controller.rb
+++ b/app/controllers/api/v0/articles_controller.rb
@@ -5,7 +5,6 @@ module Api
 
       before_action :authenticate!, only: %i[create update me]
       before_action -> { doorkeeper_authorize! :public }, only: %w[index show], if: -> { doorkeeper_token }
-      before_action -> { doorkeeper_authorize! :read_articles }, only: %w[me], if: -> { doorkeeper_token }
 
       before_action :set_cache_control_headers, only: [:index]
       caches_action :show,
@@ -47,6 +46,9 @@ module Api
       end
 
       def me
+        doorkeeper_scope = %w[unpublished all].include?(params[:status]) ? :read_articles : :public
+        doorkeeper_authorize! doorkeeper_scope if doorkeeper_token
+
         per_page = (params[:per_page] || 30).to_i
         num = [per_page, 1000].min
 

--- a/app/controllers/api/v0/articles_controller.rb
+++ b/app/controllers/api/v0/articles_controller.rb
@@ -4,7 +4,7 @@ module Api
       respond_to :json
 
       before_action :authenticate!, only: %i[create update me]
-
+      before_action -> { doorkeeper_authorize! :public }, only: %w[index show me], if: -> { doorkeeper_token }
       before_action :set_cache_control_headers, only: [:index]
       caches_action :show,
                     cache_path: proc { |c| c.params.permit! },

--- a/app/controllers/api/v0/webhooks_controller.rb
+++ b/app/controllers/api/v0/webhooks_controller.rb
@@ -3,7 +3,7 @@ module Api
     class WebhooksController < ApiController
       respond_to :json
       before_action :authenticate!
-
+      before_action -> { doorkeeper_authorize! :public }, if: -> { doorkeeper_token }
       skip_before_action :verify_authenticity_token, only: %w[create destroy]
 
       def index

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -163,7 +163,7 @@ Doorkeeper.configure do
   # For more information go to
   # https://github.com/doorkeeper-gem/doorkeeper/wiki/Using-Scopes
   #
-  default_scopes :public
+  default_scopes :public, :read_articles
   # optional_scopes :write, :update
 
   # Define scopes_by_grant_type to restrict only certain scopes for grant_type

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -163,7 +163,7 @@ Doorkeeper.configure do
   # For more information go to
   # https://github.com/doorkeeper-gem/doorkeeper/wiki/Using-Scopes
   #
-  # default_scopes  :public
+  default_scopes :public
   # optional_scopes :write, :update
 
   # Define scopes_by_grant_type to restrict only certain scopes for grant_type

--- a/config/locales/doorkeeper.en.yml
+++ b/config/locales/doorkeeper.en.yml
@@ -18,6 +18,10 @@ en:
               not_match_configured: "doesn't match configured on the server."
 
   doorkeeper:
+    scopes:
+      public: 'Access public profile data and published articles'
+      read_articles: 'Access all articles including drafts'
+
     applications:
       confirmations:
         destroy: 'Are you sure?'

--- a/spec/requests/api/v0/articles_spec.rb
+++ b/spec/requests/api/v0/articles_spec.rb
@@ -113,22 +113,28 @@ RSpec.describe "Api::V0::Articles", type: :request do
 
   describe "GET /api/articles/me(/:status)" do
     context "when request is unauthenticated" do
+      let(:user) { create(:user) }
+      let(:public_token) { create :doorkeeper_access_token, resource_owner: user, scopes: "public" }
+
       it "return unauthorized" do
         get me_api_articles_path
         expect(response).to have_http_status(:unauthorized)
       end
 
-      it "returns unauthorized when lack of scopes" do
-        user = create(:user)
-        access_token = create :doorkeeper_access_token, resource_owner: user, scopes: "public"
-        get me_api_articles_path, params: { access_token: access_token.token }
+      it "returns forbidden when requesting for all with only public scope" do
+        get me_api_articles_path(status: :all), params: { access_token: public_token.token }
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "returns forbidden status when requesting unpublished with public scope" do
+        get me_api_articles_path(status: :unpublished), params: { access_token: public_token.token }
         expect(response).to have_http_status(:forbidden)
       end
     end
 
     context "when request is authenticated" do
       let_it_be(:user) { create(:user) }
-      let_it_be(:access_token) { create :doorkeeper_access_token, resource_owner: user, scopes: "public, read_articles" }
+      let_it_be(:access_token) { create :doorkeeper_access_token, resource_owner: user, scopes: "public read_articles" }
 
       it "works with bearer authorization" do
         headers = { "authorization" => "Bearer #{access_token.token}", "content-type" => "application/json" }
@@ -138,8 +144,15 @@ RSpec.describe "Api::V0::Articles", type: :request do
         expect(response).to have_http_status(:ok)
       end
 
-      it "return proper response specification" do
+      it "returns proper response specification" do
         get me_api_articles_path, params: { access_token: access_token.token }
+        expect(response.content_type).to eq("application/json")
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "returns success when requesting publiched articles with public token" do
+        public_token = create(:doorkeeper_access_token, resource_owner: user, scopes: "public")
+        get me_api_articles_path(status: :published), params: { access_token: public_token.token }
         expect(response.content_type).to eq("application/json")
         expect(response).to have_http_status(:ok)
       end

--- a/spec/requests/api/v0/articles_spec.rb
+++ b/spec/requests/api/v0/articles_spec.rb
@@ -83,6 +83,7 @@ RSpec.describe "Api::V0::Articles", type: :request do
       )
     end
 
+    # rubocop:disable RSpec/ExampleLength
     it "returns all the relevant datetimes" do
       article.update_columns(
         edited_at: 1.minute.from_now, crossposted_at: 2.minutes.ago, last_comment_at: 30.seconds.ago,
@@ -96,6 +97,7 @@ RSpec.describe "Api::V0::Articles", type: :request do
         "last_comment_at" => article.last_comment_at.utc.iso8601,
       )
     end
+    # rubocop:enable RSpec/ExampleLength
 
     it "fails with an unpublished article" do
       article.update_columns(published: false)
@@ -119,7 +121,7 @@ RSpec.describe "Api::V0::Articles", type: :request do
 
     context "when request is authenticated" do
       let_it_be(:user) { create(:user) }
-      let_it_be(:access_token) { create :doorkeeper_access_token, resource_owner: user }
+      let_it_be(:access_token) { create :doorkeeper_access_token, resource_owner: user, scopes: "public" }
 
       it "works with bearer authorization" do
         headers = { "authorization" => "Bearer #{access_token.token}", "content-type" => "application/json" }

--- a/spec/requests/api/v0/articles_spec.rb
+++ b/spec/requests/api/v0/articles_spec.rb
@@ -117,11 +117,18 @@ RSpec.describe "Api::V0::Articles", type: :request do
         get me_api_articles_path
         expect(response).to have_http_status(:unauthorized)
       end
+
+      it "returns unauthorized when lack of scopes" do
+        user = create(:user)
+        access_token = create :doorkeeper_access_token, resource_owner: user, scopes: "public"
+        get me_api_articles_path, params: { access_token: access_token.token }
+        expect(response).to have_http_status(:forbidden)
+      end
     end
 
     context "when request is authenticated" do
       let_it_be(:user) { create(:user) }
-      let_it_be(:access_token) { create :doorkeeper_access_token, resource_owner: user, scopes: "public" }
+      let_it_be(:access_token) { create :doorkeeper_access_token, resource_owner: user, scopes: "public, read_articles" }
 
       it "works with bearer authorization" do
         headers = { "authorization" => "Bearer #{access_token.token}", "content-type" => "application/json" }

--- a/spec/requests/api/v0/webhooks_spec.rb
+++ b/spec/requests/api/v0/webhooks_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe "Api::V0::Webhooks", type: :request do
   describe "authorized with doorkeeper" do
     let!(:oauth_app) { create(:application) }
     let!(:oauth_app2) { create(:application) }
-    let(:access_token) { create :doorkeeper_access_token, resource_owner: user, application: oauth_app2 }
+    let(:access_token) { create :doorkeeper_access_token, resource_owner: user, application: oauth_app2, scopes: "public" }
 
     it "renders index successfully" do
       get api_webhooks_path, params: { access_token: access_token.token }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
- created a doorkeeper `public` scope
- added doorkeeper authorization to webhooks and articles API actions

Maybe there are other actions which are accessed with the doorkeeper token and also need authorization.

Existing `Doorkeeper::AccessToken`s' `scopes` need to be updated to `"public"`

## Related issues
#3715 