### PR TITLE
Use latest Node LTS

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/dubnium
+lts/*


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

Node v12.13.0 is [the latest LTS](https://nodejs.org/en/blog/release/v12.13.0/), see also the [node download page](https://nodejs.org/en/download/). 

This change tells NVM to use the latest LTS: https://github.com/nvm-sh/nvm#nvmrc
