### PR TITLE
Add SiteConfig to internal and enable "main_social_image"

### DIFF
--- a/app/controllers/internal/configs_controller.rb
+++ b/app/controllers/internal/configs_controller.rb
@@ -1,0 +1,19 @@
+class Internal::ConfigsController < Internal::ApplicationController
+  layout "internal"
+
+  def show; end
+
+  def create
+    config_params.keys.each do |key|
+      SiteConfig.public_send("#{key}=", config_params[key].strip) unless config_params[key].nil?
+    end
+    redirect_to internal_config_path, notice: "Site configuration was successfully updated."
+  end
+
+  private
+
+  def config_params
+    # put this stuff in the policy or in the model
+    params.require(:site_config).permit(:main_social_image)
+  end
+end

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -7,4 +7,6 @@ class SiteConfig < RailsSettings::Base
   # the site configuration is cached, change this if you want to force update
   # the cache, or call SiteConfig.clear_cache
   cache_prefix { "v1" }
+
+  field :main_social_image, default: "https://thepracticaldev.s3.amazonaws.com/i/6hqmcjaxbgbon8ydw93z.png"
 end

--- a/app/views/internal/articles/index.html.erb
+++ b/app/views/internal/articles/index.html.erb
@@ -8,7 +8,7 @@
   }
 </style>
 
-<div class="editor-image-upload" style="position:fixed;top:50px;z-index:10000;padding:10px;background:white;left:0;right:0;text-align:center;border-bottom:2px solid gray">
+<div class="editor-image-upload" style="position:fixed;top:100px;z-index:10000;padding:10px;background:white;left:0;right:0;text-align:center;border-bottom:2px solid gray">
   <input type="file" id="image-upload" name="file" accept="image/*" style="display:none">
   <button id="image-upload-button">Upload Image</button>
   <span style="width:500px;display:inline-block">

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -1,13 +1,36 @@
 <h1>Site configuration</h1>
 
+<style>
+  .panel {
+    margin-top: 2rem;
+  }
+
+  .preview {
+    margin: 1rem 0;
+  }
+
+  .help-block {
+    font-size: 1.5rem;
+  }
+</style>
+
 <%= form_for(SiteConfig.new, url: internal_config_path) do |f| %>
-  <div class="form-group">
-    <%= f.label "Main social image" %>
-    <%= f.text_field :main_social_image, value: SiteConfig.main_social_image, class: "form-control", placeholder: "https://image.url" %>
-    <img alt="main social image" src="<%= SiteConfig.main_social_image %>" width="30%" />
+  <div class="panel panel-default">
+    <div class="panel-heading">Images</div>
+    <div class="panel-body">
+      <div class="form-group">
+        <%= f.label "Main social image" %>
+        <%= f.text_field :main_social_image,
+                         class: "form-control",
+                         value: SiteConfig.main_social_image,
+                         placeholder: "https://image.url" %>
+        <span class="help-block">Used as the main image in social networks and OpenGraph</span>
+        <img alt="main social image" class="preview" src="<%= SiteConfig.main_social_image %>" width="50%" />
+      </div>
+    </div>
   </div>
 
   <div class="form-group">
-    <%= f.submit "Update", class: "btn btn-primary" %>
+    <%= f.submit "Update site configuration", class: "btn btn-primary" %>
   </div>
 <% end %>

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -1,0 +1,13 @@
+<h1>Site configuration</h1>
+
+<%= form_for(SiteConfig.new, url: internal_config_path) do |f| %>
+  <div class="form-group">
+    <%= f.label "Main social image" %>
+    <%= f.text_field :main_social_image, value: SiteConfig.main_social_image, class: "form-control", placeholder: "https://image.url" %>
+    <img alt="main social image" src="<%= SiteConfig.main_social_image %>" width="30%" />
+  </div>
+
+  <div class="form-group">
+    <%= f.submit "Update", class: "btn btn-primary" %>
+  </div>
+<% end %>

--- a/app/views/internal/shared/_navbar.html.erb
+++ b/app/views/internal/shared/_navbar.html.erb
@@ -1,4 +1,4 @@
-<% menu_items = %w[comments articles users tags welcome broadcasts reports pages tools chat_channels growth mods].each_with_object({}) { |v, h| h[v] = v } %>
+<% menu_items = %w[comments articles users tags welcome broadcasts reports pages tools chat_channels growth mods config].each_with_object({}) { |v, h| h[v] = v } %>
 <% menu_items[:listings] = "classified_listings" %>
 <% menu_items[:podcasts] = "podcasts" %>
 <% menu_items[:webhooks] = "webhook_endpoints" %>

--- a/app/views/internal/shared/_navbar.html.erb
+++ b/app/views/internal/shared/_navbar.html.erb
@@ -1,7 +1,7 @@
 <% menu_items = %w[comments articles users tags welcome broadcasts reports pages tools chat_channels growth mods].each_with_object({}) { |v, h| h[v] = v } %>
 <% menu_items[:listings] = "classified_listings" %>
