### PR TITLE
Rails 5.2 features: Enable AES-256-GCM on encrypted cookies

### DIFF
--- a/config/initializers/new_framework_defaults_5_2.rb
+++ b/config/initializers/new_framework_defaults_5_2.rb
@@ -17,7 +17,7 @@
 # It's best enabled when your entire app is migrated and stable on 5.2.
 #
 # Existing cookies will be converted on read then written with the new scheme.
-# Rails.application.config.action_dispatch.use_authenticated_cookie_encryption = true
+Rails.application.config.action_dispatch.use_authenticated_cookie_encryption = true
 
 # Use AES-256-GCM authenticated encryption as default cipher for encrypting messages
 # instead of AES-256-CBC, when use_authenticated_message_encryption is set to true.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

We've been running Rails 5.2 since April 3rd (https://github.com/thepracticaldev/dev.to/pull/1408), in an effort to get closer to the defaults and improve security I'm submitting this PR to flip one of the flags that are currently disabled, in this case the one selecting the encryption algorithm for cookies.

It doesn't require any other change, Rails is smart enough to update existing cookies:

https://github.com/thepracticaldev/dev.to/blob/6a8c766322a9af31c97abc42370dcdf9854493b7/config/initializers/new_framework_defaults_5_2.rb#L13-L19

(I've tested this manually)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
