### PR TITLE
Add ability to set the app site email through environment variable

### DIFF
--- a/Envfile
+++ b/Envfile
@@ -30,6 +30,9 @@ variable :DEPLOYMENT_SIGNATURE, :String, default: "Optional"
 # For Redis storage
 variable :REDIS_URL, :String, default: "redis://localhost:6379"
 
+# For Default Email
+ variable :DEFAULT_SITE_EMAIL, :String, default: "yo@dev.to"
+
 ################################################
 ############## 3rd Party Services ##############
 ################################################

--- a/app/controllers/api_secrets_controller.rb
+++ b/app/controllers/api_secrets_controller.rb
@@ -23,7 +23,7 @@ class ApiSecretsController < ApplicationController
     if @secret.destroy
       flash[:notice] = "Your API Key has been revoked."
     else
-      flash[:error] = "An error occurred. Please try again or send an email to: yo@dev.to"
+      flash[:error] = "An error occurred. Please try again or send an email to: #{ApplicationConfig["DEFAULT_SITE_EMAIL"]}"
     end
 
     redirect_back(fallback_location: root_path)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -94,7 +94,7 @@ class UsersController < ApplicationController
 
       flash[:settings_notice] = "Your #{provider.capitalize} account was successfully removed."
     else
-      flash[:error] = "An error occurred. Please try again or send an email to: yo@dev.to"
+      flash[:error] = "An error occurred. Please try again or send an email to: #{ApplicationConfig["DEFAULT_SITE_EMAIL"]}"
     end
     redirect_to "/settings/#{@tab}"
   end

--- a/app/labor/error_message_cleaner.rb
+++ b/app/labor/error_message_cleaner.rb
@@ -7,7 +7,7 @@ class ErrorMessageCleaner
 
   def clean
     if error_message.include? "expected key while parsing a block mapping at line"
-      "There was a problem parsing the front-matter YAML. Perhaps you need to escape a quote or a colon or something. Email yo@dev.to if you are having trouble."
+      "There was a problem parsing the front-matter YAML. Perhaps you need to escape a quote or a colon or something. Email #{ApplicationConfig["DEFAULT_SITE_EMAIL"]} if you are having trouble."
     else
       error_message
     end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,5 +1,5 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "DEV Community <yo@dev.to>"
+  default from: "DEV Community <#{ApplicationConfig["DEFAULT_SITE_EMAIL"]}>"
   layout "mailer"
   default template_path: ->(mailer) { "mailers/#{mailer.class.name.underscore}" }
 

--- a/app/mailers/digest_mailer.rb
+++ b/app/mailers/digest_mailer.rb
@@ -1,5 +1,5 @@
 class DigestMailer < ApplicationMailer
-  default from: "DEV Digest <yo@dev.to>"
+  default from: "DEV Digest <#{ApplicationConfig["DEFAULT_SITE_EMAIL"]}>"
 
   def digest_email(user, articles)
     @user = user

--- a/app/mailers/pro_membership_mailer.rb
+++ b/app/mailers/pro_membership_mailer.rb
@@ -1,5 +1,5 @@
 class ProMembershipMailer < ApplicationMailer
-  default from: "DEV Pro Memberships <yo@dev.to>"
+  default from: "DEV Pro Memberships <#{ApplicationConfig["DEFAULT_SITE_EMAIL"]}>"
 
   def expiring_membership(pro_membership, expiration_date)
     @pro_membership = pro_membership

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -33,7 +33,7 @@ class Organization < ApplicationRecord
             format: { with: /\A[a-zA-Z0-9\-_]+\Z/ },
             length: { in: 2..18 },
             exclusion: { in: ReservedWords.all,
-                         message: "%<value>s is a reserved word. Contact yo@dev.to for help registering your organization." }
+                         message: "%<value>s is a reserved word. Contact #{ApplicationConfig["DEFAULT_SITE_EMAIL"]} for help registering your organization." }
   validates :url, url: { allow_blank: true, no_local: true, schemes: %w[https http] }
   validates :secret, uniqueness: { allow_blank: true }
   validates :location, :email, :company_size, length: { maximum: 64 }

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -33,7 +33,7 @@ class Organization < ApplicationRecord
             format: { with: /\A[a-zA-Z0-9\-_]+\Z/ },
             length: { in: 2..18 },
             exclusion: { in: ReservedWords.all,
-                         message: "%<value>s is a reserved word. Contact #{ApplicationConfig["DEFAULT_SITE_EMAIL"]} for help registering your organization." }
+                         message: "%<value>s is a reserved word. Contact '#{ApplicationConfig["DEFAULT_SITE_EMAIL"]}' for help registering your organization." }
   validates :url, url: { allow_blank: true, no_local: true, schemes: %w[https http] }
   validates :secret, uniqueness: { allow_blank: true }
   validates :location, :email, :company_size, length: { maximum: 64 }

