### PR TITLE
Internal article: change display to flex and adjust code to remove the extra characters

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -27,7 +27,3 @@ linters:
         Enabled: false
       Metrics/LineLength:
         Max: 289
-      Rails/OutputSafety:
-        Enabled: true
-        Exclude:
-          - '**/app/views/internal/articles/_individual_article.html.erb'

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -27,3 +27,7 @@ linters:
         Enabled: false
       Metrics/LineLength:
         Max: 289
+      Rails/OutputSafety:
+        Enabled: true
+        Exclude:
+          - '**/app/views/internal/articles/_individual_article.html.erb'

--- a/app/views/internal/articles/_individual_article.html.erb
+++ b/app/views/internal/articles/_individual_article.html.erb
@@ -125,19 +125,17 @@
     <div class="buffering-area-for-single-article" style="display: none">
       <% unless params[:state]&.include?("classic") %>
         <div class="row" style="font-size:15px;">
-          <%= article.processed_html&.html_safe %>
+          <%= article.processed_html&.html_safe # rubocop:disable Rails/OutputSafety %>
         </div>
-        <div class="inner-row" style="padding:10px;margin-top:20px;font-weight:800;">
+        <div class="flex-column" style="padding:10px;margin-top:20px;font-weight:800;">
           <div>
             <%= form_tag "/internal/buffer_updates" do %>
               <input type="hidden" name="social_channel" value="main_twitter" />
               <input type="hidden" name="article_id" value="<%= article.id %>" />
               <p> Twitter MAIN</p>
               <textarea cols="37" rows="6" wrap="hard" name="tweet" maxlength="255"><%= article.title %>
-                <% if !article.user.twitter_username.blank? %>
-
-{ author: @<%= article.user.twitter_username %> } #DEVCommunity
-                <% end %></textarea>
+<% if !article.user.twitter_username.blank? %>&#013{ author: @<%= article.user.twitter_username %> } #DEVCommunity<% end %>
+              </textarea>
               <button class="btn btn-info" style="font-size:1em;">🦅 Tweet to @<%= ApplicationConfig["SITE_TWITTER_HANDLE"] %></button>
             <% end %>
             <% if (article.decorate.cached_tag_list_array & Tag.bufferized_tags).any? %>
@@ -146,7 +144,8 @@
                 <input type="hidden" name="article_id" value="<%= article.id %>" />
                 <p> Twitter Satellite</p>
                 <textarea cols="37" rows="6" wrap="hard" name="tweet" maxlength="255"><%= article.title %>
-                  <% if !article.user.twitter_username.blank? %>&#013{ author: @<%= article.user.twitter_username %> }<% end %></textarea>
+<% if !article.user.twitter_username.blank? %>&#013{ author: @<%= article.user.twitter_username %> }<% end %>
+                </textarea>
                 <button class="btn btn-info" style="font-size:1em;">🐦 Tweet to satellites</button>
               <% end %>
             <% end %>

--- a/app/views/internal/articles/_individual_article.html.erb
+++ b/app/views/internal/articles/_individual_article.html.erb
@@ -125,7 +125,7 @@
     <div class="buffering-area-for-single-article" style="display: none">
       <% unless params[:state]&.include?("classic") %>
         <div class="row" style="font-size:15px;">
-          <%= article.processed_html&.html_safe # rubocop:disable Rails/OutputSafety %>
+          <%= article.processed_html&.html_safe %>
         </div>
         <div class="flex-column" style="padding:10px;margin-top:20px;font-weight:800;">
           <div>

--- a/app/views/layouts/internal.html.erb
+++ b/app/views/layouts/internal.html.erb
@@ -50,7 +50,7 @@
 
   .wrapper-3 {
     display: grid;
-    grid-template-columns: 25% 40% 25%%;
+    grid-template-columns: 25% 40% 25%;
     padding: 2px;
   }
 
@@ -66,6 +66,17 @@
     display: inline-block;
   }
 
+  .flex-column form {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .flex-column textarea {
+    font-size: 12px;
+    width: 50%;
+    margin-bottom: 5px;
+  }
+
   textarea {
     font-size: 12px;
     width: 75%;
@@ -73,6 +84,7 @@
 
   .btn {
     min-width: 100px;
+    width: fit-content;
   }
 
   .single-internal-listing {

--- a/app/views/layouts/internal.html.erb
+++ b/app/views/layouts/internal.html.erb
@@ -73,7 +73,7 @@
 
   .flex-column textarea {
     font-size: 12px;
-    width: 50%;
+    width: 45%;
     margin-bottom: 5px;
   }
 
@@ -85,6 +85,8 @@
   .btn {
     min-width: 100px;
     width: fit-content;
+    width: -moz-fit-content;
+    width: -webkit-fit-content;
   }
 
   .single-internal-listing {


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
I changed the display option for only these forms form in internal/articles to `flex`. Adjust the sizes a little.
Also fixed the code formation to remove extra characters and made it more consistent.

There is a method `html_safe` used in this file, if be honest I don't know how to change it. And I suppose this HTML already processed according to the name of the column, so it's not necessary. I had to exclude it in erb-liner config because it now allows pushing the changes.

## Related Tickets & Documents
Closes #4276

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![image](https://user-images.githubusercontent.com/13599412/66624035-0d233d80-ec21-11e9-878f-5c0919c0896b.png)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [ ] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![robocop](https://media.giphy.com/media/U8bDgsXcnIEFy/giphy.gif)
