### PR TITLE
Fix invalid anchored links due to "//" prefix.

### DIFF
--- a/app/lib/redcarpet/render/html_rouge.rb
+++ b/app/lib/redcarpet/render/html_rouge.rb
@@ -16,6 +16,8 @@ module Redcarpet
         end
         if (/\A(https?:\/\/)/.match? link) || link.nil?
           %(<a href="#{link}"#{link_attributes}>#{content}</a>)
+        elsif link.start_with?("#")
+          %(<a href="#{link}"#{link_attributes}>#{content}</a>)
         else
           %(<a href="//#{link}"#{link_attributes}>#{content}</a>)
         end

--- a/spec/labor/markdown_parser_spec.rb
+++ b/spec/labor/markdown_parser_spec.rb
@@ -77,6 +77,12 @@ RSpec.describe MarkdownParser do
       test = generate_and_parse_markdown(code_span)
       expect(test).to eq("<p><a href=\"//github.com\">github</a></p>\n\n")
     end
+
+    it "renders properly anchored links" do
+      code_span = "[Chapter 1](#chapter-1)"
+      test = generate_and_parse_markdown(code_span)
+      expect(test).to eq("<p><a href=\"#chapter-1\">Chapter 1</a></p>\n\n")
+    end
   end
 
   describe "mentions" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

Fix invalid anchored links due to "//" prefix.

* Updates app/lib/redcarpet/render/html_rouge.rb
* If link starts with "#", keep link as it is, since it's an anchored link

## Related Tickets & Documents

#4338

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
