### PR TITLE
Select Path When Loading Buffered Article Urls

### DIFF
--- a/app/controllers/buffered_articles_controller.rb
+++ b/app/controllers/buffered_articles_controller.rb
@@ -11,6 +11,7 @@ class BufferedArticlesController < ApplicationController
     if Rails.env.production?
       Article.
         where("last_buffered > ? OR published_at > ?", 24.hours.ago, 20.minutes.ago).
+        select(:path).
         map { |a| "https://#{ApplicationConfig['APP_DOMAIN']}#{a.path}" }
     else
       Article.all.map { |a| "https://#{ApplicationConfig['APP_DOMAIN']}#{a.path}" }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
Rather than loading the entire Article object here, let's just select the path column since that is all we are mapping over. 

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

![Gif that says easy peasy lemon squeezy](https://media2.giphy.com/media/xUA7aQOxkz00lvCAOQ/giphy.gif)
