### PR TITLE
Add cache breaker variable, resolves #4703

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -1,4 +1,6 @@
 FROM gitpod/workspace-postgres
+# The below variable is to be modified to trigger a Dockerfile rebuild (this is in YYYY-MM-DD format)
+ENV IMAGE_BUILD_DATE=2019-11-3
 
 # Install Ruby
 COPY .ruby-version /tmp


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Documentation Update

## Description
Per https://www.gitpod.io/docs/42_config_docker, Gitpod only rebuilds their Docker images when the Dockerfile is changed.

This patch adds an environment variable to the Gitpod Dockerfile that can be changed in order to trigger a rebuild.

## Related Tickets & Documents
PR resolves #4703 
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
None
## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed