### PR TITLE
Mod tooling: add tags via /mod

### DIFF
--- a/app/controllers/moderations_controller.rb
+++ b/app/controllers/moderations_controller.rb
@@ -19,9 +19,9 @@ class ModerationsController < ApplicationController
     authorize(User, :moderation_routes?)
     @moderatable = Article.find_by(slug: params[:slug])
     @adjustments = TagAdjustment.where(article_id: @moderatable.id)
-    @removed_adjustments = @adjustments.filter { |a| a.adjustment_type == "removal" } if @adjustments
-    @added_adjustments = @adjustments.filter { |a| a.adjustment_type == "addition" } if @adjustments
-    @already_adjusted_names = @adjustments.map(&:tag_name).join(", ") if @adjustments
+    @removed_adjustments = @adjustments.filter { |a| a.adjustment_type == "removal" }
+    @added_adjustments = @adjustments.filter { |a| a.adjustment_type == "addition" }
+    @already_adjusted_tags = @adjustments.map(&:tag_name).join(", ")
     @allowed_to_add = @moderatable.class.name == "Article" && (current_user.has_role?(:super_admin) || current_user.has_role?(:tag_moderator, :any))
     render template: "moderations/mod"
   end

--- a/app/controllers/moderations_controller.rb
+++ b/app/controllers/moderations_controller.rb
@@ -19,6 +19,9 @@ class ModerationsController < ApplicationController
     authorize(User, :moderation_routes?)
     @moderatable = Article.find_by(slug: params[:slug])
     @adjustments = TagAdjustment.where(article_id: @moderatable.id)
+    @removed_adjustments = @adjustments.filter { |a| a.adjustment_type == "removal" } if @adjustments
+    @added_adjustments = @adjustments.filter { |a| a.adjustment_type == "addition" } if @adjustments
+    @allowed_to_add = @moderatable.class.name == "Article" && (current_user.has_role?(:super_admin) || current_user.has_role?(:tag_moderator, :any))
     render template: "moderations/mod"
   end
 

--- a/app/controllers/moderations_controller.rb
+++ b/app/controllers/moderations_controller.rb
@@ -21,6 +21,7 @@ class ModerationsController < ApplicationController
     @adjustments = TagAdjustment.where(article_id: @moderatable.id)
     @removed_adjustments = @adjustments.filter { |a| a.adjustment_type == "removal" } if @adjustments
     @added_adjustments = @adjustments.filter { |a| a.adjustment_type == "addition" } if @adjustments
+    @already_adjusted_names = @adjustments.map(&:tag_name).join(", ") if @adjustments
     @allowed_to_add = @moderatable.class.name == "Article" && (current_user.has_role?(:super_admin) || current_user.has_role?(:tag_moderator, :any))
     render template: "moderations/mod"
   end

--- a/app/controllers/moderations_controller.rb
+++ b/app/controllers/moderations_controller.rb
@@ -18,6 +18,7 @@ class ModerationsController < ApplicationController
   def article
     authorize(User, :moderation_routes?)
     @moderatable = Article.find_by(slug: params[:slug])
+    @adjustments = TagAdjustment.where(article_id: @moderatable.id)
     render template: "moderations/mod"
   end
 

--- a/app/controllers/tag_adjustments_controller.rb
+++ b/app/controllers/tag_adjustments_controller.rb
@@ -9,12 +9,13 @@ class TagAdjustmentsController < ApplicationController
       article_id: params[:tag_adjustment][:article_id],
       reason_for_adjustment: params[:tag_adjustment][:reason_for_adjustment],
     )
-    if service.tag_adjustment.save
-      service.create
+    tag_adjustment = service.tag_adjustment
+    if tag_adjustment.save
+      service.update_tags_and_notify
     else
-      errors = service.tag_adjustment.errors.full_messages.join(", ")
-      flash[:error_removal] = errors if service.tag_adjustment.adjustment_type == "removal"
-      flash[:error_addition] = errors if service.tag_adjustment.adjustment_type == "addition"
+      errors = tag_adjustment.errors.full_messages.join(", ")
+      flash[:error_removal] = errors if tag_adjustment.adjustment_type == "removal"
+      flash[:error_addition] = errors if tag_adjustment.adjustment_type == "addition"
     end
     @article = Article.find(params[:tag_adjustment][:article_id])
     redirect_to "#{URI.parse(@article.path).path}/mod"

