### PR TITLE
Add additional keys to site configuration

### DIFF
--- a/app/controllers/internal/configs_controller.rb
+++ b/app/controllers/internal/configs_controller.rb
@@ -22,6 +22,7 @@ class Internal::ConfigsController < Internal::ApplicationController
       ga_view_id ga_fetch_rate
       mailchimp_newsletter_id mailchimp_sustaining_members_id
       mailchimp_tag_moderators_id mailchimp_community_moderators_id
+      periodic_email_digest_max periodic_email_digest_min
     ]
     params.require(:site_config).permit(allowed_params)
   end

--- a/app/controllers/internal/configs_controller.rb
+++ b/app/controllers/internal/configs_controller.rb
@@ -15,7 +15,7 @@ class Internal::ConfigsController < Internal::ApplicationController
   private
 
   def config_params
-    allowed_params = %i[main_social_image favicon_url logo_svg rate_limit_follow_count_daily]
+    allowed_params = %i[staff_user_id main_social_image favicon_url logo_svg rate_limit_follow_count_daily]
     params.require(:site_config).permit(allowed_params)
   end
 end

--- a/app/controllers/internal/configs_controller.rb
+++ b/app/controllers/internal/configs_controller.rb
@@ -15,7 +15,11 @@ class Internal::ConfigsController < Internal::ApplicationController
   private
 
   def config_params
-    allowed_params = %i[staff_user_id main_social_image favicon_url logo_svg rate_limit_follow_count_daily]
+    allowed_params = %i[
+      staff_user_id default_site_email
+      main_social_image favicon_url logo_svg
+      rate_limit_follow_count_daily
+    ]
     params.require(:site_config).permit(allowed_params)
   end
 end

--- a/app/controllers/internal/configs_controller.rb
+++ b/app/controllers/internal/configs_controller.rb
@@ -13,7 +13,7 @@ class Internal::ConfigsController < Internal::ApplicationController
   private
 
   def config_params
-    allowed_params = %i[main_social_image rate_limit_follow_count_daily]
+    allowed_params = %i[main_social_image favicon_url rate_limit_follow_count_daily]
     params.require(:site_config).permit(allowed_params)
   end
 end

--- a/app/controllers/internal/configs_controller.rb
+++ b/app/controllers/internal/configs_controller.rb
@@ -13,7 +13,7 @@ class Internal::ConfigsController < Internal::ApplicationController
   private
 
   def config_params
-    # put this stuff in the policy or in the model
-    params.require(:site_config).permit(:main_social_image)
+    allowed_params = %i[main_social_image rate_limit_follow_count_daily]
+    params.require(:site_config).permit(allowed_params)
   end
 end

--- a/app/controllers/internal/configs_controller.rb
+++ b/app/controllers/internal/configs_controller.rb
@@ -19,6 +19,7 @@ class Internal::ConfigsController < Internal::ApplicationController
       staff_user_id default_site_email social_networks_handle
       main_social_image favicon_url logo_svg
       rate_limit_follow_count_daily
+      ga_view_id ga_fetch_rate
     ]
     params.require(:site_config).permit(allowed_params)
   end

--- a/app/controllers/internal/configs_controller.rb
+++ b/app/controllers/internal/configs_controller.rb
@@ -1,7 +1,9 @@
 class Internal::ConfigsController < Internal::ApplicationController
   layout "internal"
 
-  def show; end
+  def show
+    @logo_svg = SiteConfig.logo_svg.html_safe # rubocop:disable Rails/OutputSafety
+  end
 
   def create
     config_params.keys.each do |key|
@@ -13,7 +15,7 @@ class Internal::ConfigsController < Internal::ApplicationController
   private
 
   def config_params
-    allowed_params = %i[main_social_image favicon_url rate_limit_follow_count_daily]
+    allowed_params = %i[main_social_image favicon_url logo_svg rate_limit_follow_count_daily]
     params.require(:site_config).permit(allowed_params)
   end
 end

