### PR TITLE
Add tag rules to article v2 editor

### DIFF
--- a/app/assets/stylesheets/classified_listings.scss
+++ b/app/assets/stylesheets/classified_listings.scss
@@ -396,7 +396,7 @@
   position: absolute;
   right: 8px;
   top: 9px;
-  border: 0px;
+  border: 0;
   border-radius: 3px;
   background: var(--theme-anchor-color, $sky-blue);
   color: var(--theme-container-background, white);

--- a/app/assets/stylesheets/classified_listings.scss
+++ b/app/assets/stylesheets/classified_listings.scss
@@ -388,36 +388,9 @@
   }
 }
 
-.listingform__tagsoptionsbottomrow {
+.listingform__tagsoptionsbottomrow, .listingform__tagsoptionrulesbutton, .listingform__tagrules--inactive {
   display: none; //not yet fully functional or relevant
 }
-
-.listingform__tagsoptionrulesbutton {
-  position: absolute;
-  right: 8px;
-  top: 9px;
-  border: 0;
-  border-radius: 3px;
-  background: var(--theme-anchor-color, $sky-blue);
-  color: var(--theme-container-background, white);
-  font-size: 0.8em;
-  display: none; //not yet fully functional or relevant
-}
-
-.listingform__tagrules--inactive {
-  display: none
-}
-
-.listingform__tagrules--active {
-  font-size: 0.76em;
-  max-height: 300px;
-  overflow: auto;
-  border: 1px solid $medium-gray;
-  border-radius: 3px;
-  margin-top: 8px;
-  padding: 0px 8px;
-}
-
 
 .listingform__tagoptionrow--active {
   background: $green;

--- a/app/assets/stylesheets/classified_listings.scss
+++ b/app/assets/stylesheets/classified_listings.scss
@@ -381,11 +381,39 @@
 .listingform__tagoptionrow {
   padding: 10px;
   cursor: pointer;
+  position: relative;
   &:hover {
     background: lighten($green, 27%);
     color: $black;
   }
 }
+
+.listingform__tagsoptionrulesbutton {
+  position: absolute;
+  right: 8px;
+  top: 9px;
+  border: 0px;
+  border-radius: 3px;
+  background: var(--theme-anchor-color, $sky-blue);
+  color: var(--theme-container-background, white);
+  font-size: 0.8em;
+  display: none; //not yet fully functional or relevant
+}
+
+.listingform__tagrules--inactive {
+  display: none
+}
+
+.listingform__tagrules--active {
+  font-size: 0.76em;
+  max-height: 300px;
+  overflow: auto;
+  border: 1px solid $medium-gray;
+  border-radius: 3px;
+  margin-top: 8px;
+  padding: 0px 8px;
+}
+
 
 .listingform__tagoptionrow--active {
   background: $green;

--- a/app/assets/stylesheets/classified_listings.scss
+++ b/app/assets/stylesheets/classified_listings.scss
@@ -388,6 +388,10 @@
   }
 }
 
+.listingform__tagsoptionsbottomrow {
+  display: none; //not yet fully functional or relevant
+}
+
 .listingform__tagsoptionrulesbutton {
   position: absolute;
   right: 8px;

--- a/app/assets/stylesheets/preact/article-form.scss
+++ b/app/assets/stylesheets/preact/article-form.scss
@@ -269,6 +269,7 @@
   padding: 10px;
   font-weight: bold;
   cursor: pointer;
+  position: relative;
   &:hover {
     background: lighten($green, 27%);
     background: var(--theme-container-background-hover, lighten($green, 27%));
@@ -277,6 +278,33 @@
 
   }
 }
+
+.articleform__tagsoptionrulesbutton {
+  position: absolute;
+  right: 8px;
+  top: 9px;
+  border: 0px;
+  border-radius: 3px;
+  background: var(--theme-anchor-color, $sky-blue);
+  color: var(--theme-container-background, white);
+  font-size: 0.8em;
+  width: 100px;
+}
+
+.articleform__tagrules--inactive {
+  display: none
+}
+
+.articleform__tagrules--active {
+  font-size: 0.76em;
+  max-height: 270px;
+  overflow: auto;
+  border: 1px solid $medium-gray;
+  border-radius: 3px;
+  margin-top: 8px;
+  padding: 0px 8px;
+}
+
 .articleform__tagoptionrow--active {
   background: $green;
   background: var(--theme-container-accent-background, $green);

--- a/app/assets/stylesheets/preact/article-form.scss
+++ b/app/assets/stylesheets/preact/article-form.scss
@@ -279,6 +279,18 @@
   }
 }
 
