### PR TITLE
Increase STATEMENT_TIMEOUT when running migrations

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-release: bundle exec rails db:migrate
+release: STATEMENT_TIMEOUT=180000 bundle exec rails db:migrate
 web: bin/start-pgbouncer bundle exec puma -C config/puma.rb
 worker: bundle exec rails jobs:work


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
Currently, if we have to run a migration that is going to take a long time we have to manually increase the value of the STATEMENT_TIMEOUT variable in Heroku before running the migration in order to give the migration adequate time to run. Then after it is run we have to reset it back to the original value.  We can avoid this manual process by setting the STATEMENT_TIMEOUT when we run the migration during the release phase. 

I choose 3 minutes because that "felt" like it would be plenty given our db size for just about anything we wanted to do. I am open to other suggestions though! 

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

![Girl rolling her eyes saying Dassit](https://media.giphy.com/media/rjjbSS3k4DIgE/giphy.gif)
