### PR TITLE
Fix tabbing order of article engagement icons

### DIFF
--- a/app/views/articles/_single_story.html.erb
+++ b/app/views/articles/_single_story.html.erb
@@ -36,13 +36,6 @@
       <a href="/t/<%= tag %>"><span class="tag">#<%= tag %></span></a>
     <% end %>
   </div>
-  <% if story.comments_count > 0 %>
-    <div class="article-engagement-count comments-count">
-      <a href="<%= story.path %>#comments">
-        <img src="<%= asset_path("comments-bubble.png") %>" alt="chat" /><span class="engagement-count-number"><%= story.comments_count %></span>
-      </a>
-    </div>
-  <% end %>
   <div class="article-engagement-count reactions-count" data-reaction-count data-reactable-id="<%= story.id %>">
     <a href="<%= story.path %>">
       <img src="<%= asset_path("reactions-stack.png") %>" alt="Reactions" /><span id="engagement-count-number-<%= story.id %>" class="engagement-count-number">
@@ -50,6 +43,13 @@
         </span>
     </a>
   </div>
+  <% if story.comments_count > 0 %>
+    <div class="article-engagement-count comments-count">
+      <a href="<%= story.path %>#comments">
+        <img src="<%= asset_path("comments-bubble.png") %>" alt="chat" /><span class="engagement-count-number"><%= story.comments_count %></span>
+      </a>
+    </div>
+  <% end %>
   <a
     href="<%= story.path %>"
     class="article-reading-time">


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

When navigating through the article cards with a keyboard, currently the engagement icons are tabbed to in different order than what you would expect visually. (Comments are tabbed to first even though visually, it is second). Logical focus order should follow visual order when possible so a keyboard user knows what to expect.

The fix was to change the order of the elements in the markup.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Before:
![GIF of the second icon being focused before the first](https://i.imgur.com/n0GDLSr.gif)

After:
![GIF of the fix, having the first icon focused first and the second focused after](https://i.imgur.com/QW8Dgy5.gif)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
