### PR TITLE
[deploy] Move cached_following_podcasts_ids to Redis

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -258,7 +258,7 @@ class User < ApplicationRecord
   end
 
   def cached_following_podcasts_ids
-    Rails.cache.fetch(
+    RedisRailsCache.fetch(
       "user-#{id}-#{updated_at}-#{last_followed_at}/following_podcasts_ids",
       expires_in: 120.hours,
     ) do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
Move cached_following_podcasts_ids to Redis. This cache key is only used in one location and since there are a small number of podcasts I figured it would be a small key and safe place to start. 

## Related Tickets & Documents
Issue #4670 

## Added to documentation?

- [x] no documentation needed

![man saying game on!!!](https://media0.giphy.com/media/pjd6Oggp5BIzJp33CK/giphy.gif)
