### PR TITLE
Rails 5.2 features: Enable AES-256-GCM on encrypted messages

### DIFF
--- a/config/initializers/new_framework_defaults_5_2.rb
+++ b/config/initializers/new_framework_defaults_5_2.rb
@@ -21,7 +21,7 @@ Rails.application.config.action_dispatch.use_authenticated_cookie_encryption = t
 
 # Use AES-256-GCM authenticated encryption as default cipher for encrypting messages
 # instead of AES-256-CBC, when use_authenticated_message_encryption is set to true.
-# Rails.application.config.active_support.use_authenticated_message_encryption = true
+Rails.application.config.active_support.use_authenticated_message_encryption = true
 
 # Add default protection from forgery to ActionController::Base instead of in
 # ApplicationController.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

After https://github.com/thepracticaldev/dev.to/pull/4216 I'm submitting this PR to enable `AES-256-GCM` on encrypted messages as well.

Rails uses this algorithm to encrypt messages and to generate `rails secrets`. In our code we use `ActiveSupport::MessageEncryptor` in the Google Analytics controller to scramble the IP:

https://github.com/thepracticaldev/dev.to/blob/fbbb02e241d4d91f5df4941ffe904220f3f636dc/app/controllers/ga_events_controller.rb#L30-L33

After manual test I did determine that indeed the default encryption algorithm has been changed. For obvious reasons switching algorithms will generate different strings, but we do not decrypt those strings anywhere so this shouldn't be a problem.
