### PR TITLE
Make follow button centerized

### DIFF
--- a/app/assets/stylesheets/articles.scss
+++ b/app/assets/stylesheets/articles.scss
@@ -1107,7 +1107,10 @@
             position: absolute;
             color: $black;
             right: 5px;
-            top: 2px;
+            top: 50%;
+            -webkit-transform: translateY(-50%);
+            -ms-transform: translateY(-50%);
+            transform: translateY(-50%);
             text-align: center;
             border-radius: 3px;
             font-weight: 900;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
Currently, when user hover sidebar item, the button is shown, but it isn't center in a row

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
Before:
![Before](https://i.imgur.com/NrigTso.png)

After:
![After](https://i.imgur.com/1hsJGfB.png)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
