### PR TITLE
Specs: use a bigger sample for badges titles

### DIFF
--- a/spec/factories/badges.rb
+++ b/spec/factories/badges.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
   )
 
   factory :badge do
-    title { Faker::Games::Overwatch.quote }
+    title { Faker::Book.title }
     description { Faker::Lorem.sentence }
     badge_image { image }
   end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

We've had multiple times specs failing for this unrelated error:

```ruby
  1) Badges GET /badges when logged in shows all the badges

     Failure/Error: let!(:badges) { create_list(:badge, 3) }

     

     ActiveRecord::RecordInvalid:

       Validation failed: Title has already been taken

     # ./spec/requests/badges_spec.rb:7:in `block (3 levels) in <top (required)>'
```

See https://travis-ci.com/thepracticaldev/dev.to/builds/131156060 for example

I've investigated a bit and I think the issue is that [Faker::Games::Overwatch.title](https://github.com/faker-ruby/faker/blob/master/lib/faker/games/overwatch.rb) has a [sample that's too small](https://github.com/faker-ruby/faker/blob/4555159b7da9813235395d271b1b65a32407086b/lib/locales/en/overwatch.yml)

I've switched to a generator with a bigger sample
