### PR TITLE
Saved articles does not gets updated under reading list immediately

### DIFF
--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -62,8 +62,8 @@ class ReactionsController < ApplicationController
         category: category,
       )
       @result = "create"
-      Notification.send_reaction_notification(reaction, reaction.reactable.user)
-      Notification.send_reaction_notification(reaction, reaction.reactable.organization) if organization_article?(reaction)
+      Notification.send_reaction_notification_without_delay(reaction, reaction.reactable.user)
+      Notification.send_reaction_notification_without_delay(reaction, reaction.reactable.organization) if organization_article?(reaction)
     end
     render json: { result: @result, category: category }
   end


### PR DESCRIPTION
… - #4839

<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

- [x] Bug Fix

## Description

Articles are not reflected immediately under the 'reading list' after saving it. It takes a few seconds to update. This issue happens due to the background job that takes a few seconds to complete.

Fix: Running `send_reaction_notification_without_delay` prioritizes the notifications to complete from the queue and the lists get updated immediately.

## Related Tickets & Documents

The issue is reported here - https://github.com/thepracticaldev/dev.to/issues/4839

- [x] no documentation needed
