### PR TITLE
Simplify key codes expression in Tags component

### DIFF
--- a/app/javascript/shared/components/__tests__/tags.test.jsx
+++ b/app/javascript/shared/components/__tests__/tags.test.jsx
@@ -26,8 +26,8 @@ describe('<Tags />', () => {
 
   describe('handleKeyDown', () => {
     const preventDefaultMock = jest.fn();
-    const createKeyDown = code => ({
-      keyCode: code,
+    const createKeyDown = key => ({
+      key,
       preventDefault: preventDefaultMock,
     });
 
@@ -36,12 +36,16 @@ describe('<Tags />', () => {
     });
 
     test('calls preventDefault on unused keyCode', () => {
-      tags.find('#tag-input').simulate('keydown', createKeyDown(1));
-      expect(preventDefaultMock).toHaveBeenCalled();
+      tags.find('#tag-input').simulate('keydown', createKeyDown('§'));
+      tags.find('#tag-input').simulate('keydown', createKeyDown('1'));
+      tags.find('#tag-input').simulate('keydown', createKeyDown('\\'));
+      expect(preventDefaultMock).toHaveBeenCalledTimes(3);
     });
 
     test('does not call preventDefault on used keyCode', () => {
-      tags.find('#tag-input').simulate('keypress', createKeyDown(188));
+      tags.find('#tag-input').simulate('keypress', createKeyDown('a'));
+      tags.find('#tag-input').simulate('keypress', createKeyDown(','));
+      tags.find('#tag-input').simulate('keypress', createKeyDown('Enter'));
       expect(preventDefaultMock).not.toHaveBeenCalled();
     });
   });

--- a/app/javascript/shared/components/__tests__/tags.test.jsx
+++ b/app/javascript/shared/components/__tests__/tags.test.jsx
@@ -1,0 +1,48 @@
+import { h } from 'preact';
+import { deep } from 'preact-render-spy';
+import Tags from '../tags';
+
+describe('<Tags />', () => {
+  beforeAll(() => {
+    const publicId = document.createElement('meta');
+    publicId.setAttribute('name', 'algolia-public-id');
+    const publicKey = document.createElement('meta');
+    publicKey.setAttribute('name', 'algolia-public-key');
+    const environment = document.createElement('meta');
+    environment.setAttribute('name', 'environment');
+    document.body.appendChild(publicId);
+    document.body.appendChild(publicKey);
+    document.body.appendChild(environment);
+    global.algoliasearch = () => ({
+      initIndex: () => 'initIndex',
+    });
+  });
+
+  let tags;
+
+  beforeEach(() => {
+    tags = deep(<Tags defaultValue="defaultValue" listing />);
+  });
+
+  describe('handleKeyDown', () => {
+    const preventDefaultMock = jest.fn();
+    const createKeyDown = code => ({
+      keyCode: code,
+      preventDefault: preventDefaultMock,
+    });
+
+    beforeEach(() => {
+      preventDefaultMock.mockClear();
+    });
+
+    test('calls preventDefault on unused keyCode', () => {
+      tags.find('#tag-input').simulate('keydown', createKeyDown(1));
+      expect(preventDefaultMock).toHaveBeenCalled();
+    });
+
+    test('does not call preventDefault on used keyCode', () => {
+      tags.find('#tag-input').simulate('keypress', createKeyDown(188));
+      expect(preventDefaultMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/app/javascript/shared/components/tags.jsx
+++ b/app/javascript/shared/components/tags.jsx
@@ -20,7 +20,7 @@ const NAVIGATION_KEYS = [
   KEYS.TAB,
 ];
 
-const LETTERS = /^[a-z]+$/i;
+const LETTERS = /\w/i;
 
 /* TODO: Remove all instances of this.props.listing
    and refactor this component to be more generic */

--- a/app/javascript/shared/components/tags.jsx
+++ b/app/javascript/shared/components/tags.jsx
@@ -12,6 +12,14 @@ const KEYS = {
   DELETE: 8,
 };
 
+const COMBO_KEYS = [
+  KEYS.COMMA,
+  KEYS.DELETE,
+  KEYS.LEFT,
+  KEYS.RIGHT,
+  KEYS.TAB,
+];
+
 /* TODO: Remove all instances of this.props.listing
    and refactor this component to be more generic */
 
@@ -289,14 +297,7 @@ class Tags extends Component {
       ) {
         this.clearSelectedSearchResult();
       }
-    } else if (
-      (e.keyCode < 65 || e.keyCode > 90) &&
-      e.keyCode != KEYS.COMMA &&
-      e.keyCode != KEYS.DELETE &&
-      e.keyCode != KEYS.LEFT &&
-      e.keyCode != KEYS.RIGHT &&
-      e.keyCode != KEYS.TAB
-    ) {
+    } else if ((e.keyCode < 65 || e.keyCode > 90) && !COMBO_KEYS.includes(e.keyCode)) {
       e.preventDefault();
     }
   };

--- a/app/javascript/shared/components/tags.jsx
+++ b/app/javascript/shared/components/tags.jsx
@@ -2,23 +2,25 @@ import { h, Component } from 'preact';
 import PropTypes from 'prop-types';
 
 const KEYS = {
-  UP: 38,
-  DOWN: 40,
-  LEFT: 37,
-  RIGHT: 39,
-  TAB: 9,
-  RETURN: 13,
-  COMMA: 188,
-  DELETE: 8,
+  UP: 'ArrowUp',
+  DOWN: 'ArrowDown',
+  LEFT: 'ArrowLeft',
+  RIGHT: 'ArrowRight',
+  TAB: 'Tab',
+  RETURN: 'Enter',
+  COMMA: ',',
+  DELETE: 'Backspace',
 };
 
-const COMBO_KEYS = [
+const NAVIGATION_KEYS = [
   KEYS.COMMA,
   KEYS.DELETE,
   KEYS.LEFT,
   KEYS.RIGHT,
   KEYS.TAB,
 ];
+
+const LETTERS = /^[a-z]+$/i;
 
 /* TODO: Remove all instances of this.props.listing
    and refactor this component to be more generic */
@@ -128,7 +130,7 @@ class Tags extends Component {
 
     return (
       <div className={`${this.props.classPrefix}__tagswrapper`}>
-        { this.props.listing && <label htmlFor="Tags">Tags</label> }
+        {this.props.listing && <label htmlFor="Tags">Tags</label>}
         <input
           id="tag-input"
           type="text"
@@ -261,23 +263,23 @@ class Tags extends Component {
 
     if (
       component.selected.length === this.props.maxTags &&
-      e.keyCode === KEYS.COMMA
+      e.key === KEYS.COMMA
     ) {
       e.preventDefault();
       return;
     }
 
     if (
-      (e.keyCode === KEYS.DOWN || e.keyCode === KEYS.TAB) &&
+      (e.key === KEYS.DOWN || e.key === KEYS.TAB) &&
       !this.isBottomOfSearchResults &&
-      component.props.defaultValue != ''
+      component.props.defaultValue !== ''
     ) {
       e.preventDefault();
       this.moveDownInSearchResults();
-    } else if (e.keyCode === KEYS.UP && !this.isTopOfSearchResults) {
+    } else if (e.key === KEYS.UP && !this.isTopOfSearchResults) {
       e.preventDefault();
       this.moveUpInSearchResults();
-    } else if (e.keyCode === KEYS.RETURN && this.isSearchResultSelected) {
+    } else if (e.key === KEYS.RETURN && this.isSearchResultSelected) {
       e.preventDefault();
       this.insertTag(
         component.state.searchResults[component.state.selectedIndex].name,
@@ -286,10 +288,10 @@ class Tags extends Component {
       setTimeout(() => {
         document.getElementById('tag-input').focus();
       }, 10);
-    } else if (e.keyCode === KEYS.COMMA && !this.isSearchResultSelected) {
+    } else if (e.key === KEYS.COMMA && !this.isSearchResultSelected) {
       this.resetSearchResults();
       this.clearSelectedSearchResult();
-    } else if (e.keyCode === KEYS.DELETE) {
+    } else if (e.key === KEYS.DELETE) {
       if (
         component.props.defaultValue[
           component.props.defaultValue.length - 1
@@ -297,7 +299,7 @@ class Tags extends Component {
       ) {
         this.clearSelectedSearchResult();
       }
-    } else if ((e.keyCode < 65 || e.keyCode > 90) && !COMBO_KEYS.includes(e.keyCode)) {
+    } else if (!LETTERS.test(e.key) && !NAVIGATION_KEYS.includes(e.key)) {
       e.preventDefault();
     }
   };

--- a/app/javascript/shared/components/tags.jsx
+++ b/app/javascript/shared/components/tags.jsx
@@ -20,7 +20,7 @@ const NAVIGATION_KEYS = [
   KEYS.TAB,
 ];
 
-const LETTERS = /\w/i;
+const LETTERS = /[a-z]/i;
 
 /* TODO: Remove all instances of this.props.listing
    and refactor this component to be more generic */
@@ -299,7 +299,9 @@ class Tags extends Component {
       ) {
         this.clearSelectedSearchResult();
       }
-    } else if (!LETTERS.test(e.key) && !NAVIGATION_KEYS.includes(e.key)) {
+    } else if (
+      !LETTERS.test(e.key) &&
+      !NAVIGATION_KEYS.includes(e.key)) {
       e.preventDefault();
     }
   };


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor

## Description
Move combination key codes to separate const in `tags.jsx` file.
Add test for checking `preventDefault` in `handleKeyDown` method.

Suggestions comes form codeclimate.
https://codeclimate.com/github/thepracticaldev/dev.to/app/javascript/shared/components/tags.jsx/source#issue-a087ee1bf368783e621a0b4563a3aaeb

## Related Tickets & Documents
https://codeclimate.com/github/thepracticaldev/dev.to/app/javascript/shared/components/tags.jsx/source#issue-a087ee1bf368783e621a0b4563a3aaeb

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
