### PR TITLE
Use Avoid Duplicate Postgres Lookup By Using current_user

### DIFF
--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -49,7 +49,7 @@ class ReactionsController < ApplicationController
       category: category,
     ).first
     if reaction
-      reaction.user.touch
+      current_user.touch
       reaction.destroy
       Notification.send_reaction_notification_without_delay(reaction, reaction.reactable.user)
       Notification.send_reaction_notification_without_delay(reaction, reaction.reactable.organization) if organization_article?(reaction)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
Rather than looking up the user again through the reaction we can use the current_user which was already used to look up the reaction object in the first place.

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

![guy saying Ill take it](https://media0.giphy.com/media/3oKIP6cQ7KAkr8scPS/giphy.gif)
