### PR TITLE
fixed Load More button not readable in night theme

### DIFF
--- a/app/assets/stylesheets/_mixins.scss
+++ b/app/assets/stylesheets/_mixins.scss
@@ -41,5 +41,6 @@
     max-width: 80%;
     border-radius: 100px;
     font-weight: bold;
+    color: inherit
   }
 }


### PR DESCRIPTION
## Type
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Related issue:
[#4068](https://github.com/thepracticaldev/dev.to/issues/4068)

## Description
In _mixins.scss:

```css
@mixin load-more() {
  text-align: center;

  button {
    ...
    color: inherit
  }
}
```

## Desktop Screenshots
![dev to](https://user-images.githubusercontent.com/49572628/65356217-e5146180-dbc1-11e9-80e8-31ea2c9cad51.png)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed