### PR TITLE
Add script to display and migrate environment variables to SiteConfig

### DIFF
--- a/lib/tasks/temporary/migrate_environment_variables_site_config.rake
+++ b/lib/tasks/temporary/migrate_environment_variables_site_config.rake
@@ -1,0 +1,58 @@
+# Migrate environment variables to SiteConfig
+
+ENV_VARS_TO_SITE_CONFIG = {
+  DEVTO_USER_ID: :staff_user_id,
+  DEFAULT_SITE_EMAIL: :default_site_email,
+  SITE_TWITTER_HANDLE: :social_networks_handle,
+
+  MAIN_SOCIAL_IMAGE: :main_social_image,
+  FAVICON_URL: :favicon_url,
+  LOGO_SVG: :logo_svg,
+
+  RATE_LIMIT_FOLLOW_COUNT_DAILY: :rate_limit_follow_count_daily,
+
+  GA_VIEW_ID: :ga_view_id,
+  GA_FETCH_RATE: :ga_fetch_rate,
+
+  MAILCHIMP_NEWSLETTER_ID: :mailchimp_newsletter_id,
+  MAILCHIMP_SUSTAINING_MEMBERS_ID: :mailchimp_sustaining_members_id,
+  MAILCHIMP_TAG_MODERATORS_ID: :mailchimp_tag_moderators_id,
+  MAILCHIMP_COMMUNITY_MODERATORS_ID: :mailchimp_community_moderators_id,
+
+  PERIODIC_EMAIL_DIGEST_MAX: :periodic_email_digest_max,
+  PERIODIC_EMAIL_DIGEST_MIN: :periodic_email_digest_min
+}.freeze
+
+def display_vars(env_var, config_var)
+  env_var_value = "ApplicationConfig[#{env_var}] = #{ApplicationConfig[env_var]}"
+  config_var_value = "SiteConfig.#{config_var} = #{SiteConfig.public_send(config_var)}"
+  Rails.logger.info([env_var_value, config_var_value].join(", "))
+end
+
+namespace :site_config do
+  desc "Display variables values"
+  task display_variables: :environment do
+    ENV_VARS_TO_SITE_CONFIG.each do |env_var, config_var|
+      display_vars(env_var, config_var)
+    end
+  end
+
+  desc "Copy non empty environment variables over to the site configuration"
+  task migrate_environment_variables: :environment do
+    ENV_VARS_TO_SITE_CONFIG.each do |env_var, config_var|
+      if ApplicationConfig[env_var].blank? || ApplicationConfig[env_var] == "Optional"
+        Rails.logger.info("Skipping #{env_var} because it is empty...")
+        next
+      end
+
+      Rails.logger.info("Copying ApplicationConfig[#{env_var}] to SiteConfig.#{config_var}...")
+      SiteConfig.public_send("#{config_var}=", ApplicationConfig[env_var])
+    end
+
+    SiteConfig.clear_cache
+
+    ENV_VARS_TO_SITE_CONFIG.each do |env_var, config_var|
+      display_vars(env_var, config_var)
+    end
+  end
+end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

After https://github.com/thepracticaldev/dev.to/pull/4861 the next step is to migrate environment variables values to their correspondent site configuration.

This temporary script does that.

There are two tasks, the first one displays the content of both environment variables and site configuration: `rails site_config:display_variables`

The second, `rails site_config:migrate_environment_variables` goes through the variables and copies their values from the environment to the site config. It also clears the configuration cache and displays the final values at the end. It does not copy over variables that are empty or valued "Optional" (to avoid overriding defaults).

After the script has run please check the `/internal/config` to make sure all the values are correctly set. 

Only then I'll start migrating each variable one by one to get rid of the env values.
