### PR TITLE
Fix comment author being notified when mentioning itself

### DIFF
--- a/app/services/mentions/create_all.rb
+++ b/app/services/mentions/create_all.rb
@@ -16,7 +16,9 @@ module Mentions
       mentions = []
       doc.css(".comment-mentioned-user").each do |link|
         username = link.text.delete("@").downcase
-        if (user = User.find_by(username: username))
+        user = User.find_by(username: username)
+
+        if user && user.id != notifiable.user_id
           usernames << username
           mentions << create_mention(user)
         end

--- a/spec/services/mentions/create_all_spec.rb
+++ b/spec/services/mentions/create_all_spec.rb
@@ -68,4 +68,11 @@ RSpec.describe Mentions::CreateAll do
     described_class.call(comment2)
     expect(Mention.all.size).to eq(0)
   end
+
+  it "cant mention self" do
+    comment.body_markdown = "Me, Myself and I @#{user.username}"
+    comment.save
+    described_class.call(comment)
+    expect(Mention.all.size).to eq(0)
+  end
 end

--- a/spec/services/mentions/create_all_spec.rb
+++ b/spec/services/mentions/create_all_spec.rb
@@ -2,18 +2,19 @@ require "rails_helper"
 
 RSpec.describe Mentions::CreateAll do
   let(:user)        { create(:user) }
+  let(:user2)       { create(:user) }
   let(:article)     { create(:article, user_id: user.id) }
-  let(:comment)     { create(:comment, user_id: user.id, commentable_id: article.id) }
+  let(:comment)     { create(:comment, user_id: user2.id, commentable_id: article.id) }
   let(:comment2)    do
     create(
       :comment,
       body_markdown: "Hello @#{user.username}, you are cool.",
-      user_id: user.id,
+      user_id: user2.id,
       commentable_id: article.id,
     )
   end
 
-  it "creates mention if there is a user mentioned" do
+  it "creates mention if there is a user mentioned and if the user doenst own the comment" do
     comment.body_markdown = "Hello @#{user.username}, you are cool."
     comment.save
     described_class.call(comment)
@@ -70,7 +71,7 @@ RSpec.describe Mentions::CreateAll do
   end
 
   it "cant mention self" do
-    comment.body_markdown = "Me, Myself and I @#{user.username}"
+    comment.body_markdown = "Me, Myself and I @#{user2.username}"
     comment.save
     described_class.call(comment)
     expect(Mention.all.size).to eq(0)


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

this fixes the issue when an owner of the comment tries to mention itself and it would trigger a notification which is redundant because owner knows already about the comment.

## Related Tickets & Documents

Fixes #4262 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [ ] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![proud](https://media.giphy.com/media/l0He0cVv8lGggpruo/giphy.gif)
