### PR TITLE
[WIP] Add StaticKit email form liquid tag

### DIFF
--- a/app/assets/stylesheets/ltags/LiquidTags.scss
+++ b/app/assets/stylesheets/ltags/LiquidTags.scss
@@ -13,3 +13,4 @@
 @import 'PollTag';
 @import 'ClassifiedListingTag';
 @import 'StackexchangeTag';
+@import 'StatickitTag';

--- a/app/assets/stylesheets/ltags/StatickitTag.scss
+++ b/app/assets/stylesheets/ltags/StatickitTag.scss
@@ -1,0 +1,31 @@
+@import 'variables';
+.ltag__statickit{
+  align-items: center;
+  display: flex;
+  font-family: $helvetica-condensed;
+  font-size: 1.4rem;
+  font-stretch: condensed;
+  padding: 0.2rem;
+  .ltag__statickit__input{
+    flex-grow: 1;
+    font-size: 1.2rem;
+    font-weight: 500;
+    margin: 0 1rem;
+    padding: 5px 12px;
+  }
+  .ltag__statickit__btn{
+    appearance: none;
+    color: white;
+    cursor: pointer;
+    background: $bold-blue;
+    border: 0;
+    border-radius: 3px;
+    font-size: 1.4rem;
+    font-weight: 500;
+    padding: 5px 12px;
+  }
+  .ltag__statickit__error{
+    color: $red;
+    margin-right: 1rem;
+  }
+}

--- a/app/liquid_tags/statickit_tag.rb
+++ b/app/liquid_tags/statickit_tag.rb
@@ -1,0 +1,19 @@
+class StatickitTag < LiquidTagBase
+  PARTIAL = "liquids/statickit".freeze
+
+  def initialize(tag_name, id, tokens)
+    super
+    @id = id.strip
+  end
+
+  def render(_context)
+    ActionController::Base.new.render_to_string(
+      partial: PARTIAL,
+      locals: {
+        id: @id
+      },
+    )
+  end
+end
+
+Liquid::Template.register_tag("statickit", StatickitTag)

--- a/app/views/liquids/_statickit.html.erb
+++ b/app/views/liquids/_statickit.html.erb
@@ -1,0 +1,23 @@
+<form id="statickit" class="ltag__statickit">
+  <label for="email" class="ltag__statickit__label">Email</label><br />
+  <input id="email" type="email" name="email" class="ltag__statickit__input" placeholder="Receive updates from the author" required />
+  <div data-sk-error="email" class="ltag__statickit__error"></div>
+  <button type="submit" class="ltag__statickit__btn">Sign up</button>
+</form>
+
+<script>
+    window.sk=window.sk||function(){(sk.q=sk.q||[]).push(arguments)};
+
+    sk('form', 'init', {
+        id: '<%= id %>',
+        element: '#statickit',
+        onSuccess: function(config) {
+            var h = config.h;
+            var form = config.form;
+            var replacement = h('div.ltag__statickit', 'Thank you for subscribing!');
+            form.parentNode.replaceChild(replacement, form);
+        }
+    });
+</script>
+
+<script defer src="https://js.statickit.com/statickit.js"></script>

--- a/spec/liquid_tags/statickit_tag_spec.rb
+++ b/spec/liquid_tags/statickit_tag_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe StatickitTag, type: :liquid_template do
+  describe "#id" do
+    let(:statickit_id) { "8h34hp284732" }
+
+    def generate_new_liquid(id)
+      Liquid::Template.register_tag("statickit", StatickitTag)
+      Liquid::Template.parse("{% statickit #{id} %}")
+    end
+
+    it "accepts statickit id" do
+      expect { generate_new_liquid(statickit_id) }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

To allow authors to have more agency in being decoupled from one centralized service, I would like to see some way to build an audience that can be reached outside of Dev. This PR is more of a proof-of-concept of what a liquid tag for allowing users to collect reader's emails using an external service, in this case [StaticKit](https://statickit.com/)

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

<img width="755" alt="emailform" src="https://user-images.githubusercontent.com/8952123/66264221-472eb280-e7cf-11e9-96e0-e2ee8b06af6a.png">

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [ ] no documentation needed