--- a/app/controllers/tag_adjustments_controller.rb
+++ b/app/controllers/tag_adjustments_controller.rb
@@ -3,7 +3,7 @@ class TagAdjustmentsController < ApplicationController
     authorize(User, :moderation_routes?)
     TagAdjustmentCreationService.new(
       current_user,
-      adjustment_type: "removal",
+      adjustment_type: params[:tag_adjustment][:adjustment_type],
       status: "committed",
       tag_name: params[:tag_adjustment][:tag_name],
       article_id: params[:tag_adjustment][:article_id],
@@ -18,7 +18,8 @@ class TagAdjustmentsController < ApplicationController
     tag_adjustment = TagAdjustment.find(params[:id])
     tag_adjustment.destroy
     @article = Article.find(tag_adjustment.article_id)
-    @article.update!(tag_list: @article.tag_list.add(tag_adjustment.tag_name))
+    @article.update!(tag_list: @article.tag_list.add(tag_adjustment.tag_name)) if tag_adjustment.adjustment_type == "removal"
+    @article.update!(tag_list: @article.tag_list.remove(tag_adjustment.tag_name)) if tag_adjustment.adjustment_type == "addition"
     redirect_to "#{URI.parse(@article.path).path}/mod"
   end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -486,6 +486,7 @@ class Article < ApplicationRecord
       self.tag_list = [] # overwrite any existing tag with those from the front matter
       tag_list.add(front_matter["tags"], parser: ActsAsTaggableOn::TagParser)
       remove_tag_adjustments_from_tag_list
+      add_tag_adjustments_to_tag_list
     end
     self.published = front_matter["published"] if %w[true false].include?(front_matter["published"].to_s)
     self.published_at = parse_date(front_matter["date"]) if published
@@ -505,6 +506,7 @@ class Article < ApplicationRecord
   def validate_tag
     # remove adjusted tags
     remove_tag_adjustments_from_tag_list
+    add_tag_adjustments_to_tag_list
 
     # check there are not too many tags
     return errors.add(:tag_list, "exceed the maximum of 4 tags") if tag_list.size > 4
@@ -518,6 +520,11 @@ class Article < ApplicationRecord
   def remove_tag_adjustments_from_tag_list
     tags_to_remove = TagAdjustment.where(article_id: id, adjustment_type: "removal", status: "committed").pluck(:tag_name)
     tag_list.remove(tags_to_remove, parser: ActsAsTaggableOn::TagParser) if tags_to_remove
+  end
+
+  def add_tag_adjustments_to_tag_list
+    tags_to_add = TagAdjustment.where(article_id: id, adjustment_type: "addition", status: "committed").pluck(:tag_name)
+    tag_list.add(tags_to_add, parser: ActsAsTaggableOn::TagParser) if tags_to_add
   end
 
   def validate_video

--- a/app/models/tag_adjustment.rb
+++ b/app/models/tag_adjustment.rb
@@ -2,7 +2,7 @@ class TagAdjustment < ApplicationRecord
   validates :user_id, presence: true
   validates :article_id, presence: true
   validates :tag_id, presence: true
-  validates :tag_name, presence: true, uniqueness: { scope: :article_id }
+  validates :tag_name, presence: true, uniqueness: { scope: :article_id, message: "can't be an already adjusted tag" }
   validates :reason_for_adjustment, presence: true
   validates :adjustment_type, inclusion: { in: %w[removal addition] }, presence: true
   validates :status, inclusion: { in: %w[committed pending committed_and_resolvable resolved] }, presence: true

--- a/app/services/tag_adjustment_creation_service.rb
+++ b/app/services/tag_adjustment_creation_service.rb
@@ -8,7 +8,7 @@ class TagAdjustmentCreationService
     @tag_adjustment ||= TagAdjustment.new(creation_args)
   end
 
-  def create
+  def update_tags_and_notify
     update_article
     Notification.send_tag_adjustment_notification(tag_adjustment)
   end

--- a/app/services/tag_adjustment_creation_service.rb
+++ b/app/services/tag_adjustment_creation_service.rb
@@ -16,6 +16,7 @@ class TagAdjustmentCreationService
   def update_article
     article = Article.find(creation_args[:article_id])
     article.update!(tag_list: article.tag_list.remove(@tag_adjustment.tag_name)) if @tag_adjustment.adjustment_type == "removal"
+    article.update!(tag_list: article.tag_list.add(@tag_adjustment.tag_name)) if @tag_adjustment.adjustment_type == "addition"
   end
 
   def creation_args

--- a/app/services/tag_adjustment_creation_service.rb
+++ b/app/services/tag_adjustment_creation_service.rb
@@ -4,11 +4,13 @@ class TagAdjustmentCreationService
     @tag_adjustment_params = tag_adjustment_params
   end
 
+  def tag_adjustment
+    @tag_adjustment ||= TagAdjustment.new(creation_args)
+  end
+
   def create
-    @tag_adjustment = TagAdjustment.create!(creation_args)
     update_article
-    Notification.send_tag_adjustment_notification(@tag_adjustment)
-    @tag_adjustment
+    Notification.send_tag_adjustment_notification(tag_adjustment)
   end
 
   private

--- a/app/views/moderations/mod.html.erb
+++ b/app/views/moderations/mod.html.erb
@@ -142,11 +142,11 @@
         <%= f.text_area :reason_for_adjustment, placeholder: "Reason for Removal (Be super kind) - Only the reason is needed, the notification will take care of the rest." %>
         <%= f.submit "Remove Tag" %>
       <% end %>
-      <% adjustments = TagAdjustment.where(article_id: @moderatable.id, adjustment_type: "removal") %>
-      <% if adjustments.any? %>
+      <% removed_adjustments = @adjustments.filter { |a| a.adjustment_type == "removal" } if @adjustments %>
+      <% if removed_adjustments.any? %>
         <br /><br />
         <b>Removed tags: </b>
-        <% adjustments.each do |adjustment| %>
+        <% removed_adjustments.each do |adjustment| %>
           <% if current_user.any_admin? %>
               <%= form_for(adjustment, url: "/tag_adjustments/#{adjustment.id}", html: { method: :delete, onsubmit: "return confirm('Are you sure you want to undo the removal of the #{adjustment.tag_name} tag?')" }) do |f| %>
                 <%= adjustment.tag_name %>
@@ -181,11 +181,11 @@
       <% else %>
         <b>Unable to add new tags. 4 tags max.</b>
       <% end %>
-      <% adjustments_type_added = TagAdjustment.where(article_id: @moderatable.id, adjustment_type: "addition") %>
-      <% if adjustments_type_added.any? %>
+      <% added_adjustments = @adjustments.filter { |a| a.adjustment_type == "addition" } if @adjustments %>
+      <% if added_adjustments.any? %>
         <br /><br />
         <b>Added tags: </b>
-        <% adjustments_type_added.each do |adjustment| %>
+        <% added_adjustments.each do |adjustment| %>
           <% if current_user.any_admin? %>
               <%= form_for(adjustment, url: "/tag_adjustments/#{adjustment.id}", html: { method: :delete, onsubmit: "return confirm('Are you sure you want to undo the addition of the #{adjustment.tag_name} tag?')" }) do |f| %>
                 <%= adjustment.tag_name %>

--- a/app/views/moderations/mod.html.erb
+++ b/app/views/moderations/mod.html.erb
@@ -137,6 +137,7 @@
         <b>Current live tags:</b> <%= @moderatable.tag_list %>
         <br /><br />
         <%= f.hidden_field :article_id, value: @moderatable.id %>
+        <%= f.hidden_field :adjustment_type, value: "removal" %>
         <%= f.text_field :tag_name, placeholder: "Tag Name" %>
         <%= f.text_area :reason_for_adjustment, placeholder: "Reason for Removal (Be super kind) - Only the reason is needed, the notification will take care of the rest." %>
         <%= f.submit "Remove Tag" %>
@@ -156,6 +157,46 @@
       <% end %>
     </div>
   <% end %>
+
+  <% if @moderatable.class.name == "Article" && (current_user.has_role?(:super_admin) || current_user.has_role?(:tag_moderator, :any)) %>
+    <div class="tag-mod-form">
+      <h2> Add Appropriate Tags</h2>
+      <% if @moderatable.tag_list.count < 4 %>
+        <%= form_for(TagAdjustment.new) do |f| %>
+          <% unless current_user.has_role?(:super_admin) %>
+            <ul>
+              <li>You can only add tags that you moderate.</li>
+              <li>Only add tags that are appropriate.</li>
+              <li>Always be friendly in your tag adding reason.</li>
+            </ul>
+          <% end %>
+          <b>Current live tags:</b> <%= @moderatable.tag_list %>
+          <br /><br />
+          <%= f.hidden_field :article_id, value: @moderatable.id %>
+          <%= f.hidden_field :adjustment_type, value: "addition" %>
+          <%= f.text_field :tag_name, placeholder: "Tag Name - only add one at a time" %>
+          <%= f.text_area :reason_for_adjustment, placeholder: "Reason for addition (Be super kind) - Only the reason is needed, the notification will take care of the rest." %>
+          <%= f.submit "Add Tag" %>
+        <% end %>
+      <% else %>
+        <b>Unable to add new tags. 4 tags max.</b>
+      <% end %>
+      <% adjustments_type_added = TagAdjustment.where(article_id: @moderatable.id, adjustment_type: "addition") %>
+      <% if adjustments_type_added.any? %>
+        <br /><br />
+        <b>Added tags: </b>
+        <% adjustments_type_added.each do |adjustment| %>
+          <% if current_user.any_admin? %>
+              <%= form_for(adjustment, url: "/tag_adjustments/#{adjustment.id}", html: { method: :delete, onsubmit: "return confirm('Are you sure you want to undo the addition of the #{adjustment.tag_name} tag?')" }) do |f| %>
+                <%= adjustment.tag_name %>
+                <%= f.submit "X", id: "undo" %>
+              <% end %>
+            <% end %>
+        <% end %>
+      <% end %>
+    </div>
+  <% end %>
+
   <% if @moderatable.class.name == "Article" %>
     <% if @moderatable.last_buffered.blank? %>
       <div class="tag-mod-form">

--- a/app/views/moderations/mod.html.erb
+++ b/app/views/moderations/mod.html.erb
@@ -136,7 +136,7 @@
           </ul>
         <% end %>
         <b>Current live tags:</b> <%= @moderatable.tag_list %><br>
-        <b>Already adjusted tags:</b> <%= @already_adjusted_names %>
+        <b>Already adjusted tags:</b> <%= @already_adjusted_tags %>
         <br /><br />
         <%= f.hidden_field :article_id, value: @moderatable.id %>
         <%= f.hidden_field :adjustment_type, value: "removal" %>
@@ -173,7 +173,7 @@
             </ul>
           <% end %>
           <b>Current live tags:</b> <%= @moderatable.tag_list %><br>
-          <b>Already adjusted tags:</b> <%= @already_adjusted_names %>
+          <b>Already adjusted tags:</b> <%= @already_adjusted_tags %>
           <br /><br />
           <%= f.hidden_field :article_id, value: @moderatable.id %>
           <%= f.hidden_field :adjustment_type, value: "addition" %>

--- a/app/views/moderations/mod.html.erb
+++ b/app/views/moderations/mod.html.erb
@@ -138,15 +138,14 @@
         <br /><br />
         <%= f.hidden_field :article_id, value: @moderatable.id %>
         <%= f.hidden_field :adjustment_type, value: "removal" %>
-        <%= f.text_field :tag_name, placeholder: "Tag Name" %>
-        <%= f.text_area :reason_for_adjustment, placeholder: "Reason for Removal (Be super kind) - Only the reason is needed, the notification will take care of the rest." %>
+        <%= f.text_field :tag_name, placeholder: "Tag Name", required: true %>
+        <%= f.text_area :reason_for_adjustment, placeholder: "Reason for Removal (Be super kind) - Only the reason is needed, the notification will take care of the rest.", required: true %>
         <%= f.submit "Remove Tag" %>
       <% end %>
-      <% removed_adjustments = @adjustments.filter { |a| a.adjustment_type == "removal" } if @adjustments %>
-      <% if removed_adjustments.any? %>
+      <% if @removed_adjustments.any? %>
         <br /><br />
         <b>Removed tags: </b>
-        <% removed_adjustments.each do |adjustment| %>
+        <% @removed_adjustments.each do |adjustment| %>
           <% if current_user.any_admin? %>
               <%= form_for(adjustment, url: "/tag_adjustments/#{adjustment.id}", html: { method: :delete, onsubmit: "return confirm('Are you sure you want to undo the removal of the #{adjustment.tag_name} tag?')" }) do |f| %>
                 <%= adjustment.tag_name %>
@@ -158,7 +157,7 @@
     </div>
   <% end %>
 
-  <% if @moderatable.class.name == "Article" && (current_user.has_role?(:super_admin) || current_user.has_role?(:tag_moderator, :any)) %>
+  <% if @allowed_to_add %>
     <div class="tag-mod-form">
       <h2> Add Appropriate Tags</h2>
       <% if @moderatable.tag_list.count < 4 %>
@@ -174,18 +173,17 @@
           <br /><br />
           <%= f.hidden_field :article_id, value: @moderatable.id %>
           <%= f.hidden_field :adjustment_type, value: "addition" %>
-          <%= f.text_field :tag_name, placeholder: "Tag Name - only add one at a time" %>
-          <%= f.text_area :reason_for_adjustment, placeholder: "Reason for addition (Be super kind) - Only the reason is needed, the notification will take care of the rest." %>
+          <%= f.text_field :tag_name, placeholder: "Tag Name - only add one at a time", required: true %>
+          <%= f.text_area :reason_for_adjustment, placeholder: "Reason for addition (Be super kind) - Only the reason is needed, the notification will take care of the rest.", required: true %>
           <%= f.submit "Add Tag" %>
         <% end %>
       <% else %>
         <b>Unable to add new tags. 4 tags max.</b>
       <% end %>
-      <% added_adjustments = @adjustments.filter { |a| a.adjustment_type == "addition" } if @adjustments %>
-      <% if added_adjustments.any? %>
+      <% if @added_adjustments.any? %>
         <br /><br />
         <b>Added tags: </b>
-        <% added_adjustments.each do |adjustment| %>
+        <% @added_adjustments.each do |adjustment| %>
           <% if current_user.any_admin? %>
               <%= form_for(adjustment, url: "/tag_adjustments/#{adjustment.id}", html: { method: :delete, onsubmit: "return confirm('Are you sure you want to undo the addition of the #{adjustment.tag_name} tag?')" }) do |f| %>
                 <%= adjustment.tag_name %>

--- a/app/views/moderations/mod.html.erb
+++ b/app/views/moderations/mod.html.erb
@@ -91,6 +91,11 @@
   input.undo {
     background: #ff0000; /* $red */
   }
+
+  .adjustment-error {
+    text-align:center;
+    color:red;
+  }
 </style>
 
 <div class="container" style="text-align: center">
@@ -138,6 +143,11 @@
         <b>Current live tags:</b> <%= @moderatable.tag_list %><br>
         <b>Already adjusted tags:</b> <%= @already_adjusted_tags %>
         <br /><br />
+        <% if flash[:error_removal].present? %>
+          <div class="adjustment-error">
+            <p>Error: <%= flash[:error_removal] %></p><br>
+          </div>
+        <% end %>
         <%= f.hidden_field :article_id, value: @moderatable.id %>
         <%= f.hidden_field :adjustment_type, value: "removal" %>
         <%= f.text_field :tag_name, placeholder: "Tag Name", required: true %>
@@ -175,6 +185,11 @@
           <b>Current live tags:</b> <%= @moderatable.tag_list %><br>
           <b>Already adjusted tags:</b> <%= @already_adjusted_tags %>
           <br /><br />
+          <% if flash[:error_addition].present? %>
+            <div class="adjustment-error">
+              <p>Error: <%= flash[:error_addition] %></p><br>
+            </div>
+          <% end %>
           <%= f.hidden_field :article_id, value: @moderatable.id %>
           <%= f.hidden_field :adjustment_type, value: "addition" %>
           <%= f.text_field :tag_name, placeholder: "Tag Name - only add one at a time", required: true %>

--- a/app/views/moderations/mod.html.erb
+++ b/app/views/moderations/mod.html.erb
@@ -132,9 +132,11 @@
             <li>Only remove tags which are tagged innapropriately.</li>
             <li>Use negative reactions if tag is appropriate but quality is low.</li>
             <li>Always be friendly in your tag removal reason.</li>
+            <li>Only remove tags which haven't been adjusted already.</li>
           </ul>
         <% end %>
-        <b>Current live tags:</b> <%= @moderatable.tag_list %>
+        <b>Current live tags:</b> <%= @moderatable.tag_list %><br>
+        <b>Already adjusted tags:</b> <%= @already_adjusted_names %>
         <br /><br />
         <%= f.hidden_field :article_id, value: @moderatable.id %>
         <%= f.hidden_field :adjustment_type, value: "removal" %>
@@ -167,9 +169,11 @@
               <li>You can only add tags that you moderate.</li>
               <li>Only add tags that are appropriate.</li>
               <li>Always be friendly in your tag adding reason.</li>
+              <li>Only add tags which haven't been adjusted already.</li>
             </ul>
           <% end %>
-          <b>Current live tags:</b> <%= @moderatable.tag_list %>
+          <b>Current live tags:</b> <%= @moderatable.tag_list %><br>
+          <b>Already adjusted tags:</b> <%= @already_adjusted_names %>
           <br /><br />
           <%= f.hidden_field :article_id, value: @moderatable.id %>
           <%= f.hidden_field :adjustment_type, value: "addition" %>

--- a/app/views/notifications/_tagadjustment.html.erb
+++ b/app/views/notifications/_tagadjustment.html.erb
@@ -4,20 +4,23 @@
 </div>
 <div class="content notification-content comment-content">
   <% data = notification.json_data %>
+  <% removal = data["adjustment_type"] == "removal" %>
   Hey there 👋
   <br /><br />
-  Moderators removed the
+  Moderators <%= removal ? "removed" : "added" %>  the
   <b><a href="/t/<%= data["tag_name"] %>" style="font-weight: 900">#<%= data["tag_name"] %></a></b> tag from your post
   <a href="<%= data["article"]["path"] %>"><%= h(data["article"]["title"]) %></a>.
   <br /><br />
-  Certain tags have special submission guidelines, and mods need to adjust tags to best fit the community.
+  <%= removal ? "Certain tags have special submission guidelines, and mods need to adjust tags to best fit the community." : "Mods felt this tag represented your article." %>
   <br /><br />
   <div class="comment-text">
     <div style="font-size:0.8em;margin-top: -3px;font-weight: 900;margin-bottom: 5px;">Reason for action</div>
     <%= data["reason_for_adjustment"] %>
   </div>
   <br />
-  Check out <a href="/tags">other popular tags</a> which may be more appropriate.
+  <% if removal %>
+    Check out <a href="/tags">other popular tags</a> which may be more appropriate
+  <% end %>
   <br><br />
   Thanks for being part of DEV! If you feel like this mod action was a mistake, feel free to contact
   <a href="mailto:<%= ApplicationConfig["DEFAULT_SITE_EMAIL"] %>"><%= ApplicationConfig["DEFAULT_SITE_EMAIL"] %></a>. 🤗

--- a/app/views/notifications/_tagadjustment.html.erb
+++ b/app/views/notifications/_tagadjustment.html.erb
@@ -8,7 +8,7 @@
   Hey there 👋
   <br /><br />
   Moderators <%= removal ? "removed" : "added" %>  the
-  <b><a href="/t/<%= data["tag_name"] %>" style="font-weight: 900">#<%= data["tag_name"] %></a></b> tag from your post
+  <b><a href="/t/<%= data["tag_name"] %>" style="font-weight: 900">#<%= data["tag_name"] %></a></b> tag <%= removal ? "from" : "to" %> your post
   <a href="<%= data["article"]["path"] %>"><%= h(data["article"]["title"]) %></a>.
   <br /><br />
   <%= removal ? "Certain tags have special submission guidelines, and mods need to adjust tags to best fit the community." : "Mods felt this tag represented your article." %>

--- a/spec/requests/tag_adjustments_spec.rb
+++ b/spec/requests/tag_adjustments_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe "TagAdjustments", type: :request do
     {
       tag_name: tag.name,
       article_id: article.id,
-      reason_for_adjustment: "Test #{rand(100)}"
+      reason_for_adjustment: "Test #{rand(100)}",
+      adjustment_type: "removal"
     }
   end
 
@@ -48,6 +49,43 @@ RSpec.describe "TagAdjustments", type: :request do
     end
   end
 
+  describe "POST /tag_adjustments with adjustment_type addition" do
+    before do
+      tag_adjustment_params[:adjustment_type] = "addition"
+      user.add_role(:tag_moderator, tag)
+      user.add_role(:trusted)
+      sign_in user
+      post "/tag_adjustments", params: {
+        tag_adjustment: tag_adjustment_params,
+        article_id: article.id
+      }
+    end
+
+    context "when an article doesn't use front matter" do
+      let(:article) { Article.create(user: user, title: "something", body_markdown: "blah blah #{rand(100)}", tag_list: "yoyo, bobo", published: true) }
+
+      it "adds the tag" do
+        expect(article.reload.tag_list.include?(tag.name)).to be true
+      end
+
+      it "keeps the other tags" do
+        expect(article.reload.tag_list.include?("yoyo")).to be true
+      end
+    end
+
+    context "when an article uses front matter" do
+      let(:article) { create(:article, user: user, body_markdown: "---\ntitle: Hellohnnnn#{rand(1000)}\npublished: true\ntags: heyheyhey\n---\n\nHello") }
+
+      it "adds the tag" do
+        expect(article.reload.tag_list.include?(tag.name)).to be true
+      end
+
+      it "keeps the other tags" do
+        expect(article.reload.tag_list.include?("heyheyhey")).to be true
+      end
+    end
+  end
+
   describe "DELETE /tag_adjustments/:id" do
     let(:tag_adjustment) { create(:tag_adjustment, article_id: article.id, user: user, tag: tag) }
 
@@ -77,6 +115,39 @@ RSpec.describe "TagAdjustments", type: :request do
           id: tag_adjustment.id
         }
         expect(article.tag_list).to include tag.name
