### PR TITLE
Fixed invalid body_markdown in article with video

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -56,7 +56,7 @@ class ArticlesController < ApplicationController
                elsif @tag.present?
                  skip_authorization
                  Article.new(
-                   body_markdown: "---\ntitle: \npublished: false\ndescription: \ntags: " + @tag.name + "\n---\n\n",
+                   body_markdown: "---\ntitle: \npublished: false\ndescription: \ntags: #{@tag.name}\n---\n\n",
                    processed_html: "", user_id: current_user&.id
                  )
                else

--- a/app/services/article_with_video_creation_service.rb
+++ b/app/services/article_with_video_creation_service.rb
@@ -32,15 +32,8 @@ class ArticleWithVideoCreationService
 
   def initial_article_with_params(article)
     if @current_user.editor_version == "v1"
-      article.body_markdown = <<~BODY
-        ---
-        title: Unpublished Video ~ #{rand(100_000).to_s(26)}
-        published: false
-        description:
-        tags:
-        ---
-        
-      BODY
+      title = "Unpublished Video ~ #{rand(100_000).to_s(26)}"
+      article.body_markdown = "---\ntitle: #{title}\npublished: false\ndescription: \ntags: \n---\n\n"
     else
       article.body_markdown = ""
       article.title = "Unpublished Video ~ #{rand(100_000).to_s(26)}"

--- a/spec/services/article_with_video_creation_service_spec.rb
+++ b/spec/services/article_with_video_creation_service_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe ArticleWithVideoCreationService, type: :service do
       Timecop.return
       test = build_stubbed(:article, user: user, video: link).attributes.symbolize_keys
       article = described_class.new(test, user).create!
+      expect(article.body_markdown.inspect).to include("description: \\ntags: \\n")
       expect(article.video_state).to eq("PROGRESSING")
     end
   end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
After upload video creates an article with body_markdown with an empty description and failed to parse tags

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/issues/3846

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

