### PR TITLE
Move cached_user_reactions-* keys to Redis

### DIFF
--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -69,7 +69,7 @@ class ReactionsController < ApplicationController
   end
 
   def cached_user_positive_reactions(user)
-    Rails.cache.fetch("cached_user_reactions-#{user.id}-#{user.updated_at}", expires_in: 24.hours) do
+    RedisRailsCache.fetch("cached_user_reactions-#{user.id}-#{user.updated_at}", expires_in: 24.hours) do
       Reaction.where(user_id: user.id).
         where("points > ?", 0)
     end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [X] Feature

## Description

Move cached_user_reactions-* keys to Redis. This cache key is only used in one location.

## Related Tickets & Documents
Issue #4670

## Added to documentation?

- [X] no documentation needed

