### PR TITLE
[deploy] Fix Image Overflow in Comment Preview - #4382

### DIFF
--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -345,6 +345,9 @@ a.header-link {
       code {
         word-wrap: break-word;
       }
+      .article-body-image-wrapper img{
+        max-width: 100%;
+      }
     }
     .actions {
       text-align: right;

--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -345,7 +345,7 @@ a.header-link {
       code {
         word-wrap: break-word;
       }
-      .article-body-image-wrapper img{
+      .article-body-image-wrapper img {
         max-width: 100%;
       }
     }


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
- Enforces `max-width:100%` on images in `.comment-preview-div` to prevent them from overflowing their container.

## Related Tickets & Documents
Fixes #4382 

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## Screenshots of bug fix

**Before:**
![Screen Shot 2019-10-18 at 18 43 14](https://user-images.githubusercontent.com/22113778/67097210-433f5f00-f1d7-11e9-8ef2-4b31aec94341.png)

**After:**
![Screen Shot 2019-10-18 at 18 42 59](https://user-images.githubusercontent.com/22113778/67097222-4a666d00-f1d7-11e9-8261-3de0a2837fde.png)


## [optional] What gif best describes this PR or how it makes you feel?

![get shrunk](https://media.giphy.com/media/77o9Jv2bIn09G/giphy.gif)
