### PR TITLE
Add Release Option to Procfile for Running Migrations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,8 +48,6 @@ deploy:
   api_key: '$HEROKU_AUTH_TOKEN'
   app:
     master: practicaldev
-  run:
-    - rails db:migrate
 after_deploy:
   - bash after_deploy.sh
 notifications:

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
+release: bundle exec rake db:migrate
 web: bin/start-pgbouncer bundle exec puma -C config/puma.rb
 worker: bundle exec rake jobs:work

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-release: bundle exec rake db:migrate
+release: bundle exec rails db:migrate
 web: bin/start-pgbouncer bundle exec puma -C config/puma.rb
-worker: bundle exec rake jobs:work
+worker: bundle exec rails jobs:work


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
By using the release option in our Procfile we can tell Heroku to run migrations before a release is officially deployed. If the migrations succeed the release is deployed. If the migrations fail then the release will not be deployed. This will prevent us from running into the issue of a migration failing but the code relying on it still being deployed. 

The process is shown in the picture below and further details can be found in the [Heroku release-phase docs](https://devcenter.heroku.com/articles/release-phase).

![Screen Shot 2019-10-23 at 11 08 18 AM](https://user-images.githubusercontent.com/1813380/67412764-7e4de380-f585-11e9-8df5-f95c304c55bc.png)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

![little boy saying wait, hold up hold up](https://media0.giphy.com/media/xULW8MYvpNOfMXfDH2/giphy.gif?cid=790b76117632d1efb85bf3be2a2f2ede9962b8433e1964a2&rid=giphy.gif)
