### PR TITLE
Bust non-article comment cache without issues

### DIFF
--- a/app/labor/cache_buster.rb
+++ b/app/labor/cache_buster.rb
@@ -17,14 +17,9 @@ class CacheBuster
   def bust_comment(commentable)
     return unless commentable
 
-    bust("/") if Article.published.order("hotness_score DESC").limit(3).pluck(:id).include?(commentable.id)
-    if commentable.decorate.cached_tag_list_array.include?("discuss") &&
-        commentable.featured_number.to_i > 35.hours.ago.to_i
-      bust("/")
-      bust("/?i=i")
-      bust("?i=i")
-    end
-    commentable.touch(:last_comment_at)
+    bust_article_comment(commentable) if commentable.is_a?(Article)
+    commentable.touch(:last_comment_at) if commentable.respond_to?(:last_comment_at)
+
     bust("#{commentable.path}/comments/")
     bust(commentable.path.to_s)
     commentable.comments.includes(:user).find_each do |comment|
@@ -174,5 +169,16 @@ class CacheBuster
       "/feed/#{username}"
     ]
     paths.each { |path| bust(path) }
+  end
+
+  # bust commentable if it's an article
+  def bust_article_comment(commentable)
+    bust("/") if Article.published.order("hotness_score DESC").limit(3).pluck(:id).include?(commentable.id)
+    if commentable.decorate.cached_tag_list_array.include?("discuss") &&
+        commentable.featured_number.to_i > 35.hours.ago.to_i
+      bust("/")
+      bust("/?i=i")
+      bust("?i=i")
+    end
   end
 end

--- a/spec/labor/cache_buster_spec.rb
+++ b/spec/labor/cache_buster_spec.rb
@@ -14,6 +14,11 @@ RSpec.describe CacheBuster do
     it "busts comment" do
       cache_buster.bust_comment(comment.commentable)
     end
+
+    it "busts podcast episode comment" do
+      ep_comment = create(:comment, commentable: podcast_episode)
+      cache_buster.bust_comment(ep_comment.commentable)
+    end
   end
 
   describe "#bust_article" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
`commentable` can be not only an `Article` but at least a `PodcastEpisode`. In this case `bust_comment(commentable)` failed because `PodcastEpisode` doesn't respond_to `last_comment_at`. Checks before busting the main page also are made for the `Article` commentable. This pr fixes these issues, I also added a test which would fail with the previous implementation.