### PR TITLE
add single unified swipe handler to initializeSwipeGestures to avoid duplicated code

### DIFF
--- a/app/assets/javascripts/initializers/initializeSwipeGestures.js
+++ b/app/assets/javascripts/initializers/initializeSwipeGestures.js
@@ -32,7 +32,7 @@ function initializeSwipeGestures(){
   },50)
 }
 
-function handleSwipe(e, direction){
+function handleSwipe(e, direction) {
   if (!document.getElementById("on-page-nav-controls")){
     return;
   }
@@ -46,10 +46,11 @@ function handleSwipe(e, direction){
   }
 }
 
-function handleSwipeLeft(e){
+function handleSwipeLeft(e) {
   handleSwipe(e, "left")
 }
 
-function handleSwipeRight(e){
+function handleSwipeRight(e) {
   handleSwipe(e, "right")
 }
+

--- a/app/assets/javascripts/initializers/initializeSwipeGestures.js
+++ b/app/assets/javascripts/initializers/initializeSwipeGestures.js
@@ -45,9 +45,11 @@ function handleSwipe(e, direction){
     slideSidebar(direction,"outOfView");
   }
 }
+
 function handleSwipeLeft(e){
   handleSwipe(e, "left")
 }
+
 function handleSwipeRight(e){
   handleSwipe(e, "right")
 }

--- a/app/assets/javascripts/initializers/initializeSwipeGestures.js
+++ b/app/assets/javascripts/initializers/initializeSwipeGestures.js
@@ -32,30 +32,22 @@ function initializeSwipeGestures(){
   },50)
 }
 
-
-function handleSwipeLeft(e){
+function handleSwipe(e, direction){
   if (!document.getElementById("on-page-nav-controls")){
     return;
   }
   if (swipeState == "middle"){
-    swipeState = "right"
-    slideSidebar("right","intoView");
+    swipeState = direction;
+    slideSidebar(direction,"intoView");
   }
   else{
-    swipeState = "middle"
-    slideSidebar("left","outOfView");
+    swipeState = "middle";
+    slideSidebar(direction,"outOfView");
   }
 }
+function handleSwipeLeft(e){
+  handleSwipe(e, "left")
+}
 function handleSwipeRight(e){
-  if (!document.getElementById("on-page-nav-controls")){
-    return;
-  }
-  if (swipeState == "middle"){
-    swipeState = "left"
-    slideSidebar("left","intoView");
-  }
-  else{
-    swipeState = "middle"
-    slideSidebar("right","outOfView");
-  }
+  handleSwipe(e, "right")
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
I have refactored the `handleSwipe{Right|Left}()` functions in  `app/assets/javascripts/initializers/initializeSwipeGestures.js`, adding a singular function that is called from each of the two direction specific functions as this avoids duplicated code and fixes [this](https://codeclimate.com/github/thepracticaldev/dev.to/app/assets/javascripts/initializers/initializeSwipeGestures.js/source#issue-0eea66f5733caeb28c121ac8455fc4a5) issue on CodeClimate.

## Related Tickets & Documents
[This CodeClimate Issue](https://codeclimate.com/github/thepracticaldev/dev.to/app/assets/javascripts/initializers/initializeSwipeGestures.js/source#issue-0eea66f5733caeb28c121ac8455fc4a5).

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed