### PR TITLE
Adds border styling for homepage search bar on focus

### DIFF
--- a/app/assets/stylesheets/top-bar.scss
+++ b/app/assets/stylesheets/top-bar.scss
@@ -418,7 +418,6 @@
     margin: 0;
     width: calc(100% - 12px);
     border-radius: 3px;
-    border: 0px;
     padding: 6px 9px;
     font-size: 0.9em;
     @include themeable(
@@ -432,6 +431,10 @@
       $black
     );
     -webkit-appearance: none;
+    border: 1px solid transparent;
+    &:focus {
+      border: 1px solid $dark-purple;
+    }
     &::placeholder {
       opacity: 0.5;
       @include themeable(


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
As described in #4663, the homepage search bar should be styled when it's focused in order to better indicate that fact. The example in the issue suggests using a different background color, however i want to propose a solution where we use the border for on focus styling. This i think is more in line with the default browser styling and the styling found in many websites (so it's a pattern familiar to users). I used the same color used in the border for the nav controls. Screenshots below.

## Related Tickets & Documents
#4663 


## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
* Default Theme:
![Oct-30-2019 22-23-08](https://user-images.githubusercontent.com/5598081/67897218-9a91e780-fb66-11e9-9da9-a2ffb0a3441a.gif)

* Other Themes:
<img width="983" alt="Screenshot 2019-10-31 at 11 57 48" src="https://user-images.githubusercontent.com/5598081/67937541-7241d180-fbd6-11e9-953e-bc52b44b6943.png">

<img width="984" alt="Screenshot 2019-10-31 at 11 59 28" src="https://user-images.githubusercontent.com/5598081/67937542-7241d180-fbd6-11e9-8fbf-b28a2f4d451f.png">

<img width="979" alt="Screenshot 2019-10-31 at 12 00 15" src="https://user-images.githubusercontent.com/5598081/67937543-7241d180-fbd6-11e9-8d6b-997ecbae245f.png">

<img width="973" alt="Screenshot 2019-10-31 at 12 02 16" src="https://user-images.githubusercontent.com/5598081/67937544-7241d180-fbd6-11e9-8322-de2f331a2ebb.png">


## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![rainbox](https://media.giphy.com/media/PymFtB2MigGnC/giphy.gif)
