### PR TITLE
Updated 'ten-x-hacker' var `--theme-anchor-color`

### DIFF
--- a/app/views/layouts/_user_config.html.erb
+++ b/app/views/layouts/_user_config.html.erb
@@ -47,7 +47,7 @@
         --theme-code-background: #29292e;\
         --theme-code-color: #42ff87;\
         --theme-reaction-background: #202c3d;\
-        --theme-anchor-color: #42ff87;\
+        --theme-anchor-color: #e24ec1;\
         --theme-secondary-color: #ebebeb;\
         --theme-secondary-color-border: 1px solid #cedae2;\
         --theme-top-bar-background: #1c1c1c;\


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

Simply updated the `ten-x-hacker-theme` variable `--theme-anchor-color` in order to make links stand out. Currently they are the same color as the rest of the paragraph text with no other identifiers to let the user know it is a link - one literally has to hover over the text and watch the cursor change to find them.

## Related Tickets & Documents

#4794

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![screenshot_2019-11-16_22-41-48](https://user-images.githubusercontent.com/7415984/68999573-51f66000-08c2-11ea-91d8-55531983eb38.png)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

