### PR TITLE
Add SRE team to CODEOWNERS 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,10 @@
 *        @thepracticaldev/core-pullassigner
 
+# SRE
+Gemfile @thepracticaldev/sre
+/db/ @thepracticaldev/sre
+/config/ @thepracticaldev/sre
+
+# Mac
 Gemfile   @maestromac
 yarn.lock @maestromac


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Documentation Update

## Description
Add SRE team to the CODEOWNERS file and assign Gemfile and db and config folders. Often changes in files in the db and config folders need extra care when rolling out which is why I want SRE tagged in the PRs that include them. The Gemfile I thought was important bc staying on top of new dependencies and any gem upgrades is also a good idea when it comes to maintaining site stability. 

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![Britney Spears saying play nice](https://media.giphy.com/media/mnpAjOH1kbZDi/giphy.gif)
