### PR TITLE
Show Empty State in Badges List for Mobile Views

### DIFF
--- a/app/views/articles/_badges_area.html.erb
+++ b/app/views/articles/_badges_area.html.erb
@@ -54,4 +54,24 @@
       <% end %>
     </div>
   </div>
+<% else %>
+  <style>
+    .widget-body {
+      margin: 0 auto;
+      padding: 20px;
+    }
+
+    @media screen and (min-width: 1024px) {
+      .no-badges-text {
+        display: none;
+      }
+    }
+  </style>
+  <div style="overflow: visible;padding-top:20px;">
+    <div class="widget-body">
+      <p class="no-badges-text">
+        Eat and than sleep on your face annoy the old grumpy cat, start a fight and then retreat to wash when i lose and i shall purr myself to sleep or run around the house at 4 in the morning
+      </p>
+    </div>
+  </div>
 <% end %>

--- a/app/views/articles/_badges_area.html.erb
+++ b/app/views/articles/_badges_area.html.erb
@@ -70,7 +70,7 @@
   <div style="overflow: visible;padding-top:20px;">
     <div class="widget-body">
       <p class="no-badges-text">
-        Eat and than sleep on your face annoy the old grumpy cat, start a fight and then retreat to wash when i lose and i shall purr myself to sleep or run around the house at 4 in the morning
+        Eat and than sleep on your face annoy the old grumpy cat, start a fight and then retreat to wash when I lose and I shall purr myself to sleep or run around the house at 4 in the morning.
       </p>
     </div>
   </div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

Instead of an empty sidebar, add a text that is displayed in mobile views except desktop.

Left an ipsum as suggested by @jessleenyc in https://github.com/thepracticaldev/dev.to/issues/4610#issuecomment-549384992

## Related Tickets & Documents

Would close #4610 

## Mobile & Desktop Screenshots/Recordings

![image](https://user-images.githubusercontent.com/1375981/68511941-0b12c580-0245-11ea-9bc7-74403f4565bc.png)

## Added to documentation?

- [x] no documentation needed
