### PR TITLE
Update feed to have popular posts sink a bit faster

### DIFF
--- a/app/black_box/black_box.rb
+++ b/app/black_box/black_box.rb
@@ -6,10 +6,10 @@ class BlackBox
       super_super_recent_bonus = usable_date > 1.hour.ago ? 28 : 0
       super_recent_bonus = usable_date > 8.hours.ago ? 81 : 0
       recency_bonus = usable_date > 12.hours.ago ? 280 : 0
-      today_bonus = usable_date > 26.hours.ago ? 695 : 0
-      two_day_bonus = usable_date > 48.hours.ago ? 730 : 0
-      four_day_bonus = usable_date > 96.hours.ago ? 830 : 0
-      if usable_date < 10.days.ago
+      today_bonus = usable_date > 26.hours.ago ? 795 : 0
+      two_day_bonus = usable_date > 48.hours.ago ? 830 : 0
+      four_day_bonus = usable_date > 96.hours.ago ? 930 : 0
+      if usable_date < 4.days.ago
         reaction_points /= 2 # Older posts should fade
       end
       if article.decorate.cached_tag_list_array.include?("watercooler")

--- a/spec/black_box/black_box_spec.rb
+++ b/spec/black_box/black_box_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe BlackBox do
       # + score (99)
       # + value from the function caller (5)
       score = described_class.article_hotness_score(article, function_caller)
-      expect(score).to eq(2748)
+      expect(score).to eq(3048)
     end
 
     it "returns the lower correct value if article tagged with watercooler" do
@@ -34,7 +34,7 @@ RSpec.describe BlackBox do
       # + score (99)
       # + value from the function caller (5)
       score = described_class.article_hotness_score(article, function_caller)
-      expect(score).to be < 2800 # lower because watercooler tag
+      expect(score).to be < 3040 # lower because watercooler tag
     end
   end
 


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

Sometimes we need to update the numbers so popular posts don't stick around too long as DEV grows in total use and popularity. In addition to the top secret ranking factors (obfuscated to avoid game-ability), this is an update to the naive public factors.

<img width="646" alt="Screen Shot 2019-10-14 at 12 14 55 PM" src="https://user-images.githubusercontent.com/3102842/66766510-40153d80-ee7c-11e9-90a9-2996657bf61b.png">
