### PR TITLE
Create RedisRailsCache Object to Mimic Rails.cache And Apply

### DIFF
--- a/lib/redis_rails_cache.rb
+++ b/lib/redis_rails_cache.rb
@@ -11,7 +11,7 @@ class RedisRailsCache
         entry = client.get(key_name)
         return entry if entry.present?
 
-        save_block_result_to_cache(key_name, expires_in) { |_key_name| yield _key_name }
+        save_block_result_to_cache(key_name, expires_in) { |key_name| yield key_name }
       else
         client.get(key_name)
       end

--- a/lib/redis_rails_cache.rb
+++ b/lib/redis_rails_cache.rb
@@ -11,7 +11,7 @@ class RedisRailsCache
         entry = client.get(key_name)
         return entry if entry.present?
 
-        save_block_result_to_cache(key_name, expires_in) { |key_name| yield key_name }
+        save_block_result_to_cache(key_name, expires_in) { |name| yield name }
       else
         client.get(key_name)
       end

--- a/lib/redis_rails_cache.rb
+++ b/lib/redis_rails_cache.rb
@@ -1,0 +1,40 @@
+# Temporary and will be removed after all cache keys have been moved over to Redis
+class RedisRailsCache
+  DEFAULT_EXPIRATION = 24.hours.to_i.freeze
+
+  class << self
+    def fetch(key_name, opts = {})
+      # Default expire all keys after 24 hours if expiration is not given
+      expires_in = opts[:expires_in] || DEFAULT_EXPIRATION
+
+      if block_given?
+        entry = client.get(key_name)
+        return entry if entry.present?
+
+        save_block_result_to_cache(key_name, expires_in) { |_key_name| yield _key_name }
+      else
+        client.get(key_name)
+      end
+    end
+
+    def read(key_name)
+      client.get(key_name)
+    end
+
+    def write(key_name, value, opts = {})
+      client.set(key_name, value, ex: opts[:expires_in] || DEFAULT_EXPIRATION)
+    end
+
+    private
+
+    def save_block_result_to_cache(key_name, expires_in)
+      result = yield
+      client.set(key_name, result, ex: expires_in)
+      result
+    end
+
+    def client
+      RedisClient
+    end
+  end
+end

--- a/spec/lib/redis_rails_cache_spec.rb
+++ b/spec/lib/redis_rails_cache_spec.rb
@@ -1,0 +1,76 @@
+require "rails_helper"
+
+RSpec.describe RedisRailsCache do
+  let(:redis_client) { class_double("RedisClient") }
+
+  before do
+    allow(described_class).to receive(:client) { redis_client }
+    allow(redis_client).to receive(:set).and_return("OK")
+    allow(redis_client).to receive(:get)
+  end
+
+  describe "#fetch" do
+    context "when block is present" do
+      it "returns key value if present" do
+        allow(redis_client).to receive(:get).with("five").and_return(5)
+        result = described_class.fetch("five") do
+          5
+        end
+        expect(redis_client).to have_received(:get).with("five")
+        expect(result).to eq(5)
+      end
+
+      it "when key is missing sets key value to result of the block and expiration" do
+        result = described_class.fetch("five") do
+          5
+        end
+        expect(redis_client).to have_received(:get).with("five")
+        expect(redis_client).to have_received(:set).with(
+          "five", 5, ex: described_class::DEFAULT_EXPIRATION
+        )
+        expect(result).to eq(5)
+      end
+
+      it "when key is missing sets key value and custom expiration" do
+        result = described_class.fetch("five", expires_in: 100) do
+          5
+        end
+        expect(redis_client).to have_received(:get).with("five")
+        expect(redis_client).to have_received(:set).with("five", 5, ex: 100)
+        expect(result).to eq(5)
+      end
+    end
+
+    context "without block present" do
+      it "returns the value of the key from the cache" do
+        allow(redis_client).to receive(:get).with("five").and_return(5)
+        result = described_class.fetch("five")
+        expect(redis_client).to have_received(:get).with("five")
+        expect(result).to eq(5)
+      end
+    end
+  end
+
+  describe "#read" do
+    it "gets the key from RedisClient" do
+      described_class.read("foo")
+      expect(redis_client).to have_received(:get).with("foo")
+    end
+  end
+
+  describe "#write" do
+    it "sets the key in RedisClient with default expiration" do
+      described_class.write("foo", 2)
+      expect(redis_client).to have_received(:set).with(
+        "foo", 2, ex: described_class::DEFAULT_EXPIRATION
+      )
+    end
+
+    it "sets the key in RedisClient with custom expiration" do
+      described_class.write("foo", 2, expires_in: 100)
+      expect(redis_client).to have_received(:set).with(
+        "foo", 2, ex: 100
+      )
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Rather than directly talking to our new `RedisClient` I have created a wrapper class that acts similarly to Rails.cache called `RedisRailsCache`. It responds to methods such as read, write, and [fetch](https://github.com/rails/rails/blob/66cabeda2c46c582d19738e1318be8d59584cc5b/activesupport/lib/active_support/cache.rb#L314). I will also need to implement delete at some point but I will save that for a later PR. The VAST majority of our Rails.cache calls are using fetch and from what I can tell the only option we use with fetch is `expires_in` which is why that is the only one I supported. If I come across other options I can update the wrapper to handle them but I think this will cover just about everything. 

I also applied the new wrapper to our following_podcast_ids cache since that seemed like a low risk one to start on. @benhalpern please let me know if that was a bad choice!

Let me know what you all think! 

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

![guy saying the party has just begun](https://media2.giphy.com/media/3o6fJ9FtwvoPh4izK0/giphy.gif)