### PR TITLE
Allow while displaying podcasts episodes processed html

### DIFF
--- a/app/views/podcast_episodes/show.html.erb
+++ b/app/views/podcast_episodes/show.html.erb
@@ -95,7 +95,7 @@
         <%= simple_format((@episode.processed_html || @episode.body).html_safe, sanitize: true) %>
       <% else %>
         <%= sanitize (@episode.processed_html || "").html_safe,
-                     tags: %w[strong em a table tbody thead tfoot th tr td col colgroup del p h1 h2 h3 h4 h5 h6 blockquote time div span i em u b ul ol li dd dl dt q code pre img sup cite center small],
+                     tags: %w[strong br em a table tbody thead tfoot th tr td col colgroup del p h1 h2 h3 h4 h5 h6 blockquote time div span i em u b ul ol li dd dl dt q code pre img sup cite center small],
                      attributes: %w[href strong em class ref rel src title alt colspan height width size rowspan span value start data-conversation data-lang id] %>
       <% end %>
       <p style="font-size:16px;">


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Some podcast episodes have `<br>` tags in their `content_encoded`, e.g. [this ep](https://dev.to/founderquest/don-t-let-customer-service-crush-you) . While sanitizing we remove `br`s so the formatting gets broken. Maybe we could allow `br`s so that such descriptions would look better.