### PR TITLE
Fix broken job specs

### DIFF
--- a/spec/jobs/articles/bust_cache_job_spec.rb
+++ b/spec/jobs/articles/bust_cache_job_spec.rb
@@ -3,13 +3,26 @@ require "rails_helper"
 RSpec.describe Articles::BustCacheJob, type: :job do
   describe "#perform_now" do
     let(:article) { FactoryBot.create(:article) }
+    let(:cache_buster) { double }
+
+    before { allow(cache_buster).to receive(:bust_article) }
 
     it "async busts cache" do
-      cache_buster = double
-      allow(cache_buster).to receive(:bust_article)
-
       described_class.perform_now(article.id, cache_buster)
       expect(cache_buster).to have_received(:bust_article).with(article)
+    end
+
+    context "without article" do
+      let(:article) { nil }
+
+      it "does not error" do
+        expect { described_class.perform_now(nil, cache_buster) }.not_to raise_error
+      end
+
+      it "does not bust cache" do
+        described_class.perform_now(nil, cache_buster)
+        expect(cache_buster).not_to have_received(:bust_article)
+      end
     end
   end
 end

--- a/spec/jobs/articles/bust_cache_job_spec.rb
+++ b/spec/jobs/articles/bust_cache_job_spec.rb
@@ -13,8 +13,6 @@ RSpec.describe Articles::BustCacheJob, type: :job do
     end
 
     context "without article" do
-      let(:article) { nil }
-
       it "does not error" do
         expect { described_class.perform_now(nil, cache_buster) }.not_to raise_error
       end

--- a/spec/jobs/articles/bust_cache_job_spec.rb
+++ b/spec/jobs/articles/bust_cache_job_spec.rb
@@ -8,18 +8,8 @@ RSpec.describe Articles::BustCacheJob, type: :job do
       cache_buster = double
       allow(cache_buster).to receive(:bust_article)
 
-      described_class.perform_now(article.id, cache_buster) do
-        expect(cache_buster).to have_receive(:bust_article).with(article)
-      end
-    end
-
-    it "does not async bust cache when article is not found" do
-      cache_buster = double
-      allow(cache_buster).to receive(:bust_article)
-
-      described_class.perform_now(9999, cache_buster) do
-        expect(cache_buster).not_to have_receive(:bust_article).with(article)
-      end
+      described_class.perform_now(article.id, cache_buster)
+      expect(cache_buster).to have_received(:bust_article).with(article)
     end
   end
 end

--- a/spec/jobs/articles/detect_human_language_job_spec.rb
+++ b/spec/jobs/articles/detect_human_language_job_spec.rb
@@ -11,5 +11,13 @@ RSpec.describe Articles::DetectHumanLanguageJob, type: :job do
       described_class.perform_now(article.id)
       expect(article.language).to eql("en")
     end
+
+    context "without aritcle" do
+      let(:article) { nil }
+
+      it "does not error" do
+        expect { described_class.perform_now(nil) }.not_to raise_error
+      end
+    end
   end
 end

--- a/spec/jobs/articles/detect_human_language_job_spec.rb
+++ b/spec/jobs/articles/detect_human_language_job_spec.rb
@@ -8,18 +8,8 @@ RSpec.describe Articles::DetectHumanLanguageJob, type: :job do
       detector = double
       allow(detector).to receive(:detect).and_return("en")
 
-      described_class.perform_now(article.id) do
-        expect(article.language).to be("en")
-      end
-    end
-
-    it "does not update article language with detected language when no article is found" do
-      detector = double
-      allow(detector).to receive(:detect).and_return("en")
-
-      described_class.perform_now(9999) do
-        expect(article.language).not_to be("en")
-      end
+      described_class.perform_now(article.id)
+      expect(article.language).to eql("en")
     end
   end
 end

--- a/spec/jobs/articles/detect_human_language_job_spec.rb
+++ b/spec/jobs/articles/detect_human_language_job_spec.rb
@@ -13,8 +13,6 @@ RSpec.describe Articles::DetectHumanLanguageJob, type: :job do
     end
 
     context "without aritcle" do
-      let(:article) { nil }
-
       it "does not error" do
         expect { described_class.perform_now(nil) }.not_to raise_error
       end

--- a/spec/jobs/articles/score_calc_job_spec.rb
+++ b/spec/jobs/articles/score_calc_job_spec.rb
@@ -22,8 +22,6 @@ RSpec.describe Articles::ScoreCalcJob, type: :job do
     end
 
     context "without article" do
-      let(:article) { nil }
-
       it "does not error" do
         expect { described_class.perform_now(nil) }.not_to raise_error
       end

