### PR TITLE
Add latest articles and possible spam users to internal/reports

### DIFF
--- a/app/controllers/internal/feedback_messages_controller.rb
+++ b/app/controllers/internal/feedback_messages_controller.rb
@@ -10,6 +10,11 @@ class Internal::FeedbackMessagesController < Internal::ApplicationController
       order("feedback_messages.created_at DESC").
       page(params[:page] || 1).per(5)
     @email_messages = EmailMessage.find_for_reports(@feedback_messages)
+    @new_articles = Article.limit(150).order("created_at DESC").where("score > ? AND score < ?", -10, 8)
+    @possible_spam_users = User.where("github_created_at > ? OR twitter_created_at > ?", 48.hours.ago, 48.hours.ago).
+      where("created_at > ?", 36.hours.ago).
+      order("created_at DESC").
+      where.not("username LIKE ?", "%spam_%").limit(150)
     @vomits = get_vomits
   end
 

--- a/app/views/internal/feedback_messages/index.html.erb
+++ b/app/views/internal/feedback_messages/index.html.erb
@@ -1,4 +1,39 @@
 <%= render "style" %>
+<style>
+  .single-article-actions a {
+    color: black;
+    font-size: 0.77em;
+  }
+</style>
+<h1>Latest Articles</h1>
+<div style="height: 400px; overflow: scroll;">
+  <% @new_articles.each do |article| %>
+    <% next if article.user.badge_achievements_count > 2 %>
+    <div style="border-bottom: 1px solid black; padding: 3px 0px 2px;">
+      <a href="<%= article.path %>"><%= article.title %></a>
+      <div class="single-article-actions">
+        <a href="<%= article.path %>/mod">Mod</a> |
+        <a href="<%= article.path %>/moderate">Internal</a> |
+        <a href="<%= article.user.path %>">@<%= article.user.username %></a> |
+        <a href="/internal/users/<%= article.user_id %>">Internal User</a> |
+        <a href="/internal/users/<%= article.user_id %>/edit">Destructive Actions</a>
+      </div>
+    </div>
+  <% end %>
+</div>
+
+<h1>Possible spam/abuse users</h1>
+<div style="height: 400px; overflow: scroll;">
+  <% @possible_spam_users.each do |user| %>
+    <div style="border-bottom: 1px solid black; padding: 5px 0px 2px;">
+      <a href="<%= user.path %>">@<%= user.username %></a> - <%= user.name %>
+      <div class="single-article-actions">
+        <a href="/internal/users/<%= user.id %>">Internal User</a> |
+        <a href="/internal/users/<%= user.id %>/edit">Destructive Actions</a>
+      </div>
+    </div>
+  <% end %>
+</div>
 
 <h1 class="top-nav">
   Abuse Reports -


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
This adds a list of new posts and users who have a higher likelihood of being "potential spam".

This is a basic addition to our main internal support dashboard, which could maybe be renamed. We'll see how this feature maps to our capacity to catch abuse faster.