### PR TITLE
update initializePodcastPlayback muteUnmute to use ternaries

### DIFF
--- a/app/assets/javascripts/initializers/initializePodcastPlayback.js
+++ b/app/assets/javascripts/initializers/initializePodcastPlayback.js
@@ -234,19 +234,11 @@ function initializePodcastPlayback() {
   }
 
   function muteUnmute(audio) {
-    if (audio.muted) {
-      audio.muted = false;
-      getById('mutebutt').classList.add('hidden');
-      getById('volumeindicator').classList.add('showing');
-      getById('mutebutt').classList.remove('showing');
-      getById('volumeindicator').classList.remove('hidden');
-    } else {
-      audio.muted = true;
-      getById('mutebutt').classList.add('showing');
-      getById('volumeindicator').classList.add('hidden');
-      getById('mutebutt').classList.remove('hidden');
-      getById('volumeindicator').classList.remove('showing');
-    }
+    getById('mutebutt').classList.add(audio.muted ? 'hidden' : 'showing');
+    getById('volumeindicator').classList.add(audio.muted ? 'showing' : 'hidden');
+    getById('mutebutt').classList.remove(audio.muted ? 'showing' : 'hidden');
+    getById('volumeindicator').classList.remove(audio.muted ? 'hidden' : 'showing');
+    audio.muted = !audio.muted;
   }
 
   function updateProgress(e, audio) {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
I have refactored the `muteUmute()` function in  `app/assets/javascripts/initializers/initializePodcastPlayback.js` to use ternary statements instead of if/else, as this avoids duplicated code, and fixes [this](https://codeclimate.com/github/thepracticaldev/dev.to/app/assets/javascripts/initializers/initializePodcastPlayback.js/source#issue-09bd665b3a353cb35f9d278d56f3fd41) issue on CodeClimate.

## Related Tickets & Documents
[This CodeClimate Issue](https://codeclimate.com/github/thepracticaldev/dev.to/app/assets/javascripts/initializers/initializePodcastPlayback.js/source#issue-09bd665b3a353cb35f9d278d56f3fd41).

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed