### PR TITLE
Add A Guard Clause Before Adding or Removing New User Indexes

### DIFF
--- a/db/migrate/20191025185619_add_old_username_index_to_users.rb
+++ b/db/migrate/20191025185619_add_old_username_index_to_users.rb
@@ -1,8 +1,23 @@
 class AddOldUsernameIndexToUsers < ActiveRecord::Migration[5.2]
   disable_ddl_transaction!
 
-  def change
-    add_index :users, :old_username, algorithm: :concurrently
-    add_index :users, :old_old_username, algorithm: :concurrently
+  def up
+    if indexes(:users).none? { |idx| idx.columns.map(&:to_sym) == [:old_username] }
+      add_index :users, :old_username, algorithm: :concurrently
+    end
+
+    if indexes(:users).none? { |idx| idx.columns.map(&:to_sym) == [:old_old_username] }
+      add_index :users, :old_old_username, algorithm: :concurrently
+    end
+  end
+
+  def down
+    if indexes(:users).any? { |idx| idx.columns.map(&:to_sym) == [:old_username] }
+      remove_index :users, :old_username
+    end
+
+    if indexes(:users).any? { |idx| idx.columns.map(&:to_sym) == [:old_old_username] }
+      remove_index :users, :old_old_username
+    end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
We recently had a migration fail due to a timeout. Even though the migration reported a failure, the first index of the migration was created. However, the migration was never recorded in the database bc of the failure status. This has led to us being in a state where if we try to run the migration we get an error bc the first index already exists but we still need to add the second index. In order to fix this, I have added guard clauses to check for the index before attempting to add or remove it. This will prevent the migration from failing when it sees that the first index has already been created.

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

![Man saying we are good](https://media1.tenor.com/images/3fc60bf94e5e53c8885e0356168059e7/tenor.gif?itemid=6118416)
