### PR TITLE
Fix warning on missing Faker keyword argument

### DIFF
--- a/spec/services/audit/notification_spec.rb
+++ b/spec/services/audit/notification_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Audit::Notification, type: :service do
-  let!(:listener) { Faker::Alphanumeric.alpha(10) }
+  let!(:listener) { Faker::Alphanumeric.alpha(number: 10) }
   let(:user) { build(:user, :admin) }
   let(:queue_name) { Audit::SaveToPersistentStorageJob.queue_name }
   let(:job_class) { Audit::SaveToPersistentStorageJob }


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

A few releases ago Faker switched positional arguments to keyword arguments, this fixes a standing warning that was overlooked during the reviews we did of https://github.com/thepracticaldev/dev.to/pull/3449 

## Related Tickets & Documents

https://github.com/thepracticaldev/dev.to/pull/3449
