### PR TITLE
Move cached_followed_tag_names to Redis 

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -292,7 +292,7 @@ class User < ApplicationRecord
   end
 
   def cached_followed_tag_names
-    cache_name = "user-#{id}-#{following_tags_count}-#{last_followed_at&.strftime('%Y-%m-%d-%H:%M:%S')}/followed_tag_names"
+    cache_name = "user-#{id}-#{following_tags_count}-#{last_followed_at&.rfc3339}/followed_tag_names"
     RedisRailsCache.fetch(cache_name, expires_in: 24.hours) do
       Tag.where(
         id: Follow.where(

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -292,8 +292,8 @@ class User < ApplicationRecord
   end
 
   def cached_followed_tag_names
-    cache_name = "user-#{id}-#{updated_at}/followed_tag_names"
-    Rails.cache.fetch(cache_name, expires_in: 24.hours) do
+    cache_name = "user-#{id}-#{following_tags_count}/followed_tag_names"
+    RedisRailsCache.fetch(cache_name, expires_in: 24.hours) do
       Tag.where(
         id: Follow.where(
           follower_id: id,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -292,7 +292,7 @@ class User < ApplicationRecord
   end
 
   def cached_followed_tag_names
-    cache_name = "user-#{id}-#{following_tags_count}/followed_tag_names"
+    cache_name = "user-#{id}-#{following_tags_count}-#{last_followed_at&.strftime('%Y-%m-%d-%H:%M:%S')}/followed_tag_names"
     RedisRailsCache.fetch(cache_name, expires_in: 24.hours) do
       Tag.where(
         id: Follow.where(


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
This PR will move the cached_followed_tag_names cache key to Redis and it also updates it to use the following_tags_count rather than user updated_at since that is a better indicator of when this cache would become invalid. There is a small chance that a user removes a tag and then adds a new one before hitting the cache again which could cause the incorrect tag names to be grabbed. I think the chances of this are very low and because the cache resets every 24 hours, the tradeoff of more hits for that small chance of a "race condition" adding/removing tags is worth it. As always, let me know what people think of that reasoning!!! 

## Related Tickets & Documents
#4670 

## Added to documentation?

- [x] no documentation needed

![tag you are it gif](https://media3.giphy.com/media/3o6Ei0fWOw1iQ79d0A/giphy.gif)
