### PR TITLE
Ignore .tool-versions file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ docs/.static/api/
 
 # rvm
 .ruby-gemset
+
+# asdf
+.tool-versions


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Documentation Update (kinda?)

## Description

We've decided as a project to prefer rbenv for version management. I use
asdf for my version management, so I've decided to ignore the dotfile
that asdf creates and relies on.

That lets me keep using asdf without worrying about maintaining two
version indicating dotfiles. People should be able to manually check the
.ruby-version file or Gemfile if they need to know the version for a
tool like asdf.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![external-content duckduckgo com](https://user-images.githubusercontent.com/11466782/67166394-7a874a80-f354-11e9-85f2-81b55cb2ab75.gif)

