### PR TITLE
Move cached_following_organizations_ids to Redis

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -249,7 +249,7 @@ class User < ApplicationRecord
   end
 
   def cached_following_organizations_ids
-    Rails.cache.fetch(
+    RedisRailsCache.fetch(
       "user-#{id}-#{updated_at}-#{following_orgs_count}/following_organizations_ids",
       expires_in: 120.hours,
     ) do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
Move cached_following_organizations_ids to Redis. This cache key is only used in one location, [user_data in the async info controller](https://github.com/thepracticaldev/dev.to/blob/master/app/controllers/async_info_controller.rb#L33) which already has a 15 min cache so having this cold should be nbd

## Related Tickets & Documents
Issue #4670 

## Added to documentation?

- [x] no documentation needed

![follow, ah yes follow](https://media2.giphy.com/media/93fsZ7rI488L908x0T/giphy.gif)