--- a/app/controllers/internal/configs_controller.rb
+++ b/app/controllers/internal/configs_controller.rb
@@ -16,7 +16,7 @@ class Internal::ConfigsController < Internal::ApplicationController
 
   def config_params
     allowed_params = %i[
-      staff_user_id default_site_email
+      staff_user_id default_site_email social_networks_handle
       main_social_image favicon_url logo_svg
       rate_limit_follow_count_daily
     ]

--- a/app/controllers/internal/configs_controller.rb
+++ b/app/controllers/internal/configs_controller.rb
@@ -20,6 +20,8 @@ class Internal::ConfigsController < Internal::ApplicationController
       main_social_image favicon_url logo_svg
       rate_limit_follow_count_daily
       ga_view_id ga_fetch_rate
+      mailchimp_newsletter_id mailchimp_sustaining_members_id
+      mailchimp_tag_moderators_id mailchimp_community_moderators_id
     ]
     params.require(:site_config).permit(allowed_params)
   end

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -10,6 +10,7 @@ class SiteConfig < RailsSettings::Base
 
   # staff account
   field :staff_user_id, type: :integer, default: 1
+  field :default_site_email, type: :string, default: "yo@dev.to"
 
   # images
   field :main_social_image, type: :string, default: "https://thepracticaldev.s3.amazonaws.com/i/6hqmcjaxbgbon8ydw93z.png"

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -25,4 +25,11 @@ class SiteConfig < RailsSettings::Base
   # <https://developers.google.com/analytics/devguides/reporting/core/v4>
   field :ga_view_id, type: :string, default: ""
   field :ga_fetch_rate, type: :integer, default: 25
+
+  # Mailchimp lists IDs
+  # <https://mailchimp.com/developer/>
+  field :mailchimp_newsletter_id, type: :string, default: ""
+  field :mailchimp_sustaining_members_id, type: :string, default: ""
+  field :mailchimp_tag_moderators_id, type: :string, default: ""
+  field :mailchimp_community_moderators_id, type: :string, default: ""
 end

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -8,5 +8,9 @@ class SiteConfig < RailsSettings::Base
   # the cache, or call SiteConfig.clear_cache
   cache_prefix { "v1" }
 
-  field :main_social_image, default: "https://thepracticaldev.s3.amazonaws.com/i/6hqmcjaxbgbon8ydw93z.png"
+  # images
+  field :main_social_image, type: :string, default: "https://thepracticaldev.s3.amazonaws.com/i/6hqmcjaxbgbon8ydw93z.png"
+
+  # rate limits
+  field :rate_limit_follow_count_daily, type: :integer, default: 500
 end

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -32,4 +32,8 @@ class SiteConfig < RailsSettings::Base
   field :mailchimp_sustaining_members_id, type: :string, default: ""
   field :mailchimp_tag_moderators_id, type: :string, default: ""
   field :mailchimp_community_moderators_id, type: :string, default: ""
+
+  # Email digest frequency
+  field :periodic_email_digest_max, type: :integer, default: 0
+  field :periodic_email_digest_min, type: :integer, default: 2
 end

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -9,8 +9,9 @@ class SiteConfig < RailsSettings::Base
   cache_prefix { "v1" }
 
   # staff account
-  field :staff_user_id, type: :integer, default: 1
+  field :staff_user_id, type: :integer, default: 1 # will replace DEVTO_USER_ID
   field :default_site_email, type: :string, default: "yo@dev.to"
+  field :social_networks_handle, type: :string, default: "thepracticaldev" # will replace SITE_TWITTER_HANDLE
 
   # images
   field :main_social_image, type: :string, default: "https://thepracticaldev.s3.amazonaws.com/i/6hqmcjaxbgbon8ydw93z.png"

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -11,6 +11,7 @@ class SiteConfig < RailsSettings::Base
   # images
   field :main_social_image, type: :string, default: "https://thepracticaldev.s3.amazonaws.com/i/6hqmcjaxbgbon8ydw93z.png"
   field :favicon_url, type: :string, default: "favicon.ico"
+  field :logo_svg, type: :string, default: ""
 
   # rate limits
   field :rate_limit_follow_count_daily, type: :integer, default: 500

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -20,4 +20,9 @@ class SiteConfig < RailsSettings::Base
 
   # rate limits
   field :rate_limit_follow_count_daily, type: :integer, default: 500
+
+  # Google Analytics Reporting API v4
+  # <https://developers.google.com/analytics/devguides/reporting/core/v4>
+  field :ga_view_id, type: :string, default: ""
+  field :ga_fetch_rate, type: :integer, default: 25
 end

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -8,6 +8,9 @@ class SiteConfig < RailsSettings::Base
   # the cache, or call SiteConfig.clear_cache
   cache_prefix { "v1" }
 
+  # staff account
+  field :staff_user_id, type: :integer, default: 1
+
   # images
   field :main_social_image, type: :string, default: "https://thepracticaldev.s3.amazonaws.com/i/6hqmcjaxbgbon8ydw93z.png"
   field :favicon_url, type: :string, default: "favicon.ico"

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -10,6 +10,7 @@ class SiteConfig < RailsSettings::Base
 
   # images
   field :main_social_image, type: :string, default: "https://thepracticaldev.s3.amazonaws.com/i/6hqmcjaxbgbon8ydw93z.png"
+  field :favicon_url, type: :string, default: "favicon.ico"
 
   # rate limits
   field :rate_limit_follow_count_daily, type: :integer, default: 500

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -122,6 +122,43 @@
     </div>
   </div>
 
+  <div class="panel panel-default">
+    <div class="panel-heading">Mailchimp Lists IDs</div>
+    <div class="panel-body">
+      <div class="form-group">
+        <%= f.label "Main Newsletter" %>
+        <%= f.text_field :mailchimp_newsletter_id,
+                         class: "form-control",
+                         value: SiteConfig.mailchimp_newsletter_id %>
+        <span class="help-block">Main Newsletter ID</span>
+      </div>
+
+      <div class="form-group">
+        <%= f.label "Sustaining Members Newsletter" %>
+        <%= f.text_field :mailchimp_sustaining_members_id,
+                         class: "form-control",
+                         value: SiteConfig.mailchimp_sustaining_members_id %>
+        <span class="help-block">Sustaining Members Newsletter ID</span>
+      </div>
+
+      <div class="form-group">
+        <%= f.label "Tag Moderators Newsletter" %>
+        <%= f.text_field :mailchimp_tag_moderators_id,
+                         class: "form-control",
+                         value: SiteConfig.mailchimp_tag_moderators_id %>
+        <span class="help-block">Tag Moderators Newsletter ID</span>
+      </div>
+
+      <div class="form-group">
+        <%= f.label "Community Moderators Newsletter" %>
+        <%= f.text_field :mailchimp_community_moderators_id,
+                         class: "form-control",
+                         value: SiteConfig.mailchimp_community_moderators_id %>
+        <span class="help-block">Community Moderators Newsletter ID</span>
+      </div>
+    </div>
+  </div>
+
   <div class="form-group">
     <%= f.submit "Update site configuration", class: "btn btn-primary" %>
   </div>

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -16,6 +16,21 @@
 
 <%= form_for(SiteConfig.new, url: internal_config_path) do |f| %>
   <div class="panel panel-default">
+    <div class="panel-heading">Staff</div>
+    <div class="panel-body">
+      <div class="form-group">
+        <%= f.label :staff_user_id %>
+        <%= f.number_field :staff_user_id,
+                           class: "form-control",
+                           value: SiteConfig.staff_user_id,
+                           min: 1,
+                           placeholder: "1" %>
+        <span class="help-block">The user id of the staff account</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="panel panel-default">
     <div class="panel-heading">Images</div>
     <div class="panel-body">
       <div class="form-group">

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -103,7 +103,7 @@
     <div class="panel-heading">Google Analytics Reporting API v4</div>
     <div class="panel-body">
       <div class="form-group">
-        <%= f.label "View ID" %>
+        <%= f.label :ga_view_id, "View ID" %>
         <%= f.text_field :ga_view_id,
                          class: "form-control",
                          value: SiteConfig.ga_view_id %>
