### PR TITLE
Rails 5.2 features: Enable action_view.form_with_generates_ids

### DIFF
--- a/config/initializers/new_framework_defaults_5_2.rb
+++ b/config/initializers/new_framework_defaults_5_2.rb
@@ -35,4 +35,4 @@ Rails.application.config.action_dispatch.use_authenticated_cookie_encryption = t
 # Rails.application.config.active_support.use_sha1_digests = true
 
 # Make `form_with` generate id attributes for any generated HTML tags.
-# Rails.application.config.action_view.form_with_generates_ids = true
+Rails.application.config.action_view.form_with_generates_ids = true


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

After #4216 I'm submitting this PR to get closer to Rails 5.2 default.

This change enables auto generated IDs for `form_with`, we use that only in the listings form:

https://github.com/thepracticaldev/dev.to/blob/fbbb02e241d4d91f5df4941ffe904220f3f636dc/app/views/classified_listings/_form.html.erb#L1
