### PR TITLE
[WIP] Message: simplify validation and remove RuntimeError

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -11,6 +11,7 @@ class MessagesController < ApplicationController
       message_json = create_pusher_payload(@message)
       Pusher.trigger(@message.chat_channel.pusher_channels, "message-created", message_json)
     end
+
     if @message.save
       begin
         @message.send_push

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -4,9 +4,8 @@ class Message < ApplicationRecord
 
   validates :message_html, presence: true
   validates :message_markdown, presence: true, length: { maximum: 1024 }
-  validate :channel_permission
+  validate :chat_channel_permissions
 
-  before_save       :determine_user_validity
   before_validation :evaluate_markdown
   after_create      :send_email_if_appropriate
   after_create      :update_chat_channel_last_message_at
@@ -15,10 +14,6 @@ class Message < ApplicationRecord
   def preferred_user_color
     color_options = [user.bg_color_hex || "#000000", user.text_color_hex || "#000000"]
     HexComparer.new(color_options).brightness(0.9)
-  end
-
-  def determine_user_validity
-    raise unless chat_channel.status == "active" && (chat_channel.has_member?(user) || chat_channel.channel_type == "open")
   end
 
   def send_push
@@ -70,14 +65,10 @@ class Message < ApplicationRecord
     html
   end
 
-  def channel_permission
-    errors.add(:base, "Must be part of channel.") if chat_channel_id.blank?
-
-    channel = ChatChannel.find(chat_channel_id)
-    return if channel.open?
-
-    errors.add(:base, "You are not a participant of this chat channel.") unless channel.has_member?(user)
-    errors.add(:base, "Something went wrong") if channel.status == "blocked"
+  def chat_channel_permissions
+    errors.add(:base, "Must be part of channel.") unless chat_channel
+    errors.add(:base, "Something went wrong") if chat_channel.status == "blocked"
+    errors.add(:base, "You are not a participant of this chat channel.") unless chat_channel.has_member?(user)
   end
 
   def rich_link_article(link)

--- a/spec/requests/messages_spec.rb
+++ b/spec/requests/messages_spec.rb
@@ -15,9 +15,8 @@ RSpec.describe "Messages", type: :request do
 
     it "requires user to be signed in" do
       post "/messages", params: { message: {} }
-      expect(response.status).to eq(302)
+      expect(response).to have_http_status(:redirect)
     end
-    # Pusher::Error
 
     context "when user is signed in" do
       before do
@@ -27,7 +26,7 @@ RSpec.describe "Messages", type: :request do
       end
 
       it "returns 201 upon success" do
-        expect(response.status).to eq(201)
+        expect(response).to have_http_status(:created)
       end
 
       it "returns in json" do
@@ -37,25 +36,15 @@ RSpec.describe "Messages", type: :request do
 
     context "when user is blocked" do
       before do
+        allow(Pusher).to receive(:trigger).and_return(true)
         sign_in user
         chat_channel.update(status: "blocked")
       end
 
-      it "raises an error" do
-        expect { post "/messages", params: { message: new_message } }.to raise_error
+      it "is unauthorized" do
+        post "/messages", params: { message: new_message }
+        expect(response).to have_http_status(:unauthorized)
       end
     end
-
-    # context "when Pusher isn't cooperating" do
-    #   before do
-    #     allow(Pusher).to receive(:trigger).and_raise(Pusher::Error)
-    #     sign_in user
-    #     post "/messages", params: { message: new_message }
-    #   end
-
-    #   it "returns proper message" do
-    #     expect(response.body).to include("could not trigger Pusher")
-    #   end
-    # end
   end
 end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

It all started when I noticed the following warning while I was checking a build logs:

```text
WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Actual error raised was #<WebMock::NetConnectNotAllowedError: Real HTTP connections are disabled. Unregistered request: POST ...lgolia(net\.com|\.net)\/1\/indexes/")

============================================================>. Instead consider providing a specific error class or message. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. Called from /home/travis/build/thepracticaldev/dev.to/spec/requests/messages_spec.rb:45:in `block (4 levels) in <top (required)>'.
```

`messages_spec.rb:45` contains a generic 

```ruby
expect { post "/messages", params: { message: new_message } }.to raise_error
```

which is weird, because requests specs shouldn't raise Ruby errors, only return HTTP errors. I removed the expectations and noticed how there were two things hidden there:

- a webmock error due to the fact that we weren't mocking the Pusher call
- a literal `RuntimeError` (which results in a 500 error for the user and in the logs).

I then tried to debug and noticed something more odd:

```ruby
def determine_user_validity
    raise unless chat_channel.status == "active" && (chat_channel.has_member?(user) || chat_channel.channel_type == "open")
  end
```

this method, that was called in a `before_save` raises a `RuntimeError` if the conditions are not met, instead of using the validation mechanism by Rails. Was this intentional? Am I missing something not caught by tests?

I also noticed how the permissions validation basically does the same thing.

I then proceeded to reorganize those to have a single validator and to keep the HTTP 401 error that's returned to the client in case the user is not authorized because blocked.

Another odd thing is the fact that the previous `chat_channel_permission` method loads another instance of the chat channel, despite the object being attached to a chat channel already. Was this intentional as well?

## Related Tickets & Documents

https://github.com/thepracticaldev/dev.to/pull/4411
