### PR TITLE
removed invert filter from profile header social icons

### DIFF
--- a/app/assets/stylesheets/user-profile-header.scss
+++ b/app/assets/stylesheets/user-profile-header.scss
@@ -209,6 +209,7 @@
           width:23px;
           height:23px;
           margin: 0px 0px;
+          filter: none;
           @media screen and ( min-width: 580px ){
             margin:3px;
             width:28px;


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
An invert filter was causing the social links in the profile section to be a different color in night theme than the rest of the text. This PR fixes the issue by setting `filter: none`

## Related Tickets & Documents
Fixes #2183

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
Before:
![image](https://user-images.githubusercontent.com/8535863/66180982-a1732a80-e68c-11e9-9d3c-bb5e984955ed.png)

After:
![image](https://user-images.githubusercontent.com/8535863/66180933-7ab4f400-e68c-11e9-9ec7-e5a8e38186cc.png)


## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed