### PR TITLE
remove unused variable and querySelector method in initializeBodyData.js

### DIFF
--- a/app/assets/javascripts/initializers/initializeBodyData.js
+++ b/app/assets/javascripts/initializers/initializeBodyData.js
@@ -25,7 +25,6 @@ function fetchBaseData() {
         removeExistingCSRF();
       }
       var newCsrfParamMeta = document.createElement('meta');
-      var metaTag = document.querySelector("meta[name='csrf-token']");
       newCsrfParamMeta.name = 'csrf-param';
       newCsrfParamMeta.content = json.param;
       document.getElementsByTagName('head')[0].appendChild(newCsrfParamMeta);


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
This PR deletes an unnecessary line (line 28) in app/assets/javascripts/initializers/initializeBodyData.js. It was a querySelector method assigned to a metaTag variable that was not being used anywhere.

## Related Tickets & Documents
Lint issues with JavaScript Files #3777

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [ x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![person hitting delete button and smiling](https://media.giphy.com/media/26xBIUj4Y6K2LcIz6/giphy.gif)
