### PR TITLE
Add Index to feed_source_url For Articles

### DIFF
--- a/db/migrate/20191025202354_add_articles_index_for_feed_source_url.rb
+++ b/db/migrate/20191025202354_add_articles_index_for_feed_source_url.rb
@@ -1,0 +1,7 @@
+class AddArticlesIndexForFeedSourceUrl < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :articles, :feed_source_url, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_25_185619) do
+ActiveRecord::Schema.define(version: 2019_10_25_202354) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -137,6 +137,7 @@ ActiveRecord::Schema.define(version: 2019_10_25_185619) do
     t.string "video_thumbnail_url"
     t.index ["boost_states"], name: "index_articles_on_boost_states", using: :gin
     t.index ["featured_number"], name: "index_articles_on_featured_number"
+    t.index ["feed_source_url"], name: "index_articles_on_feed_source_url"
     t.index ["hotness_score"], name: "index_articles_on_hotness_score"
     t.index ["path"], name: "index_articles_on_path"
     t.index ["published"], name: "index_articles_on_published"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
Another db lookup that I found was taking a long time(hundreds of ms) was this simple Article lookup by feed_source_url. This time I found the query through Heroku's Postgres dashboard which will show you what queries you are spending the most time on.

![Screen Shot 2019-10-25 at 3 28 02 PM](https://user-images.githubusercontent.com/1813380/67602642-afbcdf80-f73c-11e9-887e-8d8b75c7b544.png)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

![hamster dancing with text Fri-Yay over him](https://media.giphy.com/media/Rlw9PRYmEUDYYHgzSS/giphy.gif)