--- a/spec/jobs/articles/score_calc_job_spec.rb
+++ b/spec/jobs/articles/score_calc_job_spec.rb
@@ -12,20 +12,13 @@ RSpec.describe Articles::ScoreCalcJob, type: :job do
       allow(BlackBox).to receive(:calculate_spaminess).and_return(2)
     end
 
-    it "updates article scores" do
-      described_class.perform_now(article.id) do
-        expect(article.score).to be(7)
-        expect(article.hotness_score).to be(373)
-        expect(article.spaminess_rating).to be(2)
-      end
-    end
-
-    it "does not update article scores when no article" do
-      described_class.perform_now(article.id) do
-        expect(article.score).not_to be(7)
-        expect(article.hotness_score).not_to be(373)
-        expect(article.spaminess_rating).not_to be(2)
-      end
+    it "updates article scores", :aggregate_failures do
+      allow(Article).to receive(:find_by).and_return(article)
+      described_class.perform_now(article.id)
+      article.reload
+      expect(article.score).to be(7)
+      expect(article.hotness_score).to be(373)
+      expect(article.spaminess_rating).to be(2)
     end
   end
 end

--- a/spec/jobs/articles/score_calc_job_spec.rb
+++ b/spec/jobs/articles/score_calc_job_spec.rb
@@ -7,18 +7,32 @@ RSpec.describe Articles::ScoreCalcJob, type: :job do
     let(:article) { FactoryBot.create(:article) }
 
     before do
-      allow(article.reactions).to receive(:sum).and_return(7)
       allow(BlackBox).to receive(:article_hotness_score).and_return(373)
       allow(BlackBox).to receive(:calculate_spaminess).and_return(2)
     end
 
     it "updates article scores", :aggregate_failures do
       allow(Article).to receive(:find_by).and_return(article)
+      allow(article.reactions).to receive(:sum).and_return(7)
       described_class.perform_now(article.id)
       article.reload
       expect(article.score).to be(7)
       expect(article.hotness_score).to be(373)
       expect(article.spaminess_rating).to be(2)
+    end
+
+    context "without article" do
+      let(:article) { nil }
+
+      it "does not error" do
+        expect { described_class.perform_now(nil) }.not_to raise_error
+      end
+
+      it "does not calculate scores", :aggregate_failures do
+        described_class.perform_now(nil)
+        expect(BlackBox).not_to have_received(:article_hotness_score)
+        expect(BlackBox).not_to have_received(:calculate_spaminess)
+      end
     end
   end
 end

--- a/spec/jobs/articles/update_main_image_background_hex_job_spec.rb
+++ b/spec/jobs/articles/update_main_image_background_hex_job_spec.rb
@@ -12,5 +12,13 @@ RSpec.describe Articles::UpdateMainImageBackgroundHexJob, type: :job do
       described_class.perform_now(article.id)
       expect(article.reload.main_image_background_hex_color).to eql("#eee")
     end
+
+    context "without article" do
+      let(:article) { nil }
+
+      it "does not error" do
+        expect { described_class.perform_now(nil) }.not_to raise_error
+      end
+    end
   end
 end

--- a/spec/jobs/articles/update_main_image_background_hex_job_spec.rb
+++ b/spec/jobs/articles/update_main_image_background_hex_job_spec.rb
@@ -14,8 +14,6 @@ RSpec.describe Articles::UpdateMainImageBackgroundHexJob, type: :job do
     end
 
     context "without article" do
-      let(:article) { nil }
-
       it "does not error" do
         expect { described_class.perform_now(nil) }.not_to raise_error
       end

--- a/spec/jobs/articles/update_main_image_background_hex_job_spec.rb
+++ b/spec/jobs/articles/update_main_image_background_hex_job_spec.rb
@@ -7,19 +7,10 @@ RSpec.describe Articles::UpdateMainImageBackgroundHexJob, type: :job do
     it "updates articles main image background hex" do
       color_from_image = double
       allow(color_from_image).to receive(:main).and_return("#eee")
+      allow(ColorFromImage).to receive(:new).and_return(color_from_image)
 
-      described_class.perform_now(article.id) do
-        expect(article.main_image_background_hex_color).to be("#eee")
-      end
-    end
-
-    it "does not update articles main image background hex when no article is found" do
-      color_from_image = double
-      allow(color_from_image).to receive(:main).and_return("#eee")
-
-      described_class.perform_now(9999) do
-        expect(article.main_image_background_hex_color).not_to be("#eee")
-      end
+      described_class.perform_now(article.id)
+      expect(article.reload.main_image_background_hex_color).to eql("#eee")
     end
   end
 end

--- a/spec/jobs/comments/calculate_score_job_spec.rb
+++ b/spec/jobs/comments/calculate_score_job_spec.rb
@@ -5,14 +5,14 @@ RSpec.describe Comments::CalculateScoreJob, type: :job do
     let(:article) { FactoryBot.create(:article) }
     let(:comment) { FactoryBot.create(:comment, commentable: article) }
 
-    it "updates score and spaminess_rating" do
-      allow(BlackBox).to receive(:calculate_spaminess).and_return(7)
-      allow(BlackBox).to receive(:comment_quality_score).and_return(99)
+    it "updates score and spaminess_rating", :aggregate_failures do
+      allow(BlackBox).to receive(:calculate_spaminess).and_return(99)
+      allow(BlackBox).to receive(:comment_quality_score).and_return(7)
 
-      described_class.perform_now(comment.id) do
-        expect(comment.score).to be(7)
-        expect(comment.spaminess_rating).to be(99)
-      end
+      described_class.perform_now(comment.id)
+      comment.reload
+      expect(comment.score).to be(7)
+      expect(comment.spaminess_rating).to be(99)
     end
   end
 end

--- a/spec/jobs/comments/create_id_code_job_spec.rb
+++ b/spec/jobs/comments/create_id_code_job_spec.rb
@@ -6,9 +6,8 @@ RSpec.describe Comments::CreateIdCodeJob, type: :job do
     let(:comment) { FactoryBot.create(:comment, commentable: article) }
 
     it "creates an id code" do
-      described_class.perform_now(comment.id) do
-        expect(comment.id_code).to eql(comment.id.to_s(26))
-      end
+      described_class.perform_now(comment.id)
+      expect(comment.reload.id_code).to eql(comment.id.to_s(26))
     end
   end
 end

--- a/spec/jobs/comments/send_email_notification_job_spec.rb
+++ b/spec/jobs/comments/send_email_notification_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Comments::SendEmailNotificationJob, type: :job do
     let(:comment) { FactoryBot.create(:comment, commentable: article) }
 
     it "sends notify email" do
-      allow(NotifyMailer).to receive(:new_reply_email).and_call_original
+      allow(NotifyMailer).to receive(:new_reply_email)
 
       described_class.perform_now(comment.id)
       expect(NotifyMailer).to have_received(:new_reply_email).with(comment)

--- a/spec/jobs/comments/send_email_notification_job_spec.rb
+++ b/spec/jobs/comments/send_email_notification_job_spec.rb
@@ -6,11 +6,10 @@ RSpec.describe Comments::SendEmailNotificationJob, type: :job do
     let(:comment) { FactoryBot.create(:comment, commentable: article) }
 
     it "sends notify email" do
-      allow(NotifyMailer).to receive(:new_reply_email)
+      allow(NotifyMailer).to receive(:new_reply_email).and_call_original
 
-      described_class.perform_now(comment.id) do
-        expect(NotifyMailer).to have_receive(:new_reply_email).with(comment).and_call_original
-      end
+      described_class.perform_now(comment.id)
+      expect(NotifyMailer).to have_received(:new_reply_email).with(comment)
     end
   end
 end

--- a/spec/jobs/comments/touch_user_job_spec.rb
+++ b/spec/jobs/comments/touch_user_job_spec.rb
@@ -2,14 +2,17 @@ require "rails_helper"
 
 RSpec.describe Comments::TouchUserJob, type: :job do
   describe "#perform_now" do
-    let(:article) { FactoryBot.create(:article) }
-    let(:comment) { FactoryBot.create(:comment, commentable: article) }
+    let!(:article) { FactoryBot.create(:article) }
+    let!(:comment) { FactoryBot.create(:comment, commentable: article) }
+    let(:user) { comment.user }
+    let(:touched_at) { 5.minutes.from_now }
 
-    it "touches user updated_at and last_comment_at columns" do
-      allow(comment.user).to receive(:touch)
-
-      described_class.perform_now(comment.id) do
-        expect(comment.user).to have_receive(:touch).with(:updated_at, :last_comment_at)
+    it "touches user updated_at and last_comment_at columns", :aggregate_failures do
+      Timecop.freeze(touched_at) do
+        described_class.perform_now(comment.id)
+        user.reload
+        expect(user.updated_at).to eql(touched_at)
+        expect(user.last_comment_at).to eql(touched_at)
       end
     end
   end

--- a/spec/jobs/comments/touch_user_job_spec.rb
+++ b/spec/jobs/comments/touch_user_job_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Comments::TouchUserJob, type: :job do
     let!(:article) { FactoryBot.create(:article) }
     let!(:comment) { FactoryBot.create(:comment, commentable: article) }
     let(:user) { comment.user }
-    let(:touched_at) { 5.minutes.from_now }
+    let(:touched_at) { 5.minutes.from_now.beginning_of_minute }
 
     it "touches user updated_at and last_comment_at columns", :aggregate_failures do
       Timecop.freeze(touched_at) do

--- a/spec/jobs/pro_memberships/populate_history_job_spec.rb
+++ b/spec/jobs/pro_memberships/populate_history_job_spec.rb
@@ -4,16 +4,16 @@ RSpec.describe ProMemberships::PopulateHistoryJob, type: :job do
   include_examples "#enqueues_job", "pro_memberships_populate_history", 1
 
   describe "#perform_now" do
-    let(:user) { create(:user) }
+    let(:user) { create(:user, :pro) }
 
     before do
+      allow(User).to receive(:find_by).and_return(user)
       allow(user.page_views).to receive(:reindex!)
     end
 
     it "indexes user page views" do
-      described_class.perform_now(user.id) do
-        expect(user.page_views).to have_received(:reindex!).once
-      end
+      described_class.perform_now(user.id)
+      expect(user.page_views).to have_received(:reindex!).once
     end
   end
 end

--- a/spec/jobs/users/bust_cache_job_spec.rb
+++ b/spec/jobs/users/bust_cache_job_spec.rb
@@ -10,9 +10,8 @@ RSpec.describe Users::BustCacheJob, type: :job do
       cache_buster = double
       allow(cache_buster).to receive(:bust_user)
 
-      described_class.perform_now(user.id, cache_buster) do
-        expect(cache_buster).to have_received(:bust_user).with(user)
-      end
+      described_class.perform_now(user.id, cache_buster)
+      expect(cache_buster).to have_received(:bust_user).with(user)
     end
   end
 end

--- a/spec/jobs/users/resave_articles_job_spec.rb
+++ b/spec/jobs/users/resave_articles_job_spec.rb
@@ -10,9 +10,8 @@ RSpec.describe Users::ResaveArticlesJob, type: :job do
     it "resaves articles" do
       old_updated_at = article.updated_at
       Timecop.freeze(Time.current) do
-        described_class.perform_now(user.id) do
-          expect(article.reload.updated_at > old_updated_at).to be(true)
-        end
+        described_class.perform_now(user.id)
+        expect(article.reload.updated_at > old_updated_at).to be(true)
       end
     end
   end

--- a/spec/jobs/users/subscribe_to_mailchimp_newsletter_job_spec.rb
+++ b/spec/jobs/users/subscribe_to_mailchimp_newsletter_job_spec.rb
@@ -9,10 +9,11 @@ RSpec.describe Users::SubscribeToMailchimpNewsletterJob, type: :job do
     it "subscribes user to mailchimp newsletter" do
       mailchimp_bot = double
       allow(MailchimpBot).to receive(:new).and_return(mailchimp_bot)
-
-      expect(mailchimp_bot).to receive(:upsert)
+      allow(mailchimp_bot).to receive(:upsert)
 
       described_class.perform_now(user.id)
+
+      expect(mailchimp_bot).to have_received(:upsert)
     end
   end
 end

--- a/spec/jobs/users/subscribe_to_mailchimp_newsletter_job_spec.rb
+++ b/spec/jobs/users/subscribe_to_mailchimp_newsletter_job_spec.rb
@@ -7,13 +7,12 @@ RSpec.describe Users::SubscribeToMailchimpNewsletterJob, type: :job do
     let(:user) { FactoryBot.create(:user) }
 
     it "subscribes user to mailchimp newsletter" do
-      mailchimp_bot = MailchimpBot.new(user)
+      mailchimp_bot = double
+      allow(MailchimpBot).to receive(:new).and_return(mailchimp_bot)
 
-      allow(mailchimp_bot).to receive(:upsert)
+      expect(mailchimp_bot).to receive(:upsert)
 
-      described_class.perform_now(user.id) do
-        expect(mailchimp_bot).to have_received(:upsert)
-      end
+      described_class.perform_now(user.id)
     end
   end
 end


### PR DESCRIPTION
Resolves #4269 

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description


Many job specs were putting their assertions inside a block provided to
ActiveJob's perform_now. Unfortunately, this syntax does not error and
simply ignores the provided block.

The tests were therefore not executing their assertions. As a result
many of them were actually broken to begin with. Many used incorrect
stubbing, were trying to stub instances of models that wouldn't actually
be returned by ActiveRecord queries, etc.

This commit fixes the syntax and does it's best to fix the tests. Many
of these assertions/spec could use more TLC, but this work at least gets
them passing/executing.

## Related Tickets & Documents
#4269 

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?
<img src="https://media1.tenor.com/images/89a3e55b61cfd2db4664ea5350272d98/tenor.gif?itemid=4513526"/>