@@ -111,7 +111,7 @@
       </div>
 
       <div class="form-group">
-        <%= f.label "Fetch rate" %>
+        <%= f.label :ga_fetch_rate, "Fetch rate" %>
         <%= f.number_field :ga_fetch_rate,
                            class: "form-control",
                            value: SiteConfig.ga_fetch_rate,
@@ -126,7 +126,7 @@
     <div class="panel-heading">Mailchimp Lists IDs</div>
     <div class="panel-body">
       <div class="form-group">
-        <%= f.label "Main Newsletter" %>
+        <%= f.label :mailchimp_newsletter_id, "Main Newsletter" %>
         <%= f.text_field :mailchimp_newsletter_id,
                          class: "form-control",
                          value: SiteConfig.mailchimp_newsletter_id %>
@@ -134,7 +134,7 @@
       </div>
 
       <div class="form-group">
-        <%= f.label "Sustaining Members Newsletter" %>
+        <%= f.label :mailchimp_sustaining_members_id, "Sustaining Members Newsletter" %>
         <%= f.text_field :mailchimp_sustaining_members_id,
                          class: "form-control",
                          value: SiteConfig.mailchimp_sustaining_members_id %>
@@ -142,7 +142,7 @@
       </div>
 
       <div class="form-group">
-        <%= f.label "Tag Moderators Newsletter" %>
+        <%= f.label :mailchimp_tag_moderators_id, "Tag Moderators Newsletter" %>
         <%= f.text_field :mailchimp_tag_moderators_id,
                          class: "form-control",
                          value: SiteConfig.mailchimp_tag_moderators_id %>
@@ -150,11 +150,34 @@
       </div>
 
       <div class="form-group">
-        <%= f.label "Community Moderators Newsletter" %>
+        <%= f.label :mailchimp_community_moderators_id, "Community Moderators Newsletter" %>
         <%= f.text_field :mailchimp_community_moderators_id,
                          class: "form-control",
                          value: SiteConfig.mailchimp_community_moderators_id %>
         <span class="help-block">Community Moderators Newsletter ID</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="panel panel-default">
+    <div class="panel-heading">Email digest frequency</div>
+    <div class="panel-body">
+      <div class="form-group">
+        <%= f.label :periodic_email_digest_max %>
+        <%= f.number_field :periodic_email_digest_max,
+                           class: "form-control",
+                           value: SiteConfig.periodic_email_digest_max,
+                           placeholder: 0 %>
+        <span class="help-block">Determines the maximum for the periodic email digest</span>
+      </div>
+
+      <div class="form-group">
+        <%= f.label :periodic_email_digest_min %>
+        <%= f.number_field :periodic_email_digest_min,
+                           class: "form-control",
+                           value: SiteConfig.periodic_email_digest_min,
+                           placeholder: 2 %>
+        <span class="help-block">Determines the mininum for the periodic email digest</span>
       </div>
     </div>
   </div>

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -36,6 +36,15 @@
                           placeholder: "email@staff.com" %>
         <span class="help-block">Email of the staff account</span>
       </div>
+
+      <div class="form-group">
+        <%= f.label :social_networks_handle %>
+        <%= f.text_field :social_networks_handle,
+                         class: "form-control",
+                         value: SiteConfig.social_networks_handle,
+                         placeholder: "thepracticaldev" %>
+        <span class="help-block">Social networks handle (eg. Twitter, GitHub)</span>
+      </div>
     </div>
   </div>
 

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -93,8 +93,31 @@
                            class: "form-control",
                            value: SiteConfig.rate_limit_follow_count_daily,
                            min: 0,
-                           placeholder: "500" %>
+                           placeholder: 500 %>
         <span class="help-block">Used to limit the amount of users a person can follow daily</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="panel panel-default">
