### PR TITLE
Wrap <figcaption> elements and content inside <figure> elements

### DIFF
--- a/app/assets/stylesheets/article-show.scss
+++ b/app/assets/stylesheets/article-show.scss
@@ -555,6 +555,10 @@ article {
       margin: 0.3em auto;
     }
 
+    figure {
+      margin: 0;
+    }
+
     figcaption {
       font-style: italic;
       text-align: center;

--- a/app/assets/stylesheets/article-show.scss
+++ b/app/assets/stylesheets/article-show.scss
@@ -192,17 +192,17 @@ article {
       min-height: 40px;
       font-size: calc(2vw + 26px);
       word-break: break-word;
-      
+
       @media screen and (min-width: 1600px) {
         font-size: 57px;
       }
 
       .title-block {
         display: inline-block;
-      }    
-      
+      }
+
       &.medium {
-        font-size: calc(1.85vw + 25px);        
+        font-size: calc(1.85vw + 25px);
         @media screen and (min-width: 1600px) {
           font-size: 47px;
         }
@@ -568,7 +568,7 @@ article {
       display: block;
     }
 
-    p ~ figcaption {
+    p + figcaption {
       margin-top: -0.8em;
     }
 

--- a/app/labor/markdown_parser.rb
+++ b/app/labor/markdown_parser.rb
@@ -205,7 +205,7 @@ class MarkdownParser
   def wrap_all_figures_with_tags(html)
     html_doc = Nokogiri::HTML(html)
 
-    html_doc.xpath("//html/body/figcaption").each do |caption|
+    html_doc.xpath("//figcaption").each do |caption|
       next if caption.parent.name == "figure"
       next unless caption.previous_element
 

--- a/app/labor/markdown_parser.rb
+++ b/app/labor/markdown_parser.rb
@@ -29,6 +29,7 @@ class MarkdownParser
     html = remove_empty_paragraphs(html)
     html = escape_colon_emojis_in_codeblock(html)
     html = unescape_raw_tag_in_codeblocks(html)
+    html = wrap_all_figures_with_tags(html)
     wrap_mentions_with_links!(html)
   end
 
@@ -193,6 +194,24 @@ class MarkdownParser
       indices.each do |i|
         codeblock.children[i].content = codeblock.children[i].content.delete("----")
       end
+    end
+    if html_doc.at_css("body")
+      html_doc.at_css("body").inner_html
+    else
+      html_doc.to_html
+    end
+  end
+
+  def wrap_all_figures_with_tags(html)
+    html_doc = Nokogiri::HTML(html)
+
+    html_doc.xpath("//html/body/figcaption").each do |caption|
+      next if caption.parent.name == "figure"
+      next unless caption.previous_element
+
+      fig = html_doc.create_element "figure"
+      prev = caption.previous_element
+      prev.replace(fig) << prev << caption
     end
     if html_doc.at_css("body")
       html_doc.at_css("body").inner_html

--- a/spec/labor/markdown_parser_spec.rb
+++ b/spec/labor/markdown_parser_spec.rb
@@ -64,6 +64,24 @@ RSpec.describe MarkdownParser do
     expect(generate_and_parse_markdown(code_span)).to include random_word
   end
 
+  it "wraps figcaptions with figures" do
+    code_span = "<p>Statement</p>\n<figcaption>A fig</figcaption>"
+    test = generate_and_parse_markdown("<p>case: </p>" + code_span)
+    expect(test).to eq("<p>case: </p>\n<figure>" + code_span + "</figure>\n\n\n\n")
+  end
+
+  it "does not wrap figcaptions already in figures" do
+    code_span = "<figure><p>Statement</p>\n<figcaption>A fig</figcaption></figure>"
+    test = generate_and_parse_markdown(code_span)
+    expect(test).to eq(code_span + "\n\n\n\n")
+  end
+
+  it "does not wrap figcaptions without predecessors" do
+    code_span = "<figcaption>A fig</figcaption>"
+    test = generate_and_parse_markdown(code_span)
+    expect(test).to eq(code_span + "\n\n")
+  end
+
   context "when rendering links markdown" do
     # the following specs are testing HTMLRouge
     it "renders properly if protocol http is included" do


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

This PR has two parts:
- `<figure>` tags area created so that every`<figcaption>` tag is nested under a `<figure>` to produce semantically correct markup
- @Elecweb's change to fix the vertical offset of `<figcaption>` elements is incorporated

## Related Tickets & Documents

Fixes #3439

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

|Before|After|
|--|---|
|![image](https://user-images.githubusercontent.com/644551/60987393-cbdd7200-a341-11e9-8184-2fa212932998.jpg) | ![image](https://user-images.githubusercontent.com/18223213/67709590-7a520500-f97b-11e9-8e79-9ecfa0ea70bc.png) |


## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed