### PR TITLE
removing unneeded margin-left in @media tag

### DIFF
--- a/app/assets/stylesheets/footer.scss
+++ b/app/assets/stylesheets/footer.scss
@@ -17,7 +17,6 @@ footer {
       width: 97%;
       max-width: 722px;
       @media screen and (min-width: 950px) and (max-width: 1119px) {
-        margin-left: 310px;
         max-width: calc(100% - 377px);
       }
       @media screen and (min-width: 1120px) {


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
@media tags are fighting. There's a unneeded `margin-left: 310px;` in there for the @media tag for `@media screen and (max-width: 1119px) and (min-width: 950px) footer .container.centered-footer {` removed it to resolve issue.

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/issues/3112

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
before: ![before screenshot of footer](https://i.imgur.com/caE5yGW.png)

after: ![after screenshot of footer](https://i.imgur.com/8M8YWMp.png)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![aligned space planets](https://media1.giphy.com/media/xUA7b7nNgbuprWGNkQ/giphy.gif)