+    <div class="panel-heading">Google Analytics Reporting API v4</div>
+    <div class="panel-body">
+      <div class="form-group">
+        <%= f.label "View ID" %>
+        <%= f.text_field :ga_view_id,
+                         class: "form-control",
+                         value: SiteConfig.ga_view_id %>
+        <span class="help-block">Google Analytics Reporting API v4 - View ID</span>
+      </div>
+
+      <div class="form-group">
+        <%= f.label "Fetch rate" %>
+        <%= f.number_field :ga_fetch_rate,
+                           class: "form-control",
+                           value: SiteConfig.ga_fetch_rate,
+                           min: 1,
+                           placeholder: 1 %>
+        <span class="help-block">Determines how often the site updates its Google Analytics stats</span>
       </div>
     </div>
   </div>

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -19,13 +19,28 @@
     <div class="panel-heading">Images</div>
     <div class="panel-body">
       <div class="form-group">
-        <%= f.label "Main social image" %>
+        <%= f.label :main_social_image %>
         <%= f.text_field :main_social_image,
                          class: "form-control",
                          value: SiteConfig.main_social_image,
                          placeholder: "https://image.url" %>
         <span class="help-block">Used as the main image in social networks and OpenGraph</span>
         <img alt="main social image" class="preview" src="<%= SiteConfig.main_social_image %>" width="50%" />
+      </div>
+    </div>
+  </div>
+
+  <div class="panel panel-default">
+    <div class="panel-heading">Rate limits</div>
+    <div class="panel-body">
+      <div class="form-group">
+        <%= f.label :rate_limit_follow_count_daily %>
+        <%= f.number_field :rate_limit_follow_count_daily,
+                           class: "form-control",
+                           value: SiteConfig.rate_limit_follow_count_daily,
+                           min: 0,
+                           placeholder: "500" %>
+        <span class="help-block">Used to limit the amount of users a person can follow daily</span>
       </div>
     </div>
   </div>

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -37,6 +37,17 @@
         <span class="help-block">Used as the site favicon</span>
         <img alt="favicon" class="preview" src="<%= SiteConfig.favicon_url %>" />
       </div>
+
+      <div class="form-group">
+        <%= f.label :logo_svg %>
+        <%= f.text_area :logo_svg,
+                        class: "form-control",
+                        value: SiteConfig.logo_svg,
+                        rows: 6,
+                        placeholder: "<svg ...></svg>" %>
+        <span class="help-block">Used as the SVG logo of the community</span>
+        <%= @logo_svg %>
+      </div>
     </div>
   </div>
 

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -27,6 +27,16 @@
         <span class="help-block">Used as the main image in social networks and OpenGraph</span>
         <img alt="main social image" class="preview" src="<%= SiteConfig.main_social_image %>" width="50%" />
       </div>
+
+      <div class="form-group">
+        <%= f.label :favicon_url %>
+        <%= f.text_field :favicon_url,
+                         class: "form-control",
+                         value: SiteConfig.favicon_url,
+                         placeholder: "https://image.url" %>
+        <span class="help-block">Used as the site favicon</span>
+        <img alt="favicon" class="preview" src="<%= SiteConfig.favicon_url %>" />
+      </div>
     </div>
   </div>
 

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -25,7 +25,16 @@
                            value: SiteConfig.staff_user_id,
                            min: 1,
                            placeholder: "1" %>
-        <span class="help-block">The user id of the staff account</span>
+        <span class="help-block">User ID of the staff account</span>
+      </div>
+
+      <div class="form-group">
+        <%= f.label :default_site_email %>
+        <%= f.email_field :default_site_email,
+                          class: "form-control",
+                          value: SiteConfig.default_site_email,
+                          placeholder: "email@staff.com" %>
+        <span class="help-block">Email of the staff account</span>
       </div>
     </div>
   </div>

--- a/spec/requests/internal/configs_spec.rb
+++ b/spec/requests/internal/configs_spec.rb
@@ -19,9 +19,17 @@ RSpec.describe "/internal/config", type: :request do
       sign_in(admin)
     end
 
