### PR TITLE
Expire Frequently Updated Cache Keys Sooner

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -242,7 +242,7 @@ class User < ApplicationRecord
   def cached_following_users_ids
     RedisRailsCache.fetch(
       "user-#{id}-#{updated_at}-#{following_users_count}/following_users_ids",
-      expires_in: 120.hours,
+      expires_in: 12.hours,
     ) do
       Follow.where(follower_id: id, followable_type: "User").limit(150).pluck(:followable_id)
     end
@@ -251,7 +251,7 @@ class User < ApplicationRecord
   def cached_following_organizations_ids
     RedisRailsCache.fetch(
       "user-#{id}-#{updated_at}-#{following_orgs_count}/following_organizations_ids",
-      expires_in: 120.hours,
+      expires_in: 12.hours,
     ) do
       Follow.where(follower_id: id, followable_type: "Organization").limit(150).pluck(:followable_id)
     end
@@ -260,7 +260,7 @@ class User < ApplicationRecord
   def cached_following_podcasts_ids
     RedisRailsCache.fetch(
       "user-#{id}-#{updated_at}-#{last_followed_at}/following_podcasts_ids",
-      expires_in: 120.hours,
+      expires_in: 12.hours,
     ) do
       Follow.where(follower_id: id, followable_type: "Podcast").pluck(:followable_id)
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -241,7 +241,7 @@ class User < ApplicationRecord
 
   def cached_following_users_ids
     RedisRailsCache.fetch(
-      "user-#{id}-#{updated_at}-#{following_users_count}/following_users_ids",
+      "user-#{id}-#{last_followed_at}-#{following_users_count}/following_users_ids",
       expires_in: 12.hours,
     ) do
       Follow.where(follower_id: id, followable_type: "User").limit(150).pluck(:followable_id)
@@ -250,7 +250,7 @@ class User < ApplicationRecord
 
   def cached_following_organizations_ids
     RedisRailsCache.fetch(
-      "user-#{id}-#{updated_at}-#{following_orgs_count}/following_organizations_ids",
+      "user-#{id}-#{last_followed_at}-#{following_orgs_count}/following_organizations_ids",
       expires_in: 12.hours,
     ) do
       Follow.where(follower_id: id, followable_type: "Organization").limit(150).pluck(:followable_id)
@@ -259,7 +259,7 @@ class User < ApplicationRecord
 
   def cached_following_podcasts_ids
     RedisRailsCache.fetch(
-      "user-#{id}-#{updated_at}-#{last_followed_at}/following_podcasts_ids",
+      "user-#{id}-#{last_followed_at}/following_podcasts_ids",
       expires_in: 12.hours,
     ) do
       Follow.where(follower_id: id, followable_type: "Podcast").pluck(:followable_id)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
During some cache investigating in Redis, I noticed that we make a lot of duplicate keys for these user keys because some users are updated a lot. For example here are the stats for following_organizations_ids:
```
110k keys total representing 34k users 
79k duplicates for 9100 users who have more than 2 keys in Redis bc of updated_at timestamp being updated
```
To avoid having those old, out of date keys hanging around for 5 days I shortened the expiration to 12 hours. I think having to run these quick commands an additional 10 times possibly over the course of 5 days is not going to be a big hit to performance but I do think it will save us a bit of space in Redis.   

Ideally, I want to come up with a better caching strategy to avoid leaving all these out of date keys hanging around in Redis but I haven't decided exactly how I want to approach that yet so this is a temporary bandaid. 

## Related Tickets & Documents
#4670 

## Added to documentation?
- [x] no documentation needed

![woman saying its all temporary](https://thumbs.gfycat.com/CrispAlarmingArmyworm-small.gif)