### PR TITLE
Add Z-Index to Editor Image Upload Container

### DIFF
--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -928,6 +928,7 @@ a.header-link {
   .editor-image-upload {
     width: initial;
     text-align: left;
+    z-index: 6;
 
     .uploaded-image {
       width: calc(93% - 3.375rem);


### PR DESCRIPTION
Reply actions container has a z-index of 5, and extends over the upload button
and uploaded input.

<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

The editor upload button gets covered by the fixed width of the `.reply-actions` bar. It has a Z-index of 5, so I set the z-index of the Upload button to 6 so the button and associated input are clickable. 

## Related Tickets & Documents

N/a

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![dev-to z-index fix](https://user-images.githubusercontent.com/20668329/66668639-ef4edc00-ec12-11e9-8900-55c1b55ba11c.gif)


## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![fri-yay!](https://thumbs.gfycat.com/AmusedDefinitiveIrukandjijellyfish-size_restricted.gif)
