### PR TITLE
Rescue SocketError when trying to fetch a podcast

### DIFF
--- a/app/services/podcasts/feed.rb
+++ b/app/services/podcasts/feed.rb
@@ -19,7 +19,7 @@ module Podcasts
       end
       podcast.update_columns(reachable: true, status_notice: "")
       feed.items.size
-    rescue Net::OpenTimeout, Errno::ECONNREFUSED => _e
+    rescue Net::OpenTimeout, Errno::ECONNREFUSED, SocketError => _e
       set_unreachable(:unreachable, force_update)
     rescue OpenSSL::SSL::SSLError => _e
       set_unreachable(:ssl_failed, force_update)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Rescue `SocketError` and mark a podcast as unreachable in that case.