### PR TITLE
Limit access to the API actions when authorized by doorkeeper token

### DIFF
--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -59,8 +59,10 @@ class Api::V0::ApiController < ApplicationController
   def authenticate_with_api_key_or_current_user!
     if request.headers["api-key"]
       authenticate_with_api_key!
-    else
+    elsif current_user
       @user = current_user
+    else
+      error_unauthorized
     end
   end
 

--- a/app/controllers/api/v0/articles_controller.rb
+++ b/app/controllers/api/v0/articles_controller.rb
@@ -3,7 +3,8 @@ module Api
     class ArticlesController < ApiController
       respond_to :json
 
-      before_action :authenticate!, only: %i[create update me]
+      before_action :authenticate_with_api_key_or_current_user!, only: %i[create update]
+      before_action :authenticate!, only: :me
       before_action -> { doorkeeper_authorize! :public }, only: %w[index show], if: -> { doorkeeper_token }
 
       before_action :set_cache_control_headers, only: [:index]

--- a/app/controllers/api/v0/classified_listings_controller.rb
+++ b/app/controllers/api/v0/classified_listings_controller.rb
@@ -5,7 +5,7 @@ module Api
       respond_to :json
 
       before_action :set_classified_listing, only: %i[show update]
-      before_action :authenticate!, only: %i[create update]
+      before_action :authenticate_with_api_key_or_current_user!, only: %i[create update]
 
       # skip CSRF checks for create and update
       skip_before_action :verify_authenticity_token, only: %i[create update]

--- a/app/controllers/api/v0/users_controller.rb
+++ b/app/controllers/api/v0/users_controller.rb
@@ -2,6 +2,7 @@ module Api
   module V0
     class UsersController < ApiController
       before_action :authenticate!, only: %i[me]
+      before_action -> { doorkeeper_authorize! :public }, only: :me, if: -> { doorkeeper_token }
 
       def index
         if !user_signed_in? || less_than_one_day_old?(current_user)

--- a/spec/requests/api/v0/articles_spec.rb
+++ b/spec/requests/api/v0/articles_spec.rb
@@ -231,20 +231,20 @@ RSpec.describe "Api::V0::Articles", type: :request do
         post api_articles_path, headers: { "api-key" => api_secret.secret, "content-type" => "application/json" }
         expect(response).to have_http_status(:unauthorized)
       end
+
+      it "fails when oauth's access_token" do
+        access_token = create(:doorkeeper_access_token, resource_owner_id: user.id)
+        headers = { "authorization" => "Bearer #{access_token.token}", "content-type" => "application/json" }
+
+        post api_articles_path, params: { article: { title: Faker::Book.title } }.to_json, headers: headers
+        expect(response).to have_http_status(:unauthorized)
+      end
     end
 
     describe "when authorized" do
       def post_article(**params)
         headers = { "api-key" => api_secret.secret, "content-type" => "application/json" }
         post api_articles_path, params: { article: params }.to_json, headers: headers
-      end
-
-      it "supports oauth's access_token" do
-        access_token = create(:doorkeeper_access_token, resource_owner_id: user.id)
-        headers = { "authorization" => "Bearer #{access_token.token}", "content-type" => "application/json" }
-
-        post api_articles_path, params: { article: { title: Faker::Book.title } }.to_json, headers: headers
-        expect(response).to have_http_status(:created)
       end
 
       it "fails if no params are given" do
@@ -481,6 +481,17 @@ RSpec.describe "Api::V0::Articles", type: :request do
         put path, headers: { "api-key" => api_secret.secret, "content-type" => "application/json" }
         expect(response).to have_http_status(:unauthorized)
       end
+
+      it "fails with oauth's access_token" do
+        access_token = create(:doorkeeper_access_token, resource_owner_id: user.id)
+        headers = { "authorization" => "Bearer #{access_token.token}", "content-type" => "application/json" }
+
+        title = Faker::Book.title
+        body_markdown = "foobar"
+        params = { title: title, body_markdown: body_markdown }
+        put path, params: { article: params }.to_json, headers: headers
+        expect(response).to have_http_status(:unauthorized)
+      end
     end
 
     describe "when authorized" do
@@ -489,19 +500,6 @@ RSpec.describe "Api::V0::Articles", type: :request do
       def put_article(**params)
         headers = { "api-key" => api_secret.secret, "content-type" => "application/json" }
         put path, params: { article: params }.to_json, headers: headers
-      end
-
-      it "supports oauth's access_token" do
-        access_token = create(:doorkeeper_access_token, resource_owner_id: user.id)
-        headers = { "authorization" => "Bearer #{access_token.token}", "content-type" => "application/json" }
-
-        title = Faker::Book.title
-        body_markdown = "foobar"
-        params = { title: title, body_markdown: body_markdown }
-        put path, params: { article: params }.to_json, headers: headers
-        expect(response).to have_http_status(:ok)
-        expect(article.reload.title).to eq(title)
-        expect(article.body_markdown).to eq(body_markdown)
       end
 
       it "returns not found if the article does not belong to the user" do

--- a/spec/requests/api/v0/users_spec.rb
+++ b/spec/requests/api/v0/users_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Api::V0::Users", type: :request do
 
     context "when request is authenticated" do
       let_it_be(:user)         { create(:user) }
-      let_it_be(:access_token) { create(:doorkeeper_access_token, resource_owner: user) }
+      let_it_be(:access_token) { create(:doorkeeper_access_token, resource_owner: user, scopes: "public") }
 
       it "return user's information" do
         get me_api_users_path, params: { access_token: access_token.token }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Security improvement

## Description
User authorized with an OAuth token should only able to access endpoints that correspond to the selected scopes. In this pr, I limited access to creating and updating records in this case.

## Related Tickets & Documents
#3715 
