### PR TITLE
Add ability to turn on & off coverage report generation with env variable

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,4 +1,4 @@
-if ENV["COVERAGE"]
+unless ENV["COVERAGE"] == false
   SimpleCov.start "rails" do
     add_filter "/spec/"
     add_filter "/dashboards/"

--- a/.simplecov
+++ b/.simplecov
@@ -1,4 +1,4 @@
-unless ENV["COVERAGE"] == false
+unless ENV["COVERAGE"] == "false"
   SimpleCov.start "rails" do
     add_filter "/spec/"
     add_filter "/dashboards/"

--- a/docs/tests/code-coverage.md
+++ b/docs/tests/code-coverage.md
@@ -34,6 +34,8 @@ bin/rspec spec/models/user_spec.rb
 
 After the test run is complete, open `coverage/index.html` with a browser so you can check the code coverage.
 
+To turn off coverage report generation please set environment variable `COVERAGE` value to `false`.
+
 ## Preact
 
 Preact tests will generate code coverage at the end of the tests.


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [x] Documentation Update

## Description
Coverage report was not being generated. Now it is generated by default but it will be possible to turn it off.

## Related Tickets & Documents
Resolves #4653 

## Added to documentation?

- [x] docs.dev.to
- [ ] readme
- [ ] no documentation needed
