### PR TITLE
[WIP] Generalize cloudinary helper method.  Add tests.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -93,17 +93,22 @@ module ApplicationHelper
   def cloudinary(url, width = nil, _quality = 80, _format = "jpg")
     return url if Rails.env.development? && (url.blank? || url.exclude?("http"))
 
-    service_path = "https://res.cloudinary.com/practicaldev/image/fetch"
-
-    if url&.size&.positive?
-      if width
-        "#{service_path}/c_scale,fl_progressive,q_auto,w_#{width}/f_auto/#{url}"
-      else
-        "#{service_path}/c_scale,fl_progressive,q_auto/f_auto/#{url}"
-      end
+    if url&.blank?
+      url = "https://pbs.twimg.com/profile_images/481625927911092224/iAVNQXjn_normal.jpeg"
+      quality = 1
     else
-      "#{service_path}/c_scale,fl_progressive,q_1/f_auto/https://pbs.twimg.com/profile_images/481625927911092224/iAVNQXjn_normal.jpeg"
+      quality = "auto"
     end
+
+    transformation = {
+      crop: "scale",
+      flags: "progressive",
+      quality: quality,
+      fetch_format: "auto"
+    }
+    transformation[:width] = width if width
+
+    Cloudinary::Utils.cloudinary_url(url, type: "fetch", transformation: transformation)
   end
 
   def cloud_cover_url(url)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -25,4 +25,44 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(helper.beautified_url("https://github.com/rails")).to eq("github.com/rails")
     end
   end
+
+  describe "#cloudinary" do
+    before do
+      stub_const("BASE_URL", "https://res.cloudinary.com/TEST-CLOUD/image/fetch")
+    end
+
+    it "delivers the cloudinary url with reasonable default transforms" do
+      actual = helper.cloudinary("banana.jpg")
+
+      ["c_scale", "fl_progressive", "q_auto", "f_auto", "banana.jpg", BASE_URL].each do |setting|
+        expect(actual).to include(setting)
+      end
+
+      # Also it should be a valid URL
+      expect(actual).to match(URI.regexp(["https"]))
+    end
+
+    it "can specify an image width" do
+      actual = helper.cloudinary("banana.jpg", width: 400)
+
+      ["w_400", "c_scale", "fl_progressive", "q_auto", "f_auto", "banana.jpg", BASE_URL].each do |setting|
+        expect(actual).to include(setting)
+      end
+
+      # Also it should be a valid URL
+      expect(actual).to match(URI.regexp(["https"]))
+    end
+
+    it "returns a blank image if the url is blank" do
+      blank_image_url = "https://pbs.twimg.com/profile_images/481625927911092224/iAVNQXjn_normal.jpeg"
+      actual = helper.cloudinary("")
+
+      ["c_scale", "fl_progressive", "q_1", "f_auto", blank_image_url, BASE_URL].each do |setting|
+        expect(actual).to include(setting)
+      end
+
+      # Also it should be a valid URL
+      expect(actual).to match(URI.regexp(["https"]))
+    end
+  end
 end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

I'm not 100% sure about this one, but I thought I'd run it by you and see what you thought.  I converted the `cloudinary` method in the `ApplicationHelper` to use the already-existing Cloudinary gem's functionality a bit better.

Pros:
 - It generalizes the code, taking out a bunch of hard-coded, DEV-specific url strings, making things less brittle if Cloudinary updates their API or if someone wants to stand up their own community.
 - It's easier to modify because it explicitly outlines the settings rather than burying them in a url string.

Cons:
 - Using the gem makes it harder to test because the order of the Cloudinary url settings isn't necessarily guaranteed, so you can't hard-code an expected url.  As a result, we're left checking that the url contains all the right pieces and hoping it doesn't contain anything yucky.
 - Maybe more complicated?  Maybe not.  I'd like to think I simplified the conditional structure.

Anyways, let me know what you think.  I'm totally cool if you want to just scrap this PR or rewrite the method but approach it another way.  😃 

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
