### PR TITLE
[deploy] Add Index for old_username and old_old_usernames

### DIFF
--- a/db/migrate/20191025185619_add_old_username_index_to_users.rb
+++ b/db/migrate/20191025185619_add_old_username_index_to_users.rb
@@ -1,0 +1,8 @@
+class AddOldUsernameIndexToUsers < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :users, :old_username, algorithm: :concurrently
+    add_index :users, :old_old_username, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,8 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_16_135034) do
-
+ActiveRecord::Schema.define(version: 2019_10_25_185619) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -1178,6 +1177,8 @@ ActiveRecord::Schema.define(version: 2019_10_16_135034) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["github_username"], name: "index_users_on_github_username", unique: true
     t.index ["language_settings"], name: "index_users_on_language_settings", using: :gin
+    t.index ["old_old_username"], name: "index_users_on_old_old_username"
+    t.index ["old_username"], name: "index_users_on_old_username"
     t.index ["organization_id"], name: "index_users_on_organization_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["twitter_username"], name: "index_users_on_twitter_username", unique: true


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
While in Skylight investigating our recent uptick in response times I noticed this User lookup query that was taken over 500ms to execute. Turns out we have no indexes on old_username or old_old_username which means we have to do a full table scan for this lookup every single time.  
![Screen Shot 2019-10-25 at 2 11 07 PM](https://user-images.githubusercontent.com/1813380/67597697-6c10a880-f731-11e9-8097-3f9294f13f87.png)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

![Woman grimacing](https://media3.giphy.com/media/3o7WIGx1wesMLfrQgo/giphy.gif)
