### PR TITLE
Prepend before_destroy(s) in models with destroy dependents

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -70,7 +70,7 @@ class Article < ApplicationRecord
   after_save        :detect_human_language
   before_save       :update_cached_user
   after_update      :update_notifications, if: proc { |article| article.notifications.any? && !article.saved_changes.empty? }
-  before_destroy    :before_destroy_actions
+  before_destroy    :before_destroy_actions, prepend: true
 
   serialize :ids_for_suggested_articles
   serialize :cached_user

--- a/app/models/chat_channel.rb
+++ b/app/models/chat_channel.rb
@@ -29,7 +29,7 @@ class ChatChannel < ApplicationRecord
     ranking ["desc(last_message_at)"]
   end
 
-  before_destroy :remove_from_index!
+  before_destroy :remove_from_index!, prepend: true
 
   def open?
     channel_type == "open"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -157,10 +157,10 @@ class User < ApplicationRecord
   before_validation :set_config_input
   before_validation :downcase_email
   before_validation :check_for_username_change
-  before_destroy :remove_from_algolia_index
-  before_destroy :destroy_empty_dm_channels
-  before_destroy :destroy_follows
-  before_destroy :unsubscribe_from_newsletters
+  before_destroy :remove_from_algolia_index, prepend: true
+  before_destroy :destroy_empty_dm_channels, prepend: true
+  before_destroy :destroy_follows, prepend: true
+  before_destroy :unsubscribe_from_newsletters, prepend: true
 
   algoliasearch per_environment: true, enqueue: :trigger_delayed_index do
     attribute :name


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

While reviewing other PRs I noticed something and went confirming it with the Rails docs: 

> before_destroy callbacks should be placed before dependent: :destroy associations (or use the prepend: true option), to ensure they execute before the records are deleted by dependent: :destroy.

So if an object has objects that will be destroyed by association, its `before_destroy` callbacks should run *before* those objects are in turn destroyed.

I added `prepend: true` to the three models that match the scenario.

## Related Tickets & Documents

See https://guides.rubyonrails.org/active_record_callbacks.html#destroying-an-object
