### PR TITLE
[WIP] add series liquid tag 

### DIFF
--- a/app/assets/stylesheets/article-show.scss
+++ b/app/assets/stylesheets/article-show.scss
@@ -337,83 +337,6 @@ article {
     }
   }
 
-  .article-collection-wrapper {
-    font-family: $helvetica;
-    font-size: 16px;
-    border-radius: 5px;
-    border: 1px solid $light-medium-gray;
-    width: 92%;
-    max-width: 500px;
-    margin: calc(1.1vw + 5px) auto 1.0vw;
-    box-shadow: $bold-shadow;
-    p {
-      margin: 0px auto;
-      padding: calc(0.1vw + 9px);
-      font-weight: bold;
-      font-size: 0.96em;
-    }
-
-    .article-collection {
-      user-select: none;
-      font-size: 16px;
-      overflow: hidden;
-      position: relative;
-      z-index: 8;
-      a {
-        @include themeable (
-          color,
-          theme-color,
-          $black
-        );
-        padding: calc(0.1vw + 9px);
-        display: block;
-        position: relative;
-        z-index: 4;
-        border-top: 1px solid $light-medium-gray;
-        font-size: 0.88em;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        &:last-child {
-          border-bottom-left-radius: 5px;
-          border-bottom-right-radius: 5px;
-        }
-
-        &:hover {
-          @include themeable (
-            background,
-            theme-series-article-hover,
-            $lightest-gray
-          );
-        }
-
-        &.current-article {
-          @include themeable (
-            background,
-            theme-series-article-background,
-            lighten($sky-blue, 21%)
-          );
-        }
-
-        &.coming-soon {
-          pointer-events: none;
-          color: lighten($black, 78%);
-        }
-        &.collection-link-hidden {
-          display: none;
-        }
-      }
-    }
-
-    &.article-collection-wrapper-bottom {
-      margin-bottom: 3vw;
-
-      p {
-        margin-top: 5px;
-      }
-    }
-  }
-
   .body {
     margin: auto;
     width: 82%;
@@ -766,6 +689,83 @@ article {
 
     .twitter-tweet {
       margin: auto;
+    }
+  }
+
+  .article-collection-wrapper {
+    font-family: $helvetica;
+    font-size: 16px;
+    border-radius: 5px;
+    border: 1px solid $light-medium-gray;
+    width: 92%;
+    max-width: 500px;
+    margin: calc(1.1vw + 5px) auto 1.0vw;
+    box-shadow: $bold-shadow;
+    p {
+      margin: 0px auto;
+      padding: calc(0.1vw + 9px);
+      font-weight: bold;
+      font-size: 0.96em;
+    }
+
+    .article-collection {
+      user-select: none;
+      font-size: 16px;
+      overflow: hidden;
+      position: relative;
+      z-index: 8;
+      a {
+        @include themeable (
+          color,
+          theme-color,
+          $black
+        );
+        padding: calc(0.1vw + 9px);
+        display: block;
+        position: relative;
+        z-index: 4;
+        border-top: 1px solid $light-medium-gray;
+        font-size: 0.88em;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        &:last-child {
+          border-bottom-left-radius: 5px;
+          border-bottom-right-radius: 5px;
+        }
+
+        &:hover {
+          @include themeable (
+            background,
+            theme-series-article-hover,
+            $lightest-gray
+          );
+        }
+
+        &.current-article {
+          @include themeable (
+            background,
+            theme-series-article-background,
+            lighten($sky-blue, 21%)
+          );
+        }
+
+        &.coming-soon {
+          pointer-events: none;
+          color: lighten($black, 78%);
+        }
+        &.collection-link-hidden {
+          display: none;
+        }
+      }
+    }
+
+    &.article-collection-wrapper-bottom {
+      margin-bottom: 3vw;
+
+      p {
+        margin-top: 5px;
+      }
     }
   }
 

--- a/app/liquid_tags/series_tag.rb
+++ b/app/liquid_tags/series_tag.rb
@@ -1,0 +1,46 @@
+class SeriesTag < LiquidTagBase
+  include ActionView::Helpers
+  PARTIAL = "liquids/collection".freeze
+
+  def initialize(_tag_name, slug, _tokens)
+    @collection = get_collection(slug)
+  end
+
+  def render(_context)
+    ActionController::Base.new.render_to_string(
+      partial: PARTIAL,
+      locals: { collection: @collection },
+    )
+  end
+
+  def get_collection(slug)
+    slug = ActionController::Base.helpers.strip_tags(slug).strip
+    collection = find_collection_by_user(collection_hash(slug)) || find_collection_by_org(collection_hash(slug))
+    raise StandardError, "Invalid series slug or series does not exist" unless collection
+
+    collection
+  end
+
+  def collection_hash(slug)
+    path = Addressable::URI.parse(slug).path
+    path.slice!(0) if path.starts_with?("/") # remove leading slash if present
+    path.slice!(-1) if path.ends_with?("/") # remove trailing slash if present
+    Addressable::Template.new("{username}/{slug}").extract(path)&.symbolize_keys
+  end
+
+  def find_collection_by_user(hash)
+    user = User.find_by(username: hash[:username])
+    return unless user
+
+    user.collections.where(slug: hash[:slug].tr("-", " "))&.first
+  end
+
+  def find_collection_by_org(hash)
+    org = Organization.find_by(slug: hash[:username])
+    return unless org
+
+    org.collections.where(slug: hash[:slug].tr("-", " "))&.first
+  end
+end
+
+Liquid::Template.register_tag("series", SeriesTag)

--- a/app/views/liquids/_collection.html.erb
+++ b/app/views/liquids/_collection.html.erb
@@ -1,0 +1,29 @@
+<% if collection.present? && collection.articles.published.size > 1 %>
+  <div class="article-collection-wrapper article-collection-wrapper-top">
+    <% if collection.slug.present? %>
+      <p><%= collection.slug %> (<%= collection.articles.published.size %> Part Series)</p>
+    <% else %>
+      <p><%= collection.articles.published.size %> Part Series</p>
+    <% end %>
+    <div class="article-collection">
+      <% collection.articles.published.order("published_at ASC").each_with_index do |article, i| %>
+        <% if collection.articles.published.size > 5 && i == 2 %>
+          <a
+            href="<%= article.path if article.published %>"
+            class="collection-link-inbetween"
+            id="collection-link-inbetween"
+            data-no-instant
+            title="View more">
+            3 ... <%= collection.articles.published.size - 2 %>
+          </a>
+        <% end %>
+        <a
+          href="<%= article.path if article.published %>"
+          class="<%= "collection-link-hidden" if collection.articles.published.size > 5 && (i > 1 && i < collection.articles.published.size - 2) %>"
+          title="Published <%= article.readable_publish_date %>">
+          <%= i + 1 %>) <%= article.title %>
+        </a>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/spec/liquid_tags/series_tag_spec.rb
+++ b/spec/liquid_tags/series_tag_spec.rb
@@ -1,0 +1,83 @@
+require "rails_helper"
+
+RSpec.describe SeriesTag, type: :liquid_template do
+  let(:user) { create(:user, username: "username45", name: "Chase Danger", profile_image: nil) }
+  let(:collection) { create(:collection, slug: "test series", user: user) }
+  let(:article) do
+    create(:article, user_id: user.id, title: "test this please", tags: "tag1 tag2 tag3", collection_id: collection.id, published: true)
+  end
+  let(:article2) do
+    create(:article, user_id: user.id, title: "test this again", tags: "tag1 tag2 tag3", collection_id: collection.id, published: true)
+  end
+  let(:org) { create(:organization) }
+  let(:org_collection) { create(:collection, slug: "org test series", organization: org) }
+  let(:org_user) { create(:user, organization_id: org.id) }
+  let(:org_article) do
+    create(:article, user_id: org_user.id, title: "test this please", tags: "tag1 tag2 tag3",
+                     organization_id: org.id, collection_id: org_collection.id, published: true)
+  end
+  let(:org_article2) do
+    create(:article, user_id: org_user.id, title: "test this again", tags: "tag1 tag2 tag3",
+                     organization_id: org.id, collection_id: org_collection.id, published: true)
+  end
+
+  def correct_series_html(collection)
+    return "" unless collection.articles.published.size > 1
+
+    articles = collection.articles.published.order("published_at ASC").each_with_index do |article, i|
+      <<~HTML
+        <a href="#{article.path}" class="" title="Published #{article.readable_publish_date}">
+        	#{i + 1}) #{article.title}
+        </a>
+      HTML
+    end.join
+    <<~HTML
+      <div class="article-collection-wrapper">
+          <p>#{collection.slug} (#{collection.articles.published.size} Part Series)</p>
+      	<div class="article-collection">
+      		#{articles}
+      	</div>
+      </div>
+    HTML
+  end
+
+  def generate_new_liquid(slug)
+    Liquid::Template.register_tag("series", SeriesTag)
+    Liquid::Template.parse("{% series #{slug.tr(' ', '-')} %}")
+  end
+
+  it "raises an error when invalid" do
+    expect { generate_new_liquid("fake_username/fake_article_slug") }.
+      to raise_error("Invalid series slug or series does not exist")
+  end
+
+  it "renders when valid username and slug are given" do
+    liquid = generate_new_liquid("#{user.username}/#{collection.slug}")
+    expect { liquid.render }.not_to raise_error
+  end
+
+  it "also tries to look for collection by organization if failed to find by username" do
+    liquid = generate_new_liquid("#{org.slug}/#{org_collection.slug}")
+    expect { liquid.render }.not_to raise_error
+  end
+
+  it "renders with a leading slash" do
+    liquid = generate_new_liquid("/#{user.username}/#{collection.slug}")
+    expect { liquid.render }.not_to raise_error
+  end
+
+  it "renders with a trailing slash" do
+    liquid = generate_new_liquid("#{user.username}/#{collection.slug}/")
+    expect { liquid.render }.not_to raise_error
+  end
+
+  it "renders with both leading and trailing slash" do
+    liquid = generate_new_liquid("/#{user.username}/#{collection.slug}/")
+    expect { liquid.render }.not_to raise_error
+  end
+
+  it "renders a proper series tag" do
+    liquid = generate_new_liquid("#{user.username}/#{collection.slug}")
+    expect(liquid.render).to eq(correct_series_html(collection))
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Using liquid tags to link to a Series based on the Series' slug. It displays a card similar to the one rendered when an article is a part of a series.

## Related Tickets & Documents
issue #3046 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [ ] no documentation needed