-    it "updates staff_user_id" do
-      post "/internal/config", params: { site_config: { staff_user_id: 2 } }
-      expect(SiteConfig.staff_user_id).to eq(2)
+    describe "staff" do
+      it "updates staff_user_id" do
+        post "/internal/config", params: { site_config: { staff_user_id: 2 } }
+        expect(SiteConfig.staff_user_id).to eq(2)
+      end
+
+      it "updates default_site_email" do
+        expected_email = "foo@bar.com"
+        post "/internal/config", params: { site_config: { default_site_email: expected_email } }
+        expect(SiteConfig.default_site_email).to eq(expected_email)
+      end
     end
 
     describe "images" do
@@ -44,9 +52,11 @@ RSpec.describe "/internal/config", type: :request do
       end
     end
 
-    it "updates rate_limit_follow_count_daily" do
-      post "/internal/config", params: { site_config: { rate_limit_follow_count_daily: 3 } }
-      expect(SiteConfig.rate_limit_follow_count_daily).to eq(3)
+    describe "rate limits" do
+      it "updates rate_limit_follow_count_daily" do
+        post "/internal/config", params: { site_config: { rate_limit_follow_count_daily: 3 } }
+        expect(SiteConfig.rate_limit_follow_count_daily).to eq(3)
+      end
     end
   end
 end

--- a/spec/requests/internal/configs_spec.rb
+++ b/spec/requests/internal/configs_spec.rb
@@ -19,6 +19,11 @@ RSpec.describe "/internal/config", type: :request do
       sign_in(admin)
     end
 
+    it "updates staff_user_id" do
+      post "/internal/config", params: { site_config: { staff_user_id: 2 } }
+      expect(SiteConfig.staff_user_id).to eq(2)
+    end
+
     describe "images" do
       it "updates main_social_image" do
         expected_image_url = "https://dummyimage.com/300x300"

--- a/spec/requests/internal/configs_spec.rb
+++ b/spec/requests/internal/configs_spec.rb
@@ -64,5 +64,17 @@ RSpec.describe "/internal/config", type: :request do
         expect(SiteConfig.rate_limit_follow_count_daily).to eq(3)
       end
     end
+
+    describe "Google Analytics Reporting API v4" do
+      it "updates ga_view_id" do
+        post "/internal/config", params: { site_config: { ga_view_id: "abc" } }
+        expect(SiteConfig.ga_view_id).to eq("abc")
+      end
+
+      it "updates ga_fetch_rate" do
+        post "/internal/config", params: { site_config: { ga_fetch_rate: 3 } }
+        expect(SiteConfig.ga_fetch_rate).to eq(3)
+      end
+    end
   end
 end

--- a/spec/requests/internal/configs_spec.rb
+++ b/spec/requests/internal/configs_spec.rb
@@ -25,5 +25,10 @@ RSpec.describe "/internal/config", type: :request do
       post "/internal/config", params: { site_config: { main_social_image: expected_image_url } }
       expect(SiteConfig.main_social_image).to eq(expected_image_url)
     end
+
+    it "updates rate_limit_follow_count_daily" do
+      post "/internal/config", params: { site_config: { rate_limit_follow_count_daily: 3 } }
+      expect(SiteConfig.rate_limit_follow_count_daily).to eq(3)
+    end
   end
 end

--- a/spec/requests/internal/configs_spec.rb
+++ b/spec/requests/internal/configs_spec.rb
@@ -31,6 +31,12 @@ RSpec.describe "/internal/config", type: :request do
         post "/internal/config", params: { site_config: { favicon_url: expected_image_url } }
         expect(SiteConfig.favicon_url).to eq(expected_image_url)
       end
+
+      it "updates logo_svg" do
+        expected_image_url = "https://dummyimage.com/300x300"
+        post "/internal/config", params: { site_config: { logo_svg: expected_image_url } }
+        expect(SiteConfig.logo_svg).to eq(expected_image_url)
+      end
     end
 
     it "updates rate_limit_follow_count_daily" do

--- a/spec/requests/internal/configs_spec.rb
+++ b/spec/requests/internal/configs_spec.rb
@@ -76,5 +76,27 @@ RSpec.describe "/internal/config", type: :request do
         expect(SiteConfig.ga_fetch_rate).to eq(3)
       end
     end