+.articleform__tagsoptionsbottomrow {
+  padding: 12px 10px 10px;
+  font-weight: bold;
+  cursor: pointer;
+  position: relative;
+  font-size: 0.7em;
+  font-style: italic;
+  border-top: 1px solid $medium-gray;
+  color: var(--theme-secondary-color, $black);
+
+}
+
 .articleform__tagsoptionrulesbutton {
   position: absolute;
   right: 8px;

--- a/app/assets/stylesheets/preact/article-form.scss
+++ b/app/assets/stylesheets/preact/article-form.scss
@@ -288,7 +288,6 @@
   font-style: italic;
   border-top: 1px solid $medium-gray;
   color: var(--theme-secondary-color, $black);
-
 }
 
 .articleform__tagsoptionrulesbutton {

--- a/app/assets/stylesheets/preact/article-form.scss
+++ b/app/assets/stylesheets/preact/article-form.scss
@@ -295,7 +295,7 @@
   position: absolute;
   right: 8px;
   top: 9px;
-  border: 0px;
+  border: 0;
   border-radius: 3px;
   background: var(--theme-anchor-color, $sky-blue);
   color: var(--theme-container-background, white);

--- a/app/javascript/article-form/__tests__/__snapshots__/articleForm.test.jsx.snap
+++ b/app/javascript/article-form/__tests__/__snapshots__/articleForm.test.jsx.snap
@@ -31,7 +31,7 @@ exports[`<ArticleForm /> renders properly 1`] = `
           class="articleform__tagswrapper"
         >
           <input
-            autoComplete="on"
+            autoComplete="off"
             class="articleform__tags"
             id="tag-input"
             onBlur={[Function]}

--- a/app/javascript/article-form/articleForm.jsx
+++ b/app/javascript/article-form/articleForm.jsx
@@ -416,7 +416,8 @@ export default class ArticleForm extends Component {
                 defaultValue={tagList}
                 onInput={linkState(this, 'tagList')}
                 maxTags={4}
-                classPrefix={`articleform`}
+                autoComplete='off'
+                classPrefix='articleform'
               />
               {
                 setupImageButton({

--- a/app/javascript/article-form/elements/__tests__/__snapshots__/tags.test.jsx.snap
+++ b/app/javascript/article-form/elements/__tests__/__snapshots__/tags.test.jsx.snap
@@ -7,6 +7,7 @@ Object {
   "prevLen": 0,
   "searchResults": Array [],
   "selectedIndex": -1,
+  "showingRulesForTag": null,
 }
 `;
 
@@ -15,7 +16,7 @@ exports[`<Tags /> renders properly 1`] = `
   class="articleform__tagswrapper"
 >
   <input
-    autoComplete="on"
+    autoComplete="off"
     class="articleform__tags"
     id="tag-input"
     onBlur={[Function]}
@@ -37,6 +38,7 @@ Object {
   "prevLen": 0,
   "searchResults": Array [],
   "selectedIndex": -1,
+  "showingRulesForTag": null,
 }
 `;
 
@@ -47,6 +49,7 @@ Object {
   "prevLen": 0,
   "searchResults": Array [],
   "selectedIndex": -1,
+  "showingRulesForTag": null,
 }
 `;
 
@@ -86,6 +89,7 @@ Object {
     },
   ],
   "selectedIndex": 0,
+  "showingRulesForTag": null,
 }
 `;
 
@@ -125,5 +129,6 @@ Object {
     },
   ],
   "selectedIndex": 0,