+      end
+    end
+  end
+
+  describe "DELETE /tag_adjustments/:id with adjustment_type addition" do
+    let(:tag_adjustment) { create(:tag_adjustment, article_id: article.id, user: user, tag: tag, adjustment_type: "addition") }
+
+    before do
+      user.add_role(:admin)
+      user.add_role(:trusted)
+      tag_adjustment
+      sign_in user
+    end
+
+    context "when an article doesn't use front matter" do
+      let(:article) { Article.create(user: user, title: "something", body_markdown: "blah blah #{rand(100)}", tag_list: "yoyo, bobo", published: true) }
+
+      it "removes the added tag" do
+        delete "/tag_adjustments/#{tag_adjustment.id}", params: {
+          id: tag_adjustment.id
+        }
+        expect(article.tag_list).not_to include tag.name
+      end
+    end
+
+    context "when an article uses front matter" do
+      let(:article) { create(:article, user: user, body_markdown: "---\ntitle: Hellohnnnn#{rand(1000)}\npublished: true\ntags: heyheyhey\n---\n\nHello") }
+
+      it "removes the added tag" do
+        delete "/tag_adjustments/#{tag_adjustment.id}", params: {
+          id: tag_adjustment.id
+        }
+        expect(article.tag_list).not_to include tag.name
       end
     end
   end

