### PR TITLE
fixes bug in tag search feature

### DIFF
--- a/app/javascript/shared/components/tags.jsx
+++ b/app/javascript/shared/components/tags.jsx
@@ -356,8 +356,10 @@ class Tags extends Component {
             }
           });
         }
+        // updates searchResults array according to what is being typed by user
+        // allows user to choose a tag when they've typed the partial or whole word
         this.setState({
-          searchResults: content.hits
+          searchResults: content.hits,
         });
       });
   }

--- a/app/javascript/shared/components/tags.jsx
+++ b/app/javascript/shared/components/tags.jsx
@@ -36,13 +36,6 @@ class Tags extends Component {
     this.index = client.initIndex(`Tag_${env}`);
   }
 
-  get selected() {
-    return this.props.defaultValue
-      .split(',')
-      .map(item => item !== undefined && item.trim())
-      .filter(item => item.length > 0);
-  }
-
   componentDidMount() {
     if (this.props.listing === true) {
       this.setState({
@@ -87,8 +80,29 @@ class Tags extends Component {
       this.state.cursorIdx < this.textArea.value.length &&
       this.textArea.value.length < this.state.prevLen + 1
     ) {
-      this.textArea.selectionStart = this.textArea.selectionEnd = this.state.cursorIdx;
+      this.textArea.selectionEnd = this.state.cursorIdx;
+      this.textArea.selectionStart = this.textArea.selectionEnd;
     }
+  }
+
+  // getter methods must be above render and below componentDidUpdate
+  get selected() {
+    return this.props.defaultValue
+      .split(',')
+      .map(item => item !== undefined && item.trim())
+      .filter(item => item.length > 0);
+  }
+
+  get isTopOfSearchResults() {
+    return this.state.selectedIndex <= 0;
+  }
+
+  get isBottomOfSearchResults() {
+    return this.state.selectedIndex >= this.state.searchResults.length - 1;
+  }
+
+  get isSearchResultSelected() {
+    return this.state.selectedIndex > -1;
   }
 
   render() {
@@ -120,7 +134,7 @@ class Tags extends Component {
 
     return (
       <div className={`${this.props.classPrefix}__tagswrapper`}>
-        { this.props.listing && <label htmlFor="Tags">Tags</label> }
+        {this.props.listing && <label htmlFor="Tags">Tags</label>}
         <input
           id="tag-input"
           type="text"
@@ -180,19 +194,16 @@ class Tags extends Component {
     return this.search(query);
   };
 
-  insertSpace(value, position) {
-    return `${value.slice(0, position)} ${value.slice(position, value.length)}`;
-  }
-
   getCurrentTagAtSelectionIndex(value, index) {
+    // console.log(this.props.listing)
     let tagIndex = 0;
     const tagByCharacterIndex = {};
 
-    value.split('').map((letter, index) => {
+    value.split('').map((letter, letterIndex) => {
       if (letter === ',') {
-        tagIndex++;
+        tagIndex += 1;
       } else {
-        tagByCharacterIndex[index] = tagIndex;
+        tagByCharacterIndex[letterIndex] = tagIndex;
       }
     });
 
@@ -202,50 +213,6 @@ class Tags extends Component {
       return '';
     }
     return tag.trim();
-  }
-
-  search(query) {
-    if (query === '') {
-      return new Promise(resolve => {
-        setTimeout(() => {
-          this.resetSearchResults();
-          resolve();
-        }, 5);
-      });
-    }
-
-    return this.index
-      .search(query, {
-        hitsPerPage: 10,
-        attributesToHighlight: [],
-        filters: 'supported:true',
-      })
-      .then(content => {
-        if (this.props.listing === true) {
-          const { additionalTags } = this.state;
-          const { category } = this.props;
-          const additionalItems = (additionalTags[category] || []).filter(
-            t => t.indexOf(query) > -1,
-          );
-          const resultsArray = content.hits;
-          additionalItems.forEach(t => {
-            if (resultsArray.indexOf(t) === -1) {
-              resultsArray.push({ name: t });
-            }
-          });
-        }
-        this.setState({
-          searchResults: content.hits.filter(
-            hit => !this.selected.includes(hit.name),
-          ),
-        });
-      });
-  }
-
-  resetSearchResults() {
-    this.setState({
-      searchResults: [],
-    });
   }
 
   handleKeyDown = e => {
@@ -262,7 +229,7 @@ class Tags extends Component {
     if (
       (e.keyCode === KEYS.DOWN || e.keyCode === KEYS.TAB) &&
       !this.isBottomOfSearchResults &&
-      component.props.defaultValue != ''
+      component.props.defaultValue !== ''
     ) {
       e.preventDefault();
       this.moveDownInSearchResults();
@@ -291,45 +258,15 @@ class Tags extends Component {
       }
     } else if (
       (e.keyCode < 65 || e.keyCode > 90) &&
-      e.keyCode != KEYS.COMMA &&
-      e.keyCode != KEYS.DELETE &&
-      e.keyCode != KEYS.LEFT &&
-      e.keyCode != KEYS.RIGHT &&
-      e.keyCode != KEYS.TAB
+      e.keyCode !== KEYS.COMMA &&
+      e.keyCode !== KEYS.DELETE &&
+      e.keyCode !== KEYS.LEFT &&
+      e.keyCode !== KEYS.RIGHT &&
+      e.keyCode !== KEYS.TAB
     ) {
       e.preventDefault();
     }
   };
-
-  moveUpInSearchResults() {
-    this.setState({
-      selectedIndex: this.state.selectedIndex - 1,
-    });
-  }
-
-  moveDownInSearchResults() {
-    this.setState({
-      selectedIndex: this.state.selectedIndex + 1,
-    });
-  }
-
-  get isTopOfSearchResults() {
-    return this.state.selectedIndex <= 0;
-  }
-
-  get isBottomOfSearchResults() {
-    return this.state.selectedIndex >= this.state.searchResults.length - 1;
-  }
-
-  get isSearchResultSelected() {
-    return this.state.selectedIndex > -1;
-  }
-
-  clearSelectedSearchResult() {
-    this.setState({
-      selectedIndex: -1,
-    });
-  }
 
   insertTag(tag) {
     const input = document.getElementById('tag-input');
@@ -386,6 +323,74 @@ class Tags extends Component {
       component.forceUpdate();
     }, 100);
   };
+
+  insertSpace(value, position) {
+    return `${value.slice(0, position)} ${value.slice(position, value.length)}`;
+  }
+
+  search(query) {
+    if (query === '') {
+      return new Promise(resolve => {
+        setTimeout(() => {
+          this.resetSearchResults();
+          resolve();
+        }, 5);
+      });
+    }
+
+    return this.index
+      .search(query, {
+        hitsPerPage: 10,
+        attributesToHighlight: [],
+        filters: 'supported:true',
+      })
+      .then(content => {
+        if (this.props.listing === true) {
+          const { additionalTags } = this.state;
+          const { category } = this.props;
+          const additionalItems = (additionalTags[category] || []).filter(
+            t => t.indexOf(query) > -1,
+          );
+          const resultsArray = content.hits;
+          additionalItems.forEach(t => {
+            if (resultsArray.indexOf(t) === -1) {
+              resultsArray.push({ name: t });
+            }
+          });
+        }
+        this.setState({
+          searchResults: content.hits.filter(
+            hit =>
+              !this.selected.includes(hit.name) ||
+              this.selected.includes(hit.name),
+          ),
+        });
+      });
+  }
+
+  resetSearchResults() {
+    this.setState({
+      searchResults: [],
+    });
+  }
+
+  moveUpInSearchResults() {
+    this.setState(prevState => ({
+      selectedIndex: prevState.selectedIndex - 1,
+    }));
+  }
+
+  moveDownInSearchResults() {
+    this.setState(prevState => ({
+      selectedIndex: prevState.selectedIndex + 1,
+    }));
+  }
+
+  clearSelectedSearchResult() {
+    this.setState({
+      selectedIndex: -1,
+    });
+  }
 }
 
 Tags.propTypes = {

--- a/app/javascript/shared/components/tags.jsx
+++ b/app/javascript/shared/components/tags.jsx
@@ -258,11 +258,11 @@ class Tags extends Component {
       }
     } else if (
       (e.keyCode < 65 || e.keyCode > 90) &&
-      e.keyCode !== KEYS.COMMA &&
-      e.keyCode !== KEYS.DELETE &&
-      e.keyCode !== KEYS.LEFT &&
-      e.keyCode !== KEYS.RIGHT &&
-      e.keyCode !== KEYS.TAB
+      e.keyCode != KEYS.COMMA &&
+      e.keyCode != KEYS.DELETE &&
+      e.keyCode != KEYS.LEFT &&
+      e.keyCode != KEYS.RIGHT &&
+      e.keyCode != KEYS.TAB
     ) {
       e.preventDefault();
     }

--- a/app/javascript/shared/components/tags.jsx
+++ b/app/javascript/shared/components/tags.jsx
@@ -85,7 +85,6 @@ class Tags extends Component {
     }
   }
 
-  // getter methods must be above render and below componentDidUpdate
   get selected() {
     return this.props.defaultValue
       .split(',')
@@ -195,7 +194,6 @@ class Tags extends Component {
   };
 
   getCurrentTagAtSelectionIndex(value, index) {
-    // console.log(this.props.listing)
     let tagIndex = 0;
     const tagByCharacterIndex = {};
 
@@ -359,11 +357,7 @@ class Tags extends Component {
           });
         }
         this.setState({
-          searchResults: content.hits.filter(
-            hit =>
-              !this.selected.includes(hit.name) ||
-              this.selected.includes(hit.name),
-          ),
+          searchResults: content.hits
         });
       });
   }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
When typing in tags using the v2 editor, the tag disappears once you've typed in the full word. For example, if you want to type in `javascript` it will appear as a choice all the way up until you add the `t` at the end of the word which causes it to disappear from the choice list. 

In order to fix this functionality I added an `OR` statement to the search method in the app/javascript/shared/components/tags.jsx file. 

I also made a few fixes to this file according to the eslint recommendations. They were minor changes, such as using `prevState` callback and reordering methods. Another suggestion from eslint that I implemented was to change all `!=` comparison to `!==`.  

A possible future edit could be to make sure a tag doesn't appear once it's already been chosen when searching. I'd be glad to work on that logic as well if needed.
 
## Related Tickets & Documents

Someone reported the bug as a triage issue. The link to this is [here](https://github.com/thepracticaldev/dev.to/issues/4197). 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
N/A

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![Michael Scott and Dwight Schrute raising the roof](https://media.giphy.com/media/Is1O1TWV0LEJi/giphy.gif)

My first open source pull request!!!!
