### PR TITLE
Revert Redis fragment cache

### DIFF
--- a/app/views/articles/_org_branding.html.erb
+++ b/app/views/articles/_org_branding.html.erb
@@ -15,7 +15,7 @@
       </div>
       <div class="profile-image">
         <a href="/<%= organization.slug %>">
-          <% RedisRailsCache.fetch("article-organization-image-#{organization.id}-#{organization.updated_at.rfc3339}", expires_in: 100.hours) do %>
+          <% cache("article-organization-image-#{organization.id}-#{organization.updated_at.rfc3339}", expires_in: 100.hours) do %>
             <img src="<%= ProfileImage.new(organization).get %>" alt="<%= organization.name %>" />
           <% end %>
         </a>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -199,7 +199,7 @@
     <%= render "articles/full_comment_area" %>
   </div>
 
-  <% RedisRailsCache.fetch("article-bottom-content-#{@article.id}", expires_in: 18.hours) do %>
+  <% cache("article-bottom-content-#{@article.id}", expires_in: 18.hours) do %>
     <% @classic_article = Suggester::Articles::Classic.new(@article, not_ids: [@article.id]).get.first %>
     <% if @classic_article %>
       <%= render "additional_content_boxes/article_box",


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
The changes in #4927 and #4930 are actually causing no HTML to be rendered.

There should be "bottom content" under these articles, but the output of the fragment cache seems to be nothing.

<img width="977" alt="Screen Shot 2019-11-25 at 7 11 39 PM" src="https://user-images.githubusercontent.com/3102842/69588778-c1054000-0fb7-11ea-9762-5119c1925bdf.png">

I have to say, I kind of like the page _without_ this bottom content, which is kind of busy, but it is a bug we should fix anyway. 😋 