### PR TITLE
Fix logic error with creating comment block

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -47,11 +47,12 @@ class CommentsController < ApplicationController
   # POST /comments
   # POST /comments.json
   def create
-    authorize Comment
     raise if RateLimitChecker.new(current_user).limit_by_action("comment_creation")
 
     @comment = Comment.new(permitted_attributes(Comment))
     @comment.user_id = current_user.id
+
+    authorize @comment
 
     if @comment.save
       current_user.update(checked_code_of_conduct: true) if params[:checked_code_of_conduct].present? && !current_user.checked_code_of_conduct

--- a/spec/requests/comments_create_spec.rb
+++ b/spec/requests/comments_create_spec.rb
@@ -37,4 +37,17 @@ RSpec.describe "CommentsCreate", type: :request do
       end.to raise_error(Pundit::NotAuthorizedError)
     end
   end
+
+  context "when user is posting on an author that does not block user, but the user has been blocked elsewhere" do
+    it "returns unauthorized" do
+      user.update(blocked_by_count: 1)
+      blocker_article = create(:article, user_id: blocker.id)
+      post "/comments", params: {
+        comment: { body_markdown: "something allowed", commentable_id: blocker_article.id, commentable_type: "Article" }
+      }
+      new_comment = Comment.last
+      expect(new_comment.body_markdown).to eq("something allowed")
+      expect(new_comment.id).not_to eq(nil)
+    end
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Fixes a logic error when there is a valid UserBlock and the blocked user is creating a comment.