### PR TITLE
Use libhoney explicitly and group initializers

### DIFF
--- a/Envfile
+++ b/Envfile
@@ -117,8 +117,8 @@ variable :FASTLY_API_KEY, :String, default: "Optional"
 variable :FASTLY_SERVICE_ID, :String, default: "Optional"
 
 # Honeycomb for monitoring and observability
-# https://www.honeycomb.io/
-variable :HONEYCOMB_API_KEY, :String, default: "Optional"
+# (https://www.honeycomb.io/)
+variable :HONEYCOMB_API_KEY, :String, default: ""
 
 # Google analytic
 # (https://developers.google.com/analytics/devguides/reporting/core/v4)

--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ gem "inline_svg", "~> 1.5" # Embed SVG documents in your Rails views and style t
 gem "jbuilder", "~> 2.9" # Create JSON structures via a Builder-style DSL
 gem "jquery-rails", "~> 4.3" #  A gem to automate using jQuery with Rails
 gem "kaminari", "~> 1.1" # A Scope & Engine based, clean, powerful, customizable and sophisticated paginator
+gem "libhoney", "~> 1.14" # Ruby gem for sending data to Honeycomb
 gem "liquid", "~> 4.0" # A secure, non-evaling end user template engine with aesthetic markup
 gem "nokogiri", "~> 1.10" # HTML, XML, SAX, and Reader parser
 gem "octokit", "~> 4.14" # Simple wrapper for the GitHub API

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -930,6 +930,7 @@ DEPENDENCIES
   jquery-rails (~> 4.3)
   kaminari (~> 1.1)
   launchy (~> 2.4)
+  libhoney (~> 1.14)
   liquid (~> 4.0)
   memory_profiler (~> 0.9)
   nakayoshi_fork (~> 0.0.4)

--- a/config/initializers/honeycomb.rb
+++ b/config/initializers/honeycomb.rb
@@ -1,5 +1,8 @@
+honeycomb_api_key = ApplicationConfig["HONEYCOMB_API_KEY"]
+
+# Honeycomb automatic Rails integration
 Honeycomb.configure do |config|
-  config.write_key = ENV["HONEYCOMB_API_KEY"]
+  config.write_key = honeycomb_api_key
   config.dataset = "rails"
   config.notification_events = %w[
     sql.active_record
@@ -12,3 +15,6 @@ Honeycomb.configure do |config|
     deliver.action_mailer
   ].freeze
 end
+
+# here we create an additional Honeycomb client that can be used to send custom events
+HoneycombClient = Libhoney::Client.new(writekey: honeycomb_api_key, dataset: "dev-ruby")

--- a/config/initializers/honeycomb.rb
+++ b/config/initializers/honeycomb.rb
@@ -1,24 +1,28 @@
-honeycomb_api_key = ApplicationConfig["HONEYCOMB_API_KEY"]
+if Rails.env.test?
+  Honeycomb.configure do |config|
+    config.client = Libhoney::TestClient.new
+  end
 
-# Honeycomb automatic Rails integration
-Honeycomb.configure do |config|
-  config.write_key = honeycomb_api_key
-  config.dataset = "rails"
-  config.notification_events = %w[
-    sql.active_record
-    render_template.action_view
-    render_partial.action_view
-    render_collection.action_view
-    process_action.action_controller
-    send_file.action_controller
-    send_data.action_controller
-    deliver.action_mailer
-  ].freeze
+  HoneycombClient = Libhoney::TestClient.new
+else
+  honeycomb_api_key = ApplicationConfig["HONEYCOMB_API_KEY"]
+
+  # Honeycomb automatic Rails integration
+  Honeycomb.configure do |config|
+    config.write_key = honeycomb_api_key
+    config.dataset = "rails"
+    config.notification_events = %w[
+      sql.active_record
+      render_template.action_view
+      render_partial.action_view
+      render_collection.action_view
+      process_action.action_controller
+      send_file.action_controller
+      send_data.action_controller
+      deliver.action_mailer
+    ].freeze
+  end
+
+  # here we create an additional Honeycomb client that can be used to send custom events
+  HoneycombClient = Libhoney::Client.new(writekey: honeycomb_api_key, dataset: "dev-ruby")
 end
-
-# here we create an additional Honeycomb client that can be used to send custom events
-HoneycombClient = if Rails.env.test?
-                    Libhoney::TestClient.new
-                  else
-                    Libhoney::Client.new(writekey: honeycomb_api_key, dataset: "dev-ruby")
-                  end

--- a/config/initializers/honeycomb.rb
+++ b/config/initializers/honeycomb.rb
@@ -17,4 +17,8 @@ Honeycomb.configure do |config|
 end
 
 # here we create an additional Honeycomb client that can be used to send custom events
-HoneycombClient = Libhoney::Client.new(writekey: honeycomb_api_key, dataset: "dev-ruby")
+HoneycombClient = if Rails.env.test?
+                    Libhoney::TestClient.new
+                  else
+                    Libhoney::Client.new(writekey: honeycomb_api_key, dataset: "dev-ruby")
+                  end

--- a/config/initializers/honeycomb_event_client.rb
+++ b/config/initializers/honeycomb_event_client.rb
@@ -1,1 +1,0 @@
-HoneycombClient = Libhoney::Client.new(writekey: ENV["HONEYCOMB_API_KEY"], dataset: 'dev-ruby')


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

Since in https://github.com/thepracticaldev/dev.to/pull/4692 we added an explicit dependency to [libhoney](https://rubygems.org/gems/libhoney) I've added it to the Gemfile, transitive dependencies are a little bit odd.

I also used `ApplicationConfig` instead of `ENV` and grouped the two initializers in the same place, this should make them easier to configure and avoid that they diverge in the future, since they are both in the same place.

It also uses [LibHoney::TestClient](https://github.com/honeycombio/libhoney-rb/blob/master/lib/libhoney/test_client.rb) during tests
