### PR TITLE
Dark-Theme: remove white background ChatMessage username link 

### DIFF
--- a/app/assets/stylesheets/chat.scss
+++ b/app/assets/stylesheets/chat.scss
@@ -1037,7 +1037,6 @@
 
 .chatmessagebody__username--link {
   color: inherit;
-  background: white;
   border-radius: 3px;
   padding: 0px 2px;
   display: inline-block;


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

While using the Night Theme everything is perfectly styled, once you hit the chat, the usernames have a white background, and while having also a white color, the username isn't visible until you hover. 

## Related Tickets & Documents

Couldn't find any issues regarding the chat 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

I removed the background-property and tested it on every theme at dev.to itself. Except the Night Theme, all themes have the chat in a white background anyway, so there is no need to have Usernames with a white background either

I wanted to provide a screenshot, but since my local docker version of dev.to just didn't wanted to run as I expected, like 3+ mins to switch from one page to another, also how to have multiple accounts (to create a chat) when you only one github account to logon? 😅 

Edit:
Current:
![image](https://user-images.githubusercontent.com/842273/66064710-39b2c780-e546-11e9-86a7-afd9aa01343a.png)

Live CSS Changes:
![image](https://user-images.githubusercontent.com/842273/66064850-839bad80-e546-11e9-8c7f-2a5c35ace91e.png)


## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

