### PR TITLE
added mod_roundrobin_notifications to user_policy.rb

### DIFF
--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -99,6 +99,7 @@ class UserPolicy < ApplicationPolicy
       mastodon_url
       medium_url
       mobile_comment_notifications
+      mod_roundrobin_notifications
       mostly_work_with
       name
       password

--- a/spec/requests/user_settings_spec.rb
+++ b/spec/requests/user_settings_spec.rb
@@ -53,6 +53,16 @@ RSpec.describe "UserSettings", type: :request do
       expect(user.reload.profile_updated_at).to be > 2.minutes.ago
     end
 
+    it "enables community-success notifications" do
+      put "/users/#{user.id}", params: { user: { tab: "notifications", mod_roundrobin_notifications: 1 } }
+      expect(user.reload.mod_roundrobin_notifications).to be(true)
+    end
+
+    it "disables community-success notifications" do
+      put "/users/#{user.id}", params: { user: { tab: "notifications", mod_roundrobin_notifications: 0 } }
+      expect(user.reload.mod_roundrobin_notifications).to be(false)
+    end
+
     it "updates username to too short username" do
       put "/users/#{user.id}", params: { user: { tab: "profile", username: "h" } }
       expect(response.body).to include("Username is too short")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
`mod_roundrobin_notifications` was missing from `permitted_attributes` in `user_policy.rb` which was preventing the community-success notification setting from getting saved. This PR adds `mod_roundrobin_notifications` to `permitted_attributes` in `user_policy.rb`.

## Related Tickets & Documents
Fixes #4210

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