-<% menu_items[:pod] = "podcasts" %>
-<% menu_items[:hooks] = "webhook_endpoints" %>
+<% menu_items[:podcasts] = "podcasts" %>
+<% menu_items[:webhooks] = "webhook_endpoints" %>
 
 <div id="navbar" class="collapse navbar-collapse">
   <ul class="nav navbar-nav" style="font-size: 0.97em;">

--- a/app/views/layouts/internal.html.erb
+++ b/app/views/layouts/internal.html.erb
@@ -25,7 +25,7 @@
 </head>
 <style>
   .starter-template {
-    padding-top: 60px;
+    padding-top: 5em;
     font-size: 1.4em;
   }
 
@@ -148,37 +148,34 @@
   .highlighted-border {
     border: 20px solid black;
   }
-
 </style>
+
 <body>
-
-<nav class="navbar navbar-inverse navbar-fixed-top">
-  <div class="container">
-    <div class="navbar-header">
-      <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
-        <span class="sr-only">Toggle navigation</span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-      </button>
-    </div>
-    <%= render "internal/shared/navbar" %>
-  </div>
-</nav>
-
-<div class="container">
-
-  <div class="starter-template">
-    <% flash.each do |type, message| %>
-      <div class="alert alert-<%= type %>">
-        <button class="close" data-dismiss="alert">X</button>
-        <%= message %>
+  <nav class="navbar navbar-inverse navbar-fixed-top">
+    <div class="container">
+      <div class="navbar-header">
+        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
+          <span class="sr-only">Toggle navigation</span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+        </button>
       </div>
-    <% end %>
-    <%= yield %>
-  </div>
+      <%= render "internal/shared/navbar" %>
+    </div>
+  </nav>
 
-</div>
+  <div class="container">
+    <div class="starter-template">
+      <% flash.each do |type, message| %>
+        <div class="alert alert-<%= type %>">
+          <button class="close" data-dismiss="alert">X</button>
+          <%= message %>
+        </div>
+      <% end %>
+      <%= yield %>
+    </div>
+  </div>
 
 </body>
 </html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,6 +78,7 @@ Rails.application.routes.draw do
       end
     end
     resources :webhook_endpoints, only: :index
+    resource :config
   end
 
   namespace :api, defaults: { format: "json" } do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,8 @@ Rails.application.routes.draw do
   end
 
   namespace :internal do
+    get "/", to: redirect("/internal/articles")
+
     resources :articles, only: %i[index show update]
     resources :broadcasts, only: %i[index new create edit update]
     resources :buffer_updates, only: %i[create update]

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -77,6 +77,10 @@ RSpec.configure do |config|
     ActiveRecord::Base.observers.disable :all # <-- Turn 'em all off!
   end
 
+  config.after do
+    SiteConfig.clear_cache
+  end
+
   # Only turn on VCR if :vcr is included metadata keys
   config.around do |ex|
     if ex.metadata.key?(:vcr)

--- a/spec/requests/internal/configs_spec.rb
+++ b/spec/requests/internal/configs_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe "/internal/config", type: :request do
+  let_it_be(:user) { create(:user) }
+  let_it_be(:admin) { create(:user, :super_admin) }
+
+  describe "POST internal/events as a user" do
+    before do
+      sign_in(user)
+    end
+
+    it "bars the regular user to access" do
+      expect { post "/internal/config", params: {} }.to raise_error(Pundit::NotAuthorizedError)
+    end
+  end
+
+  describe "POST internal/events" do
+    before do
+      sign_in(admin)
+    end
+
+    it "updates main_social_image" do
+      SiteConfig.main_social_image = "https://dummyimage.com/100x100"
+      expected_image_url = "https://dummyimage.com/300x300"
+      post "/internal/config", params: { site_config: { main_social_image: expected_image_url } }
+      expect(SiteConfig.main_social_image).to eq(expected_image_url)
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

Step 1 in switching to `SiteConfig`.

I created a MVP of how it would work for the internal admin to have the site configuration exposed.

For now I just created a `SiteConfig.main_social_image` which mirrors `MAIN_SOCIAL_IMAGE` in the environment variables.

I've also put the navigation bar on two rows, because one doesn't fit all the keys


## Related Tickets & Documents

https://github.com/thepracticaldev/dev.to/pull/4729 and https://github.com/thepracticaldev/dev.to/issues/4718#issuecomment-549802542

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![Screenshot_2019-11-15 configs](https://user-images.githubusercontent.com/146201/68939151-2d09cc00-07a0-11ea-8dd3-6c8faa12c5d5.png)

Demo of how it works as of now:

![site config](https://user-images.githubusercontent.com/146201/68939156-3004bc80-07a0-11ea-959d-a5e723182682.gif)
