### PR TITLE
Resolve linting issue in app/assets/javascript/sendFetch.js

### DIFF
--- a/app/assets/javascripts/.eslintrc.js
+++ b/app/assets/javascripts/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
   extends: ['airbnb-base/legacy', 'prettier'],
   parserOptions: {
-    ecmaVersion: 2017,
+    ecmaVersion: 2018,
   },
   env: {
     browser: true,

--- a/app/assets/javascripts/utilities/sendFetch.js
+++ b/app/assets/javascripts/utilities/sendFetch.js
@@ -2,7 +2,7 @@
 
 const fetchCallback = ({ url, headers = {}, addTokenToBody = false, body }) => {
   return csrfToken => {
-    addTokenToBody && body.append('authenticity_token', csrfToken);
+    if (addTokenToBody) { body.append('authenticity_token', csrfToken) };
     return window.fetch(url, {
       method: 'POST',
       headers: {


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

There was an issue with the parsing of the object spread operator in `sendFetch.js`. Bumping the ecmaVersion in the eslintrc file from 2017 => 2018 resolved the issue. However, bumping that introduced/uncovered another linting error with the use of the short circuit logic conditionally appending the authenticity_token. That is now wrapped in a standard if statement.

I did confirm that bumping the ecmaVersion _does not_ introduce any new linting errors.

## Related Tickets & Documents

https://github.com/thepracticaldev/dev.to/issues/3777

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

