### PR TITLE
Comments API: simplify controller code, add tests

### DIFF
--- a/app/controllers/api/v0/comments_controller.rb
+++ b/app/controllers/api/v0/comments_controller.rb
@@ -1,19 +1,19 @@
 module Api
   module V0
     class CommentsController < ApiController
+      respond_to :json
+
       caches_action :index,
                     cache_path: proc { |c| c.params.permit! },
                     expires_in: 10.minutes
-      respond_to :json
 
       caches_action :show,
                     cache_path: proc { |c| c.params.permit! },
                     expires_in: 10.minutes
-      respond_to :json
 
       def index
         article = Article.find(params[:a_id])
-        @comments = Comment.rooted_on(article, "Article").order(score: :desc)
+        @comments = article.comments.roots.includes(:user).select(%i[id processed_html user_id ancestry])
       end
 
       def show

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -126,13 +126,6 @@ class Comment < ApplicationRecord
     "comments-#{id}"
   end
 
-  def self.rooted_on(commentable_id, commentable_type)
-    includes(:user).
-      select(:id, :user_id, :commentable_type, :commentable_id,
-             :deleted, :created_at, :processed_html, :ancestry, :updated_at, :score).
-      where(commentable_id: commentable_id, ancestry: nil, commentable_type: commentable_type)
-  end
-
   def self.tree_for(commentable, limit = 0)
     commentable.comments.includes(:user).arrange(order: "score DESC").to_a[0..limit - 1].to_h
   end

--- a/spec/requests/api/v0/comments_spec.rb
+++ b/spec/requests/api/v0/comments_spec.rb
@@ -1,22 +1,56 @@
 require "rails_helper"
 
 RSpec.describe "Api::V0::Comments", type: :request do
-  let(:article) { create(:article) }
-
-  before do
-    FactoryBot.create(:comment, commentable_type: "Article", commentable_id: article.id)
-    FactoryBot.create(:comment, commentable_type: "Article", commentable_id: article.id)
+  def json_response
+    JSON.parse(response.body)
   end
 
+  let_it_be(:article) { create(:article) }
+
   describe "GET /api/comments" do
-    it "returns not found if inproper article id" do
+    before do
+      create(:comment, commentable: article)
+    end
+
+    it "returns not found if wrong article id" do
       get "/api/comments?a_id=gobbledygook"
       expect(response).to have_http_status(:not_found)
     end
 
-    it "returns comments for article passed" do
+    it "returns comments for article" do
       get "/api/comments?a_id=#{article.id}"
-      expect(JSON.parse(response.body).size).to eq(2)
+      expect(json_response.size).to eq(1)
+    end
+
+    it "does not include children comments in the root list" do
+      # create child comment
+      create(:comment, commentable: article, parent: article.comments.first)
+
+      get "/api/comments?a_id=#{article.id}"
+      expected_ids = article.comments.roots.map(&:id_code_generated)
+      expect(json_response.map { |cm| cm["id_code"] }).to match_array(expected_ids)
+    end
+
+    it "includes children comments in the children list" do
+      # create child comment
+      parent_comment = article.comments.first
+      child_comment = create(:comment, commentable: article, parent: parent_comment)
+
+      get "/api/comments?a_id=#{article.id}"
+      comment_with_children = json_response.detect { |cm| cm["id_code"] == parent_comment.id_code_generated }
+      expect(comment_with_children["children"][0]["id_code"]).to eq(child_comment.id_code_generated)
+    end
+
+    it "includes granchildren comments in the children-children list" do
+      # create granchild comment
+      root_comment = article.comments.first
+      child_comment = create(:comment, commentable: article, parent: root_comment)
+      granchild_comment = create(:comment, commentable: article, parent: child_comment)
+
+      get "/api/comments?a_id=#{article.id}"
+
+      comment_with_descendants = json_response.detect { |cm| cm["id_code"] == root_comment.id_code_generated }
+      expect(comment_with_descendants["children"][0]["children"][0]["id_code"]).to eq(granchild_comment.id_code_generated)
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

This PR cleans up the comment controller code that was using an otherwise unused `rooted_on` method that was overly complicated.

I decided to submit this PR after starting to look into this https://github.com/thepracticaldev/dev.to/issues/2250 which I believe it's a separate problem that has to do with the fact that those actions both have server side caching and the edge caching active.

In the meantime we can still cleanup the code

