### PR TITLE
Move URL Social Preview Cache from Memcache to Redis

### DIFF
--- a/app/lib/html_css_to_image.rb
+++ b/app/lib/html_css_to_image.rb
@@ -14,13 +14,13 @@ module HtmlCssToImage
 
   def self.fetch_url(html:, css: nil, google_fonts: nil)
     cache_key = "htmlcssimage/#{html}/#{css}/#{google_fonts}"
-    cached_url = Rails.cache.read(cache_key)
+    cached_url = RedisClient.get(cache_key)
 
     return cached_url if cached_url.present?
 
     image_url = url(html: html, css: css, google_fonts: google_fonts)
 
-    Rails.cache.write(cache_key, image_url) unless image_url == FALLBACK_IMAGE
+    RedisClient.set(cache_key, image_url, ex: 600) unless image_url == FALLBACK_IMAGE
 
     image_url
   end

--- a/spec/lib/html_css_to_image_spec.rb
+++ b/spec/lib/html_css_to_image_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe HtmlCssToImage do
 
   describe ".fetch_url" do
     before do
-      allow(Rails.cache).to receive(:write)
-      allow(Rails.cache).to receive(:read)
+      allow(RedisClient).to receive(:get)
+      allow(RedisClient).to receive(:set)
     end
 
     it "caches the image url when successful" do
@@ -34,7 +34,7 @@ RSpec.describe HtmlCssToImage do
                   headers: { "Content-Type" => "application/json" })
 
       expect(described_class.fetch_url(html: "test")).to eq("https://hcti.io/v1/image/6c52de9d-4d37-4008-80f8-67155589e1a1")
-      expect(Rails.cache).to have_received(:write).once
+      expect(RedisClient).to have_received(:set).once
     end
 
     it "does not cache errors" do
@@ -44,7 +44,7 @@ RSpec.describe HtmlCssToImage do
                   headers: { "Content-Type" => "application/json" })
 
       expect(described_class.fetch_url(html: "test")).to eq described_class::FALLBACK_IMAGE
-      expect(Rails.cache).not_to have_received(:write)
+      expect(RedisClient).not_to have_received(:set)
     end
   end
 end

--- a/spec/requests/social_previews_spec.rb
+++ b/spec/requests/social_previews_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe "SocialPreviews", type: :request do
       to_return(status: 200,
                 body: "{ \"url\": \"#{image_url}\" }",
                 headers: { "Content-Type" => "application/json" })
+    allow(RedisClient).to receive(:get)
+    allow(RedisClient).to receive(:set)
   end
 
   describe "GET /social_previews/article/:id" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
This switches the cache for image URLs from Memcache to Redis. I set the expiration to 10 minutes since this is used for previews on Social Media platforms I think figuring out what you want to post likely happens in a few minutes but some extra time doesn't hurt. Open to other suggestions!  

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

![guy saying the party has just begun](https://media2.giphy.com/media/3o6fJ9FtwvoPh4izK0/giphy.gif)
