### PR TITLE
Add /future redirect

### DIFF
--- a/config/initializers/honeycomb.rb
+++ b/config/initializers/honeycomb.rb
@@ -1,4 +1,4 @@
-if Rails.env.test?
+if Rails.env.test? || ApplicationConfig["HONEYCOMB_API_KEY"].blank?
   Honeycomb.configure do |config|
     config.client = Libhoney::TestClient.new
   end

--- a/config/initializers/honeycomb.rb
+++ b/config/initializers/honeycomb.rb
@@ -1,4 +1,4 @@
-if Rails.env.test? || ApplicationConfig["HONEYCOMB_API_KEY"].blank?
+if Rails.env.test?
   Honeycomb.configure do |config|
     config.client = Libhoney::TestClient.new
   end

--- a/config/initializers/reserved_words.rb
+++ b/config/initializers/reserved_words.rb
@@ -84,6 +84,7 @@ class ReservedWords
     amp
     live
     online
+    future
     jokes
     funny
     funnies

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -216,32 +216,7 @@ Rails.application.routes.draw do
 
   get "/async_info/base_data", controller: "async_info#base_data", defaults: { format: :json }
 
-  get "/hello-goodbye-to-the-go-go-go",
-      to: redirect("ben/hello-goodbye-to-the-go-go-go")
-  get "/dhh-on-the-future-of-rails",
-      to: redirect("ben/dhh-on-the-future-of-rails")
-  get "/christopher-chedeau-on-the-philosophies-of-react",
-      to: redirect("ben/christopher-chedeau-on-the-philosophies-of-react")
-  get "/javascript-fatigue-buzzword",
-      to: redirect("ben/javascript-fatigue-buzzword")
-  get "/chris-seaton-making-ruby-fast",
-      to: redirect("ben/chris-seaton-making-ruby-fast")
-  get "/communicating-intent-the-perpetually-misunderstood-ruby-bang",
-      to: redirect("tom/communicating-intent-the-perpetually-misunderstood-ruby-bang")
-  get "/quick-tip-grepping-rails-routes",
-      to: redirect("tom/quick-tip-grepping-rails-routes")
-  get "/use-cases-for-githubs-new-direct-upload-feature",
-      to: redirect("ben/use-cases-for-githubs-new-direct-upload-feature")
-  get "/this-blog-post-was-written-using-draft-js",
-      to: redirect("ben/this-blog-post-was-written-using-draft-js")
-  get "/the-future-of-software-development",
-      to: redirect("ben/the-future-of-software-development")
-  get "/the-zen-of-missing-out-on-the-next-great-programming-tool",
-      to: redirect("ben/the-zen-of-missing-out-on-the-next-great-programming-tool")
-  get "/the-joy-and-benefit-of-being-an-early-adopter-in-programming",
-      to: redirect("ben/the-joy-and-benefit-of-being-an-early-adopter-in-programming")
-  get "/watkinsmatthewp/every-developer-should-write-a-personal-automation-api",
-      to: redirect("anotherdevblog/every-developer-should-write-a-personal-automation-api")
+  get "/future", to: redirect("devteam/the-future-of-dev-160n")
 
   # Settings
   post "users/update_language_settings" => "users#update_language_settings"


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
We plan to send people to `dev.to/future` in order to read this blog post. This adds that functionality. We could hypothetically add "redirect" as a less hardcoded functionality, perhaps as a type of `Page` since they are sort of the top level catch all.

But for now I think hardcoded is correct.

We had a handful of old hardcoded redirects from way way way way way way back in the history of the project. I think it's safe to let them die off. All it means is that a handful of links floating around the web will break, but it kind of makes sense to break with the old as we look to the future.