### PR TITLE
Move user_data Async Controller Cache to Redis

### DIFF
--- a/app/controllers/async_info_controller.rb
+++ b/app/controllers/async_info_controller.rb
@@ -30,7 +30,7 @@ class AsyncInfoController < ApplicationController
   end
 
   def user_data
-    Rails.cache.fetch(user_cache_key, expires_in: 15.minutes) do
+    RedisRailsCache.fetch(user_cache_key, expires_in: 15.minutes) do
       {
         id: @user.id,
         name: @user.name,
@@ -60,7 +60,7 @@ class AsyncInfoController < ApplicationController
   end
 
   def user_cache_key
-    "#{current_user&.id}__
+    "user-info-#{current_user&.id}__
     #{current_user&.last_sign_in_at}__
     #{current_user&.last_followed_at}__
     #{current_user&.updated_at}__


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
This is a heavily used key that I want to move to Redis to get a better idea of how we are using it. I prepended "user-info" on to the key so that I would have something to grep for when sifting through the keys in Redis.

## Related Tickets & Documents
#4670 

## Added to documentation?
- [x] no documentation needed

![another one bites the dust](https://cdn.promodj.com/afs/4d13ae82af2d9632e014add2e651f36f12:resize:3000x3000:same:promodj:2b11a0)
