### PR TITLE
Fix scrollHeight calculation in initScrolling

### DIFF
--- a/app/assets/javascripts/initializers/initScrolling.js.erb
+++ b/app/assets/javascripts/initializers/initScrolling.js.erb
@@ -24,21 +24,38 @@ function checkIfNearBottomOfPage() {
 }
 
 function fetchNextPageIfNearBottom() {
-  var elCheck = document.getElementById("index-container") && !document.getElementById("query-wrapper");
+  var indexContainer = document.getElementById("index-container");
+  var elCheck =  indexContainer && !document.getElementById("query-wrapper");
   if (!elCheck) {
     return;
   }
-  if ( !done && !fetching && (window.scrollY) > (document.documentElement.scrollHeight - 3700) ) {
+  
+  var indexWhich = indexContainer.dataset.which;
+
+  var fetchCallback;
+  var scrollableElemId;
+  if (indexWhich == "podcast-episodes") {
+    scrollableElemId = "articles-list";
+    fetchCallback = function() {
+      fetchNextPodcastPage(indexContainer);
+    };
+  } else if (indexWhich == "videos") {
+    scrollableElemId = "video-collection";
+    fetchCallback = function() {
+      fetchNextVideoPage(indexContainer);
+    };
+  } else {
+    scrollableElemId = "articles-list";
+    fetchCallback = function() {
+      algoliaPaginate(indexContainer.dataset.algoliaTag);
+    };
+  }
+
+  var scrollableElem = document.getElementById(scrollableElemId);
+
+  if ( !done && !fetching && (window.scrollY) > (scrollableElem.scrollHeight - 3700) ) {
     fetching = true;
-    var el = document.getElementById("index-container");
-    var indexWhich = el.dataset.which;
-    if (indexWhich == "podcast-episodes") {
-      fetchNextPodcastPage(el);
-    } else if (indexWhich == "videos") {
-      fetchNextVideoPage(el)
-    } else {
-      algoliaPaginate(el.dataset.algoliaTag);
-    }
+    fetchCallback();
   }
 }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
Fixes #1805 by changing scrollHeight calculation in `initScrolling` to use the actual scrollable element vs. the document element.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
