### PR TITLE
Rescue Net::HTTPGone on message push

### DIFF
--- a/app/jobs/messages/send_push_job.rb
+++ b/app/jobs/messages/send_push_job.rb
@@ -9,6 +9,8 @@ module Messages
       return unless user && chat_channel
 
       service.call(user, chat_channel, message_html)
+    rescue Net::HTTPGone => e
+      Rails.logger.error("Sending push failed: #{e}")
     end
   end
 end

--- a/spec/jobs/messages/send_push_job_spec.rb
+++ b/spec/jobs/messages/send_push_job_spec.rb
@@ -45,5 +45,14 @@ RSpec.describe Messages::SendPushJob, type: :job do
         expect(messages_send_push_service).to have_received(:call).with(user, chat_channel, "<html>")
       end
     end
+
+    context "when 404 gone" do
+      it "rescues an exception" do
+        allow(messages_send_push_service).to receive(:call).and_raise(Net::HTTPGone)
+        expect do
+          described_class.perform_now(456, 789, "<html>", messages_send_push_service)
+        end.not_to raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
There are a lot of 

## Related Tickets & Documents
Similar to #3938 `Net::HTTPGone` happening while executing `Messages::SendPushJob`.
The exception message is:
```
host: fcm.googleapis.com, #<Net::HTTPGone 410 Gone readbody=true>
body: push subscription has unsubscribed or expired.
```
I decided to rescue this error for several reasons:
- these jobs are retried multiple times and waste resources, but this seems like a permanent error so retries don't succeed
- we are not working on implementing another fix right now
- it takes time to go through these failed jobs each time when we check for other errors

Please, notify me if we need another solution to this issue.

