### PR TITLE
Allow backticks within codeblocks

### DIFF
--- a/config/initializers/redcarpet.rb
+++ b/config/initializers/redcarpet.rb
@@ -2,6 +2,7 @@
   autolink: true,
   no_intra_emphasis: true,
   fenced_code_blocks: true,
+  disable_indented_code_blocks: true,
   lax_html_blocks: true,
   lax_spacing: true,
   strikethrough: true,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

There are a couple reports about being unable to display backticks within codeblock examples, but sometimes it's helpful to be able to do so.

It looks like we're using the [Redcarpet gem](https://github.com/vmg/redcarpet) to render markdown, and the gem allows [a couple configuration options](https://github.com/vmg/redcarpet#and-its-like-really-simple-to-use)

We are using the `fenced_code_blocks` option, which allows us to create a codeblock with three or more `~` tildes or backticks, but it's recommended to use the `disable_indented_code_blocks` option with this, which would allow ignoring of indented codeblocks. Enabling this option allows users to create a codeblock, and then to display the backticks _within_ the codeblock, indent the backticks by 4 spaces.

NOTE: I am not sure if any users are _currently_ using 4-space-indented backticks, in which case, this update would remove the codeblock rendering for those posts. That seems like an unlikely use case, but I figured maintainers would be able to make the call whether this update is a risky one.

## Related Tickets & Documents

Resolves https://github.com/thepracticaldev/dev.to/issues/3648
Resolves https://github.com/thepracticaldev/dev.to/issues/4400

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Some examples of how the various markdown is rendered:
<img width="396" alt="Screen Shot 2019-10-14 at 9 53 02 PM" src="https://user-images.githubusercontent.com/7559041/66794098-2c92c280-eece-11e9-875b-23be4a267e5a.png">
<img width="840" alt="Screen Shot 2019-10-14 at 9 52 21 PM" src="https://user-images.githubusercontent.com/7559041/66794104-30bee000-eece-11e9-9df0-efa8effa4442.png">

<img width="367" alt="Screen Shot 2019-10-14 at 9 53 07 PM" src="https://user-images.githubusercontent.com/7559041/66794114-39171b00-eece-11e9-9e32-3aaeecef37b6.png">
<img width="836" alt="Screen Shot 2019-10-14 at 9 52 28 PM" src="https://user-images.githubusercontent.com/7559041/66794115-3c120b80-eece-11e9-88bb-c3b335a2037b.png">
<img width="522" alt="Screen Shot 2019-10-14 at 9 53 12 PM" src="https://user-images.githubusercontent.com/7559041/66794122-416f5600-eece-11e9-98a5-43f77b5baaeb.png">
<img width="841" alt="Screen Shot 2019-10-14 at 9 52 35 PM" src="https://user-images.githubusercontent.com/7559041/66794127-4502dd00-eece-11e9-851b-bb89bb83477c.png">


## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed (I think this is the case, but happy to make updates if that's not true)

## [optional] What gif best describes this PR or how it makes you feel?

![pumpkin dance](https://media.giphy.com/media/3oz8xwooUvMqNB1zEs/giphy.gif)
