### PR TITLE
Update the docs readme with instructions [ci skip]

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -16,7 +16,7 @@ For more information on how to use GitDocs read the [GitDocs guide](https://gitd
 
 ## Running the Docs Locally
 
-Install the [GitDocs NodeJs library](https://www.npmjs.com/package/gitdocs)
+Install the [GitDocs NodeJS library](https://www.npmjs.com/package/gitdocs):
 
 ```shell
 npm install gitdocs -g
@@ -30,8 +30,7 @@ If you use yarn you can instead issue:
 yarn global add gitdocs
 ```
 
-Once installed, to run gitdocs you need to navigate to the root
-directory of the DEV.to codebase and run
+Once installed, you can run `gitdocs serve` from the root of the dev.to project or from the `/docs` directory.
 
 ```shell
 gitdocs serve

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -17,3 +17,35 @@ items:
 # Welcome to DEV's developer documentation
 
 Here you can find instructions on how to setup your own local copy of DEV, how to navigate the code, how to contribute, and how to troubleshoot issues, among other things.
+
+# Running the documentation locally
+
+DEV's documentation is built with [GitDocs NodeJS library](https://www.npmjs.com/package/gitdocs).
+
+The first step to running the documentations it locally is to install the `GitDocs` package globally.
+
+With npm:
+```shell
+npm install gitdocs -g
+```
+
+Alternatively, you can use Yarn:
+
+```shell
+yarn global add gitdocs
+```
+
+Once installed, you can run `gitdocs serve` from the root of the dev.to project or from the `/docs` directory.
+
+```shell
+gitdocs serve
+```
+
+This will start a server where you can browse the documentation: <http://localhost:8000/>
+
+When you add new markdown pages or rename existing ones, you'll have to restart
+the server before you notice any changes.
+
+# Contributing to the docs
+
+If you're looking for more information on contributing, check out the [Contributing article](https://docs.dev.to/contributing/).


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Documentation Update

## Description

The readme should include instructions to run the docs site so that
people don't have to go searching for the contributing.md file if they
are stumbling upon the docs in their code editor instead of via the
docs.dev.to website.

## Added to documentation?

- [x] docs.dev.to
- [x] readme
- [ ] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![Tom from Parks and Rec brushing his shoulder](https://user-images.githubusercontent.com/11466782/66617743-f4bd0f80-eb9b-11e9-9c76-63f3b0b56ddd.gif)
