### PR TITLE
Remove OAuth access from Listings API

### DIFF
--- a/app/controllers/api/v0/classified_listings_controller.rb
+++ b/app/controllers/api/v0/classified_listings_controller.rb
@@ -5,7 +5,7 @@ module Api
       respond_to :json
 
       before_action :set_classified_listing, only: %i[show update]
-      before_action :authenticate!, only: %i[create update]
+      before_action :authenticate_with_api_key!, only: %i[create update]
 
       # skip CSRF checks for create and update
       skip_before_action :verify_authenticity_token, only: %i[create update]


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

Removing OAuth access to listings API for now. OAuth is still in beta and third party apps shouldn't have access to their user's listings unconditionally.

We should probably setup scopes and permissions before re-enabling this.

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
