### PR TITLE
Add a clearer error message when link tag contains non-article URL

### DIFF
--- a/app/liquid_tags/link_tag.rb
+++ b/app/liquid_tags/link_tag.rb
@@ -26,7 +26,10 @@ class LinkTag < LiquidTagBase
     path = Addressable::URI.parse(slug).path
     path.slice!(0) if path.starts_with?("/") # remove leading slash if present
     path.slice!(-1) if path.ends_with?("/") # remove trailing slash if present
-    Addressable::Template.new("{username}/{slug}").extract(path)&.symbolize_keys
+    extracted_hash = Addressable::Template.new("{username}/{slug}").extract(path)&.symbolize_keys
+    raise StandardError, "This URL is not an article link" unless extracted_hash
+
+    extracted_hash
   end
 
   def find_article_by_user(hash)

--- a/app/liquid_tags/link_tag.rb
+++ b/app/liquid_tags/link_tag.rb
@@ -27,7 +27,7 @@ class LinkTag < LiquidTagBase
     path.slice!(0) if path.starts_with?("/") # remove leading slash if present
     path.slice!(-1) if path.ends_with?("/") # remove trailing slash if present
     extracted_hash = Addressable::Template.new("{username}/{slug}").extract(path)&.symbolize_keys
-    raise StandardError, "This URL is not an article link {% link #{slug} %}" unless extracted_hash
+    raise StandardError, "This URL is not an article link: {% link #{slug} %}" unless extracted_hash
 
     extracted_hash
   end

--- a/app/liquid_tags/link_tag.rb
+++ b/app/liquid_tags/link_tag.rb
@@ -27,7 +27,7 @@ class LinkTag < LiquidTagBase
     path.slice!(0) if path.starts_with?("/") # remove leading slash if present
     path.slice!(-1) if path.ends_with?("/") # remove trailing slash if present
     extracted_hash = Addressable::Template.new("{username}/{slug}").extract(path)&.symbolize_keys
-    raise StandardError, "This URL is not an article link" unless extracted_hash
+    raise StandardError, "This URL is not an article link {% link #{slug} %}" unless extracted_hash
 
     extracted_hash
   end

--- a/spec/liquid_tags/liquid/raw_spec.rb
+++ b/spec/liquid_tags/liquid/raw_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Liquid::Raw, type: :liquid_template do
   it "raise error message when link tag contain non article URL" do
     invalid_markdown = "{% link /some-random-link/ %}"
     expect { Liquid::Template.parse(invalid_markdown) }.to(
-      raise_error(StandardError, "This URL is not an article link {% link /some-random-link/ %}"),
+      raise_error(StandardError, "This URL is not an article link: {% link /some-random-link/ %}"),
     )
   end
 end

--- a/spec/liquid_tags/liquid/raw_spec.rb
+++ b/spec/liquid_tags/liquid/raw_spec.rb
@@ -5,4 +5,11 @@ RSpec.describe Liquid::Raw, type: :liquid_template do
     invalid_markdown = '<img src="x" class="before{% raw %}inside{% endraw ">%}rawafter"onerror=alert(document.domain) '
     expect { Liquid::Template.parse(invalid_markdown) }.to raise_error(StandardError)
   end
+
+  it "raise error message when link tag contain non article URL" do
+    invalid_markdown = "{% link /some-random-link/ %}"
+    expect { Liquid::Template.parse(invalid_markdown) }.to(
+      raise_error(StandardError, "This URL is not an article link"),
+    )
+  end
 end

--- a/spec/liquid_tags/liquid/raw_spec.rb
+++ b/spec/liquid_tags/liquid/raw_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Liquid::Raw, type: :liquid_template do
   it "raise error message when link tag contain non article URL" do
     invalid_markdown = "{% link /some-random-link/ %}"
     expect { Liquid::Template.parse(invalid_markdown) }.to(
-      raise_error(StandardError, "This URL is not an article link"),
+      raise_error(StandardError, "This URL is not an article link {% link /some-random-link/ %}"),
     )
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
Add a clearer error message when link tag contains non-article URL

## Related Tickets & Documents
Fixing #4271 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![image](https://user-images.githubusercontent.com/17341000/66510539-65fab500-eaff-11e9-8fe7-12b699ec903e.png)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