--- a/app/views/devise/shared/_authorization_error.html.erb
+++ b/app/views/devise/shared/_authorization_error.html.erb
@@ -25,6 +25,6 @@
       <%= flash[:alert] %>
       <br>
     <% end %>
-    Please try again below, or contact <a href="mailto:yo@dev.to">yo@dev.to</a> if this persists.
+    Please try again below, or contact <a href="mailto:#{ApplicationConfig["DEFAULT_SITE_EMAIL"]}><%= ApplicationConfig["DEFAULT_SITE_EMAIL"]%></a> if this persists.
   </div>
 <% end %>

--- a/app/views/feedback_messages/index.html.erb
+++ b/app/views/feedback_messages/index.html.erb
@@ -4,7 +4,7 @@
     <h2>Thank you for your report.</h2>
     <h3><a href="/">Return to home page</a></h3>
     <p>
-      Questions? Send an email to <a href="mailto:yo@dev.to">yo@dev.to</a>
+      Questions? Send an email to <a href='mailto:#{ApplicationConfig["DEFAULT_SITE_EMAIL"]}'><%= ApplicationConfig["DEFAULT_SITE_EMAIL"]%></a>
     </p>
   </div>
 </div>

--- a/app/views/mailers/notify_mailer/account_deleted_email.html.erb
+++ b/app/views/mailers/notify_mailer/account_deleted_email.html.erb
@@ -7,7 +7,7 @@
 </p>
 
 <p>
-  Contact us at <a href="mailto:yo@dev.to">yo@dev.to</a> if there is anything more we can help with. 😊
+  Contact us at <a href='mailto:#{ApplicationConfig["DEFAULT_SITE_EMAIL"]}'><%= ApplicationConfig["DEFAULT_SITE_EMAIL"]%></a> if there is anything more we can help with. 😊
 </p>
 
 <p>

--- a/app/views/mailers/notify_mailer/account_deleted_email.text.erb
+++ b/app/views/mailers/notify_mailer/account_deleted_email.text.erb
@@ -1,6 +1,9 @@
 Hi <%= @name %>, your account has been successfully deleted.
 
-Contact us at yo@dev.to if there is anything more we can help with.
+Contact us at <%= ApplicationConfig["DEFAULT_SITE_EMAIL"]%> if there is anything more we can help with.
 
 Thanks,
 The DEV Team
+
+
+

--- a/app/views/moderations/index.html.erb
+++ b/app/views/moderations/index.html.erb
@@ -150,7 +150,7 @@
     <h1 style="text-align: center">DEV Mods</h1>
     <div class="body">
       <p>We periodically award some DEV members with heightened privileges to help moderate the community.</p>
-      <p>Email <a href="mailto:yo@dev.to">yo@dev.to</a> if you'd like to be considered right away.</p>
+      <p>Email <a href='mailto:#{ApplicationConfig["DEFAULT_SITE_EMAIL"]}'><%= ApplicationConfig["DEFAULT_SITE_EMAIL"]%></a> if you'd like to be considered right away.</p>
       <% if !user_signed_in? %>
         <p><em>P.S. You are not currently signed in.</em></p>
       <% end %>

--- a/app/views/notifications/_notifications_list.html.erb
+++ b/app/views/notifications/_notifications_list.html.erb
@@ -14,7 +14,7 @@
   <div class="content notification-content comment-content">
     An error occurred! This has been logged and we're tracking it.
     <br>
