### PR TITLE
Remove Cacheing for preferred_languages_array [deploy]

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -236,7 +236,7 @@ class User < ApplicationRecord
   def followed_articles
     Article.tagged_with(cached_followed_tag_names, any: true).
       union(Article.where(user_id: cached_following_users_ids)).
-      where(language: cached_preferred_langs, published: true)
+      where(language: preferred_languages_array, published: true)
   end
 
   def cached_following_users_ids
@@ -263,12 +263,6 @@ class User < ApplicationRecord
       expires_in: 120.hours,
     ) do
       Follow.where(follower_id: id, followable_type: "Podcast").pluck(:followable_id)
-    end
-  end
-
-  def cached_preferred_langs
-    Rails.cache.fetch("user-#{id}-#{updated_at}/cached_preferred_langs", expires_in: 24.hours) do
-      preferred_languages_array
     end
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature
- [x] Bug Fix

## Description
The cached_preferred_langs method was caching an array that we don't have to make any external calls to build, we only have to run a little bit of Ruby logic. By adding an external call here we will actually end up slowing our code down. 

```ruby
irb(main):014:0> RedisRailsCache.write("fooo", [1,2,3])
=> "OK"
irb(main):015:0> Benchmark.realtime{  RedisRailsCache.read("fooo") }
=> 0.004682420985773206
irb(main):016:0> Benchmark.realtime{ me.preferred_languages_array }
=> 5.205301567912102e-05
```

## Related Tickets & Documents
Issue #4670 

## Added to documentation?

- [x] no documentation needed

![girl saying I dont require your help](https://media1.giphy.com/media/obxlpBKOkjohq/giphy.gif)
