### PR TITLE
Internal articles: fix some eager loading problems and refactor controller

### DIFF
--- a/app/controllers/internal/articles_controller.rb
+++ b/app/controllers/internal/articles_controller.rb
@@ -9,55 +9,19 @@ class Internal::ArticlesController < Internal::ApplicationController
     case params[:state]
     when /not\-buffered/
       days_ago = params[:state].split("-")[2].to_f
-      @articles = Article.published.where(last_buffered: nil).
-        where("published_at > ? OR crossposted_at > ?", days_ago.days.ago, days_ago.days.ago).
-        includes(:user, :buffer_updates).
-        limited_columns_internal_select.
-        order("positive_reactions_count DESC").
-        page(params[:page]).
-        per(50)
+      @articles = articles_not_buffered(days_ago)
     when /top\-/
-      @articles = Article.published.
-        where("published_at > ?", params[:state].split("-")[1].to_i.months.ago).
-        includes(:user, :buffer_updates).
-        limited_columns_internal_select.
-        order("positive_reactions_count DESC").
-        page(params[:page]).
-        per(50)
+      months_ago = params[:state].split("-")[1].to_i.months.ago
+      @articles = articles_top(months_ago)
     when "satellite"
-      @articles = Article.published.where(last_buffered: nil).
-        includes(:user, :buffer_updates).
-        tagged_with(Tag.bufferized_tags, any: true).
-        limited_columns_internal_select.
-        order("hotness_score DESC").
-        page(params[:page]).
-        per(60)
+      @articles = articles_satellite
     when "boosted-additional-articles"
-      @articles = Article.boosted_via_additional_articles.
-        includes(:user, :buffer_updates).
-        limited_columns_internal_select.
-        order("published_at DESC").
-        page(params[:page]).
-        per(100)
+      @articles = articles_boosted_additional
     when "chronological"
-      @articles = Article.published.
-        limited_columns_internal_select.
-        order("published_at DESC").
-        page(params[:page]).
-        per(50)
-    else # MIX
-      @articles = Article.published.
-        limited_columns_internal_select.
-        order("hotness_score DESC").
-        page(params[:page]).
-        per(30)
-
-      @featured_articles = Article.published.or(Article.where(published_from_feed: true)).
-        where(featured: true).
-        where("featured_number > ?", Time.current.to_i).
-        includes(:user, :buffer_updates).
-        limited_columns_internal_select.
-        order("featured_number DESC")
+      @articles = articles_chronological
+    else
+      @articles = articles_mixed
+      @featured_articles = articles_featured
     end
   end
 
@@ -84,18 +48,86 @@ class Internal::ArticlesController < Internal::ApplicationController
 
   private
 
+  def articles_not_buffered(days_ago)
+    Article.published.
+      where(last_buffered: nil).
+      where("published_at > ? OR crossposted_at > ?", days_ago.days.ago, days_ago.days.ago).
+      includes(:user).
+      limited_columns_internal_select.
+      order("positive_reactions_count DESC").
+      page(params[:page]).
+      per(50)
+  end
+
+  def articles_top(months_ago)
+    Article.published.
+      where("published_at > ?", months_ago).
+      includes(user: [:notes]).
+      limited_columns_internal_select.
+      order("positive_reactions_count DESC").
+      page(params[:page]).
+      per(50)
+  end
+
+  def articles_satellite
+    Article.published.where(last_buffered: nil).
+      includes(:user, :buffer_updates).
+      tagged_with(Tag.bufferized_tags, any: true).
+      limited_columns_internal_select.
+      order("hotness_score DESC").
+      page(params[:page]).
+      per(60)
+  end
+
+  def articles_boosted_additional
+    Article.boosted_via_additional_articles.
+      includes(:user, :buffer_updates).
+      limited_columns_internal_select.
+      order("published_at DESC").
+      page(params[:page]).
+      per(100)
+  end
+
+  def articles_chronological
+    Article.published.
+      includes(user: [:notes]).
+      limited_columns_internal_select.
+      order("published_at DESC").
+      page(params[:page]).
+      per(50)
+  end
+
+  def articles_mixed
+    Article.published.
+      includes(user: [:notes]).
+      limited_columns_internal_select.
+      order("hotness_score DESC").
+      page(params[:page]).
+      per(30)
+  end
+
+  def articles_featured
+    Article.published.or(Article.where(published_from_feed: true)).
+      where(featured: true).
+      where("featured_number > ?", Time.current.to_i).
+      includes(:user, :buffer_updates).
+      limited_columns_internal_select.
+      order("featured_number DESC")
+  end
+
   def article_params
-    params.require(:article).permit(:featured,
-                                    :social_image,
-                                    :body_markdown,
-                                    :approved,
-                                    :live_now,
-                                    :email_digest_eligible,
-                                    :boosted_additional_articles,
-                                    :boosted_dev_digest_email,
-                                    :main_image_background_hex_color,
-                                    :featured_number,
-                                    :user_id,
-                                    :last_buffered)
+    allowed_params = %i[featured
+                        social_image
+                        body_markdown
+                        approved
+                        live_now
+                        email_digest_eligible
+                        boosted_additional_articles
+                        boosted_dev_digest_email
+                        main_image_background_hex_color
+                        featured_number
+                        user_id
+                        last_buffered]
+    params.require(:article).permit(allowed_params)
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

While reviewing another PR I noticed a few of these:

```text
GET /internal/articles
USE eager loading detected
  Article => [:user]
  Add to your finder: :includes => [:user]
```

so I went on and fixed them. I also grouped stuff into methods to avoid `Metrics/AbcSize` errors. The controller action was far too long.
