### PR TITLE
Add additional cache value for block

### DIFF
--- a/app/controllers/async_info_controller.rb
+++ b/app/controllers/async_info_controller.rb
@@ -71,6 +71,7 @@ class AsyncInfoController < ApplicationController
     #{current_user&.checked_code_of_conduct}__
     #{current_user&.articles_count}__
     #{current_user&.pro?}__
+    #{current_user&.blocking_others_count}__
     #{cookies[:remember_user_token]}"
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This fixes an issue where the async info cached object is not cleared when someone is newly blocked or unblocked. 

## [optional] What gif best describes this PR or how it makes you feel?

![Bart Simpson shouts "Hey, Lawn Boy! You missed a spot!"](https://media.giphy.com/media/3o6MbsYvlRRFEjWve0/200w_d.gif)