### PR TITLE
adjust css bottom value for notifcations menu

### DIFF
--- a/app/assets/stylesheets/article-show.scss
+++ b/app/assets/stylesheets/article-show.scss
@@ -1008,7 +1008,7 @@ article {
         left: 80px !important;
         bottom: 0px !important;
         @media screen and (min-width: 1365px) {
-          bottom: -155px !important;
+          bottom: -185px !important;
         }
         a {
           background: transparent !important;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Documentation Update

## Description
Adjusting the notifcations options menu on a post. Was set to -155px, but likely changed the number of items in the list recently, and needs a bit more space. Setting to -185px seems to do the trick.

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/issues/4097

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed
