### PR TITLE
added 'bundle install' prior to 'bin setup'

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ This section provides a high-level requirement & quick start guide. **For detail
    - If you are missing `ENV` variables on bootup, `envied` gem will alert you with messages similar to `'error_on_missing_variables!': The following environment variables should be set: A_MISSING_KEY.`.
    - You do not need "real" keys for basic development. Some features require certain keys, so you may be able to add them as you go.
 
+1. Run `bundle install`
 1. Run `bin/setup`
 1. That's it! Run `bin/startup` to start the application and head to `http://localhost:3000/`
 


### PR DESCRIPTION
Running `bin/setup` as per instructions produced the following line in red, but apparently non-fatally, as it continued running:

> https://github.com/thepracticaldev/acts_as_follower.git (at master@288690c) is not yet checked out. Run `bundle install` first.

So I ctrl-C'ed that, ran `bundle install` (took several minutes), started `bin/setup` again, didn't get above error. But seems I still have some work to do getting the (apparently graduate-level) post-GRE-SQL set up.

>   (3018.4ms)  CREATE DATABASE "PracticalDeveloper_development" ENCODING = 'unicode'
>PG::QueryCanceled: ERROR:  canceling statement due to statement timeout
>: CREATE DATABASE "PracticalDeveloper_development" ENCODING = 'unicode'
>Couldn't create 'PracticalDeveloper_development' database. Please check your configuration.
>rails aborted!
>ActiveRecord::QueryCanceled: PG::QueryCanceled: ERROR:  canceling statement due to statement timeout
>: CREATE DATABASE "PracticalDeveloper_development" ENCODING = 'unicode'
>bin/rails:4:in `<main>'

>Caused by:
>PG::QueryCanceled: ERROR:  canceling statement due to statement timeout
>bin/rails:4:in `<main>'
>Tasks: TOP => db:setup => db:schema:load_if_ruby => db:create
>(See full trace by running task with --trace)
>**Airbrake: closed
>
>== Command ["bin/rails db:setup"] failed ==
>

<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Documentation Update

## Description

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [x] readme
- [ ] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![post-GRE](https://blog.timescale.com/content/images/2018/12/moving.gif)