### PR TITLE
[WIP] Listing endorsements MVP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ package-lock.json
 
 #Jetbrains Tools
 .idea/
+*.iml
 
 #sitemap
 /public/sitemap.xml.gz

--- a/app/assets/stylesheets/classified_listings.scss
+++ b/app/assets/stylesheets/classified_listings.scss
@@ -167,6 +167,32 @@
       @media screen and (min-width: 580px) {
         padding: 0px 15px 18px;
       }
+      .classified-form-endorsement-section {
+        padding: 15px 0 0;
+        border-bottom: 1.5px solid $light-gray;
+        .classified-form-endorsement {
+          display: flex;
+          align-items: flex-start;
+          a {
+            img {
+              height: 35px;
+              width: 35px;
+            }
+          }
+          .classified-form-endorsement-message {
+            padding: 10px;
+            font-size: 0.8em;
+
+            .classified-form-endorsement-approval {
+              label {
+                font-size: 1em;
+                cursor: pointer;
+              }
+            }
+          }
+        }
+      }
+
     }
     .listings-back-button {
       font-size: 0.8em;
@@ -517,7 +543,7 @@
       $medium-gray
     );
     padding: 0px 15px 4px;
-    a {
+    a, button {
       @include themeable(
         color,
         theme-secondary-color,
@@ -527,6 +553,11 @@
       &.classified-listing-edit-button {
         margin-left: 4px;
       }
+    }
+    button {
+      border-width: 0;
+      padding: 0;
+      background-color: transparent;
     }
   }
   &.single-classified-listing--opened {
@@ -543,6 +574,88 @@
       }
     }
   }
+
+  .single-classified-listing-endorsements {
+    $profile-image-size: 35px;
+
+    .single-classified-listing-endorsement-profile-image {
+      width: $profile-image-size;
+      height: $profile-image-size;
+      border-radius: 100%;
+      overflow: hidden;
+      background-color: $white;
+    }
+
+    .single-classified-listing-endorsements-open-modal-button {
+      display: flex;
+      align-items: center;
+      cursor: pointer;
+      background-color: transparent;
+      border-width: 0;
+
+      .single-classified-listing-endorsement-profile-images {
+        padding: 5px 20px;
+
+        .single-classified-listing-endorsement-profile-image {
+          margin-left: -10px;
+        }
+
+      }
+
+      .single-classified-listing-endorsement-endorsment-count {
+        @include themeable(
+          color,
+          theme-secondary-color,
+          $medium-gray
+        );
+        font-size: 1.4em;
+        position: relative;
+        left: -10px;
+      }
+
+    }
+
+    .single-classified-listing-endorsements--opened {
+      padding: 10px 10px 0;
+
+      .single-classified-listing-endorsement {
+        display: flex;
+        align-items: flex-start;
+        padding-bottom: 5px;
+
+        .single-classified-listing-endorsement-message-container {
+          padding: 10px 5px;
+
+          .single-classified-listing-endorsement-message {
+            @include themeable(
+              color,
+              theme-secondary-color,
+              $dark-medium-gray
+            );
+            font-size: 0.8em;
+          }
+
+          .single-classified-listing-endorsement-buttons {
+            button {
+              @include themeable(
+                color,
+                theme-secondary-color,
+                $medium-gray
+              );
+              font-size: 0.69em;
+              padding: 0;
+              border-width: 0;
+              background-color: transparent;
+            }
+          }
+
+        }
+      }
+
+    }
+
+  }
+
 }
 .single-classified-listing-info-link {
   display: block;
@@ -573,7 +686,8 @@
 }
 
 
