### PR TITLE
Remove required Chrome version, allowing Travis to track stable Chrome

### DIFF
--- a/spec/support/initializers/capybara.rb
+++ b/spec/support/initializers/capybara.rb
@@ -2,7 +2,6 @@ require "capybara/rails"
 require "capybara/rspec"
 require "webdrivers/chromedriver"
 
-Webdrivers::Chromedriver.required_version = "78.0.3904.70"
 Webdrivers.cache_time = 86_400
 
 Capybara.default_max_wait_time = 5


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

After https://github.com/thepracticaldev/dev.to/pull/4554 was merged, we realized we might not need to track a specific version of Chrome since Travis [automatically tracks Chrome stable](https://docs.travis-ci.com/user/chrome):

```
Take note that the underlying Chrome version can change from one build to another when Google updates the stable or beta version.
```


## Related Tickets & Documents

https://github.com/thepracticaldev/dev.to/issues/4553
