### PR TITLE
Add edited_at publicly for comments

### DIFF
--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -608,6 +608,16 @@ a.header-link {
   .low-quality-comment > *:not(.dropdown) {
     opacity: 0.5;
   }
+  .comment-edited-notice {
+    font-size: 0.66em;
+    font-style: italic;
+    margin-top: -6px;
+    @include themeable(
+      color,
+      theme-secondary-color,
+      $medium-gray
+    );
+  }
   .body {
     padding: 1px;
     padding-left: 1.5%;

--- a/app/decorators/comment_decorator.rb
+++ b/app/decorators/comment_decorator.rb
@@ -12,4 +12,14 @@ class CommentDecorator < ApplicationDecorator
 
     created_at.utc.iso8601
   end
+
+  def edited_timestamp
+    return "" if edited_at.nil?
+
+    edited_at.utc.iso8601
+  end
+
+  def display_edited?
+    edited_at && (edited_at - created_at) > 3.minutes
+  end
 end

--- a/app/labor/random_gif.rb
+++ b/app/labor/random_gif.rb
@@ -19,8 +19,7 @@ class RandomGif
       "l0K4glBiv82lZ0Zuo" => { aspect_ratio: 0.563 },
       "7EcgJbeY0yCRy" => { aspect_ratio: 0.750 },
       "Gf3fU0qPtI6uk" => { aspect_ratio: 0.750 },
-      "5GoVLqeAOo6PK" => { aspect_ratio: 0.780 },
-      "82lalqBsmW56Z6E2oV" => { aspect_ratio: 0.562 }
+      "5GoVLqeAOo6PK" => { aspect_ratio: 0.780 }
     }
   end
 

--- a/app/views/comments/_comment_proper.html.erb
+++ b/app/views/comments/_comment_proper.html.erb
@@ -68,14 +68,7 @@
       </div>
 
       <div class="body <%= "low-quality-comment" if decorated_comment.low_quality %>">
-        <% if decorated_comment.display_edited? %>
-          <div class="comment-edited-notice comment-date">
-            Edited
-            <time datetime="<%= decorated_comment.edited_timestamp %>">
-              <%= decorated_comment.edited_at %>
-            </time>
-          </div>
-        <% end %>
+        <%= render "comments/edited_notice" decorated_comment: decorated_comment %>
         <%= comment.processed_html.html_safe %>
         <button class="reaction-button" id="button-for-comment-<%= comment.id %>" data-comment-id="<%= comment.id %>" title="heart">
           <%= image_tag("favorite-heart-outline-button.svg", alt: "Favorite heart outline button") %>

--- a/app/views/comments/_comment_proper.html.erb
+++ b/app/views/comments/_comment_proper.html.erb
@@ -68,6 +68,14 @@
       </div>
 
       <div class="body <%= "low-quality-comment" if decorated_comment.low_quality %>">
+        <% if decorated_comment.display_edited? %>
+          <div class="comment-edited-notice comment-date">
+            Edited
+            <time datetime="<%= decorated_comment.edited_timestamp %>">
+              <%= decorated_comment.edited_at %>
+            </time>
+          </div>
+        <% end %>
         <%= comment.processed_html.html_safe %>
         <button class="reaction-button" id="button-for-comment-<%= comment.id %>" data-comment-id="<%= comment.id %>" title="heart">
           <%= image_tag("favorite-heart-outline-button.svg", alt: "Favorite heart outline button") %>

--- a/app/views/comments/_comment_proper.html.erb
+++ b/app/views/comments/_comment_proper.html.erb
@@ -68,7 +68,7 @@
       </div>
 
       <div class="body <%= "low-quality-comment" if decorated_comment.low_quality %>">
-        <%= render "comments/edited_notice" decorated_comment: decorated_comment %>
+        <%= render "comments/edited_notice", decorated_comment: decorated_comment %>
         <%= comment.processed_html.html_safe %>
         <button class="reaction-button" id="button-for-comment-<%= comment.id %>" data-comment-id="<%= comment.id %>" title="heart">
           <%= image_tag("favorite-heart-outline-button.svg", alt: "Favorite heart outline button") %>

--- a/app/views/comments/_edited_notice.html.erb
+++ b/app/views/comments/_edited_notice.html.erb
@@ -1,0 +1,8 @@
+<% if decorated_comment.display_edited? %>
+  <div class="comment-edited-notice comment-date">
+    Edited
+    <time datetime="<%= decorated_comment.edited_timestamp %>">
+      <%= decorated_comment.edited_at %>
+    </time>
+  </div>
+<% end %>

--- a/app/views/comments/_liquid.html.erb
+++ b/app/views/comments/_liquid.html.erb
@@ -19,14 +19,7 @@
     <%= render "comments/comment_date", decorated_comment: comment.decorate %>
   </div>
   <div class="body">
-    <% if comment.decorate.display_edited? %>
-      <div class="comment-edited-notice comment-date">
-        Edited
-        <time datetime="<%= comment.decorate.edited_timestamp %>">
-          <%= comment.decorate.edited_at %>
-        </time>
-      </div>
-    <% end %>
+    <%= render "comments/edited_notice" decorated_comment: comment.decorate %>
     <%= comment.processed_html.html_safe %>
   </div>
 </div>

--- a/app/views/comments/_liquid.html.erb
+++ b/app/views/comments/_liquid.html.erb
@@ -19,6 +19,14 @@
     <%= render "comments/comment_date", decorated_comment: comment.decorate %>
   </div>
   <div class="body">
+    <% if comment.decorate.display_edited? %>
+      <div class="comment-edited-notice comment-date">
+        Edited
+        <time datetime="<%= comment.decorate.edited_timestamp %>">
+          <%= comment.decorate.edited_at %>
+        </time>
+      </div>
+    <% end %>
     <%= comment.processed_html.html_safe %>
   </div>
 </div>

--- a/app/views/comments/_liquid.html.erb
+++ b/app/views/comments/_liquid.html.erb
@@ -19,7 +19,7 @@
     <%= render "comments/comment_date", decorated_comment: comment.decorate %>
   </div>
   <div class="body">
-    <%= render "comments/edited_notice" decorated_comment: comment.decorate %>
+    <%= render "comments/edited_notice", decorated_comment: comment.decorate %>
     <%= comment.processed_html.html_safe %>
   </div>
 </div>

--- a/spec/liquid_tags/dev_comment_tag_spec.rb
+++ b/spec/liquid_tags/dev_comment_tag_spec.rb
@@ -36,5 +36,19 @@ RSpec.describe DevCommentTag, type: :liquid_template do
     it "embeds the comment published timestamp" do
       expect(rendered_tag).to include(comment.decorate.published_timestamp)
     end
+
+    it "displays edited if edited after grace period" do
+      comment.update_column(:edited_at, 20.minutes.from_now)
+      expect(rendered_tag).to include("comment-edited-notice")
+    end
+
+    it "displays does not display edited if edited during grace period" do
+      comment.update_column(:edited_at, 1.minute.from_now)
+      expect(rendered_tag).not_to include("comment-edited-notice")
+    end
+
+    it "displays does not display edited if not edited" do
+      expect(rendered_tag).not_to include("comment-edited-notice")
+    end
   end
 end

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -34,6 +34,23 @@ RSpec.describe "Comments", type: :request do
       expect(response.body).to include("FULL DISCUSSION")
     end
 
+    it "displays edited if edited after grace period" do
+      comment.update_column(:edited_at, 20.minutes.from_now)
+      get comment.path
+      expect(response.body).to include("comment-edited-notice")
+    end
+
+    it "displays does not display edited if edited during grace period" do
+      comment.update_column(:edited_at, 1.minute.from_now)
+      get comment.path
+      expect(response.body).not_to include("comment-edited-notice")
+    end
+
+    it "displays does not display edited if not edited" do
+      get comment.path
+      expect(response.body).not_to include("comment-edited-notice")
+    end
+
     context "when the comment a root" do
       it "does not display top of thread button" do
         get comment.path

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -37,18 +37,18 @@ RSpec.describe "Comments", type: :request do
     it "displays edited if edited after grace period" do
       comment.update_column(:edited_at, 20.minutes.from_now)
       get comment.path
-      expect(response.body).to include("comment-edited-notice")
+      expect(response.body).to include('class="comment-edited-notice comment-date')
     end
 
     it "displays does not display edited if edited during grace period" do
       comment.update_column(:edited_at, 1.minute.from_now)
       get comment.path
-      expect(response.body).not_to include("comment-edited-notice")
+      expect(response.body).not_to include('class="comment-edited-notice comment-date')
     end
 
     it "displays does not display edited if not edited" do
       get comment.path
-      expect(response.body).not_to include("comment-edited-notice")
+      expect(response.body).not_to include('class="comment-edited-notice comment-date')
     end
 
     context "when the comment a root" do

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -40,13 +40,13 @@ RSpec.describe "Comments", type: :request do
       expect(response.body).to include('class="comment-edited-notice comment-date')
     end
 
-    it "displays does not display edited if edited during grace period" do
+    it "does not display edited if edited during grace period" do
       comment.update_column(:edited_at, 1.minute.from_now)
       get comment.path
       expect(response.body).not_to include('class="comment-edited-notice comment-date')
     end
 
-    it "displays does not display edited if not edited" do
+    it "does not display edited if not edited" do
       get comment.path
       expect(response.body).not_to include('class="comment-edited-notice comment-date')
     end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
After a three minute grace period, any comment that has been edited will show that it has been edited. This is similar to top level posts.

<img width="361" alt="Screen Shot 2019-11-02 at 10 34 02 AM" src="https://user-images.githubusercontent.com/3102842/68072459-62ec9080-fd5c-11e9-8e43-fbefc3e2727f.png">

This prevents confusion or malicious use of comment edits.

this also would resolve https://github.com/thepracticaldev/dev.to/issues/4606