### PR TITLE
Refactor raise_error(specific_error) expectation

### DIFF
--- a/spec/liquid_tags/jsitor_tag_spec.rb
+++ b/spec/liquid_tags/jsitor_tag_spec.rb
@@ -29,42 +29,42 @@ RSpec.describe JsitorTag, type: :liquid_tag do
       link = "   https://jsitor.com/embed/1QgJVmCam     "
       expect do
         create_jsitor_liquid_tag(link)
-      end.not_to raise_error(StandardError)
+      end.not_to raise_error
     end
 
     it "accepts jsitor link with query params" do
       link = "https://jsitor.com/embed/1QgJVmCam?html&css"
       expect do
         create_jsitor_liquid_tag(link)
-      end.not_to raise_error(StandardError)
+      end.not_to raise_error
     end
 
     it "accepts jsitor id" do
       link = "B7FQ5tHbY"
       expect do
         create_jsitor_liquid_tag(link)
-      end.not_to raise_error(StandardError)
+      end.not_to raise_error
     end
 
     it "accepts jsitor id with parameters" do
       link = "B7FQ5tHbY?html&css"
       expect do
         create_jsitor_liquid_tag(link)
-      end.not_to raise_error(StandardError)
+      end.not_to raise_error
     end
 
     it "accepts jsitor link with hyphen id" do
       link = "https://jsitor.com/embed/2o-syYxmi"
       expect do
         create_jsitor_liquid_tag(link)
-      end.not_to raise_error(StandardError)
+      end.not_to raise_error
     end
 
     it "accepts jsitor id with hyphen" do
       link = "2o-syYxmi"
       expect do
         create_jsitor_liquid_tag(link)
-      end.not_to raise_error(StandardError)
+      end.not_to raise_error
     end
 
     it "doesnt accepts jsitor link with a / at the end" do

--- a/spec/liquid_tags/jsitor_tag_spec.rb
+++ b/spec/liquid_tags/jsitor_tag_spec.rb
@@ -26,45 +26,45 @@ RSpec.describe JsitorTag, type: :liquid_tag do
     end
 
     it "parses the link with spaces before and after" do
-      link = "   https://jsitor.com/embed/1QgJVmCam     "
-      expect do
-        create_jsitor_liquid_tag(link)
-      end.not_to raise_error
+      link = "   https://jsitor.com/embed/B7FQ5tHbY     "
+      liquid = create_jsitor_liquid_tag(link)
+      render_jsitor_iframe = liquid.render
+      Approvals.verify(render_jsitor_iframe, name: "jsitor_liquid_tag", format: :html)
     end
 
     it "accepts jsitor link with query params" do
-      link = "https://jsitor.com/embed/1QgJVmCam?html&css"
-      expect do
-        create_jsitor_liquid_tag(link)
-      end.not_to raise_error
+      link = "https://jsitor.com/embed/B7FQ5tHbY?html&css"
+      liquid = create_jsitor_liquid_tag(link)
+      render_jsitor_iframe = liquid.render
+      Approvals.verify(render_jsitor_iframe, name: "jsitor_liquid_tag_with_params", format: :html)
     end
 
     it "accepts jsitor id" do
       link = "B7FQ5tHbY"
-      expect do
-        create_jsitor_liquid_tag(link)
-      end.not_to raise_error
+      liquid = create_jsitor_liquid_tag(link)
+      render_jsitor_iframe = liquid.render
+      Approvals.verify(render_jsitor_iframe, name: "jsitor_liquid_tag", format: :html)
     end
 
     it "accepts jsitor id with parameters" do
       link = "B7FQ5tHbY?html&css"
-      expect do
-        create_jsitor_liquid_tag(link)
-      end.not_to raise_error
+      liquid = create_jsitor_liquid_tag(link)
+      render_jsitor_iframe = liquid.render
+      Approvals.verify(render_jsitor_iframe, name: "jsitor_liquid_tag_with_params", format: :html)
     end
 
     it "accepts jsitor link with hyphen id" do
       link = "https://jsitor.com/embed/2o-syYxmi"
-      expect do
-        create_jsitor_liquid_tag(link)
-      end.not_to raise_error
+      liquid = create_jsitor_liquid_tag(link)
+      render_jsitor_iframe = liquid.render
+      Approvals.verify(render_jsitor_iframe, name: "jsitor_liquid_tag_with_hyphen", format: :html)
     end
 
     it "accepts jsitor id with hyphen" do
       link = "2o-syYxmi"
-      expect do
-        create_jsitor_liquid_tag(link)
-      end.not_to raise_error
+      liquid = create_jsitor_liquid_tag(link)
+      render_jsitor_iframe = liquid.render
+      Approvals.verify(render_jsitor_iframe, name: "jsitor_liquid_tag_with_hyphen", format: :html)
     end
 
     it "doesnt accepts jsitor link with a / at the end" do

--- a/spec/support/fixtures/approvals/jsitor_liquid_tag_with_hyphen.approved.html
+++ b/spec/support/fixtures/approvals/jsitor_liquid_tag_with_hyphen.approved.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <body>
+    <iframe height="400" src="https://jsitor.com/embed/2o-syYxmi" scrolling="no" frameborder="no" loading="lazy" allowtransparency="true" style="width: 100%;">
+</iframe>
+  </body>
+</html>

--- a/spec/support/fixtures/approvals/jsitor_liquid_tag_with_params.approved.html
+++ b/spec/support/fixtures/approvals/jsitor_liquid_tag_with_params.approved.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <body>
+    <iframe height="400" src="https://jsitor.com/embed/B7FQ5tHbY?html&amp;css" scrolling="no" frameborder="no" loading="lazy" allowtransparency="true" style="width: 100%;">
+</iframe>
+  </body>
+</html>


### PR DESCRIPTION
The full RSpec warning is

<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [√ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
Using `expect { }.not_to raise_error(SpecificErrorClass)` risks false positives, since literally any other error would cause the expectation to pass, including those raised by Ruby (e.g. NoMethodError, NameError and ArgumentError), meaning the code you are intending to test may not even get reached. Instead consider using `expect { }.not_to raise_error` or `expect { }.to raise_error(DifferentSpecificErrorClass)`.
 
## Related Tickets & Documents
[4862](https://github.com/thepracticaldev/dev.to/issues/4862)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [√ ] no documentation needed