-    If you see too many of these, please report it to <a href="mailto:yo@dev.to">yo@dev.to</a>!
+    If you see too many of these, please report it to <a href='mailto:#{ApplicationConfig["DEFAULT_SITE_EMAIL"]}'><%= ApplicationConfig["DEFAULT_SITE_EMAIL"]%></a>!
   </div>
 <% end %>
 

--- a/app/views/notifications/_tagadjustment.html.erb
+++ b/app/views/notifications/_tagadjustment.html.erb
@@ -20,6 +20,6 @@
   Check out <a href="/tags">other popular tags</a> which may be more appropriate.
   <br><br />
   Thanks for being part of DEV! If you feel like this mod action was a mistake, feel free to contact
-  <a href="mailto:yo@dev.to">yo@dev.to</a>. 🤗
+  <a href='mailto:#{ApplicationConfig["DEFAULT_SITE_EMAIL"]}'><%= ApplicationConfig["DEFAULT_SITE_EMAIL"]%></a>. 🤗
   <br /><br />
 </div>

--- a/app/views/pages/_coc_text.html.erb
+++ b/app/views/pages/_coc_text.html.erb
@@ -31,7 +31,7 @@
     </ul>
     <h2>Enforcement</h2>
     <p>Violations of the Code of Conduct may be reported by contacting the team via the
-      <a href="https://dev.to/report-abuse">abuse report form</a> or by sending an email to yo@dev.to. All reports will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. Further details of specific enforcement policies may be posted separately.
+      <a href="https://dev.to/report-abuse">abuse report form</a> or by sending an email to <%= ApplicationConfig["DEFAULT_SITE_EMAIL"] %>. All reports will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. Further details of specific enforcement policies may be posted separately.
     </p>
     <p>Moderators have the right and responsibility to remove comments or other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any members for other behaviors that they deem inappropriate, threatening, offensive, or harmful.</p>
     <h2>Attribution</h2>

--- a/app/views/pages/_terms_text.html.erb
+++ b/app/views/pages/_terms_text.html.erb
@@ -76,7 +76,7 @@
 
     <p>
       Users agree and certify that they have rights to share all content that they post on dev.to — including, but not limited to, information posted in articles, discussions, and comments. This rule applies to prose, code snippets, collections of links, etc. Regardless of citation, users may not post copy and pasted content that does not belong to them. Users assume all risk for the content they post, including someone else's reliance on its accuracy, claims relating to intellectual property, or other legal rights. If you believe that a user has plagiarized content, misrepresented their identity, misappropriated work, or otherwise run afoul of DMCA regulations, please email
-      <a href="mailto:yo@dev.to">yo@dev.to</a>. DEV may remove any content users post for any reason.
+       <a href='mailto:#{ApplicationConfig["DEFAULT_SITE_EMAIL"]}'><%= ApplicationConfig["DEFAULT_SITE_EMAIL"]%></a>. DEV may remove any content users post for any reason.
     </p>
 
     <h3 id="site-terms-of-use-modifications">

--- a/app/views/pages/bounty.html.erb
+++ b/app/views/pages/bounty.html.erb
@@ -29,7 +29,7 @@
     </p>
     <p>
       Found a vulnerability in our systems? Shoot us an email at
-      <a href="mailto:yo@dev.to">yo@dev.to</a>. You'll hear back from us within two weeks at the latest, and we'll let you know a few things:
+       <a href='mailto:#{ApplicationConfig["DEFAULT_SITE_EMAIL"]}'><%= ApplicationConfig["DEFAULT_SITE_EMAIL"]%></a>. You'll hear back from us within two weeks at the latest, and we'll let you know a few things:
     </p>
     <ul>
       <li>If it's been reported previously,</li>

--- a/app/views/pages/contact.html.erb
+++ b/app/views/pages/contact.html.erb
@@ -30,7 +30,7 @@
       The Practical Dev would love to hear from you!
     </p>
     <p>
