### PR TITLE
Move Organization Profile Image Cache to Redis

### DIFF
--- a/app/views/articles/_org_branding.html.erb
+++ b/app/views/articles/_org_branding.html.erb
@@ -1,25 +1,25 @@
 <% if organization && organization.bg_color_hex.present? %>
-  <% cache("article-organization-details-#{organization.id}-#{organization.updated_at}", expires_in: 100.hours) do %>
-    <div class="org-branding" id="org-branding">
-      <div class="inner">
-        <div class="content">
-          <div class="name"><a href="/<%= organization.slug %>"><%= organization.name %></a></div>
-          <div class="summary"><%= organization.summary %></div>
-          <p class="social">
-            <% if organization.twitter_username.present? %>
-              <a href="https://twitter.com/<%= organization.twitter_username %>" target="_blank" rel="noopener">@<%= organization.twitter_username %></a>
-            <% end %>
-            <% if organization.website_url.present? %>
-              <a href="<%= organization.website_url %>" target="_blank" rel="noopener"><%= beautified_url organization.website_url %></a>
-            <% end %>
-          </p>
-        </div>
-        <div class="profile-image">
-          <a href="/<%= organization.slug %>">
+  <div class="org-branding" id="org-branding">
+    <div class="inner">
+      <div class="content">
+        <div class="name"><a href="/<%= organization.slug %>"><%= organization.name %></a></div>
+        <div class="summary"><%= organization.summary %></div>
+        <p class="social">
+          <% if organization.twitter_username.present? %>
+            <a href="https://twitter.com/<%= organization.twitter_username %>" target="_blank" rel="noopener">@<%= organization.twitter_username %></a>
+          <% end %>
+          <% if organization.website_url.present? %>
+            <a href="<%= organization.website_url %>" target="_blank" rel="noopener"><%= beautified_url organization.website_url %></a>
+          <% end %>
+        </p>
+      </div>
+      <div class="profile-image">
+        <a href="/<%= organization.slug %>">
+          <% RedisRailsCache.fetch("article-organization-image-#{organization.id}-#{organization.updated_at.rfc3339}", expires_in: 100.hours) do %>
             <img src="<%= ProfileImage.new(organization).get %>" alt="<%= organization.name %>" />
-          </a>
-        </div>
+          <% end %>
+        </a>
       </div>
     </div>
-  <% end %>
+  </div>
 <% end %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Feature

## Description
Initially, we were cacheing this entire org partial in Redis. However, the vast majority of the partial has already been loaded so there is no real need to cache it. The only part making an external request is to get the ProfileImage. I decided to reduce the size of the cache to only cache that external ProfileImage request rather than the entire partial. 

## Related Tickets & Documents
#4670 

## Added to documentation?
- [x] no documentation needed

![only a teensy bit](https://media1.giphy.com/media/9xg7AhvYIFAlacdkBD/giphy.gif)
