### PR TITLE
Avoid N+1 queries when sending Notifications for Reactions

### DIFF
--- a/app/services/notifications/reactions/send.rb
+++ b/app/services/notifications/reactions/send.rb
@@ -24,7 +24,7 @@ module Notifications
 
         reaction_siblings = Reaction.where(reactable_id: reaction.reactable_id, reactable_type: reaction.reactable_type).
           where.not(reactions: { user_id: reaction.reactable_user_id }).
-          includes(:reactable).
+          includes(:reactable, :user).
           order("created_at DESC")
 
         aggregated_reaction_siblings = reaction_siblings.map { |reaction| { category: reaction.category, created_at: reaction.created_at, user: user_data(reaction.user) } }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
In line 30 when we map over the reaction_siblings we end up calling `reaction.user` so we should be preloading user when loading those Reactions to avoid N+1 queires

## Added to documentation?
- [x] no documentation needed

![Oh there you are](https://media1.giphy.com/media/kESxgfWk7WPJumj4lS/giphy.gif)
