### PR TITLE
Add site config and remove sail

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,7 +82,6 @@ gem "rolify", "~> 5.2" # Very simple Roles library
 gem "rouge", "~> 3.12" # A pure-ruby code highlighter
 gem "rubyzip", "~> 1.2", ">= 1.3.0" # Rubyzip is a ruby library for reading and writing zip files
 gem "s3_direct_upload", "~> 0.1" # Direct Upload to Amazon S3
-gem "sail", "~> 1.5" # Sail is a lightweight Rails engine that brings an admin panel for managing configuration settings on a live Rails app
 gem "sass-rails", "~> 6.0" # Sass adapter for the Rails asset pipeline
 gem "scout_apm", "~> 2.6" # Monitors Ruby apps and reports detailed metrics on performance to Scout
 gem "serviceworker-rails", "~> 0.6" # Integrates ServiceWorker into the Rails asset pipeline

--- a/Gemfile
+++ b/Gemfile
@@ -73,6 +73,7 @@ gem "rack-timeout", "~> 0.5" # Rack middleware which aborts requests that have b
 gem "rails", "~> 5.2", ">= 5.2.3" # Ruby on Rails
 gem "rails-assets-airbrake-js-client", "~> 1.6", source: "https://rails-assets.org" # Airbrake JavaScript Notifier
 gem "rails-observers", "~> 0.1" # Rails observer (removed from core in Rails 4.0)
+gem "rails-settings-cached", ">= 2.1.1" # Settings plugin for Rails that makes managing a table of global key, value pairs easy.
 gem "recaptcha", "~> 5.2", require: "recaptcha/rails" # Helpers for the reCAPTCHA API
 gem "redcarpet", "~> 3.5" # A fast, safe and extensible Markdown to (X)HTML parser
 gem "redis", "~> 4.1.3" # Redis ruby client

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -602,6 +602,9 @@ GEM
       loofah (~> 2.3)
     rails-observers (0.1.5)
       activemodel (>= 4.0)
+    rails-settings-cached (2.1.1)
+      rails (>= 4.2.0)
+      request_store
     railties (5.2.3)
       actionpack (= 5.2.3)
       activesupport (= 5.2.3)
@@ -955,6 +958,7 @@ DEPENDENCIES
   rails (~> 5.2, >= 5.2.3)
   rails-assets-airbrake-js-client (~> 1.6)!
   rails-observers (~> 0.1)
+  rails-settings-cached (>= 2.1.1)
   recaptcha (~> 5.2)
   redcarpet (~> 3.5)
   redis (~> 4.1.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -308,8 +308,6 @@ GEM
       smart_properties
     errbase (0.1.1)
     erubi (1.9.0)
-    et-orbi (1.1.6)
-      tzinfo
     eventmachine (1.2.5)
     excon (0.65.0)
     execjs (2.7.0)
@@ -358,9 +356,6 @@ GEM
       nokogiri (>= 1.5.11, < 2.0.0)
     formatador (0.2.5)
     front_matter_parser (0.2.1)
-    fugit (1.1.6)
-      et-orbi (~> 1.1, >= 1.1.6)
-      raabro (~> 1.1)
     gemoji (3.0.1)
     get_process_mem (0.2.4)
       ffi (~> 1.0)
@@ -570,7 +565,6 @@ GEM
       jwt (~> 2.1, >= 2.1.0)
       rest-client (~> 2.0, >= 2.0.2)
     pusher-signature (0.1.8)
-    raabro (1.1.6)
     rack (2.0.7)
     rack-host-redirect (1.3.0)
       rack
@@ -694,11 +688,6 @@ GEM
     safe_yaml (1.0.5)
     safely_block (0.2.1)
       errbase
-    sail (1.5.1)
-      fugit
-      jquery-rails
-      rails
-      sass-rails
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -974,7 +963,6 @@ DEPENDENCIES
   ruby-prof (~> 1.0)
   rubyzip (~> 1.2, >= 1.3.0)
   s3_direct_upload (~> 0.1)
-  sail (~> 1.5)
   sass-rails (~> 6.0)
   scout_apm (~> 2.6)
   sdoc (~> 1.0)

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -1,0 +1,10 @@
+# Site configuration based on RailsSettings models,
+# see <https://github.com/huacnlee/rails-settings-cached> for further info
+
+class SiteConfig < RailsSettings::Base
+  self.table_name = "site_configs"
+
+  # the site configuration is cached, change this if you want to force update
+  # the cache, or call SiteConfig.clear_cache
+  cache_prefix { "v1" }
+end

--- a/db/migrate/20191106095242_create_site_configs.rb
+++ b/db/migrate/20191106095242_create_site_configs.rb
@@ -1,0 +1,15 @@
+class CreateSiteConfigs < ActiveRecord::Migration[5.2]
+  def self.up
+    create_table :site_configs do |t|
+      t.string  :var,        null: false
+      t.text    :value,      null: true
+      t.timestamps
+    end
+
+    add_index :site_configs, %i(var), unique: true
+  end
+
+  def self.down
+    drop_table :site_configs
+  end
+end

--- a/db/migrate/20191106102826_drop_sail_settings.rb
+++ b/db/migrate/20191106102826_drop_sail_settings.rb
@@ -1,0 +1,16 @@
+class DropSailSettings < ActiveRecord::Migration[5.2]
+  def up
+    drop_table :sail_settings
+  end
+
+  def down
+    create_table :sail_settings do |t|
+      t.string :name, null: false
+      t.text :description
+      t.string :value, null: false
+      t.integer :cast_type, null: false, limit: 1
+      t.timestamps
+      t.index ["name"], name: "index_settings_on_name", unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_06_095242) do
+ActiveRecord::Schema.define(version: 2019_11_06_102826) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -878,16 +878,6 @@ ActiveRecord::Schema.define(version: 2019_11_06_095242) do
     t.datetime "updated_at"
     t.index ["name", "resource_type", "resource_id"], name: "index_roles_on_name_and_resource_type_and_resource_id"
     t.index ["name"], name: "index_roles_on_name"
-  end
-
-  create_table "sail_settings", force: :cascade do |t|
-    t.integer "cast_type", limit: 2, null: false
-    t.datetime "created_at", null: false
-    t.text "description"
-    t.string "name", null: false
-    t.datetime "updated_at", null: false
-    t.string "value", null: false
-    t.index ["name"], name: "index_settings_on_name", unique: true
   end
 
   create_table "search_keywords", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_25_202354) do
+ActiveRecord::Schema.define(version: 2019_11_06_095242) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -900,6 +900,14 @@ ActiveRecord::Schema.define(version: 2019_10_25_202354) do
     t.string "keyword"
     t.datetime "updated_at", null: false
     t.index ["google_result_path"], name: "index_search_keywords_on_google_result_path"
+  end
+
+  create_table "site_configs", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.text "value"
+    t.string "var", null: false
+    t.index ["var"], name: "index_site_configs_on_var", unique: true
   end
 
   create_table "sponsorships", force: :cascade do |t|


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

This PR contains the groundwork of us switching away from too many environment variables into a "site configuration" that can be managed from the "internal" administration panel.

The first step is to create a `SiteConfig` model (I chose `SiteConfig` over setting because there's pre-existing domain language around the word "setting" relative to the user's settings) and remove `sail`.

I chose to use [rails-settings-cached](http://rubygems.org/gems/rails-settings-cached) for the reasons enumerated here: https://github.com/thepracticaldev/dev.to/issues/4718#issuecomment-549802542

The next steps would be deciding what settings to add to the site config, start using them and build a panel in "internals" to manage those.

## Related Tickets & Documents

Closes 4718
