### PR TITLE
Fix opacity issue on low quality comments

### DIFF
--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -588,7 +588,7 @@ a.header-link {
       margin-right: 2px;
     }
   }
-  .low-quality-comment {
+  .low-quality-comment > *:not(.dropdown) {
     opacity: 0.5;
   }
   .body {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Prior to this change, the opacity on the comment affects its dropdown menu, making it see-through when expanded. So I've instead applied opacity to all child elements except the dropdown.

## Screenshots

Opacity issue before this fix:
![image](https://user-images.githubusercontent.com/17580512/65341918-293e3c80-db97-11e9-977f-5235b3e589a4.png)

## Added to documentation?

- [x] no documentation needed
