### PR TITLE
Chat message: return 401 instead of 500 when a channel is blocked [deploy]

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -11,6 +11,7 @@ class MessagesController < ApplicationController
       message_json = create_pusher_payload(@message)
       Pusher.trigger(@message.chat_channel.pusher_channels, "message-created", message_json)
     end
+
     if @message.save
       begin
         @message.send_push

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -7,8 +7,6 @@ RSpec.describe Message, type: :model do
   let(:long_text) { Faker::Hipster.words(number: 1500) }
 
   describe "validations" do
-    subject { build(:message, :ignore_after_callback) }
-
     before do
       allow(ChatChannel).to receive(:find).and_return(ChatChannel.new)
     end

--- a/spec/requests/messages_spec.rb
+++ b/spec/requests/messages_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe "Messages", type: :request do
       post "/messages", params: { message: {} }
       expect(response.status).to eq(302)
     end
-    # Pusher::Error
 
     context "when user is signed in" do
       before do
@@ -41,21 +40,10 @@ RSpec.describe "Messages", type: :request do
         chat_channel.update(status: "blocked")
       end
 
-      it "raises an error" do
-        expect { post "/messages", params: { message: new_message } }.to raise_error
+      it "return unauthorized" do
+        post "/messages", params: { message: new_message }
+        expect(response).to have_http_status(:unauthorized)
       end
     end
-
-    # context "when Pusher isn't cooperating" do
-    #   before do
-    #     allow(Pusher).to receive(:trigger).and_raise(Pusher::Error)
-    #     sign_in user
-    #     post "/messages", params: { message: new_message }
-    #   end
-
-    #   it "returns proper message" do
-    #     expect(response.body).to include("could not trigger Pusher")
-    #   end
-    # end
   end
 end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

After we merged https://github.com/thepracticaldev/dev.to/pull/4411 we have a 500 error when a user attempts to create a message in a blocked channel. This PR updates the validation process in the model so that the whole chain triggers a 401 HTTP response instead.

It also fixes a warning we keep having when running tests:

```text
WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Actual error raised was #<WebMock::NetConnectNotAllowedError: Real HTTP connections are disabled. Unregistered request: POST ...lgolia(net\.com|\.net)\/1\/indexes/")

============================================================>. Instead consider providing a specific error class or message. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. Called from /home/travis/build/thepracticaldev/dev.to/spec/requests/messages_spec.rb:45:in `block (4 levels) in <top (required)>'.

messages_spec.rb:45 contains a generic
```

As a general rule we shouldn't raise `RuntimeError` in the models if we can avoid it

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [ ] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
