### PR TITLE
Bump Chrome Driver version to fix Travis CI builds

### DIFF
--- a/spec/support/initializers/capybara.rb
+++ b/spec/support/initializers/capybara.rb
@@ -2,7 +2,7 @@ require "capybara/rails"
 require "capybara/rspec"
 require "webdrivers/chromedriver"
 
-Webdrivers::Chromedriver.required_version = "76.0.3809.68"
+Webdrivers::Chromedriver.required_version = "78.0.3904.70"
 Webdrivers.cache_time = 86_400
 
 Capybara.default_max_wait_time = 5


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

Chrome 78 was recently released as a stable version and Travis CI started installing it automatically. Chrome Driver 76 was no longer compatible with Chrome 78 and the builds started failing. So the solution is to bump the required Chrome Driver version to 78.

## Related Tickets & Documents

Issue #4553 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![s'all good](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fmedia1.tenor.com%2Fimages%2F4550038c9d4dd739a325f7fcaf05df98%2Ftenor.gif%3Fitemid%3D4825079&f=1&nofb=1)
