### PR TITLE
Move ACCESS_TOKEN_AND_EXPIRATION_CACHE_KEY to redis

### DIFF
--- a/app/services/streams/twitch_access_token/get.rb
+++ b/app/services/streams/twitch_access_token/get.rb
@@ -11,7 +11,7 @@ module Streams
 
         if token.nil? || Time.zone.now >= exp
           token, exp = get_new_token
-          RedisRailsCache.write(ACCESS_TOKEN_AND_EXPIRATION_CACHE_KEY, [token, exp])
+          RedisRailsCache.write(ACCESS_TOKEN_AND_EXPIRATION_CACHE_KEY, token, expires_in: exp)
         end
 
         token

--- a/app/services/streams/twitch_access_token/get.rb
+++ b/app/services/streams/twitch_access_token/get.rb
@@ -7,11 +7,11 @@ module Streams
       end
 
       def call
-        token, exp = Rails.cache.fetch(ACCESS_TOKEN_AND_EXPIRATION_CACHE_KEY)
+        token, exp = RedisRailsCache.fetch(ACCESS_TOKEN_AND_EXPIRATION_CACHE_KEY)
 
         if token.nil? || Time.zone.now >= exp
           token, exp = get_new_token
-          Rails.cache.write(ACCESS_TOKEN_AND_EXPIRATION_CACHE_KEY, [token, exp])
+          RedisRailsCache.write(ACCESS_TOKEN_AND_EXPIRATION_CACHE_KEY, [token, exp])
         end
 
         token

--- a/app/services/streams/twitch_access_token/get.rb
+++ b/app/services/streams/twitch_access_token/get.rb
@@ -12,7 +12,7 @@ module Streams
         return token unless token.nil?
 
         token, exp = get_new_token
-        time_til_exp = exp - Time.now
+        time_til_exp = exp - Time.zone.now
         RedisRailsCache.write(ACCESS_TOKEN_AND_EXPIRATION_CACHE_KEY, token, expires_in: time_til_exp)
 
         token

--- a/app/services/streams/twitch_access_token/get.rb
+++ b/app/services/streams/twitch_access_token/get.rb
@@ -7,12 +7,13 @@ module Streams
       end
 
       def call
-        token, exp = RedisRailsCache.fetch(ACCESS_TOKEN_AND_EXPIRATION_CACHE_KEY)
+        token = RedisRailsCache.read(ACCESS_TOKEN_AND_EXPIRATION_CACHE_KEY)
 
-        if token.nil? || Time.zone.now >= exp
-          token, exp = get_new_token
-          RedisRailsCache.write(ACCESS_TOKEN_AND_EXPIRATION_CACHE_KEY, token, expires_in: exp)
-        end
+        return token unless token.nil?
+
+        token, exp = get_new_token
+        time_til_exp = exp - Time.now
+        RedisRailsCache.write(ACCESS_TOKEN_AND_EXPIRATION_CACHE_KEY, token, expires_in: time_til_exp)
 
         token
       end

--- a/spec/services/streams/twitch_access_token/get_spec.rb
+++ b/spec/services/streams/twitch_access_token/get_spec.rb
@@ -33,7 +33,6 @@ RSpec.describe Streams::TwitchAccessToken::Get, type: :service do
 
     context "when there is an expired token in the cache" do
       it "requests a new token and caches it" do
-        RedisRailsCache.write(described_class::ACCESS_TOKEN_AND_EXPIRATION_CACHE_KEY, "FAKE_EXPIRED_TWITCH_TOKEN", :expires_in => 15.days.from_now)
 
         expect(described_class.call).to eq "FAKE_BRAND_NEW_TWITCH_TOKEN"
         expect(twitch_token_stubbed_route).to have_been_requested

--- a/spec/services/streams/twitch_access_token/get_spec.rb
+++ b/spec/services/streams/twitch_access_token/get_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Streams::TwitchAccessToken::Get, type: :service do
 
     context "when there is an unexpired token in the cache" do
       it "returns the cached token" do
-        RedisRailsCache.write(described_class::ACCESS_TOKEN_AND_EXPIRATION_CACHE_KEY, ["FAKE_UNEXPIRED_TWITCH_TOKEN", 15.days.from_now])
+        RedisRailsCache.write(described_class::ACCESS_TOKEN_AND_EXPIRATION_CACHE_KEY, "FAKE_UNEXPIRED_TWITCH_TOKEN", :expires_in => 15.days.from_now)
 
         expect(described_class.call).to eq "FAKE_UNEXPIRED_TWITCH_TOKEN"
         expect(twitch_token_stubbed_route).not_to have_been_requested
@@ -33,7 +33,7 @@ RSpec.describe Streams::TwitchAccessToken::Get, type: :service do
 
     context "when there is an expired token in the cache" do
       it "requests a new token and caches it" do
-        RedisRailsCache.write(described_class::ACCESS_TOKEN_AND_EXPIRATION_CACHE_KEY, ["FAKE_EXPIRED_TWITCH_TOKEN", 15.days.ago])
+        RedisRailsCache.write(described_class::ACCESS_TOKEN_AND_EXPIRATION_CACHE_KEY, "FAKE_EXPIRED_TWITCH_TOKEN", :expires_in => 15.days.from_now)
 
         expect(described_class.call).to eq "FAKE_BRAND_NEW_TWITCH_TOKEN"
         expect(twitch_token_stubbed_route).to have_been_requested

--- a/spec/services/streams/twitch_access_token/get_spec.rb
+++ b/spec/services/streams/twitch_access_token/get_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Streams::TwitchAccessToken::Get, type: :service do
 
     context "when there is an unexpired token in the cache" do
       it "returns the cached token" do
-        Rails.cache.write(described_class::ACCESS_TOKEN_AND_EXPIRATION_CACHE_KEY, ["FAKE_UNEXPIRED_TWITCH_TOKEN", 15.days.from_now])
+        RedisRailsCache.write(described_class::ACCESS_TOKEN_AND_EXPIRATION_CACHE_KEY, ["FAKE_UNEXPIRED_TWITCH_TOKEN", 15.days.from_now])
 
         expect(described_class.call).to eq "FAKE_UNEXPIRED_TWITCH_TOKEN"
         expect(twitch_token_stubbed_route).not_to have_been_requested
@@ -33,7 +33,7 @@ RSpec.describe Streams::TwitchAccessToken::Get, type: :service do
 
     context "when there is an expired token in the cache" do
       it "requests a new token and caches it" do
-        Rails.cache.write(described_class::ACCESS_TOKEN_AND_EXPIRATION_CACHE_KEY, ["FAKE_EXPIRED_TWITCH_TOKEN", 15.days.ago])
+        RedisRailsCache.write(described_class::ACCESS_TOKEN_AND_EXPIRATION_CACHE_KEY, ["FAKE_EXPIRED_TWITCH_TOKEN", 15.days.ago])
 
         expect(described_class.call).to eq "FAKE_BRAND_NEW_TWITCH_TOKEN"
         expect(twitch_token_stubbed_route).to have_been_requested


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Move ACCESS_TOKEN_AND_EXPIRATION_CACHE_KEY to redis
## Related Tickets & Documents
handle #4670 

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed
