### PR TITLE
Setting width & height attribites to SVGs on articles#show page

### DIFF
--- a/app/helpers/articles_helper.rb
+++ b/app/helpers/articles_helper.rb
@@ -21,13 +21,13 @@ module ArticlesHelper
     end
   end
 
-  def image_tag_or_inline_svg(service_name)
+  def image_tag_or_inline_svg(service_name, width: nil, height: nil)
     name = "#{service_name}-logo.svg"
 
     if internal_navigation?
-      image_tag(name, class: "icon-img", alt: "#{service_name} logo")
+      image_tag(name, class: "icon-img", alt: "#{service_name} logo", width: width, height: height)
     else
-      inline_svg(name, class: "icon-img", aria: true, title: "#{service_name} logo")
+      inline_svg(name, class: "icon-img", aria: true, title: "#{service_name} logo", width: width, height: height)
     end
   end
 

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -125,10 +125,10 @@
             </a>
           </span>
           <% if @user.twitter_username.present? %>
-            <a href="http://twitter.com/<%= @user.twitter_username %>"><%= image_tag_or_inline_svg "twitter" %></a>
+            <a href="http://twitter.com/<%= @user.twitter_username %>"><%= image_tag_or_inline_svg "twitter", width: 18, height: 18 %></a>
           <% end %>
           <% if @user.github_username.present? %>
-            <a href="http://github.com/<%= @user.github_username %>"><%= image_tag_or_inline_svg "github" %></a>
+            <a href="http://github.com/<%= @user.github_username %>"><%= image_tag_or_inline_svg "github", width: 18, height: 18 %></a>
           <% end %>
           <% if @article.published_timestamp.present? %>
             <time itemprop="datePublished" datetime="<%= @article.published_timestamp %>"><%= @article.readable_publish_date %></time>

--- a/spec/helpers/articles_helper_spec.rb
+++ b/spec/helpers/articles_helper_spec.rb
@@ -22,4 +22,35 @@ describe ArticlesHelper do
       expect(host).to eq "example.com"
     end
   end
+
+  describe "#image_tag_or_inline_svg" do
+    helper do
+      def internal_navigation?
+        true
+      end
+    end
+    subject { helper.image_tag_or_inline_svg("twitter") }
+
+    it { is_expected.to include('<img class="icon-img" alt="twitter logo" src="/assets/twitter-logo') }
+
+    context "with a width and height" do
+      subject { helper.image_tag_or_inline_svg("twitter", width: 18, height: 18) }
+
+      it { is_expected.to include('<img class="icon-img" alt="twitter logo" width="18" height="18" src="/assets/twitter-logo') }
+    end
+
+    describe "#internal_navigation? returns false" do
+      before { allow(helper).to receive(:internal_navigation?).and_return(false) }
+
+      it { is_expected.to include('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 612 612" class="icon-img" role="img"') }
+    end
+
+    describe "with a width and height and #internal_navigation? returns false" do
+      subject { helper.image_tag_or_inline_svg("twitter", width: 18, height: 18) }
+
+      before { allow(helper).to receive(:internal_navigation?).and_return(false) }
+
+      it { is_expected.to include('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 612 612" class="icon-img" height="18" width="18" role="img"') }
+    end
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Documentation Update

## Description

When viewing an article in reader mode on Safari mobile, the github & twitter icons would take up as much as 50% of the screen pushing the article content down.

This PR adds a width/height of 18px to the two svg images which fixes this.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

### A post in production

![image](https://user-images.githubusercontent.com/325384/68085716-d1545000-fe3b-11e9-928a-39eab3f5008b.png)

### With this change applied (On my local with seed data)

![image](https://user-images.githubusercontent.com/325384/68085724-ecbf5b00-fe3b-11e9-81ed-2d2c1ea6417e.png)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![Bacon Pancakes](http://giphygifs.s3.amazonaws.com/media/StYTkwUST4HUQ/giphy.gif)
