### PR TITLE
[WIP] Change ArticleForm layout to improve UX on Android

### DIFF
--- a/app/assets/stylesheets/preact/article-form.scss
+++ b/app/assets/stylesheets/preact/article-form.scss
@@ -5,8 +5,6 @@
   @media screen and (min-width: 500px) {
     padding-top: calc(90px + 0.2vw);
   }
-
-  padding-bottom: calc(94px + 2vw);
 }
 
 .article-form-video-preview {
@@ -394,7 +392,7 @@
 }
 
 .articleform__body {
-  min-height: calc(80vh - 370px);
+  height: 300px;
   width: 98%;
   border: 0;
   font-size: 15px;
@@ -403,7 +401,6 @@
   font-family: $monospace;
   // scrollbars not needed because the preact-textarea-autosize package
   // automatically resizes the article form
-  overflow: hidden;
   background: white;
   background: var(--theme-container-background, white);
   color: $black;
@@ -433,11 +430,8 @@
   justify-content: center;
   align-items: center;
   text-align: center;
-  position: fixed;
   flex-wrap: wrap-reverse;
   bottom: 0px;
-  left: 0;
-  right: 0;
   background: white;
   background: var(--theme-container-background, white);
   z-index: 20;

--- a/app/javascript/article-form/elements/bodyMarkdown.jsx
+++ b/app/javascript/article-form/elements/bodyMarkdown.jsx
@@ -1,9 +1,8 @@
 import { h } from 'preact';
 import PropTypes from 'prop-types';
-import Textarea from 'preact-textarea-autosize';
 
 const BodyMarkdown = ({ onChange, defaultValue }) => (
-  <Textarea
+  <textarea
     className="articleform__body"
     id="article_body_markdown"
     placeholder="Body Markdown"


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

This PR still needs tidying up, hence the WIP. I just want to confirm if this is a good approach or not.

I want to help with this but of course there isn't an easy fix.

There are issues on Android browsers when using dynamic element heights and/or fixed positioning while opening the keyboard. The reason is that when opening the keyboard on Android browsers, the body height will change by subtracting the keyboard height. Dynamic heights will change while the keyboard is opening and cause the browser's "autoscroll to cursor" behavior to go nuts.

I managed to make the behavior a bit better by changing the layout:
  - I removed `preact-textarea-autosize`, added a hardcoded `height: 300px` to the textarea and re-introduced the scroll
  - bottom buttons are no longer with `position: fixed`

I'm not sure what else needs to change, for example I noticed that sometimes there's a `v1` for `articleform__form articleform__form--v2` about which I'm not sure but we can discuss it here.

## Related Tickets & Documents

Issue #4385 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Result in Firefox:
![firefox](https://user-images.githubusercontent.com/2506871/67225461-eee8e900-f43b-11e9-981e-5ecbe5ac1944.gif)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![it's fine](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fmedia1.tenor.com%2Fimages%2Fd6add31c664d6a7f9066d81d52a46259%2Ftenor.gif%3Fitemid%3D5182223&f=1&nofb=1)

or

![just css things](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fcdn-images-1.medium.com%2Fmax%2F800%2F1*ZPlE0Td0GCO2mt3Ivrmp5g.gif&f=1&nofb=1)