### PR TITLE
Do not cache articles notifications "time ago" indication

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -26,7 +26,7 @@ class NotificationsController < ApplicationController
                        @user.notifications
                      end
 
-    @notifications = @notifications.without_past_aggregations.order(notified_at: :desc)
+    @notifications = @notifications.includes(:notifiable).without_past_aggregations.order(notified_at: :desc)
 
     # if offset based pagination is invoked by the frontend code, we filter out all earlier ones
     @notifications = @notifications.where("notified_at < ?", notified_at_offset) if notified_at_offset

--- a/app/views/notifications/_article.html.erb
+++ b/app/views/notifications/_article.html.erb
@@ -22,7 +22,7 @@
     </a>
   <% end %>
   <div class="content notification-content article-content">
-    <% cache "activity-published-article-#{json_data['article']['id']}-#{json_data['article']['updated_at']}" do %>
+    <% cache "activity-published-article-user-info-#{json_data['article']['id']}-#{json_data['article']['updated_at']}" do %>
       <a href="<%= json_data["user"]["path"] %>">
         <%= json_data["user"]["name"] %>
       </a>
@@ -30,13 +30,21 @@
       <% if json_data["organization"] %>
         under <a href="<%= json_data["organization"]["path"] %>"><%= json_data["organization"]["name"] %></a>:
       <% end %>
-      <div>
-        <% if json_data["article"]["published_at"] %>
-          <small><%= time_ago_in_words json_data["article"]["published_at"] %> ago</small>
-        <% else %>
-          <small><%= time_ago_in_words notification.notifiable.published_at %> ago</small>
-        <% end %>
-      </div>
+    <% end %>
+
+    <%# keeping this section of out the cache: if the article is never updated
+        the containing cache will likely never expire and this section will be
+        fixed in time until expired randomly by Memcache's algorithm, which can
+        be too late for the freshness of the user experience %>
+    <div>
+      <% if json_data["article"]["published_at"] %>
+        <small><%= time_ago_in_words json_data["article"]["published_at"] %> ago</small>
+      <% else %>
+        <small><%= time_ago_in_words notification.notifiable.published_at %> ago</small>
+      <% end %>
+    </div>
+
+    <% cache "activity-published-article-summary-#{json_data['article']['id']}-#{json_data['article']['updated_at']}" do %>
       <a href="<%= json_data["article"]["path"] %>">
         <div class="notification-new-post">
           <div class="notification-new-post-title">
@@ -50,6 +58,7 @@
         </div>
       </a>
     <% end %>
+
     <% cache "activity-published-article-reactions-#{@last_user_reaction}-#{json_data['article']['updated_at']}-#{json_data['article']['id']}" do %>
       <div class="comment-actions">
         <button class="reaction-button <%= Reaction.cached_any_reactions_for?(notification.mocked_object("article"), current_user, "like") ? "reacted" : "" %>" data-reactable-id="<%= json_data["article"]["id"] %>" data-category="like" data-reactable-type="Article">


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

Fragment caching does not support an explicit expiration date for simplicitly, which means that cached resources are tied to the update datetime of the model.

In this case unfortunately this is not sufficient: a cached time that potentially never gets expired can stale quickly when applied to a time sensitive item like a notification.

Since the "time ago" computation is not particularly heavy and notifications are paginated, I ended up removing that part from the cache altogether.

As a byproduct I created two new separate cache keys for the article notification, one of each section surrounding the time.

## Related Tickets & Documents

Closes #4023 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
