### PR TITLE
add anchor links to each heading in editor guide

### DIFF
--- a/app/views/pages/_editor_guide_text.html.erb
+++ b/app/views/pages/_editor_guide_text.html.erb
@@ -20,9 +20,11 @@
     <p>Below are some examples of commonly used markdown syntax. If you want to dive deeper, check out
       <a href="https://github.com/adam-p/markdown-here/wiki/Markdown-Here-Cheatsheet" target="_blank" rel="noopener">this cheat sheet.</a>
     </p>
+    <a name="bold_italic" href="#bold_italic" class="anchor"></a>
     <h3><strong>Bold & Italic</strong></h3>
     <p><em>Italics</em>: <code>*asterisks* or _underscores_</code></p>
     <p><strong>Bold</strong>: <code>**double asterisks** or __double underscores__</code></p>
+    <a name="links" href="#links" class="anchor"></a>
     <h3><strong>Links</strong></h3>
     <p><a href="https://dev.to">I'm an inline link</a>: <code>[I'm an inline link](put-link-here)</code></p>
     <p><a name="anchored">Anchored links</a> (For things like a Table of Contents)</p>
@@ -33,6 +35,7 @@
 
       ### Chapter 1 <%= "<a name=\"chapter-1\"></a>" %>
     </pre>
+    <a name="inline_images" href="#inline_images" class="anchor"></a>
     <h3><strong>Inline Images</strong></h3>
     <p>
       When adding GIFs to posts and comments, please note that there is a limit of 200 megapixels per frame/page.
@@ -42,6 +45,7 @@
         ![Alt text of image](put-link-to-image-here)
     </pre>
     <figcaption> You can even add a caption using the HTML <code>figcaption</code> tag!</figcaption>
+    <a name="headers" href="#headers" class="anchor"></a>
     <h3><strong>Headers</strong></h3>
     <p>Add a header to your post with this syntax:</p>
     <pre>
@@ -50,6 +54,7 @@
     <h1>One '#' for a h1 header</h1>
     <h2>Two '#'s for a h2 header</h2>
     <h6>Six '#'s for a h6 header</h6>
+    <a name="author_notes" href="#author_notes" class="anchor"></a>
     <h3><strong>Author Notes/Comments</strong></h3>
     <p>Add some hidden notes/comments to your article with this syntax:</p>
     <pre>
@@ -59,6 +64,7 @@
     <p>We support native
       <a href="https://shopify.github.io/liquid/" target="_blank" rel="noopener">Liquid tags</a> in our editor, but have created our own custom tags listed below:
     </p>
+    <a name="article_embed" href="#article_embed" class="anchor"></a>
     <h3><strong>dev.to Article/Post Embed</strong></h3>
     <p>All you need is the full link of the article:</p>
     <code>{% link https://dev.to/kazz/boost-your-productivity-using-markdown-1be %}</code>
@@ -68,30 +74,37 @@
     <code>{% post https://dev.to/kazz/boost-your-productivity-using-markdown-1be %}</code>
     <p>or this:</p>
     <code>{% post kazz/boost-your-productivity-using-markdown-1be %}</code>
+    <a name="user_embed" href="#user_embed" class="anchor"></a>
     <h3><strong>dev.to User Embed</strong></h3>
     <p>All you need is the DEV username:</p>
     <code>{% user jess %}</code>
+    <a name="tag_embed" href="#tag_embed" class="anchor"></a>
     <h3><strong>dev.to Tag Embed</strong></h3>
     <p>All you need is the tag name:</p>
     <code>{% tag git %}</code>
+    <a name="comment_embed" href="#comment_embed" class="anchor"></a>
     <h3><strong>dev.to Comment Embed</strong></h3>
     <p>All you need is the
       <code>ID</code> at the end of a comment URL. To get the comment link, click either the timestamp or the menu button in the top right corner on a comment and then click "Permalink". Here's an example:
     </p>
     <code>{% devcomment 2d1a %}</code>
+    <a name="podcast_embed" href="#podcast_embed" class="anchor"></a>
     <h3><strong>dev.to Podcast Episode Embed</strong></h3>
     <p>All you need is the full link of the podcast episode:</p>
     <code>{% podcast https://dev.to/basecspodcast/s2e2--queues-irl %}</code>
+    <a name="listing_embed" href="#listing_embed" class="anchor"></a>
     <h3><strong>dev.to Listing Embed</strong></h3>
     <p>All you need is the full link of the listing:</p>
     <code>{% listing https://dev.to/listings/collabs/dev-is-open-source-823 %}</code>
     <p>You can also use the category and slug like this:</p>
     <code>{% listing collabs/dev-is-open-source-823 %}</code>
     <p>Note: Expired listings will raise an error. Make sure the listing is published or recently bumped.</p>
+    <a name="twitter_embed" href="#twitter_embed" class="anchor"></a>
     <h3><strong>Twitter Embed</strong></h3>
     <p>Using the Twitter Liquid tag will allow the tweet to pre-render from the server, providing your reader with a better experience. All you need is the tweet
       <code>id</code> from the url.</p>
     <code>{% twitter 834439977220112384 %}</code>
+    <a name="glitch_embed" href="#glitch_embed" class="anchor"></a>
     <h3><strong>Glitch embed</strong></h3>
     <p>All you need is the Glitch project slug</p>
     <code>{% glitch earthy-course %}</code>
@@ -130,6 +143,7 @@
         <code>{% glitch earthy-course file=script.js %}</code>
       </dd>
     </dl>
+    <a name="github_repo_embed" href="#github_repo_embed" class="anchor"></a>
     <h3><strong>GitHub Repo Embed</strong></h3>
     <p>All you need is the GitHub username and repo:</p>
     <code>{% github thepracticaldev/dev.to %}</code>
@@ -140,9 +154,11 @@
         <code>{% github thepracticaldev/dev.to no-readme %}</code>
       </dd>
     </dl>
+    <a name="github_issuepr_embed" href="#github_issuepr_embed" class="anchor"></a>
     <h3><strong>GitHub Issue, Pull request or Comment Embed</strong></h3>
     <p>All you need is the GitHub issue, PR or comment URL:</p>
     <code>{% github https://github.com/thepracticaldev/dev.to/issues/9 %}</code>
+    <a name="github_gist_embed" href="#github_gist_embed" class="anchor"></a>
     <h3><strong>GitHub Gist Embed</strong></h3>
     <p>All you need is the gist link:</p>
     <code>
@@ -173,18 +189,22 @@
         </code></p>
       </dd>
     </dl>
+    <a name="video_embed" href="#video_embed" class="anchor"></a>
     <h3><strong>Video Embed</strong></h3>
     <p>All you need is the <code>id</code> from the URL.
       <ul>
         <li><strong>YouTube:</strong> <code>{% youtube dQw4w9WgXcQ %}</code></li>
         <li><strong>Vimeo:</strong> <code>{% vimeo 193110695 %}</code></li>
       </ul>
+      <a name="medium_embed" href="#medium_embed" class="anchor"></a>
       <h3><strong>Medium Embed</strong></h3>
       <p>Just enter the full URL of the Medium article you are trying to embed.</p>
       <code>{% medium https://medium.com/s/story/boba-science-how-can-i-drink-a-bubble-tea-to-ensure-that-i-dont-finish-the-tea-before-the-bobas-7fc5fd0e442d %}</code>
+      <a name="slideshare_embed" href="#slideshare_embed" class="anchor"></a>
       <h3><strong>SlideShare Embed</strong></h3>
       <p>All you need is the SlideShare <code>key</code></p>
       <code>{% slideshare rdOzN9kr1yK5eE %}</code>
+      <a name="codepen_embed" href="#codepen_embed" class="anchor"></a>
       <h3><strong>CodePen Embed</strong></h3>
       <p>All you need is the full CodePen <code>link</code>, ending in the pen ID code, as follows:</p>
       <code>{% codepen https://codepen.io/twhite96/pen/XKqrJX %}</code>
@@ -195,13 +215,16 @@
           <code>{% codepen https://codepen.io/twhite96/pen/XKqrJX default-tab=js,result %}</code>
         </dd>
       </dl>
+      <a name="kotlin_playground" href="#kotlin_playground" class="anchor"></a>
       <h3><strong>Kotlin Playground</strong></h3>
       <p>To create a runnable kotlin snippet, create a Kotlin Snippet at <a href="https://play.kotlinlang.org">https://play.kotlinlang.org</a></p>
       <p>Go to <code>Share</code> dialog and copy the full <code>link</code> from the <code>Medium</code> tab. Use it as follows:</p>
       <code>{% kotlin https://pl.kotl.in/owreUFFUG?theme=darcula&from=3&to=6&readOnly=true %}</code>
+      <a name="runkit_embed" href="#runkit_embed" class="anchor"></a>
       <h3><strong>RunKit Embed</strong></h3>
       <p>Put executable code within a runkit liquid block, as follows:</p>
       <pre>{% runkit<br>// hidden setup JavaScript code goes in this preamble area<br>const hiddenVar = 42<br>%}<br>// visible, reader-editable JavaScript code goes here<br>console.log(hiddenVar)<br>{% endrunkit %} <br></pre>
+      <a name="stackblitz_embed" href="#stackblitz_embed" class="anchor"></a>
       <h3><strong>Stackblitz Embed</strong></h3>
       <p>All you need is the ID of the Stackblitz:</p>
       <code>{% stackblitz ball-demo %}</code>
@@ -217,6 +240,7 @@
           You can change the default file you want your embed to point to<br>
           <code>{% stackblitz ball-demo file=style.css %}</code>
         </dd>
+        <a name="codesandbox_embed" href="#codesandbox_embed" class="anchor"></a>
         <h3><strong>CodeSandbox Embed</strong></h3>
         <p>All you need is the ID of the Sandbox:</p>
         <code>{% codesandbox ppxnl191zx %}</code>
@@ -240,6 +264,7 @@
             <code>{% codesandbox ppxnl191zx runonclick=1 %}</code>
           </dd>
         </dl>
+        <a name="jsfiddle_embed" href="#jsfiddle_embed" class="anchor"></a>
         <h3><strong>JSFiddle Embed</strong></h3>
         <p>All you need is the full JSFiddle <code>link</code>, ending in the fiddle ID code, as follows:</p>
         <code>{% jsfiddle https://jsfiddle.net/link2twenty/v2kx9jcd %}</code>
@@ -250,12 +275,15 @@
             <code>{% jsfiddle https://jsfiddle.net/webdevem/Q8KVC result,html,css %}</code>
           </dd>
         </dl>
+        <a name="replit_embed" href="#replit_embed" class="anchor"></a>
         <h3><strong>repl.it Embed</strong></h3>
         <p>All you need is the URL after the domain name:</p>
         <code>{% replit @WigWog/PositiveFineOpensource %}</code>
+        <a name="instagram_embed" href="#instagram_embed" class="anchor"></a>
         <h3><strong>Instagram Embed</strong></h3>
         <p>All you need is the Instagram post <code>id</code> from the URL.</p>
         <code>{% instagram BXgGcAUjM39 %}</code>
+        <a name="speakerdeck_tag" href="#speakerdeck_tag" class="anchor"></a>
         <h3><strong>Speakerdeck Tag</strong></h3>
         <p>All you need is the data-id code from the embed link:</p>
         <pre>
@@ -267,9 +295,11 @@
         <pre>
       {% speakerdeck <span style="color: orange;">7e9f8c0fa0c949bd8025457181913fd0</span> %}
     </pre>
+        <a name="soundcloud_embed" href="#soundcloud_embed" class="anchor"></a>
         <h3><strong>Soundcloud Embed</strong></h3>
         <p>Just enter the full URL of the Soundcloud track you are trying to embed.</p>
         <code>{% soundcloud https://soundcloud.com/user-261265215/dev-to-review-episode-1 %}</code>
+       <a name="spotify_embed" href="#spotify_embed" class="anchor"></a>
         <h3><strong>Spotify Embed</strong></h3>
         <p>
           Enter the Spotify URI of the Spotify track / playlist /
@@ -278,16 +308,19 @@
         <pre>
       {% spotify <span style="color: #1DB954;">spotify:episode:5V4XZWqZQJvbddd31n56mf</span> %}
     </pre>
+        <a name="blogcast_tag" href="#blogcast_tag" class="anchor"></a>
         <h3><strong>Blogcast Tag</strong></h3>
         <p>All you need is the article id code from the embed code:</p>
         <pre>
       {% blogcast <span style="color: orange;">1234</span> %}
     </pre>
+        <a name="parler_tag" href="#parler_tag" class="anchor"></a>
         <h3><strong>Parler Tag</strong></h3>
         <p>Enter the full url of the Parler.io audio file you want to embed. </p>
         <pre>
       {% parler https://www.parler.io/audio/73240183203/d53cff009eac2ab1bc9dd8821a638823c39cbcea.7dd28611-b7fc-4cf8-9977-b6e3aaf644a1.mp3 %}
         </pre>
+        <a name="stackexchange_tag" href="#stackexchange_tag" class="anchor"></a>
         <h3><strong>Stack Exchange / Stack Overflow Tag</strong></h3>
         <p>
           You'll need the question or answer's ID code, and the site. When using <code>{% stackoverflow %}</code> as the tag, the site will default to Stack Overflow.
@@ -325,15 +358,18 @@
 {% stackexchange <span style="color: aquamarine;">170185</span> <span style="color: orange;">diy</span> %}
         </pre>
         </p>
+        <a name="asciinema_embed" href="#asciinema_embed" class="anchor"></a>
         <h3><strong>Asciinema Embed</strong></h3>
         <p>All you need is the Asciinema id:</p>
         <code>{% asciinema 239367 %}</code>
+        <a name="parsing_liquid_tags" href="#parsing_liquid_tags" class="anchor"></a>
         <h3><strong>Parsing Liquid Tags as a Code Example</strong></h3>
         <p>To parse Liquid tags as code, simply wrap it with a single backtick or triple backticks.</p>
         <p><code>`{% mytag %}{{ site.SOMETHING }}{% endmytag %}`</code></p>
         <p>One specific edge case is with using the <code>raw</code> tag. To properly escape it, use this format:
         </p>
         <p><code>`{% raw %}{{site.SOMETHING }} {% ``endraw`` %}`</code></p>
+        <a name="gotchas" href="#gotchas" class="anchor"></a>
         <h3><strong>Common Gotchas</strong></h3>
         <p>
           Lists are written just like any other Markdown editor.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

Went with a normal anchor tag rather than just adding `id=` to the `h3` tags, this is similar to how it's done in articles currently. No need to dupe the CSS this way.

Example:

```
        <a name="jsfiddle_embed" href="#jsfiddle_embed" class="anchor"></a>
        <h3><strong>JSFiddle Embed</strong></h3>
```

## Related Tickets & Documents

closes #4507

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)



## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![finish](https://media2.giphy.com/media/39zbpCQocXLi0/giphy.gif)
