### PR TITLE
Freely color social icon backgrounds for each theme. 

### DIFF
--- a/app/assets/stylesheets/article-show.scss
+++ b/app/assets/stylesheets/article-show.scss
@@ -873,7 +873,7 @@ article {
             background: transparent;
             @include themeable(
               background,
-              theme-secondary-color,
+              theme-social-icon-color,
               transparent
             );
           }

--- a/app/views/layouts/_user_config.html.erb
+++ b/app/views/layouts/_user_config.html.erb
@@ -65,7 +65,7 @@
       --theme-container-box-shadow: none;\
       --theme-container-border: 1px solid #ff4983;\
       --theme-subtle-border: 1px solid #ffa8c3;\
-      --theme-social-icon-color: #ffccdb;\
+      --theme-social-icon-color: #rgba(255, 204, 219, 0);\
       --theme-social-icon-invert: invert(0);\
       --theme-prime-option-border-color: rgba(255, 255, 255, 0.55)</style>'
     } else if(bodyClass.includes('minimal-light-theme')) {
@@ -97,7 +97,7 @@
         --theme-container-box-shadow: none;\
         --theme-container-border: 1px solid #e3e3e5;\
         --theme-subtle-border: 1px solid #fcfcfc;\
-        --theme-social-icon-color: #505159;\
+        --theme-social-icon-color: rgba(80, 81, 89, 0);\
         --theme-social-icon-invert: invert(0)</style>'
     }
     if (navigator.userAgent === 'DEV-Native-ios') {

--- a/app/views/layouts/_user_config.html.erb
+++ b/app/views/layouts/_user_config.html.erb
@@ -65,7 +65,7 @@
       --theme-container-box-shadow: none;\
       --theme-container-border: 1px solid #ff4983;\
       --theme-subtle-border: 1px solid #ffa8c3;\
-      --theme-social-icon-color: #rgba(255, 204, 219, 0);\
+      --theme-social-icon-color: rgba(255, 204, 219, 0);\
       --theme-social-icon-invert: invert(0);\
       --theme-prime-option-border-color: rgba(255, 255, 255, 0.55)</style>'
     } else if(bodyClass.includes('minimal-light-theme')) {

--- a/app/views/layouts/_user_config.html.erb
+++ b/app/views/layouts/_user_config.html.erb
@@ -32,6 +32,7 @@
         --theme-container-border: 1px solid #22303f;\
         --theme-subtle-border: 1px solid #1f2c3a;\
         --theme-social-icon-invert: invert(100);\
+        --theme-social-icon-color: #cedae2;\
         --theme-current-article-background: #1143ca;\
         --theme-series-article-background: #314d9c;\
         --theme-series-article-hover: #1b2e63;</style>'
@@ -64,6 +65,7 @@
       --theme-container-box-shadow: none;\
       --theme-container-border: 1px solid #ff4983;\
       --theme-subtle-border: 1px solid #ffa8c3;\
+      --theme-social-icon-color: #ffccdb;\
       --theme-social-icon-invert: invert(0);\
       --theme-prime-option-border-color: rgba(255, 255, 255, 0.55)</style>'
     } else if(bodyClass.includes('minimal-light-theme')) {
@@ -95,6 +97,7 @@
         --theme-container-box-shadow: none;\
         --theme-container-border: 1px solid #e3e3e5;\
         --theme-subtle-border: 1px solid #fcfcfc;\
+        --theme-social-icon-color: #505159;\
         --theme-social-icon-invert: invert(0)</style>'
     }
     if (navigator.userAgent === 'DEV-Native-ios') {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Documentation Update

## Description
Social icons are discolored on the pink theme, in the about-the-author section. 

The icons appear discolored because `--theme-secondary-color` (#4e57ef) takes priority over `transparent` in this following code snippet from article-show.scss:

```
.icon-img {
  ...
  background: transparent;
  @include themeable(
    background,
    theme-secondary-color,
    transparent
  );
}
```

This doesn't show up on the Dark or Light themes because their theme-secondary-color doesn't clash with the rest of the theme. If we can add a background for the social icons, we can control their color better for themes in the future.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
BEFORE: 
![](https://i.imgur.com/2DYpqFB.png)
AFTER: 
![](https://i.imgur.com/BEIVzyS.png)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed

## What gif best describes this PR or how it makes you feel?

![Morpheus: "At last."](https://media.giphy.com/media/FA77mwaxV74SA/giphy.gif)
