### PR TITLE
Change reply notification background color

### DIFF
--- a/app/assets/stylesheets/notifications.scss
+++ b/app/assets/stylesheets/notifications.scss
@@ -305,9 +305,9 @@
           }
         }
         .reply-sent-notice {
+          @include themeable(background, theme-container-background, $light-green);
           text-align: center;
           padding: 10px 0px;
-          background: $light-green;
           a {
             display: inline-block;
             background: $green;


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

Another CSS color thing I noticed!

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Before:
Pretty hard to read!
![Screenshot_2019-09-18 Notifications - dev to](https://user-images.githubusercontent.com/11466782/65255237-296d0800-dac3-11e9-8c1b-4a8131181715.png)

After:
Less hard to read!
![image](https://user-images.githubusercontent.com/11466782/65255264-31c54300-dac3-11e9-9437-57fbee97186b.png)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![Spongebob lifting weights](https://user-images.githubusercontent.com/11466782/65259054-a8fdd580-dac9-11e9-90c3-9dbdd8c7455c.gif)

