### PR TITLE
Move has_pro_membership cache to Redis

### DIFF
--- a/app/models/pro_membership.rb
+++ b/app/models/pro_membership.rb
@@ -56,6 +56,6 @@ class ProMembership < ApplicationRecord
   end
 
   def bust_cache
-    Rails.cache.delete("user-#{user.id}/has_pro_membership")
+    RedisRailsCache.delete("user-#{user.id}/has_pro_membership")
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -331,7 +331,7 @@ class User < ApplicationRecord
   end
 
   def pro?
-    Rails.cache.fetch("user-#{id}/has_pro_membership", expires_in: 200.hours) do
+    RedisRailsCache.fetch("user-#{id}/has_pro_membership", expires_in: 200.hours) do
       pro_membership&.active? || has_role?(:pro)
     end
   end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Move `has_pro_membership` cache to redis.
I picked a key that looked quite low risk (based on absolutely nothing else than my gut feeling). Hope that's fine!

> Can this cache safely become cold?

I think so.

> Does this cache key make sense? Is there a better/more clearer one?

I think it does make sense as is.

> Should this be a cache at all? There might be places where we can live without a cache and simply removing it might be the best move rather than switching it to Redis.

I'd leave it here.

> Does the current expiration make sense?

It seems to be one of the longest (if not the longest) expirations on the site. Again, this seems sensible considering what the key represents.

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/issues/4670

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?
Tentatively trying to do the right thing
![not-too-sure](https://media.giphy.com/media/fvYR60mQCKt2x9hV3y/giphy.gif)
