### PR TITLE
fix scrollheight calculation by using scrollable element instead of document element

### DIFF
--- a/app/assets/javascripts/initializers/initScrolling.js.erb
+++ b/app/assets/javascripts/initializers/initScrolling.js.erb
@@ -24,21 +24,38 @@ function checkIfNearBottomOfPage() {
 }
 
 function fetchNextPageIfNearBottom() {
-  var elCheck = document.getElementById("index-container") && !document.getElementById("query-wrapper");
+  var indexContainer = document.getElementById("index-container");
+  var elCheck =  indexContainer && !document.getElementById("query-wrapper");
   if (!elCheck) {
     return;
   }
-  if ( !done && !fetching && (window.scrollY) > (document.documentElement.scrollHeight - 3700) ) {
+  
+  var indexWhich = indexContainer.dataset.which;
+
+  var fetchCallback;
+  var scrollableElemId;
+  if (indexWhich == "podcast-episodes") {
+    scrollableElemId = "articles-list";
+    fetchCallback = function() {
+      fetchNextPodcastPage(indexContainer);
+    };
+  } else if (indexWhich == "videos") {
+    scrollableElemId = "video-collection";
+    fetchCallback = function() {
+      fetchNextVideoPage(indexContainer);
+    };
+  } else {
+    scrollableElemId = "articles-list";
+    fetchCallback = function() {
+      algoliaPaginate(indexContainer.dataset.algoliaTag);
+    };
+  }
+
+  var scrollableElem = document.getElementById(scrollableElemId);
+
+  if ( !done && !fetching && (window.scrollY) > (scrollableElem.scrollHeight - 3700) ) {
     fetching = true;
-    var el = document.getElementById("index-container");
-    var indexWhich = el.dataset.which;
-    if (indexWhich == "podcast-episodes") {
-      fetchNextPodcastPage(el);
-    } else if (indexWhich == "videos") {
-      fetchNextVideoPage(el)
-    } else {
-      algoliaPaginate(el.dataset.algoliaTag);
-    }
+    fetchCallback();
   }
 }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
Fixes #1805 by changing scrollHeight calculation in initScrolling to use the actual scrollable element vs. the document element.

Re-submission of https://github.com/thepracticaldev/dev.to/pull/4247. Initial commit in that PR was made without having my git identity setup (new laptop). This re-submission is simply to associate my git identity with the commits to satisfy CLA Assistant.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
