### PR TITLE
Delete messages without instantiating ActiveRecord objects

### DIFF
--- a/app/controllers/chat_channels_controller.rb
+++ b/app/controllers/chat_channels_controller.rb
@@ -44,7 +44,7 @@ class ChatChannelsController < ApplicationController
       banned_user = User.find_by(username: command[1])
       if banned_user
         banned_user.add_role :banned
-        banned_user.messages.each(&:destroy!)
+        banned_user.messages.delete_all
         Pusher.trigger(@chat_channel.pusher_channels,
                        "user-banned",
                        { userId: banned_user.id }.to_json)

--- a/app/models/chat_channel.rb
+++ b/app/models/chat_channel.rb
@@ -44,7 +44,7 @@ class ChatChannel < ApplicationRecord
   end
 
   def clear_channel
-    messages.find_each(&:destroy!)
+    messages.delete_all
     Pusher.trigger(pusher_channels, "channel-cleared", { chat_channel_id: id }.to_json)
     true
   rescue Pusher::Error => e


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

Favors `delete_all` over `destroy` in a deleting a collection of `Message`s. The former is efficient as it doesn't  instantiate any `ActiveRecord` objects. Since the `Message` model has no `before_destroy` callbacks, I believe it's safe to use `delete_all`. Do let me know if I am missing something.

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

