### PR TITLE
Remove extra dependencies for PageViewsController

### DIFF
--- a/app/controllers/application_metal_controller.rb
+++ b/app/controllers/application_metal_controller.rb
@@ -1,0 +1,10 @@
+class ApplicationMetalController < ActionController::Metal
+  # Any shared behavior across metal-oriented controllers can go here.
+
+  def session_current_user_id
+    # This method should stay in sync with the ApplicationController equivalent
+    # Could/should be extracted to the appropriate place for ideal code sharing and efficiency
+
+    session["warden.user.user.key"].flatten[0] if session["warden.user.user.key"].present?
+  end
+end

--- a/app/controllers/page_views_controller.rb
+++ b/app/controllers/page_views_controller.rb
@@ -1,4 +1,4 @@
-class PageViewsController < ActionController::Metal
+class PageViewsController < ApplicationMetalController
   # ActionController::Metal because we do not need all bells and whistles of ApplicationController
   include ActionController::Head
 
@@ -58,10 +58,5 @@ class PageViewsController < ActionController::Metal
     organic_count_past_month_count = page_views_from_google_com.
       where("created_at > ?", 1.month.ago).sum(:counts_for_number_of_views)
     @article.update_column(:organic_page_views_past_month_count, organic_count_past_month_count) if organic_count_past_month_count > @article.organic_page_views_past_month_count
-  end
-
-  def session_current_user_id
-    # custom defined here, because controller does not inherent from application_controller
-    session["warden.user.user.key"].flatten[0] if session["warden.user.user.key"].present?
   end
 end

--- a/app/controllers/page_views_controller.rb
+++ b/app/controllers/page_views_controller.rb
@@ -1,4 +1,4 @@
-class PageViewsController < ApplicationController
+class PageViewsController < ApplicationMetalController
   # ActionController::Metal because we do not need all bells and whistles of ApplicationController
   include ActionController::Head
 

--- a/app/controllers/page_views_controller.rb
+++ b/app/controllers/page_views_controller.rb
@@ -1,4 +1,4 @@
-class PageViewsController < ApplicationMetalController
+class PageViewsController < ApplicationController
   # ActionController::Metal because we do not need all bells and whistles of ApplicationController
   include ActionController::Head
 
@@ -30,7 +30,7 @@ class PageViewsController < ApplicationMetalController
   private
 
   def update_article_page_views
-    return if Rails.env.production? && rand(10) != 1 # We don't need to update the article page views every time.
+    return if Rails.env.production? && rand(8) != 1 # We don't need to update the article page views every time.
 
     @article = Article.find(page_view_params[:article_id])
     new_page_views_count = @article.page_views.sum(:counts_for_number_of_views)
@@ -44,7 +44,7 @@ class PageViewsController < ApplicationMetalController
   end
 
   def update_organic_page_views
-    return if Rails.env.production? && rand(50) != 1 # We need to do this operation only once in a while.
+    return if Rails.env.production? && rand(20) != 1 # We need to do this operation only once in a while.
 
     page_views_from_google_com = @article.page_views.where(referrer: "https://www.google.com/")
 

--- a/app/controllers/page_views_controller.rb
+++ b/app/controllers/page_views_controller.rb
@@ -1,6 +1,5 @@
 class PageViewsController < ActionController::Metal
   # ActionController::Metal because we do not need all bells and whistles of ApplicationController
-  include ActionController::StrongParameters
   include ActionController::Head
 
   def create
@@ -41,7 +40,7 @@ class PageViewsController < ActionController::Metal
   end
 
   def page_view_params
-    params.require(:page_view).permit(%i[article_id referrer user_agent])
+    params.slice(:article_id, :referrer, :user_agent)
   end
 
   def update_organic_page_views

--- a/app/controllers/page_views_controller.rb
+++ b/app/controllers/page_views_controller.rb
@@ -1,5 +1,8 @@
-class PageViewsController < ApplicationController
-  # No policy needed. All views are for all users
+class PageViewsController < ActionController::Metal
+  # ActionController::Metal because we do not need all bells and whistles of ApplicationController
+  include ActionController::StrongParameters
+  include ActionController::Head
+
   def create
     page_view_create_params = if session_current_user_id
                                 page_view_params.merge(user_id: session_current_user_id)
@@ -28,7 +31,7 @@ class PageViewsController < ApplicationController
   private
 
   def update_article_page_views
-    return if Rails.env.production? && rand(8) != 1 # We don't need to update the article page views every time.
+    return if Rails.env.production? && rand(10) != 1 # We don't need to update the article page views every time.
 
     @article = Article.find(page_view_params[:article_id])
     new_page_views_count = @article.page_views.sum(:counts_for_number_of_views)
@@ -42,7 +45,7 @@ class PageViewsController < ApplicationController
   end
 
   def update_organic_page_views
-    return if Rails.env.production? && rand(20) != 1 # We need to do this operation only once in a while.
+    return if Rails.env.production? && rand(50) != 1 # We need to do this operation only once in a while.
 
     page_views_from_google_com = @article.page_views.where(referrer: "https://www.google.com/")
 
@@ -56,5 +59,10 @@ class PageViewsController < ApplicationController
     organic_count_past_month_count = page_views_from_google_com.
       where("created_at > ?", 1.month.ago).sum(:counts_for_number_of_views)
     @article.update_column(:organic_page_views_past_month_count, organic_count_past_month_count) if organic_count_past_month_count > @article.organic_page_views_past_month_count
+  end
+
+  def session_current_user_id
+    # custom defined here, because controller does not inherent from application_controller
+    session["warden.user.user.key"].flatten[0] if session["warden.user.user.key"].present?
   end
 end

