### PR TITLE
Change branching naming scheme for PRs [ci skip]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,9 +34,9 @@ When in doubt, ask a [core team member](https://github.com/thepracticaldev/dev.t
 ### How to contribute
 
 1. Fork the project & clone locally. Follow the initial setup [here](https://github.com/thepracticaldev/dev.to/#getting-started).
-2. Create a branch, naming it either a feature or bug: `git checkout -b feature/that-new-feature` or `bug/fixing-that-bug`
+2. Create a branch with your GitHub username as a prefix and the ID of the [issue](https://github.com/thepracticaldev/dev.to/issues) as a suffix, for example: `git checkout -b USERNAME/that-new-feature-1234` or `git checkout -b USERNAME/fixing-that-bug-1234` where `USERNAME` should be replaced by your username and `1234` is the ID of the issue tied to your pull request. If there is no issue, you can leave the number out.
 3. Code and commit your changes. Bonus points if you write a [good commit message](https://chris.beams.io/posts/git-commit/): `git commit -m 'Add some feature'`
-4. Push to the branch: `git push origin feature/that-new-feature`
+4. Push to the branch: `git push origin USERNAME/that-new-feature-1234`
 5. [Create a pull request](https://github.com/thepracticaldev/dev.to/#create-a-pull-request) for your branch 🎉
 
 ## Contribution guideline


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Documentation Update

## Description

To help in code reviews I'm proposing this new scheme of branching, for both contributors and maintainers:

`USERNAME/DESCRIPTION-ISSUE_ID`

I've been reviewing many PRs lately and it's not always easy when you're browsing your local branches to understand who's doing what, related to which issue.
