### PR TITLE
Move bottom_content Article Content to Redis

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -60,6 +60,7 @@ Rails/OutputSafety:
     - 'app/models/display_ad.rb'
     - 'app/models/message.rb'
     - 'app/views/articles/feed.rss.builder'
+    - 'app/views/articles/show.html.erb'
 
 # Offense count: 25
 # Cop supports --auto-correct.

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -199,7 +199,7 @@
     <%= render "articles/full_comment_area" %>
   </div>
 
-  <% cache("article-bottom-content-#{@article.id}", expires_in: 18.hours) do %>
+  <% RedisRailsCache.fetch("article-bottom-content-#{@article.id}", expires_in: 18.hours) do %>
     <% @classic_article = Suggester::Articles::Classic.new(@article, not_ids: [@article.id]).get.first %>
     <% if @classic_article %>
       <%= render "additional_content_boxes/article_box",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description
Time to start moving the view cache's to Redis. This PR moves the bottom_content for an article from Memcache to Redis. 

## Related Tickets & Documents
#4670 

## Added to documentation?

- [x] no documentation needed

![minion saying bottom](https://media0.giphy.com/media/arBdoeWbFZy6Y/source.gif)
