### PR TITLE
Rails 5.2 features: Enable active_record.sqlite3.represent_boolean_as_integer

### DIFF
--- a/config/initializers/new_framework_defaults_5_2.rb
+++ b/config/initializers/new_framework_defaults_5_2.rb
@@ -29,7 +29,7 @@ Rails.application.config.action_dispatch.use_authenticated_cookie_encryption = t
 
 # Store boolean values are in sqlite3 databases as 1 and 0 instead of 't' and
 # 'f' after migrating old data.
-# Rails.application.config.active_record.sqlite3.represent_boolean_as_integer = true
+Rails.application.config.active_record.sqlite3.represent_boolean_as_integer = true
 
 # Use SHA-1 instead of MD5 to generate non-sensitive digests, such as the ETag header.
 # Rails.application.config.active_support.use_sha1_digests = true


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

After https://github.com/thepracticaldev/dev.to/pull/4216 I'm submitting this PR to get closer to Rails 5.2 default. We don't use sqlite3 so this doesn't impact the app.
