### PR TITLE
Fix render codeblocks using tildes

### DIFF
--- a/app/labor/markdown_parser.rb
+++ b/app/labor/markdown_parser.rb
@@ -9,7 +9,7 @@ class MarkdownParser
   end
 
   def finalize(link_attributes: {})
-    options = { hard_wrap: true, filter_html: false, link_attributes: link_attributes }
+    options = { hard_wrap: false, filter_html: false, link_attributes: link_attributes }
     renderer = Redcarpet::Render::HTMLRouge.new(options)
     markdown = Redcarpet::Markdown.new(renderer, REDCARPET_CONFIG)
     catch_xss_attempts(@content)

--- a/spec/labor/markdown_parser_spec.rb
+++ b/spec/labor/markdown_parser_spec.rb
@@ -27,6 +27,11 @@ RSpec.describe MarkdownParser do
     expect(generate_and_parse_markdown(code_block)).not_to include("----")
   end
 
+  it "does not render '<br>' when using tildes to delimit codeblocks preceded by a header" do
+    code_block = "~~~\nputs 'hello'\n~~~\n# header\n"
+    expect(generate_and_parse_markdown(code_block)).not_to include("<br>")
+  end
+
   it "does not remove the non-'raw tag related' four dashes" do
     code_block = "```\n----\n```"
     expect(generate_and_parse_markdown(code_block)).to include("----")


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

Removes line breaks added between each line in code blocks preceded by header. 

I'm setting ```hard_wrap``` to ```false``` according to the [Redcarpet documentation](https://github.com/vmg/redcarpet):
> ```:hard_wrap:``` insert HTML ```<br>``` tags inside paragraphs where the original Markdown document had newlines (by default, Markdown ignores these newlines).

I also added a test case to reproduce the reported [issue](https://github.com/thepracticaldev/dev.to/issues/1446).

## Related Tickets & Documents
Fixes [1446](https://github.com/thepracticaldev/dev.to/issues/1446)

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
