### PR TITLE
[deploy] Reading list: Add clear filter button/icon

### DIFF
--- a/app/assets/stylesheets/item-list.scss
+++ b/app/assets/stylesheets/item-list.scss
@@ -37,6 +37,25 @@
       @include themeable(color, theme-color, $black);
     }
 
+    .filters-header {
+      display: flex;
+      justify-content: space-between;
+      padding: 10px 5px;
+      .filters-header-text {
+        font-size: 0.9em;
+        font-family: $monospace;
+        text-decoration: underline;
+        @include themeable(color, theme-secondary-color, $medium-gray);
+      }
+      .filters-header-action {
+        font-size: 0.8em;
+        background: none;
+        border: none;
+        text-decoration: underline;
+        @include themeable(color, theme-color, $blue);
+      }
+    }
+
     .tags {
       .tag {
         padding: 5px 0px;
@@ -214,7 +233,6 @@
       margin-bottom: -15px;
 
       .filters {
-        height: 85px;
         min-height: 85px;
 
         .tags {

--- a/app/javascript/readingList/__tests__/__snapshots__/readingList.test.jsx.snap
+++ b/app/javascript/readingList/__tests__/__snapshots__/readingList.test.jsx.snap
@@ -15,6 +15,15 @@ exports[`<ReadingList /> renders properly 1`] = `
         placeHolder="search your list"
       />
       <div
+        class="filters-header"
+      >
+        <h4
+          class="filters-header-text"
+        >
+          my tags
+        </h4>
+      </div>
+      <div
         class="tags"
       >
         <a

--- a/app/javascript/readingList/readingList.jsx
+++ b/app/javascript/readingList/readingList.jsx
@@ -9,6 +9,7 @@ import {
   performInitialSearch,
   search,
   toggleTag,
+  clearSelectedTags,
 } from '../searchableItemList/searchableItemList';
 import { ItemListItem } from '../src/components/ItemList/ItemListItem';
 import { ItemListItemArchiveButton } from '../src/components/ItemList/ItemListItemArchiveButton';
@@ -45,6 +46,7 @@ export class ReadingList extends Component {
     this.performInitialSearch = performInitialSearch.bind(this);
     this.search = search.bind(this);
     this.toggleTag = toggleTag.bind(this);
+    this.clearSelectedTags = clearSelectedTags.bind(this);
   }
 
   componentDidMount() {
@@ -198,7 +200,23 @@ export class ReadingList extends Component {
               onKeyUp={this.onSearchBoxType}
               placeHolder="search your list"
             />
-
+            <div className="filters-header">
+              <h4 className="filters-header-text">my tags</h4>
+              {Boolean(selectedTags.length) && (
+                <a
+                  className="filters-header-action"
+                  href={
+                    isStatusViewValid
+                      ? READING_LIST_PATH
+                      : READING_LIST_ARCHIVE_PATH
+                  }
+                  onClick={this.clearSelectedTags}
+                  data-no-instant
+                >
+                  clear all
+                </a>
+              )}
+            </div>
             <ItemListTags
               availableTags={availableTags}
               selectedTags={selectedTags}

--- a/app/javascript/searchableItemList/searchableItemList.js
+++ b/app/javascript/searchableItemList/searchableItemList.js
@@ -48,6 +48,16 @@ export function toggleTag(event, tag) {
   component.search(query, { tags: newTags, statusView });
 }
 
+export function clearSelectedTags(event) {
+  event.preventDefault();
+
+  const component = this;
+  const { query, statusView } = component.state;
+  const newTags = [];
+  component.setState({ selectedTags: newTags, page: 0, items: [] });
+  component.search(query, { tags: newTags, statusView });
+}
+
 // Perform the initial search
 export function performInitialSearch({
   containerId,


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
This PR adds a "My Tags" heading to the tag filter list in the Reading List view, as well as a "Clear All" button that removes all of the tag filters. The button is only visible when there are active tag filters. The heading is styled to match the "My Tags" heading in the home view sidebar. 

## Related Tickets & Documents
Fixes #3819 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
No filters selected (Desktop):
<img width="313" alt="Screen Shot 2019-10-27 at 4 59 43 PM" src="https://user-images.githubusercontent.com/13258203/67642599-4e7f4280-f8db-11e9-81ee-e4f7d3f5b6d5.png">

Active filters (Desktop):
<img width="313" alt="Screen Shot 2019-10-27 at 4 59 51 PM" src="https://user-images.githubusercontent.com/13258203/67642602-5343f680-f8db-11e9-9913-6c9372c64cfe.png">

No filters selected (Mobile):
<img width="443" alt="Screen Shot 2019-10-27 at 5 02 37 PM" src="https://user-images.githubusercontent.com/13258203/67642629-9bfbaf80-f8db-11e9-91f2-a2a0cc0502af.png">

Active filters (Mobile):
<img width="443" alt="Screen Shot 2019-10-27 at 5 02 43 PM" src="https://user-images.githubusercontent.com/13258203/67642632-a1f19080-f8db-11e9-8881-a7a5b363054e.png">

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