--- a/spec/services/notifications/tag_adjustment_notification/send_spec.rb
+++ b/spec/services/notifications/tag_adjustment_notification/send_spec.rb
@@ -36,6 +36,13 @@ RSpec.describe Notifications::TagAdjustmentNotification::Send do
     expect(json["adjustment_type"]). to eq "removal"
   end
 
+  it "tests JSON data for addition" do
+    tag_adjustment.adjustment_type = "addition"
+    json = notification.json_data
+    expect(json["article"]["title"]).to start_with("Hello")
+    expect(json["adjustment_type"]). to eq "addition"
+  end
+
   specify "notification to be inserted on DB" do
     expect do
       described_class.call(tag_adjustment)

--- a/spec/services/tag_adjustment_creation_service_spec.rb
+++ b/spec/services/tag_adjustment_creation_service_spec.rb
@@ -2,13 +2,13 @@ require "rails_helper"
 
 RSpec.describe TagAdjustmentCreationService do
   let(:user) { create(:user) }
-  let(:article) { create(:article) }
+  let(:article) { create(:article, tags: tag.name) }
   let(:tag) { create(:tag) }
 
-  def create_tag_adjustment
+  def create_tag_adjustment(type)
     described_class.new(
       user,
-      adjustment_type: "removal",
+      adjustment_type: type,
       status: "committed",
       tag_name: tag.name,
       article_id: article.id,
@@ -20,19 +20,38 @@ RSpec.describe TagAdjustmentCreationService do
     user.add_role(:tag_moderator, tag)
   end
 
-  it "creates tag adjustment" do
-    tag_adjustment = create_tag_adjustment
+  describe "creates tag adjustment" do
+    it "with adjustment_type removal" do
+      tag_adjustment = create_tag_adjustment("removal")
+      expect(tag_adjustment).to be_valid
+      expect(tag_adjustment.tag_id).to eq(tag.id)
+      expect(tag_adjustment.status).to eq("committed")
+    end
 
-    expect(tag_adjustment).to be_valid
-    expect(tag_adjustment.tag_id).to eq(tag.id)
-    expect(tag_adjustment.status).to eq("committed")
+    it "with adjustment_type addition" do
+      tag_adjustment = create_tag_adjustment("addition")
+
+      expect(tag_adjustment).to be_valid
+      expect(tag_adjustment.tag_id).to eq(tag.id)
+      expect(tag_adjustment.status).to eq("committed")
+    end
   end
 
-  it "creates notification" do
-    perform_enqueued_jobs do
-      tag_adjustment = create_tag_adjustment
-      expect(Notification.last.user_id).to eq(article.user_id)
-      expect(Notification.last.json_data["adjustment_type"]).to eq(tag_adjustment.adjustment_type)
+  describe "creates notification" do
+    it "with adjustment_type removal" do
+      perform_enqueued_jobs do
+        tag_adjustment = create_tag_adjustment("removal")
+        expect(Notification.last.user_id).to eq(article.user_id)
+        expect(Notification.last.json_data["adjustment_type"]).to eq(tag_adjustment.adjustment_type)
+      end
+    end
+
+    it "with adjustment_type addition" do
+      perform_enqueued_jobs do
+        tag_adjustment = create_tag_adjustment("addition")
+        expect(Notification.last.user_id).to eq(article.user_id)
+        expect(Notification.last.json_data["adjustment_type"]).to eq(tag_adjustment.adjustment_type)
+      end
     end
   end
 end

--- a/spec/services/tag_adjustment_update_service_spec.rb
+++ b/spec/services/tag_adjustment_update_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe TagAdjustmentUpdateService do
       tag_name: tag.name,
       article_id: article.id,
       reason_for_adjustment: "reasons",
-    ).create
+    )
   end
 
   before do
