### PR TITLE
Use named function so duplicate event handlers are discarded

### DIFF
--- a/app/assets/javascripts/initializers/initializeTouchDevice.js
+++ b/app/assets/javascripts/initializers/initializeTouchDevice.js
@@ -25,6 +25,10 @@ function removeShowingMenu() {
   }, 150);
 }
 
+function toggleMenu() {
+  getClassList('navbar-menu-wrapper').toggle('showing');
+}
+
 function initializeTouchDevice() {
   var isTouchDevice = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini|DEV-Native-ios/i.test(
     navigator.userAgent,
@@ -37,9 +41,7 @@ function initializeTouchDevice() {
   setTimeout(() => {
     removeShowingMenu();
     if (isTouchDevice) {
-      getById('navigation-butt').addEventListener('click', e =>
-        getClassList('navbar-menu-wrapper').toggle('showing'),
-      );
+      getById('navigation-butt').addEventListener('click', toggleMenu);
     } else {
       getClassList('navbar-menu-wrapper').add('desktop');
       getById('navigation-butt').addEventListener('focus', e =>

--- a/app/assets/javascripts/initializers/initializeTouchDevice.js
+++ b/app/assets/javascripts/initializers/initializeTouchDevice.js
@@ -41,6 +41,7 @@ function initializeTouchDevice() {
   setTimeout(() => {
     removeShowingMenu();
     if (isTouchDevice) {
+      // Use a named function instead of anonymous so duplicate event handlers are discarded
       getById('navigation-butt').addEventListener('click', toggleMenu);
     } else {
       getClassList('navbar-menu-wrapper').add('desktop');


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

Multiple event listeners were being added to the navigation button. Changed to add a named function instead of anonymous so that duplicates are discarded.

Looks like the system tests are only running with desktop chrome browser, so I've not made any updates there.

## Related Tickets & Documents

Fixes #4571 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

n/a

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

