### PR TITLE
Fix text color "Load more listings" button

### DIFF
--- a/app/assets/stylesheets/classified_listings.scss
+++ b/app/assets/stylesheets/classified_listings.scss
@@ -323,6 +323,11 @@
   .classifieds-load-more-button {
     text-align: center;
     button {
+      @include themeable(
+          color,
+          theme-color,
+          $black
+      );
       background: transparent;
       @include themeable(
         border,
@@ -423,7 +428,7 @@
     @media screen and (min-width: 950px) {
       left: 0;
       right: 0;
-      box-sizing: border-box;  
+      box-sizing: border-box;
     }
     .single-classified-listing-container__spacer {
       height: 150px;
@@ -690,7 +695,7 @@ form.listings-contact-via-connect {
       padding-bottom: 30px;
 
       @media screen and (max-width: 768px) {
-        width: 90%; 
+        width: 90%;
       }
       a {
         font-size: 0.9em;
@@ -708,7 +713,7 @@ form.listings-contact-via-connect {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    
+
     .listings-dashboard-filter-buttons {
       margin-bottom: -10px;
     }
@@ -743,7 +748,7 @@ form.listings-contact-via-connect {
       }
     }
   }
-  
+
   .dashboard-listings-view {
 
     .dashboard-listing-row {
@@ -839,7 +844,7 @@ form.listings-contact-via-connect {
           border: 2px solid transparent;
           margin-top: 6px;
           display: inline-block;
-    
+
           &.green {
             background: $green;
             color: $black;
@@ -849,11 +854,11 @@ form.listings-contact-via-connect {
             background: $yellow;
             color: $black;
           }
-    
+
           &.red {
             background: $red;
           }
-    
+
           &.black {
             background: $dark-gray;
           }


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
Fixes the text color of the "Load more listings" button at the bottom of the /listings page for night theme.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
Before:
![Before](https://user-images.githubusercontent.com/11406433/66255751-b1236980-e787-11e9-9a12-261dfe3cc18a.png)

After:
![After](https://user-images.githubusercontent.com/11406433/66255766-d6b07300-e787-11e9-8332-6a3d8b909d2a.png)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

