### PR TITLE
User profile details fix

### DIFF
--- a/app/assets/stylesheets/user-profile-header.scss
+++ b/app/assets/stylesheets/user-profile-header.scss
@@ -235,6 +235,7 @@
   .user-metadata-details{
     font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
     width: 97%;
+    overflow-y: scroll;
     @media screen and ( min-width: 1100px ){
       position: absolute;
       right: 0px;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Documentation Update

## Description

Users with too much information in their metadata are overflowing the `.user-profile-metadata` section which makes some information inaccessible.

## Related Tickets & Documents

Related to https://github.com/thepracticaldev/dev.to/issues/3253 and https://github.com/thepracticaldev/dev.to/issues/4712

Not 100% fixed.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

*Before*

<img width="365" alt="Screen Shot 2019-11-13 at 10 32 29" src="https://user-images.githubusercontent.com/47985/68731632-aea70180-05c8-11ea-8798-108bda0acb3a.png">

Note that everything after "joined" is missing and there's no way to get to it.

*After*

<img width="354" alt="Screen Shot 2019-11-13 at 10 45 15" src="https://user-images.githubusercontent.com/47985/68731664-ca120c80-05c8-11ea-8ddf-e5fe6a365b7c.png">

The `.user-metadata-section` is now scrollable, so all information can be accessed.


## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed
