### PR TITLE
Fix issue where cover image shows up when it shouldn't

### DIFF
--- a/app/javascript/article-form/elements/bodyPreview.jsx
+++ b/app/javascript/article-form/elements/bodyPreview.jsx
@@ -38,13 +38,20 @@ function titleArea(previewResponse, version, articleState) {
 
   const previewTitle = previewResponse.title || articleState.title || '';
 
-  return (
-    <div>
+  let coverImageHTML = '';
+  if (coverImage.length > 0) {
+    coverImageHTML = (
       <CoverImage
         className="articleform__mainimage articleform__mainimagepreview"
         imageSrc={coverImage}
         imageAlt="cover"
       />
+    );
+  }
+
+  return (
+    <div>
+      {coverImageHTML}
       <div className="title" style={{ width: '90%', maxWidth: '1000px' }}>
         <h1
           className={


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
There's a bug in prod where the cover image area shows up even when the cover image hasn't been added to v2 editor

<img width="930" alt="Screen Shot 2019-10-24 at 5 41 48 PM" src="https://user-images.githubusercontent.com/3102842/67527710-a9b7f780-f685-11e9-8f38-ceaca66805b2.png">

This adds a conditional to fix that. I couldn't find anyone who reported this.