### PR TITLE
Listings: fix 'Contact via Connect' checkbox to be checkable [deploy]

### DIFF
--- a/app/javascript/listings/listingForm.jsx
+++ b/app/javascript/listings/listingForm.jsx
@@ -107,7 +107,7 @@ export default class ListingForm extends Component {
           />
           {selectOrg}
           <ContactViaConnect
-            defaultValue={contactViaConnect}
+            checked={contactViaConnect}
             onChange={linkState(this, 'contactViaConnect')}
           />
         </div>


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
Fixes the "Contact via Connect" checkbox so that it is actually checkable. `defaultValue` was being passed in, but unused so the state wouldn't update, but using `checked` in its place allows the state to be updated with a default value of checked.

I felt `defaultValue` didn't make a lot of sense in this context since the actual default is determined where `contactViaConnect` is defined in the `ListingForm` state. To me it made more sense to pass this default directly to `checked`. 

## Related Tickets & Documents

Fixes: #4336 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![gif showing fixed checkbox](https://user-images.githubusercontent.com/1540803/67638735-40aeca80-f8a5-11e9-8be9-9d949f945d9e.gif)
## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![guy saying "looks good to me" gif](https://media.tenor.com/images/5cc7e070aafc7bb4830cb7b417ad7c67/tenor.gif)
