### PR TITLE
Rails 5.2 features: Enable default protect from forgery

### DIFF
--- a/config/initializers/new_framework_defaults_5_2.rb
+++ b/config/initializers/new_framework_defaults_5_2.rb
@@ -25,7 +25,7 @@ Rails.application.config.action_dispatch.use_authenticated_cookie_encryption = t
 
 # Add default protection from forgery to ActionController::Base instead of in
 # ApplicationController.
-# Rails.application.config.action_controller.default_protect_from_forgery = true
+Rails.application.config.action_controller.default_protect_from_forgery = true
 
 # Store boolean values are in sqlite3 databases as 1 and 0 instead of 't' and
 # 'f' after migrating old data.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

After https://github.com/thepracticaldev/dev.to/pull/4216 I'm submitting this PR to enable "protect from forgery" by default.

This won't affect us as all our controllers (internals included) inherit from our `ApplicationController` which already has a call to `protect_from_forgery`: 

https://github.com/thepracticaldev/dev.to/blob/fbbb02e241d4d91f5df4941ffe904220f3f636dc/app/controllers/application_controller.rb#L2

What Rails does when this is enabled by default is to add the following in the `ActionController::Base` controller:

https://github.com/rails/rails/blob/2b42f33fda9733d0ca91c0c1b88cc4df4b7230e8/actionpack/lib/action_controller/railtie.rb#L77-L79

Our call already overrides any possible default.