### PR TITLE
Improve error message when creating article using API

### DIFF
--- a/app/controllers/api/v0/articles_controller.rb
+++ b/app/controllers/api/v0/articles_controller.rb
@@ -43,7 +43,7 @@ module Api
           render "show", status: :created, location: @article.url
         else
           message = @article.errors.full_messages
-          render json: { errorS: message, status: 422 }, status: :unprocessable_entity
+          render json: { errors: message, status: 422 }, status: :unprocessable_entity
         end
       end
 

--- a/app/controllers/api/v0/articles_controller.rb
+++ b/app/controllers/api/v0/articles_controller.rb
@@ -43,7 +43,7 @@ module Api
           render "show", status: :created, location: @article.url
         else
           message = @article.errors.full_messages
-          render json: { error: message, status: 422 }, status: :unprocessable_entity
+          render json: { errorS: message, status: 422 }, status: :unprocessable_entity
         end
       end
 

--- a/app/controllers/api/v0/articles_controller.rb
+++ b/app/controllers/api/v0/articles_controller.rb
@@ -39,7 +39,12 @@ module Api
 
       def create
         @article = Articles::Creator.call(@user, article_params)
-        render "show", status: :created, location: @article.url
+        if @article.persisted?
+          render "show", status: :created, location: @article.url
+        else
+          message = @article.errors.full_messages
+          render json: { error: message, status: 422 }, status: :unprocessable_entity
+        end
       end
 
       def update

--- a/app/services/articles/creator.rb
+++ b/app/services/articles/creator.rb
@@ -48,7 +48,7 @@ module Articles
       article.user_id = user.id
       article.show_comments = true
       article.collection = Collection.find_series(series, user) if series.present?
-      article.save!
+      article.save
       article
     end
   end

--- a/app/services/articles/creator.rb
+++ b/app/services/articles/creator.rb
@@ -48,7 +48,7 @@ module Articles
       article.user_id = user.id
       article.show_comments = true
       article.collection = Collection.find_series(series, user) if series.present?
-      article.save
+      article.save!
       article
     end
   end

--- a/spec/requests/api/v0/articles_spec.rb
+++ b/spec/requests/api/v0/articles_spec.rb
@@ -257,6 +257,12 @@ RSpec.describe "Api::V0::Articles", type: :request do
         expect(response).to have_http_status(:unprocessable_entity)
       end
 
+      it "fails if missing required params" do
+        tags = %w[meta discussion]
+        post_article(body_markdown: "Yo ho ho", tags: tags)
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
       it "creates an article belonging to the user" do
         post_article(title: Faker::Book.title)
         expect(response).to have_http_status(:created)


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
Made a change from `save` to `save!` so an exception is raised in `creator.rb` if an article cannot be saved. The exception is handled by the controller and a more specific error message is sent back to the user.

If the title is missing, you get a response like the example below.
__EDIT__
```
{
    "error": [
        "Title can't be blank"
    ],
    "status": 422
}
```
An issue I have with the above error message is that title is spelt `Title` and not `title` which could be misleading

## Related Tickets & Documents
Resolves #4402 

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
