### PR TITLE
Add post as an alias to the link liquid tag

### DIFF
--- a/app/liquid_tags/link_tag.rb
+++ b/app/liquid_tags/link_tag.rb
@@ -45,3 +45,4 @@ class LinkTag < LiquidTagBase
 end
 
 Liquid::Template.register_tag("link", LinkTag)
+Liquid::Template.register_tag("post", LinkTag)

--- a/app/views/pages/_editor_guide_text.html.erb
+++ b/app/views/pages/_editor_guide_text.html.erb
@@ -64,6 +64,10 @@
     <code>{% link https://dev.to/kazz/boost-your-productivity-using-markdown-1be %}</code>
     <p>You can also use the slug like this:</p>
     <code>{% link kazz/boost-your-productivity-using-markdown-1be %}</code>
+    <p>You can also use the alias post instead of link like this:</p>
+    <code>{% post https://dev.to/kazz/boost-your-productivity-using-markdown-1be %}}</code>
+    <p>or this:</p>
+    <code>{% post kazz/boost-your-productivity-using-markdown-1be %}</code>
     <h3><strong>dev.to User Embed</strong></h3>
     <p>All you need is the DEV username:</p>
     <code>{% user jess %}</code>

--- a/spec/liquid_tags/link_tag_spec.rb
+++ b/spec/liquid_tags/link_tag_spec.rb
@@ -42,6 +42,13 @@ RSpec.describe LinkTag, type: :liquid_template do
     HTML
   end
 
+  it 'can use "post" as an alias' do
+    Liquid::Template.register_tag("post", described_class)
+    test_liquid = Liquid::Template.parse("{% post fake_username/fake_article_slug %}")
+    expect { generate_new_liquid("fake_username/fake_article_slug") }.
+      to eq(test_liquid)
+  end
+
   it "raises an error when invalid" do
     expect { generate_new_liquid("fake_username/fake_article_slug") }.
       to raise_error("Invalid link URL or link URL does not exist")

--- a/spec/liquid_tags/link_tag_spec.rb
+++ b/spec/liquid_tags/link_tag_spec.rb
@@ -20,6 +20,11 @@ RSpec.describe LinkTag, type: :liquid_template do
     Liquid::Template.parse("{% link #{slug} %}")
   end
 
+  def generate_new_liquid_alias(slug)
+    Liquid::Template.register_tag("post", described_class)
+    Liquid::Template.parse("{% post #{slug} %}")
+  end
+
   def correct_link_html(article)
     tags = article.tag_list.map { |t| "<span class='ltag__link__tag'>##{t}</span>" }.reverse.join
     <<~HTML
@@ -43,10 +48,8 @@ RSpec.describe LinkTag, type: :liquid_template do
   end
 
   it 'can use "post" as an alias' do
-    Liquid::Template.register_tag("post", described_class)
-    test_liquid = Liquid::Template.parse("{% post fake_username/fake_article_slug %}")
-    expect { generate_new_liquid("fake_username/fake_article_slug") }.
-      to eq(test_liquid)
+    liquid = generate_new_liquid_alias("/#{user.username}/#{article.slug}")
+    expect(liquid.render).to eq(correct_link_html(article))
   end
 
   it "raises an error when invalid" do


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Added an alias (post) for the 'link_tag' liquid test, along with a test to check that it would function as an alias. It's my first  time contributing to an OSS so any feedback would be appreciated.


## Related Tickets & Documents

Fixes https://github.com/thepracticaldev/dev.to/issues/3376

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
