### PR TITLE
Remove article-main-reactions Cache Key

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -59,6 +59,7 @@ Rails/OutputSafety:
     - 'app/models/comment.rb'
     - 'app/models/display_ad.rb'
     - 'app/models/message.rb'
+    - 'app/views/articles/_actions.html.erb'
     - 'app/views/articles/feed.rss.builder'
 
 # Offense count: 25

--- a/app/views/articles/_actions.html.erb
+++ b/app/views/articles/_actions.html.erb
@@ -1,15 +1,13 @@
 <div class="article-actions" id="article-reaction-actions">
-  <% cache("article-main-reactions", expires_in: 200.hours) do %>
-    <button id="reaction-butt-like" class="article-reaction-butt like-reaction-button" data-category="like" alt="heart-emoji" title="heart">
-      <img alt="heart" src="<%= asset_path("emoji/emoji-one-heart.png") %>" /><span class="reaction-number" id="reaction-number-like"></span>
-    </button>
-    <button id="reaction-butt-unicorn" class="article-reaction-butt unicorn-reaction-button" data-category="unicorn" alt="unicorn-emoji" title="unicorn">
-      <img alt="unicorn" src="<%= asset_path("emoji/emoji-one-unicorn.png") %>" /><span class="reaction-number" id="reaction-number-unicorn"></span>
-    </button>
-    <button id="reaction-butt-readinglist" class="article-reaction-butt readinglist-reaction-button" data-category="readinglist" alt="unicorn-emoji" title="reading list">
-      <img alt="reading list" src="<%= asset_path("emoji/emoji-one-bookmark.png") %>" /><span class="reaction-number" id="reaction-number-readinglist"></span>
-    </button>
-  <% end %>
+  <button id="reaction-butt-like" class="article-reaction-butt like-reaction-button" data-category="like" alt="heart-emoji" title="heart">
+    <img alt="heart" src="<%= asset_path("emoji/emoji-one-heart.png") %>" /><span class="reaction-number" id="reaction-number-like"></span>
+  </button>
+  <button id="reaction-butt-unicorn" class="article-reaction-butt unicorn-reaction-button" data-category="unicorn" alt="unicorn-emoji" title="unicorn">
+    <img alt="unicorn" src="<%= asset_path("emoji/emoji-one-unicorn.png") %>" /><span class="reaction-number" id="reaction-number-unicorn"></span>
+  </button>
+  <button id="reaction-butt-readinglist" class="article-reaction-butt readinglist-reaction-button" data-category="readinglist" alt="unicorn-emoji" title="reading list">
+    <img alt="reading list" src="<%= asset_path("emoji/emoji-one-bookmark.png") %>" /><span class="reaction-number" id="reaction-number-readinglist"></span>
+  </button>
   <a class="article-actions-tweet-button"
      id="article-actions-tweet-button"
      rel="noopener"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
This cache is only caching simple HTML buttons and no external requests so I think it is one that we could do without rather than moving to Redis. Thoughts?

## Related Tickets & Documents
#4670 

## Added to documentation?
- [x] no documentation needed

![maybe](https://media2.giphy.com/media/6qmOIwxEJnt96/giphy.gif)
