### PR TITLE
Center podcast page footer.

### DIFF
--- a/app/assets/stylesheets/footer.scss
+++ b/app/assets/stylesheets/footer.scss
@@ -49,3 +49,9 @@ footer {
     }
   }
 }
+
+@media screen and (min-width: 1250px) {
+  .stories-show + footer .inner-footer-container {
+    margin-left: 0;
+  }
+}

--- a/app/assets/stylesheets/footer.scss
+++ b/app/assets/stylesheets/footer.scss
@@ -46,9 +46,6 @@ footer {
       padding: 50px 30px;
       line-height: 3em;
       margin: auto;
-      @media screen and (min-width: 1250px) {
-        margin-left: 0px;
-      }
     }
   }
 }


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
On screens above 1250px, the footer on the podcast page isn't centered. This PR fixes that. 

## Related Tickets & Documents
Resolves #4768 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Podcast page 

![image](https://user-images.githubusercontent.com/11851029/68662633-44ea1180-054e-11ea-959a-bbc92f04c534.png)

it works well with articles page 

![image](https://user-images.githubusercontent.com/11851029/68662679-5f23ef80-054e-11ea-9824-2e715d933ea0.png)


## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?
Considering this is my first PR, hopefully this is a first of many 🥂 

![😬 ](https://giphy.com/gifs/missamerica-miss-america-2016-3oz8xHS1NHANj2uwms)
