### PR TITLE
Move users' has_trusted_role keys to redis

### DIFF
--- a/app/labor/assign_tag_moderator.rb
+++ b/app/labor/assign_tag_moderator.rb
@@ -6,7 +6,7 @@ module AssignTagModerator
     user.add_role :trusted
     user.update(email_community_mod_newsletter: true)
     MailchimpBot.new(user).manage_community_moderator_list
-    Rails.cache.delete("user-#{user.id}/has_trusted_role")
+    RedisRailsCache.delete("user-#{user.id}/has_trusted_role")
     NotifyMailer.trusted_role_email(user).deliver
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -331,7 +331,7 @@ class User < ApplicationRecord
   end
 
   def trusted
-    Rails.cache.fetch("user-#{id}/has_trusted_role", expires_in: 200.hours) do
+    RedisRailsCache.fetch("user-#{id}/has_trusted_role", expires_in: 200.hours) do
       has_role? :trusted
     end
   end

--- a/app/services/moderator/manage_activity_and_roles.rb
+++ b/app/services/moderator/manage_activity_and_roles.rb
@@ -148,7 +148,7 @@ module Moderator
     end
 
     def update_trusted_cache
-      Rails.cache.delete("user-#{@user.id}/has_trusted_role")
+      RedisRailsCache.delete("user-#{@user.id}/has_trusted_role")
       @user.trusted
     end
 


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [X] Feature

## Description
Move users' has_trusted_role keys to Redis.

## Related Tickets & Documents
Issue #4670

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [X] no documentation needed