@@ -21,7 +21,8 @@ RSpec.describe TagAdjustmentUpdateService do
   end
 
   it "creates tag adjustment" do
-    tag_adjustment = create_tag_adjustment
+    tag_adjustment = create_tag_adjustment.tag_adjustment
+    tag_adjustment.save
     described_class.new(tag_adjustment, status: "resolved").update
 
     expect(tag_adjustment).to be_valid


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

Via /mod, This allows admin and tag moderators to add tags to articles similar to how they remove tags. I followed the functionality of the remove tags feature on the related pull requests: #1252 Allow mods to remove tags and send user notification & #3653 Allow admins to undo a tag adjustment.

> Might be some considerations around people re-tagging previously removed tags, but that could be a complication not worth thinking about.

There already is a data validation on TagAdjustment tag_name that would prevent re-tagging previously removed tags for mods. This will also prevent removing tags that were previously added by mods.

I added a second TagAdjustment form to the mod view but could refactor to combine to a single add/remove form if preferred.

Closes https://github.com/thepracticaldev/dev.to/issues/4720

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![Screen Shot 2019-11-07 at 5 22 10 PM](https://user-images.githubusercontent.com/25860670/68442197-21f1e300-0185-11ea-9e53-fb7476dc45ca.png)

![Screen Shot 2019-11-12 at 1 02 40 PM](https://user-images.githubusercontent.com/25860670/68717856-aa44ff00-055c-11ea-81d4-c11580e92cf9.png)
