### PR TITLE
Simplify sort tests in user_sorts_dashboard_articles_spec.rb

### DIFF
--- a/spec/system/dashboards/user_sorts_dashboard_articles_spec.rb
+++ b/spec/system/dashboards/user_sorts_dashboard_articles_spec.rb
@@ -7,16 +7,18 @@ RSpec.describe "Sorting Dashboard Articles", type: :system, js: true do
   let(:article3) { create(:article, user_id: user.id, published_at: 5.minutes.ago, created_at: 3.days.ago, positive_reactions_count: 0, page_views_count: 1000, comments_count: 50) }
   let(:articles) { [article1, article2, article3] }
 
-  let(:comments_count_to_article) do
+  let(:article_with_comments_count_of) do
     ->(target_count) { articles.detect { |article| article.comments_count == target_count } }
   end
 
   let(:test_article_order) do
     lambda do |url, expected_article_array|
       visit url
-      comments_counts_as_displayed = page.all(".single-article .comments-count span.value").map { |e| e.text.to_i }
-      articles_as_displayed = comments_counts_as_displayed.map { |count| comments_count_to_article.call(count) }
-      expect(articles_as_displayed).to eq(expected_article_array)
+      comments_counts_on_page = page.all(".single-article .comments-count span.value").map { |e| e.text.to_i }
+      articles_on_page = comments_counts_on_page.map do |count|
+        article_with_comments_count_of.call(count)
+      end
+      expect(articles_on_page).to eq(expected_article_array)
     end
   end
 

--- a/spec/system/dashboards/user_sorts_dashboard_articles_spec.rb
+++ b/spec/system/dashboards/user_sorts_dashboard_articles_spec.rb
@@ -5,6 +5,20 @@ RSpec.describe "Sorting Dashboard Articles", type: :system, js: true do
   let(:article1) { create(:article, user_id: user.id, published_at: 10.minutes.ago, created_at: 1.day.ago, positive_reactions_count: 5, page_views_count: 0, comments_count: 100) }
   let(:article2) { create(:article, user_id: user.id, published_at: 1.minute.ago, created_at: 2.days.ago, positive_reactions_count: 1, page_views_count: 10, comments_count: 0) }
   let(:article3) { create(:article, user_id: user.id, published_at: 5.minutes.ago, created_at: 3.days.ago, positive_reactions_count: 0, page_views_count: 1000, comments_count: 50) }
+  let(:articles) { [article1, article2, article3] }
+
+  let(:comments_count_to_article) do
+    ->(target_count) { articles.detect { |article| article.comments_count == target_count } }
+  end
+
+  let(:test_article_order) do
+    lambda do |url, expected_article_array|
+      visit url
+      comments_counts_as_displayed = page.all(".single-article .comments-count span.value").map { |e| e.text.to_i }
+      articles_as_displayed = comments_counts_as_displayed.map { |count| comments_count_to_article.call(count) }
+      expect(articles_as_displayed).to eq(expected_article_array)
+    end
+  end
 
   before do
     article1
@@ -14,56 +28,26 @@ RSpec.describe "Sorting Dashboard Articles", type: :system, js: true do
   end
 
   it "shows articles sorted by default in created_at DESC" do
-    visit "/dashboard"
-    values = page.all(".single-article .comments-count span.value").map { |e| e.text.to_i }
-    value1 = article1.comments_count # 1 days ago
-    value2 = article2.comments_count # 2 days ago
-    value3 = article3.comments_count # 3 days ago
-    expect(values).to eql([value1, value2, value3])
+    test_article_order.call("/dashboard", [article1, article2, article3])
   end
 
   it "shows articles sorted by created_at ASC" do
-    visit "/dashboard?sort=creation-asc"
-    values = page.all(".single-article .comments-count span.value").map { |e| e.text.to_i }
-    value3 = article3.comments_count # 3 days ago
-    value2 = article2.comments_count # 2 days ago
-    value1 = article1.comments_count # 1 days ago
-    expect(values).to eql([value3, value2, value1])
+    test_article_order.call("/dashboard?sort=creation-asc", [article3, article2, article1])
   end
 
   it "shows articles sorted by comments_count DESC" do
-    visit "/dashboard?sort=comments-desc"
-    values = page.all(".single-article .comments-count span.value").map { |e| e.text.to_i }
-    value1 = article1.comments_count # 100
-    value3 = article3.comments_count # 50
-    value2 = article2.comments_count # 0
-    expect(values).to eql([value1, value3, value2])
+    test_article_order.call("/dashboard?sort=comments-desc", [article1, article3, article2])
   end
 
   it "shows articles sorted by page_views_count ASC" do
-    visit "/dashboard?sort=views-asc"
-    values = page.all(".single-article .comments-count span.value").map { |e| e.text.to_i }
-    value1 = article1.comments_count # 0
-    value2 = article2.comments_count # 10
-    value3 = article3.comments_count # 100
-    expect(values).to eql([value1, value2, value3])
+    test_article_order.call("/dashboard?sort=views-asc", [article1, article2, article3])
   end
 
   it "shows articles sorted by positive_reactions_count ASC" do
-    visit "/dashboard?sort=reactions-asc"
-    values = page.all(".single-article .comments-count span.value").map { |e| e.text.to_i }
-    value3 = article3.comments_count # 0
-    value2 = article2.comments_count # 1
-    value1 = article1.comments_count # 5
-    expect(values).to eql([value3, value2, value1])
+    test_article_order.call("/dashboard?sort=reactions-asc", [article3, article2, article1])
   end
 
   it "shows articles sorted by published_at DESC" do
-    visit "/dashboard?sort=published-desc"
-    values = page.all(".single-article .comments-count span.value").map { |e| e.text.to_i }
-    value2 = article2.comments_count # 10 minutes ago
-    value3 = article3.comments_count # 5 minutes ago
-    value1 = article1.comments_count # 1 minute ago
-    expect(values).to eql([value2, value3, value1])
+    test_article_order.call("/dashboard?sort=published-desc", [article2, article3, article1])
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

For reasons unknown to me, the `it "shows articles sorted by positive_reactions_count ASC"` test in `user_sorts_dashboard_articles_spec.rb` file failed when I ran it. (It no longer fails.)  I examined that file.  I realize that the style of test code used currently is popular, but think that if the tests were expressed differently they would have been easier for me (and, I believe, future others) to understand. The changes I recommend are in this PR. I believe they would improve the test code by:

* separating high from low level code
* enabling the high level code (`it` clause) to more clearly express the nature of the specific test (as it differs from other tests), because there is no low level code there to dilute the high level code (i.e. the call to the lambda)
* reduce the cost of adding similar tests
* reduce code size

I use lambdas rather than RSpec shared examples because they are simpler. For example, there is no need to move code around to avoid scoping issues when using lambdas.

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed