### PR TITLE
Increased redirects limit when fetching podcasts

### DIFF
--- a/app/services/podcasts/feed.rb
+++ b/app/services/podcasts/feed.rb
@@ -8,6 +8,7 @@ module Podcasts
     end
 
     def get_episodes(limit: 100, force_update: false)
+      # increased the redirect limit from 5 (default) to 7 to be able to handle such urls
       rss = HTTParty.get(podcast.feed_url, limit: 7).body
       feed = RSS::Parser.parse(rss, false)
 

--- a/app/services/podcasts/feed.rb
+++ b/app/services/podcasts/feed.rb
@@ -8,7 +8,7 @@ module Podcasts
     end
 
     def get_episodes(limit: 100, force_update: false)
-      rss = HTTParty.get(podcast.feed_url).body
+      rss = HTTParty.get(podcast.feed_url, limit: 7).body
       feed = RSS::Parser.parse(rss, false)
 
       set_unreachable(:unparsable, force_update) && return unless feed


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Increased redirects limit when fetching podcasts to avoid `HTTP redirects too deep` error.