+  "showingRulesForTag": null,
 }
 `;

--- a/app/javascript/shared/components/tags.jsx
+++ b/app/javascript/shared/components/tags.jsx
@@ -120,6 +120,7 @@ class Tags extends Component {
       >
         {tag.name}
         {(tag.rules_html && tag.rules_html.length > 0) ? <button
+          type='button'
           className={`${this.props.classPrefix}__tagsoptionrulesbutton`}
           onClick={this.handleRulesClick}
           data-content={tag.name}

--- a/app/javascript/shared/components/tags.jsx
+++ b/app/javascript/shared/components/tags.jsx
@@ -25,6 +25,7 @@ class Tags extends Component {
       additionalTags: [],
       cursorIdx: 0,
       prevLen: 0,
+      showingRulesForTag: null,
     };
 
     const algoliaId = document.querySelector("meta[name='algolia-public-id']")
@@ -118,11 +119,19 @@ class Tags extends Component {
         data-content={tag.name}
       >
         {tag.name}
+        {(tag.rules_html && tag.rules_html.length > 0) ? <button
+          className={`${this.props.classPrefix}__tagsoptionrulesbutton`}
+          onClick={this.handleRulesClick}
+          data-content={tag.name}
+        >
+        {this.state.showingRulesForTag === tag.name ? 'Hide Rules' : 'View Rules'}
+        </button> : ''}
+        <div className={`${this.props.classPrefix}__tagrules--${this.state.showingRulesForTag === tag.name ? 'active' : 'inactive'}`} dangerouslySetInnerHTML={{ __html: tag.rules_html }} />
       </div>
     ));
     if (
       this.state.searchResults.length > 0 &&
-      document.activeElement.id === 'tag-input'
+      (document.activeElement.id === 'tag-input' || document.activeElement.className === 'articleform__tagsoptionrulesbutton')
     ) {
       searchResultsHTML = (
         <div className={`${this.props.classPrefix}__tagsoptions`}>
@@ -140,7 +149,7 @@ class Tags extends Component {
           ref={t => (this.textArea = t)}
           className={`${this.props.classPrefix}__tags`}
           placeholder={`${this.props.maxTags} tags max, comma separated, no spaces or special characters`}
-          autoComplete={this.props.autoComplete || 'on'}
+          autoComplete='off'
           value={this.props.defaultValue}
           onInput={this.handleInput}
           onKeyDown={this.handleKeyDown}
@@ -152,10 +161,22 @@ class Tags extends Component {
     );
   }
 
+  handleRulesClick = e => {
+    e.preventDefault();
+    if (this.state.showingRulesForTag === e.target.dataset.content) {
+      this.setState({showingRulesForTag: null});
+    } else {
+      this.setState({showingRulesForTag: e.target.dataset.content});
+    }
+    // alert('hey hey')
+  }
+
   handleTagClick = e => {
+    if (e.target.className === 'articleform__tagsoptionrulesbutton') {
+      return;
+    }
     const input = document.getElementById('tag-input');
     input.focus();
-
     this.insertTag(e.target.dataset.content);
   };
 
@@ -189,7 +210,7 @@ class Tags extends Component {
       cursorIdx: e.target.selectionStart,
       prevLen: this.textArea.value.length,
     });
-
+    console.log('handle inputs')
     return this.search(query);
   };
 
@@ -244,6 +265,7 @@ class Tags extends Component {
         document.getElementById('tag-input').focus();
       }, 10);
     } else if (e.keyCode === KEYS.COMMA && !this.isSearchResultSelected) {
+      console.log('handle key down')
       this.resetSearchResults();
       this.clearSelectedSearchResult();
     } else if (e.keyCode === KEYS.DELETE) {
@@ -283,6 +305,7 @@ class Tags extends Component {
       input.value.slice(range[1], input.value.length);
 
     this.props.onInput(newInput);
+    console.log('insert tag')
     this.resetSearchResults();
     this.clearSelectedSearchResult();
   }
@@ -319,7 +342,7 @@ class Tags extends Component {
         return;
       }
       component.forceUpdate();
-    }, 100);
+    }, 250);
   };
 
   insertSpace(value, position) {
@@ -330,6 +353,7 @@ class Tags extends Component {
     if (query === '') {
       return new Promise(resolve => {
         setTimeout(() => {
+          'search query'
           this.resetSearchResults();
           resolve();
         }, 5);
@@ -338,7 +362,7 @@ class Tags extends Component {
 
     return this.index
       .search(query, {
-        hitsPerPage: 10,
+        hitsPerPage: 8,
         attributesToHighlight: [],
         filters: 'supported:true',
       })
@@ -358,6 +382,7 @@ class Tags extends Component {
         }
         // updates searchResults array according to what is being typed by user
         // allows user to choose a tag when they've typed the partial or whole word
+        console.log('return search results')
         this.setState({
           searchResults: content.hits,
         });

--- a/app/javascript/shared/components/tags.jsx
+++ b/app/javascript/shared/components/tags.jsx
@@ -136,6 +136,7 @@ class Tags extends Component {
       searchResultsHTML = (
         <div className={`${this.props.classPrefix}__tagsoptions`}>
           {searchResultsRows}
+          <div className={`${this.props.classPrefix}__tagsoptionsbottomrow`}>Some tags have rules and guidelines determined by community moderators</div>
         </div>
       );
     }

--- a/app/javascript/shared/components/tags.jsx
+++ b/app/javascript/shared/components/tags.jsx
@@ -211,7 +211,6 @@ class Tags extends Component {
       cursorIdx: e.target.selectionStart,
       prevLen: this.textArea.value.length,
     });
-    console.log('handle inputs')
     return this.search(query);
   };
 
@@ -266,7 +265,6 @@ class Tags extends Component {
         document.getElementById('tag-input').focus();
       }, 10);
     } else if (e.keyCode === KEYS.COMMA && !this.isSearchResultSelected) {
-      console.log('handle key down')
       this.resetSearchResults();
       this.clearSelectedSearchResult();
     } else if (e.keyCode === KEYS.DELETE) {
@@ -306,7 +304,6 @@ class Tags extends Component {
       input.value.slice(range[1], input.value.length);
 
     this.props.onInput(newInput);
-    console.log('insert tag')
     this.resetSearchResults();
     this.clearSelectedSearchResult();
   }

--- a/app/javascript/shared/components/tags.jsx
+++ b/app/javascript/shared/components/tags.jsx
@@ -169,7 +169,6 @@ class Tags extends Component {
     } else {
       this.setState({showingRulesForTag: e.target.dataset.content});
     }
-    // alert('hey hey')
   }
 
   handleTagClick = e => {
@@ -380,7 +379,6 @@ class Tags extends Component {
         }
         // updates searchResults array according to what is being typed by user
         // allows user to choose a tag when they've typed the partial or whole word
-        console.log('return search results')
         this.setState({
           searchResults: content.hits,
         });

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -37,7 +37,7 @@ class Tag < ActsAsTaggableOn::Tag
   before_save :mark_as_updated
 
   algoliasearch per_environment: true do
-    attribute :name, :bg_color_hex, :text_color_hex, :hotness_score, :supported, :short_summary
+    attribute :name, :bg_color_hex, :text_color_hex, :hotness_score, :supported, :short_summary, :rules_html
     attributesForFaceting [:supported]
     customRanking ["desc(hotness_score)"]
     searchableAttributes %w[name short_summary]

--- a/app/views/articles/_v2_form.html.erb
+++ b/app/views/articles/_v2_form.html.erb
@@ -21,7 +21,7 @@
         <input class="articleform__title articleform__titlepreview" type="text" value="<%= article.title %>" placeholder="Title" />
         <div class="articleform__detailfields">
           <div class="articleform__tagswrapper">
-            <textarea type="text" class="articleform__tags" placeholder="tags"><%= article.cached_tag_list %></textarea>
+            <textarea type="text" class="articleform__tags" placeholder="4 tags max, comma separated, no spaces or special characters"><%= article.cached_tag_list %></textarea>
           </div>
           <button class="articleform__detailsButton articleform__detailsButton--image"></button>
           <button class="articleform__detailsButton articleform__detailsButton--moreconfig"></button>


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
This feature adds a toggle to display rules so that it's more straightforward to know whether a tag has mod-enforced rules and guidelines.

Upon merging this we'll need to re-index tags that have rules with Algolia.

I did not fix some existing linting errors.

<img width="922" alt="Screen Shot 2019-10-09 at 1 08 27 PM" src="https://user-images.githubusercontent.com/3102842/66503969-3794bf80-ea96-11e9-8522-50f64b4abd8b.png">
<img width="912" alt="Screen Shot 2019-10-09 at 1 08 35 PM" src="https://user-images.githubusercontent.com/3102842/66503968-3794bf80-ea96-11e9-8c42-367f35f61348.png">
