### PR TITLE
Fix broken error interface in Article creation API

### DIFF
--- a/app/controllers/api/v0/articles_controller.rb
+++ b/app/controllers/api/v0/articles_controller.rb
@@ -42,8 +42,8 @@ module Api
         if @article.persisted?
           render "show", status: :created, location: @article.url
         else
-          message = @article.errors.full_messages
-          render json: { errors: message, status: 422 }, status: :unprocessable_entity
+          message = @article.errors.full_messages.join(", ")
+          render json: { error: message, status: 422 }, status: :unprocessable_entity
         end
       end
 

--- a/spec/requests/api/v0/articles_spec.rb
+++ b/spec/requests/api/v0/articles_spec.rb
@@ -261,6 +261,7 @@ RSpec.describe "Api::V0::Articles", type: :request do
         tags = %w[meta discussion]
         post_article(body_markdown: "Yo ho ho", tags: tags)
         expect(response).to have_http_status(:unprocessable_entity)
+        expect(json_response["error"]).to be_present
       end
 
       it "creates an article belonging to the user" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

While updating the API docs I've noticed how https://github.com/thepracticaldev/dev.to/pull/4417 broke the error interface (the client expects a string error, not an array of errors, they can't both coexist without the API client breaking).

This fixes it
