### PR TITLE
Changed color of err class on highlight snippets while creating a new post

### DIFF
--- a/app/assets/stylesheets/syntax.scss
+++ b/app/assets/stylesheets/syntax.scss
@@ -16,7 +16,7 @@ div.inner-comment div.body div.highlight pre.highlight {
 .highlight .hll { background-color: #49483e }
 .highlight  { background: #29292e; color: #f8f8f2 }
 .highlight .c { color: #75715e } /* Comment */
-.highlight .err { color: #960050; background-color: #1e0010 } /* Error */
+.highlight .err { color: #ffffff; background-color: #721c24 } /* Error */
 .highlight .k { color: #66d9ef } /* Keyword */
 .highlight .l { color: #ae81ff } /* Literal */
 .highlight .n { color: #f8f8f2 } /* Name */


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
As described in task #4577 , there was no ideal contrast when the `err` class was added to the code due to some typing error.

## Related Tickets & Documents
Fixes #4577 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
### **Reported Behavior**
![67487263-867d5000-f665-11e9-9f74-d678501c0bd0](https://user-images.githubusercontent.com/17601527/67912889-193c5400-fb6a-11e9-9f66-e390a0d561b4.png)

### **Behavior after fixed**
<img width="477" alt="Captura de Tela 2019-10-30 às 23 09 57" src="https://user-images.githubusercontent.com/17601527/67913035-8cde6100-fb6a-11e9-959a-6eae5ee48eb5.png">

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![its magic](https://media.giphy.com/media/12NUbkX6p4xOO4/source.gif)
