### PR TITLE
Check for existence of honeycomb before using it

### DIFF
--- a/config/initializers/honeycomb.rb
+++ b/config/initializers/honeycomb.rb
@@ -1,4 +1,4 @@
-if Rails.env.test?
+if Rails.env.test? || ApplicationConfig["HONEYCOMB_API_KEY"].blank?
   Honeycomb.configure do |config|
     config.client = Libhoney::TestClient.new
   end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
Fix the issue of trying to load a honeycomb client without key. There are a few ways to do this. This one makes sense to me.

This is the error I was trying to boot it up with `""` as the key.

`ArgumentError: No WriteKey specified. Can't send event`