### PR TITLE
Fixes Github Liquid Tag alignment in notifications page

### DIFF
--- a/app/assets/stylesheets/ltags/GithubTag.scss
+++ b/app/assets/stylesheets/ltags/GithubTag.scss
@@ -8,7 +8,7 @@
     margin: 0 0 0.7em;
     @media screen and (min-width: 500px) {
       word-wrap: break-word;
-      margin-left: -20px;
+      // margin-left: -20px;
       margin-bottom: 10px;
     }
     a {

--- a/app/assets/stylesheets/ltags/GithubTag.scss
+++ b/app/assets/stylesheets/ltags/GithubTag.scss
@@ -8,7 +8,6 @@
     margin: 0 0 0.7em;
     @media screen and (min-width: 500px) {
       word-wrap: break-word;
-      // margin-left: -20px;
       margin-bottom: 10px;
     }
     a {


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
Github liquid tag header goes out of its parent element
## Related Tickets & Documents
Resolves https://github.com/thepracticaldev/dev.to/issues/3661
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
**Before**
![Screen Shot 2019-10-06 at 9 36 57 AM](https://user-images.githubusercontent.com/19770382/66275471-b93de080-e83d-11e9-81a5-21924a4a778b.png)

**After**
![Screen Shot 2019-10-06 at 1 03 13 PM](https://user-images.githubusercontent.com/19770382/66275472-bcd16780-e83d-11e9-95b3-845bdd24f608.png)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?
![shy-type](https://media.giphy.com/media/eJT738HFSQDVS/giphy.gif)
