### PR TITLE
Create greeter

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,0 +1,17 @@
+name: Greetings
+
+on: [pull_request]
+
+jobs:
+  greeting:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/first-interaction@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        pr-message: >
+          Thank you very much for your contribution!
+
+          You can expect a message from one of the DEV team members within 24 hours. Please be sure to sign the CLA agreement. Once your PR is reviewed and all the check passes, your PR will be merge! 
+
+          Please check our [documentation]() for additional information ✌️

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -10,8 +10,10 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         pr-message: >
-          Thank you very much for your contribution!
+          Thank you so much for your PR! We'll do our best to review your submission as soon as possible.
 
-          You can expect a message from one of the DEV team members within 24 hours. Please be sure to sign the CLA agreement. Once your PR is reviewed and all the check passes, your PR will be merge! 
+          If you don't hear from us within 3 business days, please ping @thepracticaldev/oss.
 
-          Please check our [documentation]() for additional information ✌️
+          Some things we look for immediately when reviewing a PR are: tests, updated docs, etc.
+
+          Please make sure you've added all relevant info in order to help us get your code merged as quickly as possible!


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)
- [x] Feature

## Description
Using Github Action's Greeter to welcome first-time contributors with some helpful message. The immediately down-side I can think of immediately is it would take up another GitHub checks. This is created with a template provided on `Actions` tab, so I'm quite certain it will work but we'll have to wait for a first-time contributor to open a PR to see it. Let me know if we need to reconsider this.
## Related Tickets & Documents
n/a
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
n/a
## Added to documentation?
- [x] no documentation needed