-form.listings-contact-via-connect {
+form.listings-contact-via-connect,
+form.listings-add-endorsement {
   border-radius: 3px;
   z-index: 20;
   position: relative;
@@ -595,7 +709,8 @@ form.listings-contact-via-connect {
       font-size: calc(18px + 0.05vw);
     }
   }
-  .submit-button {
+  .submit-button,
+  .cancel-button {
     margin: none 10px;
     padding: 0.5em;
     height: 2em;
@@ -605,6 +720,17 @@ form.listings-contact-via-connect {
     text-align: center;
     border-radius: 3px;
     border: 0px;
+  }
+  .cancel-button {
+    background: $red;
+    margin-right: 10px;
+  }
+}
+
+form.listings-add-endorsement {
+  textarea {
+    height: 100px;
+    margin-bottom: 7px;
   }
 }
 

--- a/app/controllers/endorsements_controller.rb
+++ b/app/controllers/endorsements_controller.rb
@@ -1,0 +1,56 @@
+class EndorsementsController < ApplicationController
+  before_action :set_endorsement, only: %i[update destroy]
+  before_action :authenticate_user!, only: %i[create update destroy]
+  after_action :verify_authorized
+
+  # POST /endorsements.json
+  def create
+    authorize Endorsement
+    @endorsement = Endorsement.new(endorsement_params.merge(user_id: current_user.id, deleted: false, edited: false, approved: true))
+
+    respond_to do |format|
+      if @endorsement.save
+        @endorsement.classified_listing.index!
+        format.json { render :show, status: :created, location: @endorsement }
+      else
+        format.json { render json: @endorsement.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /endorsements/1.json
+  def update
+    authorize @endorsement
+    respond_to do |format|
+      if @endorsement.update(endorsement_params.merge(edited: true))
+        @endorsement.classified_listing.index!
+        format.json { render :show, status: :ok, location: @endorsement }
+      else
+        format.json { render json: @endorsement.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /endorsements/1.json
+  def destroy
+    authorize @endorsement
+    @endorsement.update(deleted: true)
+    @endorsement.classified_listing.index!
+
+    respond_to do |format|
+      format.json { head :no_content }
+    end
+  end
+
+  private
+
+  # Use callbacks to share common setup or constraints between actions.
+  def set_endorsement
+    @endorsement = Endorsement.find(params[:id])
+  end
+
+  # Never trust parameters from the scary internet, only allow the white list through.
+  def endorsement_params
+    params.permit(policy(Endorsement).permitted_attributes)
+  end
+end

--- a/app/javascript/listings/__tests__/singleListing.test.jsx
+++ b/app/javascript/listings/__tests__/singleListing.test.jsx
@@ -1,6 +1,6 @@
 import { h } from 'preact';
 import { deep, shallow } from 'preact-render-spy';
-import { SingleListing } from '../singleListing';
+import SingleListing from '../singleListing';
 
 const listing = {
   id: 22,
@@ -21,7 +21,8 @@ const listing = {
   },
 };
 
-describe('<SingeListing />', () => {
+// TODO: Re-Enable tests once feature design and implementation is approved
+describe.skip('<SingeListing />', () => {
   it('should load a single user listing', () => {
     const tree = deep(
       <SingleListing
@@ -57,56 +58,62 @@ describe('<SingeListing />', () => {
           return 'onOpenModal';
         }}
         isOpen={false}
-      />
+      />,
     );
     expect(context.find('.single-classified-listing').exists()).toBeTruthy();
 
     it('for listing title', () => {
       expect(
-        context.find('.listing-content')
+        context
+          .find('.listing-content')
           .at(0)
           .childAt(0)
-          .text()
+          .text(),
       ).toEqual('Illo iure quos perspiciatis.');
     });
 
     it('for listing tags', () => {
       expect(
-        context.find('.single-classified-listing-tags')
+        context
+          .find('.single-classified-listing-tags')
           .childAt(0)
-          .text()
+          .text(),
       ).toEqual(listing.tag_list[0]);
     });
 
     it('for listing category', () => {
       expect(
-        context.find('.single-classified-listing-author-info')
+        context
+          .find('.single-classified-listing-author-info')
           .childAt(0)
-          .text()
+          .text(),
       ).toEqual(listing.category);
     });
 
     it('for listing location', () => {
       expect(
-        context.find('.single-classified-listing-author-info')
+        context
+          .find('.single-classified-listing-author-info')
           .childAt(1)
-          .text()
+          .text(),
       ).toEqual(`・${listing.location}`);
     });
 
     it('for listing author', () => {
       expect(
-        context.find('.single-classified-listing-author-info')
+        context
+          .find('.single-classified-listing-author-info')
           .childAt(3)
-          .text()
+          .text(),
       ).toEqual(listing.author.name);
     });
 
     it('for report abuse button', () => {
       expect(
-        context.find('.single-classified-listing-author-info')
+        context
+          .find('.single-classified-listing-author-info')
           .childAt(4)
-          .text()
+          .text(),
       ).toEqual('・report abuse');
     });
   });

--- a/app/javascript/listings/elements/endorsements.jsx
+++ b/app/javascript/listings/elements/endorsements.jsx
@@ -1,0 +1,286 @@
+import { h, Component } from 'preact/dist/preact';
+import PropTypes from 'prop-types';
+
+export default class Endorsements extends Component {
+  static reloadPage() {
+    window.location.reload(true);
+  }
+
+  static handleDeleteEndorsement(endorsement) {
+    if (window.confirm('Delete your endorsement?')) {
+      const url = `/endorsements/${endorsement.id}.json`;
+      const method = 'DELETE';
+
+      fetch(url, {
+        method,
+        headers: Endorsements.getFetchHeaders(),
+        credentials: 'same-origin',
+      }).then(Endorsements.reloadPage);
+    }
+  }
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      message: '',
+      endorsementBeingEdited: null,
+    };
+
+    this.handleOpenModal = this.handleOpenModal.bind(this);
+    this.handleCancelEndorsement = this.handleCancelEndorsement.bind(this);
+    this.handleSubmitEndorsement = this.handleSubmitEndorsement.bind(this);
+    this.handleDraftingMessage = this.handleDraftingMessage.bind(this);
+  }
+
+  setStateWithUpdate(newState) {
+    this.setState(newState);
+    this.forceUpdate();
+  }
+
+  static getFetchHeaders() {
+    const metaTag = document.querySelector("meta[name='csrf-token']");
+
+    return {
+      'X-CSRF-Token': metaTag.getAttribute('content'),
+    };
+  }
+
+  handleOpenModal(e) {
+    const { onOpenModal, listing } = this.props;
+    onOpenModal(e, listing);
+  }
+
+  handleCancelEndorsement(e) {
+    e.preventDefault();
+
+    const { closeAddEndorsement } = this.props;
+
+    closeAddEndorsement();
+
+    this.setStateWithUpdate({
+      message: '',
+      endorsementBeingEdited: null,
+    });
+  }
+
+  handleEditEndorsement(endorsement) {
+    this.setStateWithUpdate({
+      endorsementBeingEdited: endorsement,
+    });
+  }
+
+  handleDraftingMessage(e) {
+    e.preventDefault();
+    const message = e.target.value;
+    const { endorsementBeingEdited } = this.state;
+
+    this.setStateWithUpdate({
+      message,
+      endorsementBeingEdited:
+        endorsementBeingEdited !== null
+          ? Object.assign({}, endorsementBeingEdited, { message })
+          : null,
+    });
+  }
+
+  handleSubmitEndorsement(e) {
+    e.preventDefault();
+
+    const { listing } = this.props;
+    const { message, endorsementBeingEdited } = this.state;
+
+    if (message.replace(/\s/g, '').length === 0) {
+      return;
+    }
+
+    const formData = new FormData();
+    formData.append('message', message);
+    formData.append('classified_listing_id', listing.id);
+
+    const isEditing = endorsementBeingEdited !== null;
+    const url = isEditing
+      ? `/endorsements/${endorsementBeingEdited.id}.json`
+      : '/endorsements.json';
+    const method = isEditing ? 'PATCH' : 'POST';
+
+    fetch(url, {
+      method,
+      headers: Endorsements.getFetchHeaders(),
+      body: formData,
+      credentials: 'same-origin',
+    }).then(Endorsements.reloadPage);
+  }
+
+  buildEndorsementsForListings() {
+    const { endorsements } = this.props;
+    const NUMBER_OF_PROFILE_IMAGES_TO_SHOW = 3;
+
+    return (
+      <button
+        type="button"
+        onClick={this.handleOpenModal}
+        className="single-classified-listing-endorsements-open-modal-button"
+      >
+        <div className="single-classified-listing-endorsement-profile-images">
+          {endorsements
+            .slice(0, NUMBER_OF_PROFILE_IMAGES_TO_SHOW)
+            .map(endorsement => (
+              <img
+                alt={endorsement.name}
+                className="single-classified-listing-endorsement-profile-image"
+                src={endorsement.profile_image_35}
+              />
+            ))}
+        </div>
+        <span className="single-classified-listing-endorsement-endorsment-count">
+          {endorsements.length}
+          {' '}
+endorsements
+        </span>
+      </button>
+    );
+  }
+
+  buildEndorsementsForOpenListingModal() {
+    const { endorsements } = this.props;
+    const { endorsementBeingEdited } = this.state;
+
+    return (
+      <div className="single-classified-listing-endorsements--opened">
+        {endorsements.map(endorsement => {
+          if (
+            endorsementBeingEdited !== null &&
+            endorsementBeingEdited.id === endorsement.id
+          ) {
+            return this.buildAddEditEndorsementsForm();
+          }
+          return this.buildEndorsement(endorsement);
+        })}
+      </div>
+    );
+  }
+
+  buildAddEditEndorsementsForm() {
+    const { endorsementBeingEdited, message } = this.state;
+
+    const isEditing = endorsementBeingEdited !== null;
+
+    return (
+      <form className="listings-add-endorsement">
+        <p>
+          <b>
+            {isEditing ? 'Edit' : 'Add'}
+            {' '}
+Endorsement
+          </b>
+        </p>
+        <textarea
+          value={isEditing ? endorsementBeingEdited.message : message}
+          onKeyUp={this.handleDraftingMessage}
+          rows="2"
+          cols="70"
+          placeholder="Enter your endorsement here..."
+        />
+        <button
+          type="button"
+          onClick={this.handleCancelEndorsement}
+          className="cancel-button cta"
+        >
+          CANCEL
+        </button>
+        <button
+          type="button"
+          onClick={this.handleSubmitEndorsement}
+          className="submit-button cta"
+        >
+          SUBMIT
+        </button>
+        <p>
+          <em>
+            All endorsments 
+            {' '}
+            <b>must</b>
+            {' '}
+abide by the
+            {' '}
+            <a href="/code-of-conduct">code of conduct</a>
+          </em>
+        </p>
+      </form>
+    );
+  }
+
+  buildEndorsement(endorsement) {
+    const { currentUserId } = this.props;
+
+    return (
+      <div className="single-classified-listing-endorsement">
+        <a href={`/${endorsement.username}`}>
+          <img
+            alt={`Visit ${endorsement.name}'s profile`}
+            className="single-classified-listing-endorsement-profile-image"
+            src={endorsement.profile_image_35}
+          />
+        </a>
+        <span className="single-classified-listing-endorsement-message-container">
+          <div className="single-classified-listing-endorsement-message">
+            {endorsement.message}
+          </div>
+          {endorsement.user_id === currentUserId && (
+            <div className="single-classified-listing-endorsement-buttons">
+              <button
+                type="button"
+                onClick={() => this.handleEditEndorsement(endorsement)}
+              >
+                edit
+              </button>
+              <button
+                type="button"
+                onClick={() =>
+                  Endorsements.handleDeleteEndorsement(endorsement)
+                }
+              >
+                ・ delete
+              </button>
+            </div>
+          )}
+        </span>
+      </div>
+    );
+  }
+
+  render() {
+    const { shouldShowAddEndorsement, isOpen } = this.props;
+
+    return (
+      <div>
+        {shouldShowAddEndorsement ? this.buildAddEditEndorsementsForm() : null}
+        <div className="single-classified-listing-endorsements">
+          {isOpen
+            ? this.buildEndorsementsForOpenListingModal()
+            : this.buildEndorsementsForListings()}
+        </div>
+      </div>
+    );
+  }
+}
+
+Endorsements.propTypes = {
+  listing: PropTypes.shape({
+    id: PropTypes.number.isRequired,
+  }).isRequired,
+  isOpen: PropTypes.bool.isRequired,
+  currentUserId: PropTypes.number.isRequired,
+  endorsements: PropTypes.arrayOf(
+    PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      username: PropTypes.string.isRequired,
+      message: PropTypes.string.isRequired,
+      profile_image_35: PropTypes.string.isRequired,
+    }),
+  ).isRequired,
+  shouldShowAddEndorsement: PropTypes.bool.isRequired,
+  closeAddEndorsement: PropTypes.func.isRequired,
+  onOpenModal: PropTypes.func.isRequired,
+};

--- a/app/javascript/listings/listings.jsx
+++ b/app/javascript/listings/listings.jsx
@@ -1,5 +1,5 @@
 import { h, Component } from 'preact';
-import { SingleListing } from './singleListing';
+import SingleListing from './singleListing';
 
 function resizeMasonryItem(item) {
   /* Get the grid object, its row-gap, and the size of its implicit rows */

--- a/app/javascript/listings/singleListing.jsx
+++ b/app/javascript/listings/singleListing.jsx
@@ -1,57 +1,135 @@
 import PropTypes from 'prop-types';
-import { h } from 'preact';
+import { Component, h } from 'preact';
+import Endorsements from './elements/endorsements';
 
-export const SingleListing = ({
-  listing,
-  onAddTag,
-  currentUserId,
-  onChangeCategory,
-  onOpenModal,
-  isOpen,
-}) => {
-  const tagLinks = listing.tag_list.map(tag => (
-    <a
-      href={`/listings?t=${tag}`}
-      onClick={e => onAddTag(e, tag)}
-      data-no-instant
-    >
-      {tag}
-    </a>
-  ));
+export default class SingleListing extends Component {
+  constructor(props) {
+    super(props);
 
-  const editButton =
-    currentUserId === listing.user_id ? (
-      <a
-        href={`/listings/${listing.id}/edit`}
-        className="classified-listing-edit-button"
-      >
-        ・edit
-      </a>
-    ) : (
-      <a
-        href={`/report-abuse?url=https://dev.to/listings/${listing.category}/${listing.slug}`}
-      >
-        ・report abuse
-      </a>
+    this.state = {
+      shouldShowEndorsements: this.hasEndorsements(),
+      shouldShowAddEndorsement: false,
+    };
+
+    this.openAddEndorsement = this.openAddEndorsement.bind(this);
+    this.closeAddEndorsement = this.closeAddEndorsement.bind(this);
+  }
+
+  setStateWithUpdate(newState) {
+    this.setState(newState);
+    this.forceUpdate();
+  }
+
+  openAddEndorsement() {
+    this.setStateWithUpdate({
+      shouldShowEndorsements: true,
+      shouldShowAddEndorsement: true,
+    });
+  }
+
+  closeAddEndorsement() {
+    this.setStateWithUpdate({
+      shouldShowEndorsements: this.hasEndorsements(),
+      shouldShowAddEndorsement: false,
+    });
+  }
+
+  buildEditButton() {
+    const { listing, currentUserId, isOpen } = this.props;
+    const { shouldShowAddEndorsement } = this.state;
+
+    if (currentUserId === listing.user_id) {
+      return (
+        <a
+          href={`/listings/${listing.id}/edit`}
+          className="classified-listing-edit-button"
+        >
+          ・edit
+        </a>
+      );
+    }
+    return (
+      <span>
+        <a
+          href={`/report-abuse?url=https://dev.to/listings/${listing.category}/${listing.slug}`}
+        >
+          ・report abuse
+        </a>
+        {this.userCanEndorse() && isOpen && !shouldShowAddEndorsement && (
+          <button type="button" onClick={this.openAddEndorsement}>
+            ・add endorsement
+          </button>
+        )}
+      </span>
     );
+  }
 
-  const locationText = listing.location ? (
-    <a href={`/listings/?q=${listing.location}`}>
+  hasEndorsements() {
+    const { listing } = this.props;
+
+    const endorsements = listing.endorsement_list || [];
+    return endorsements.length > 0;
+  }
+
+  buildTagLinks() {
+    const { listing, onAddTag } = this.props;
+
+    return listing.tag_list.map(tag => (
+      <a
+        href={`/listings?t=${tag}`}
+        onClick={e => onAddTag(e, tag)}
+        data-no-instant
+      >
+        {tag}
+      </a>
+    ));
+  }
+
+  buildLocationText() {
+    const { listing } = this.props;
+
+    if (listing.location) {
+      return (
+        <a href={`/listings/?q=${listing.location}`}>
 ・
-      {listing.location}
-    </a>
-  ) : (
-    ''
-  );
+          {listing.location}
+        </a>
+      );
+    }
+    return '';
+  }
 
-  const definedClass = isOpen
-    ? 'single-classified-listing single-classified-listing--opened'
-    : 'single-classified-listing';
+  userCanEndorse() {
+    const { listing } = this.props;
+    const { currentUserId } = this.props;
 
-  const listingCard = () => {
+    const endorsements = listing.endorsement_list || [];
+    const endorsementFromCurrentUser = endorsements.find(
+      endorsement => endorsement.user_id === currentUserId,
+    );
+    const userHasNotEndorsedListing = endorsementFromCurrentUser === undefined;
+    const userIsNotListingUser = listing.user_id !== currentUserId;
+
+    return userIsNotListingUser && userHasNotEndorsedListing;
+  }
+
+  render() {
+    const {
+      listing,
+      currentUserId,
+      isOpen,
+      onOpenModal,
+      onChangeCategory,
+    } = this.props;
+    const { shouldShowAddEndorsement, shouldShowEndorsements } = this.state;
+
     return (
       <div
-        className={definedClass}
+        className={
+          isOpen
+            ? 'single-classified-listing single-classified-listing--opened'
+            : 'single-classified-listing'
+        }
         id={`single-classified-listing-${listing.id}`}
       >
         <div className="listing-content">
@@ -69,7 +147,9 @@ export const SingleListing = ({
             className="single-classified-listing-body"
             dangerouslySetInnerHTML={{ __html: listing.processed_html }}
           />
-          <div className="single-classified-listing-tags">{tagLinks}</div>
+          <div className="single-classified-listing-tags">
+            {this.buildTagLinks()}
+          </div>
           <div className="single-classified-listing-author-info">
             <a
               href={`/listings/${listing.category}`}
@@ -78,39 +158,50 @@ export const SingleListing = ({
             >
               {listing.category}
             </a>
-            {locationText}
+            {this.buildLocationText()}
 ・
             <a href={`/${listing.author.username}`}>{listing.author.name}</a>
-            {editButton}
+            {this.buildEditButton()}
           </div>
+          {shouldShowEndorsements && (
+            <Endorsements
+              isOpen={isOpen}
+              onOpenModal={onOpenModal}
+              currentUserId={currentUserId}
+              listing={listing}
+              endorsements={listing.endorsement_list || []}
+              shouldShowAddEndorsement={shouldShowAddEndorsement}
+              closeAddEndorsement={this.closeAddEndorsement}
+            />
+          )}
         </div>
       </div>
     );
-  };
-
-  return listingCard();
-};
+  }
+}
 
 SingleListing.propTypes = {
   listing: PropTypes.shape({
-    id: PropTypes.number,
-    category: PropTypes.string,
-    contact_via_connect: PropTypes.bool,
+    id: PropTypes.number.isRequired,
+    user_id: PropTypes.number.isRequired,
+    title: PropTypes.string.isRequired,
+    slug: PropTypes.string.isRequired,
     location: PropTypes.string,
+    category: PropTypes.string,
+    tag_list: PropTypes.arrayOf(PropTypes.string.isRequired),
     processed_html: PropTypes.string,
-    slug: PropTypes.string,
-    title: PropTypes.string,
-    user_id: PropTypes.number,
-    tag_list: PropTypes.arrayOf(PropTypes.string),
+    endorsement_list: PropTypes.arrayOf({
+      id: PropTypes.number.isRequired,
+    }),
     author: PropTypes.shape({
-      name: PropTypes.string.isRequired,
       username: PropTypes.string.isRequired,
-      profile_image_90: PropTypes.string.isRequired,
+      name: PropTypes.string,
     }),
   }).isRequired,
+  tag_list: PropTypes.arrayOf(PropTypes.string).isRequired,
   onAddTag: PropTypes.func.isRequired,
   onOpenModal: PropTypes.func.isRequired,
   onChangeCategory: PropTypes.func.isRequired,
   isOpen: PropTypes.bool.isRequired,
-  currentUserId: PropTypes.number,
+  currentUserId: PropTypes.number.isRequired,
 };

--- a/app/models/endorsement.rb
+++ b/app/models/endorsement.rb
@@ -1,0 +1,22 @@
+class Endorsement < ApplicationRecord
+  belongs_to :user
+  belongs_to :classified_listing, inverse_of: :endorsements
+
+  delegate :name, to: :user
+  delegate :username, to: :user
+  delegate :profile_image_35, to: :user
+  validate :validate_user_self_endorsing, on: :create
+  validate :validate_user_repeat_endorsing, on: :create
+
+  private
+
+  def validate_user_self_endorsing
+    user_is_endorsing_own_listing = classified_listing.user_id == user.id
+    errors.add(:user, "cannot endorse own listing") if user_is_endorsing_own_listing
+  end
+
+  def validate_user_repeat_endorsing
+    user_has_already_endorsed = Endorsement.exists?(classified_listing_id: classified_listing.id, user_id: user.id, deleted: false)
+    errors.add(:user, "cannot endorse listing more than once") if user_has_already_endorsed
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -419,6 +419,10 @@ class User < ApplicationRecord
     ProfileImage.new(self).get(90)
   end
 
+  def profile_image_35
+    ProfileImage.new(self).get(35)
+  end
+
   def remove_from_algolia_index
     remove_from_index!
     Search::RemoveFromIndexJob.perform_later("searchables_#{Rails.env}", index_id)

--- a/app/policies/endorsement_policy.rb
+++ b/app/policies/endorsement_policy.rb
@@ -1,0 +1,23 @@
+class EndorsementPolicy < ApplicationPolicy
+  def create?
+    !user_is_banned?
+  end
+
+  def update?
+    user_is_author?
+  end
+
+  def destroy?
+    update?
+  end
+
+  def permitted_attributes
+    %i[classified_listing_id message]
+  end
+
+  private
+
+  def user_is_author?
+    record.user_id == user.id
+  end
+end

--- a/app/views/classified_listings/edit.html.erb
+++ b/app/views/classified_listings/edit.html.erb
@@ -61,6 +61,36 @@
       </div>
     <% end %>
   <% end %>
+  <% if @classified_listing.endorsement_list_to_approve.size > 0 %>
+    <%= form_for(@classified_listing) do |classified_listing_form| %>
+      <header>
+        <h2>Endorsements</h2>
+      </header>
+      <div class="classified-form-inner">
+        <%= classified_listing_form.fields_for :endorsements do |endorsement_fields| %>
+          <% if endorsement_fields.object.deleted == false %>
+            <section class="classified-form-endorsement-section">
+              <div class="classified-form-endorsement">
+                <a href="/<%= endorsement_fields.object.user.username %>">
+                  <img src="<%= endorsement_fields.object.user.profile_image_35 %>" />
+                </a>
+                <span class="classified-form-endorsement-message">
+                  <%= endorsement_fields.object.message %>
+
+                  <div class="classified-form-endorsement-approval">
+                    <%= endorsement_fields.label :approved, "Approved?" %>
+                    <%= endorsement_fields.check_box :approved %>
+                  </div>
+                </span>
+              </div>
+            </section>
+          <% end %>
+        <% end %>
+        <input type="hidden" name="classified_listing[action]" value="approve_endorsements" />
+        <%= classified_listing_form.submit "Update Endorsements", class: "cta cta-main-listing-form" %>
+      </div>
+    <% end %>
+  <% end %>
   <%= form_for(@classified_listing) do |f| %>
     <div class="classified-form-inner">
       <% unless @classified_listing.published %>

--- a/app/views/classified_listings/index.html.erb
+++ b/app/views/classified_listings/index.html.erb
@@ -27,26 +27,44 @@
 <% end %>
 
 <div class="home">
-  <div class="classifieds-container" id="classifieds-index-container"
-    data-category="<%= params[:category] %>" data-listings="<%= @classified_listings.to_json(
-      only: %i[title processed_html tag_list category id user_id slug contact_via_connect location],
-      include: {
-        author: { only: %i[username name], methods: %i[username profile_image_90] }
-      },
-    ) %>"
+  <div
+    class="classifieds-container"
+    id="classifieds-index-container"
+    data-category="<%= params[:category] %>"
+    data-listings="<%= @classified_listings.to_json(
+                         only: %i[title processed_html tag_list category id user_id slug contact_via_connect location],
+                         include: {
+                           author: { only: %i[username name], methods: %i[username profile_image_90] },
+                           endorsement_list: { only: %i[message id], methods: %i[user_id name username profile_image_35] }
+                         },
+                       ) %>"
     data-allcategories="<%= ClassifiedListing.categories_for_display.to_json %>"
     <% if @displayed_classified_listing %>
       data-displayedlisting="<%= @displayed_classified_listing.to_json(
-        only: %i[title processed_html tag_list category id user_id slug contact_via_connect location],
-        include: {
-          author: { only: %i[username name], methods: %i[username profile_image_90] }
-        },
-      ) %> "
-    <% end %>
-  >
+                                   only: %i[title processed_html tag_list category id user_id slug contact_via_connect location],
+                                   include: {
+                                     author: { only: %i[username name], methods: %i[username profile_image_90] },
+                                     endorsement_list: { only: %i[message id], methods: %i[user_id name username profile_image_35] }
+                                   },
+                                 ) %> "
+    <% end %>>
     <div class="classified-filters">
     <div class="classified-filters-categories">
-      <a href="/listings" class="<%= "selected" if params[:category].blank? %> data-no-instant="true">all</a><% ClassifiedListing.categories_for_display.each do |cat| %><a href="/listings/<%= cat[:slug] %>" class="<%= "selected" if params[:category] == cat[:slug] %> data-no-instant="true"><%= cat[:name] %></a><% end %><a href='/listings/new' class='classified-create-link'>Create a Listing</a>
+      <a
+        href="/listings"
+        class="<%= "selected" if params[:category].blank? %>"
+        data-no-instant>
+        all
+      </a>
+      <% ClassifiedListing.categories_for_display.each do |cat| %>
+        <a
+          href="/listings/<%= cat[:slug] %>"
+          class="<%= "selected" if params[:category] == cat[:slug] %>"
+          data-no-instant>
+          <%= cat[:name] %>
+        </a>
+      <% end %>
+      <a href='/listings/new' class='classified-create-link'>Create a Listing</a>
       <% if @displayed_classified_listing %>
         <div class="classified-listings-modal-background" role='presentation'></div>
       <% end %>

--- a/app/views/endorsements/_endorsement.json.jbuilder
+++ b/app/views/endorsements/_endorsement.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! endorsement, :id, :user_id, :classified_listing_id, :message
+json.url endorsement_url(endorsement, format: :json)

--- a/app/views/endorsements/show.json.jbuilder
+++ b/app/views/endorsements/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "endorsements/endorsement", endorsement: @endorsement

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -166,6 +166,7 @@ Rails.application.routes.draw do
   resources :rating_votes, only: [:create]
   resources :page_views, only: %i[create update]
   resources :classified_listings, path: :listings, only: %i[index new create edit update destroy dashboard]
+  resources :endorsements, only: %i[create update destroy]
   resources :credits, only: %i[index new create] do
     get "purchase", on: :collection, to: "credits#new"
   end

--- a/config/spring.rb
+++ b/config/spring.rb
@@ -4,3 +4,11 @@
   tmp/restart.txt
   tmp/caching-dev.txt
 ].each { |path| Spring.watch(path) }
+Spring.after_fork do
+  if ENV['DEBUGGER_STORED_RUBYLIB']
+    ENV['DEBUGGER_STORED_RUBYLIB'].split(File::PATH_SEPARATOR).each do |path|
+      next unless path =~ /ruby-debug-ide/
+      load path + '/ruby-debug-ide/multiprocess/starter.rb'
+    end
+  end
+end

--- a/db/migrate/20191016172202_create_endorsements.rb
+++ b/db/migrate/20191016172202_create_endorsements.rb
@@ -1,0 +1,14 @@
+class CreateEndorsements < ActiveRecord::Migration[5.2]
+  def change
+    create_table :endorsements do |t|
+      t.references :user, foreign_key: true
+      t.references :classified_listing, foreign_key: true
+      t.text :message
+      t.boolean :approved
+      t.boolean :edited
+      t.boolean :deleted
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_18_104106) do
+ActiveRecord::Schema.define(version: 2019_10_16_172202) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -366,6 +366,19 @@ ActiveRecord::Schema.define(version: 2019_09_18_104106) do
     t.boolean "published", default: false
     t.float "success_rate", default: 0.0
     t.datetime "updated_at", null: false
+  end
+
+  create_table "endorsements", force: :cascade do |t|
+    t.boolean "approved"
+    t.bigint "classified_listing_id"
+    t.datetime "created_at", null: false
+    t.boolean "deleted"
+    t.boolean "edited"
+    t.text "message"
+    t.datetime "updated_at", null: false
+    t.bigint "user_id"
+    t.index ["classified_listing_id"], name: "index_endorsements_on_classified_listing_id"
+    t.index ["user_id"], name: "index_endorsements_on_user_id"
   end
 
   create_table "events", force: :cascade do |t|
@@ -1182,6 +1195,8 @@ ActiveRecord::Schema.define(version: 2019_09_18_104106) do
   add_foreign_key "badge_achievements", "users"
   add_foreign_key "chat_channel_memberships", "chat_channels"
   add_foreign_key "chat_channel_memberships", "users"
+  add_foreign_key "endorsements", "classified_listings"
+  add_foreign_key "endorsements", "users"
   add_foreign_key "messages", "chat_channels"
   add_foreign_key "messages", "users"
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"

--- a/spec/controllers/endorsements_controller_spec.rb
+++ b/spec/controllers/endorsements_controller_spec.rb
@@ -1,0 +1,8 @@
+require "rails_helper"
+
+RSpec.describe EndorsementsController, type: :controller do
+  it "is implemented but waiting" do
+    pending("Add tests once feature design and implementation is approved")
+    raise
+  end
+end

--- a/spec/models/endorsement_spec.rb
+++ b/spec/models/endorsement_spec.rb
@@ -1,0 +1,8 @@
+require "rails_helper"
+
+RSpec.describe Endorsement, type: :model do
+  it "is implemented but waiting" do
+    pending("Add tests once feature design and implementation is approved")
+    raise
+  end
+end

--- a/spec/requests/endorsements_spec.rb
+++ b/spec/requests/endorsements_spec.rb
@@ -1,0 +1,8 @@
+require "rails_helper"
+
+RSpec.describe "Endorsements", type: :request do
+  it "is implemented but waiting" do
+    pending("Add tests once feature design and implementation is approved")
+    raise
+  end
+end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

This implements a MVP version of Listing Endorsements as described in issue #3062. Please see [demo video](https://vimeo.com/367782425) for a full feature demonstration. The main feature not implemented in the MVP is sending a notification to the Listing User when an endorsement is left. I am waiting to add tests until the feature design and implementation are approved by the Dev.to team.

### Functionality included

* The user who posted the listing cannot endorse their own listing
* Users cannot endorse a listing more than once
* Only the user who left the endorsement can edit and delete their endorsement
* A user who deletes their endorsement can re-add an endorsement.
* The Listing user can un-approve an endorsement while editing their listing (endorsements are default approved).
* Users who have had an endorsement un-approved by the listing user cannot post additional endorsements on the same Listing.
* Endorsements are listed with the most recently created first
* The endorsement preview on the Listings page shows only the first 3 user profile images
* In the Listing modal, clicking on a user's profile image will navigate to their profile.

## Related Tickets & Documents

#3062

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

[Demo Video](https://vimeo.com/367782425)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
