### PR TITLE
Ensure that the organization slug is unique for specs

### DIFF
--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     profile_image      { File.open(Rails.root.join("app", "assets", "images", "android-icon-36x36.png")) }
     nav_image          { Faker::Avatar.image }
     url                { Faker::Internet.url }
-    slug               { "org#{rand(10_000)}" }
+    slug               { |n| "org#{n}" }
     github_username    { "org#{rand(10_000)}" }
     twitter_username   { "org#{rand(10_000)}" }
     bg_color_hex       { Faker::Color.hex_color }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description
Just had [a flaky spec failure](https://travis-ci.com/thepracticaldev/dev.to/builds/134843836) from spec/requests/api/v0/articles_spec.rb because the org created did not have a unique slug. When randomly generating a number there is a chance we randomly pick the same number twice. If instead, we increment we can ensure we never hit the same number twice. 

## Added to documentation?

- [x] no documentation needed

![](https://media1.giphy.com/media/iF0l5IExhOZ9m9cWcz/giphy.gif)