+
+    describe "Mailchimp lists IDs" do
+      it "updates mailchimp_newsletter_id" do
+        post "/internal/config", params: { site_config: { mailchimp_newsletter_id: "abc" } }
+        expect(SiteConfig.mailchimp_newsletter_id).to eq("abc")
+      end
+
+      it "updates mailchimp_sustaining_members_id" do
+        post "/internal/config", params: { site_config: { mailchimp_sustaining_members_id: "abc" } }
+        expect(SiteConfig.mailchimp_sustaining_members_id).to eq("abc")
+      end
+
+      it "updates mailchimp_tag_moderators_id" do
+        post "/internal/config", params: { site_config: { mailchimp_tag_moderators_id: "abc" } }
+        expect(SiteConfig.mailchimp_tag_moderators_id).to eq("abc")
+      end
+
+      it "updates mailchimp_community_moderators_id" do
+        post "/internal/config", params: { site_config: { mailchimp_community_moderators_id: "abc" } }
+        expect(SiteConfig.mailchimp_community_moderators_id).to eq("abc")
+      end
+    end
   end
 end

--- a/spec/requests/internal/configs_spec.rb
+++ b/spec/requests/internal/configs_spec.rb
@@ -30,6 +30,12 @@ RSpec.describe "/internal/config", type: :request do
         post "/internal/config", params: { site_config: { default_site_email: expected_email } }
         expect(SiteConfig.default_site_email).to eq(expected_email)
       end
+
+      it "updates social_networks_handle" do
+        expected_handle = "tpd"
+        post "/internal/config", params: { site_config: { social_networks_handle: expected_handle } }
+        expect(SiteConfig.social_networks_handle).to eq(expected_handle)
+      end
     end
 
     describe "images" do

--- a/spec/requests/internal/configs_spec.rb
+++ b/spec/requests/internal/configs_spec.rb
@@ -19,11 +19,18 @@ RSpec.describe "/internal/config", type: :request do
       sign_in(admin)
     end
 
-    it "updates main_social_image" do
-      SiteConfig.main_social_image = "https://dummyimage.com/100x100"
-      expected_image_url = "https://dummyimage.com/300x300"
-      post "/internal/config", params: { site_config: { main_social_image: expected_image_url } }
-      expect(SiteConfig.main_social_image).to eq(expected_image_url)
+    describe "images" do
+      it "updates main_social_image" do
+        expected_image_url = "https://dummyimage.com/300x300"
+        post "/internal/config", params: { site_config: { main_social_image: expected_image_url } }
+        expect(SiteConfig.main_social_image).to eq(expected_image_url)
+      end
+
+      it "updates favicon_url" do
+        expected_image_url = "https://dummyimage.com/300x300"
+        post "/internal/config", params: { site_config: { favicon_url: expected_image_url } }
+        expect(SiteConfig.favicon_url).to eq(expected_image_url)
+      end
     end
 
     it "updates rate_limit_follow_count_daily" do

--- a/spec/requests/internal/configs_spec.rb
+++ b/spec/requests/internal/configs_spec.rb
@@ -98,5 +98,17 @@ RSpec.describe "/internal/config", type: :request do
         expect(SiteConfig.mailchimp_community_moderators_id).to eq("abc")
       end
     end
+
+    describe "Email digest frequency" do
+      it "updates periodic_email_digest_max" do
+        post "/internal/config", params: { site_config: { periodic_email_digest_max: 1 } }
+        expect(SiteConfig.periodic_email_digest_max).to eq(1)
+      end
+
+      it "updates periodic_email_digest_min" do
+        post "/internal/config", params: { site_config: { periodic_email_digest_min: 3 } }
+        expect(SiteConfig.periodic_email_digest_min).to eq(3)
+      end
+    end
   end
 end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

After https://github.com/thepracticaldev/dev.to/pull/4831 was merged I added all the various site config keys to the new model and to the page.

As agreed, for now none of these are used anywhere in the site.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![Screenshot_2019-11-19 configs(1)](https://user-images.githubusercontent.com/146201/69167088-a54ff480-0af4-11ea-9124-ffe99bafe221.png)