-      Email: <a href="mailto:yo@dev.to">yo@dev.to</a> 😁
+      Email:  <a href='mailto:#{ApplicationConfig["DEFAULT_SITE_EMAIL"]}'><%= ApplicationConfig["DEFAULT_SITE_EMAIL"]%></a> 😁
     </p>
     <p>
       Twitter: <a href="http://twitter.com/<%= ApplicationConfig["SITE_TWITTER_HANDLE"] %>">@<%= ApplicationConfig["SITE_TWITTER_HANDLE"] %></a> 👻

--- a/app/views/pages/faq.html.erb
+++ b/app/views/pages/faq.html.erb
@@ -48,7 +48,7 @@
     <p>
       <b>How do I change my Twitter/GitHub username?</b>
       <br>
-      Email yo@dev.to and we'll take care of it.
+      Email <%= ApplicationConfig["DEFAULT_SITE_EMAIL"] %> and we'll take care of it.
     <p>
       <b>What about my post's Google ranking?</b>
       <br>
@@ -63,7 +63,7 @@
     <p>
       <b>I found a security vulnerability. How do I report it?</b>
       <br>
-      Please email yo@dev.to.
+      Please email <%= ApplicationConfig["DEFAULT_SITE_EMAIL"] %>.
     </p>
     <p>
       <b>How do I report spam?</b>
@@ -89,7 +89,7 @@
     <p>
       <b>How do I delete my account?</b>
       <br>
-      Please e-mail yo@dev.to to delete your account.
+      Please e-mail <%= ApplicationConfig["DEFAULT_SITE_EMAIL"] %> to delete your account.
     </p>
     <p>
       <b>Do I own the articles that I publish?</b>

--- a/app/views/pages/sponsorship_faq.html.erb
+++ b/app/views/pages/sponsorship_faq.html.erb
@@ -35,7 +35,7 @@
     <p>
       <b>What if I have other questions?</b>
       <br>
-      Please send an email to <a href="mailto:yo@dev.to">yo@dev.to</a>.
+      Please send an email to  <a href='mailto:#{ApplicationConfig["DEFAULT_SITE_EMAIL"]}'><%= ApplicationConfig["DEFAULT_SITE_EMAIL"]%></a>.
     </p>
   </div>
 </div>

--- a/app/views/pages/swagnets.html.erb
+++ b/app/views/pages/swagnets.html.erb
@@ -25,7 +25,7 @@
 
     <p>We understand that some of you won't have a device that supports your new Swagnet, but we hope that you have a friend who can enjoy it :)<br>By the way, you can also buy Swagnets that benefit open-source projects: you can check those out
       <b><a href="https://www.swagnets.com/pages/activism">here</a></b>.<br>Comments? Suggestions? Ping us on Twitter or at
-      <a href="mailto:yo@dev.to">yo@dev.to</a>.</p>
+       <a href='mailto:#{ApplicationConfig["DEFAULT_SITE_EMAIL"]}'><%= ApplicationConfig["DEFAULT_SITE_EMAIL"]%></a>.</p>
 
   </div>
 </div>

--- a/app/views/podcast_episodes/_sidebar.html.erb
+++ b/app/views/podcast_episodes/_sidebar.html.erb
@@ -28,7 +28,7 @@
               </div>
             </a>
           <% end %>
-          <p>If you know of a great dev podcast that should be added to this list, contact <a href="mailto:yo@dev.to">yo@dev.to</a></p>
+          <p>If you know of a great dev podcast that should be added to this list, contact  <a href='mailto:#{ApplicationConfig["DEFAULT_SITE_EMAIL"]}'><%= ApplicationConfig["DEFAULT_SITE_EMAIL"]%></a></p>
         </div>
       </div>
     <% elsif @podcast %>

--- a/app/views/users/_account.html.erb
+++ b/app/views/users/_account.html.erb
@@ -148,7 +148,7 @@
 <h3>Request Account Deletion</h3>
 <h4 style="font-weight: 400;">
   <br>
-  <a href="mailto:yo@dev.to?subject=Request Account Deletion&body=<%= @email_body %>">
+  <a href='mailto:"#{ApplicationConfig["DEFAULT_SITE_EMAIL"]}"?subject=Request Account Deletion&body=<%= @email_body %>'>
     Click this link to request account deletion via email.
   </a> This includes all articles, comments, reactions, etc. as well as any personal information you have.
   <br>

--- a/app/views/users/_publishing_from_rss.html.erb
+++ b/app/views/users/_publishing_from_rss.html.erb
@@ -26,7 +26,7 @@
 </p>
 <p>
   Your feed will be fetched every time you submit this form and updates will be automatically fetched periodically thereafter. Contact
-  <a href="mailto:yo@dev.to">yo@dev.to</a> if you encounter issues.
+ <a href='mailto:#{ApplicationConfig["DEFAULT_SITE_EMAIL"]}'><%= ApplicationConfig["DEFAULT_SITE_EMAIL"]%></a> if you encounter issues.
 </p>
 <p>
   FYI: Medium RSS feed URLs are <em>https://medium.com/feed/@your_username</em>

--- a/app/views/videos/new.html.erb
+++ b/app/views/videos/new.html.erb
@@ -33,7 +33,7 @@
   <% end %>
   <div style="margin:50px auto;max-width:80%;font-size:0.86em;">
     <p>
-      <strong>Video is beta:</strong> Email <a href="mailto:yo@dev.to">yo@dev.to</a> if you have any problems.
+      <strong>Video is beta:</strong> Email <a href='mailto:#{ApplicationConfig["DEFAULT_SITE_EMAIL"]}'><%= ApplicationConfig["DEFAULT_SITE_EMAIL"]%></a> if you have any problems.
     </p>
   </div>
 </center>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -11,7 +11,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = "dev.to <yo@dev.to>"
+  config.mailer_sender = "dev.to <#{ ApplicationConfig["DEFAULT_SITE_EMAIL"] }>"
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/docs/api_v0.yml
+++ b/docs/api_v0.yml
@@ -7,7 +7,7 @@ info:
   contact:
     name: DEV Team
     url: https://dev.to/contact
-    email: yo@dev.to
+    email: ApplicationConfig["DEFAULT_SITE_EMAIL"]
   x-logo: # https://github.com/Redocly/redoc/blob/master/docs/redoc-vendor-extensions.md#x-logo
     url: https://practicaldev-herokuapp-com.freetls.fastly.net/assets/devlogo-pwa-128-1a9016906487b8ba17f2d3d3c28f9d1cb3ae9b45d685cc2711e20f6b3c6730df.png
     backgroundColor: "#000"

--- a/spec/mailers/digest_mailer_spec.rb
+++ b/spec/mailers/digest_mailer_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe DigestMailer, type: :mailer do
 
       expect(email.subject).not_to be_nil
       expect(email.to).to eq([user.email])
-      expect(email.from).to eq(["yo@dev.to"])
+      expect(email.from).to eq(["#{ApplicationConfig["DEFAULT_SITE_EMAIL"]}"])
     end
 
     it "includes the tracking pixel" do

--- a/spec/mailers/pro_membership_mailer_spec.rb
+++ b/spec/mailers/pro_membership_mailer_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ProMembershipMailer, type: :mailer do
 
         expect(email.subject).to eq("Your Pro Membership will expire in 7 days!")
         expect(email.to).to eq([user.email])
-        expect(email.from).to eq(["yo@dev.to"])
+        expect(email.from).to eq(["#{ApplicationConfig["DEFAULT_SITE_EMAIL"]}"])
       end
     end
 

--- a/spec/requests/user_settings_spec.rb
+++ b/spec/requests/user_settings_spec.rb
@@ -232,7 +232,7 @@ RSpec.describe "UserSettings", type: :request do
       it "sets the proper error message" do
         delete "/users/remove_association", params: { provider: "github" }
         expect(flash[:error]).
-          to eq "An error occurred. Please try again or send an email to: yo@dev.to"
+          to eq "An error occurred. Please try again or send an email to: #{ApplicationConfig["DEFAULT_SITE_EMAIL"]}"
       end
 
       it "does not delete any identities" do


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ 1] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

For generalization of the platform, technical administrators would now be able to provide a Email to a custom email of their choice.

## Related Tickets & Documents
#4660 
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [ 1] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