--- a/app/controllers/page_views_controller.rb
+++ b/app/controllers/page_views_controller.rb
@@ -1,5 +1,5 @@
 class PageViewsController < ApplicationMetalController
-  # ActionController::Metal because we do not need all bells and whistles of ApplicationController
+  # ApplicationMetalController because we do not need all bells and whistles of ApplicationController, so should help performance.
   include ActionController::Head
 
   def create

--- a/spec/requests/page_views_spec.rb
+++ b/spec/requests/page_views_spec.rb
@@ -57,20 +57,20 @@ RSpec.describe "PageViews", type: :request do
       end
 
       it "stores aggregate page views" do
-        post "/page_views", params: { page_view: { article_id: article.id } }
-        post "/page_views", params: { page_view: { article_id: article.id } }
+        post "/page_views", params: { article_id: article.id }
+        post "/page_views", params: { article_id: article.id }
         expect(article.reload.page_views_count).to eq(20)
       end
 
       it "stores aggregate organic page views" do
-        post "/page_views", params: { page_view: { article_id: article.id, referrer: "https://www.google.com/" } }
-        post "/page_views", params: { page_view: { article_id: article.id } }
+        post "/page_views", params: { article_id: article.id, referrer: "https://www.google.com/" }
+        post "/page_views", params: { article_id: article.id }
         expect(article.reload.organic_page_views_count).to eq(10)
         expect(article.reload.organic_page_views_past_week_count).to eq(10)
         expect(article.reload.organic_page_views_past_month_count).to eq(10)
-        post "/page_views", params: { page_view: { article_id: article.id, referrer: "https://www.google.com/" } }
+        post "/page_views", params: { article_id: article.id, referrer: "https://www.google.com/" }
         expect(article.reload.organic_page_views_count).to eq(20)
-        post "/page_views", params: { page_view: { article_id: article.id } }
+        post "/page_views", params: { article_id: article.id }
         expect(article.reload.organic_page_views_count).to eq(20)
       end
 

--- a/spec/requests/page_views_spec.rb
+++ b/spec/requests/page_views_spec.rb
@@ -22,20 +22,16 @@ RSpec.describe "PageViews", type: :request do
 
       it "sends referrer" do
         post "/page_views", params: {
-          page_view: {
-            article_id: article.id,
-            referrer: "test"
-          }
+          article_id: article.id,
+          referrer: "test"
         }
         expect(PageView.last.referrer).to eq("test")
       end
 
       it "sends user agent" do
         post "/page_views", params: {
-          page_view: {
-            article_id: article.id,
-            user_agent: "test"
-          }
+          article_id: article.id,
+          user_agent: "test"
         }
         expect(PageView.last.user_agent).to eq("test")
       end
@@ -72,20 +68,16 @@ RSpec.describe "PageViews", type: :request do
 
       it "sends referrer" do
         post "/page_views", params: {
-          page_view: {
-            article_id: article.id,
-            referrer: "test"
-          }
+          article_id: article.id,
+          referrer: "test"
         }
         expect(PageView.last.referrer).to eq("test")
       end
 
       it "sends user agent" do
         post "/page_views", params: {
-          page_view: {
-            article_id: article.id,
-            user_agent: "test"
-          }
+          article_id: article.id,
+          user_agent: "test"
         }
         expect(PageView.last.user_agent).to eq("test")
       end
@@ -100,9 +92,7 @@ RSpec.describe "PageViews", type: :request do
 
       it "updates a new page view time on page by 15" do
         post "/page_views", params: {
-          page_view: {
-            article_id: article.id
-          }
+          article_id: article.id
         }
         put "/page_views/" + article.id.to_s
         expect(PageView.last.time_tracked_in_seconds).to eq(30)
@@ -112,9 +102,7 @@ RSpec.describe "PageViews", type: :request do
     context "when user is not signed in" do
       it "updates a new page view time on page by 15" do
         post "/page_views", params: {
-          page_view: {
-            article_id: article.id
-          }
+          article_id: article.id
         }
         put "/page_views/" + article.id.to_s
         expect(PageView.last.time_tracked_in_seconds).to eq(15)

--- a/spec/requests/page_views_spec.rb
+++ b/spec/requests/page_views_spec.rb
@@ -12,9 +12,7 @@ RSpec.describe "PageViews", type: :request do
 
       it "creates a new page view" do
         post "/page_views", params: {
-          page_view: {
-            article_id: article.id
-          }
+          article_id: article.id
         }
         expect(article.reload.page_views.size).to eq(1)
         expect(article.reload.page_views_count).to eq(1)
@@ -46,9 +44,7 @@ RSpec.describe "PageViews", type: :request do
     context "when user not signed in" do
       it "creates a new page view" do
         post "/page_views", params: {
-          page_view: {
-            article_id: article.id
-          }
+          article_id: article.id
         }
         expect(article.reload.page_views.size).to eq(1)
         expect(article.reload.page_views_count).to eq(10)

--- a/spec/system/comments/user_fills_out_comment_spec.rb
+++ b/spec/system/comments/user_fills_out_comment_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Creating Comment", type: :system, js: true do
     expect(page).to have_text(raw_comment)
   end
 
-  it "User fill out commen box then click previews and submit" do
+  it "User fill out comment box then click previews and submit" do
     visit article.path.to_s
     fill_in "text-area", with: raw_comment
     click_button("PREVIEW")


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [x] Optimization

## Description

This PR replaces `ApplicationController` with `ActionController::Metal` because we don't need all the rendering stuff. We instead include the couple modules we need. This should result in less overall compute/memory

Since `session_current_user_id` isn't inherited from `ApplicationController` I redefined it in this controller. Not the cleanest longterm, if anybody has a better idea for how to do this in general, let me know.