### PR TITLE
Remove rubyzip initializer, unnecessary on rubyzip 2

### DIFF
--- a/config/initializers/rubyzip.rb
+++ b/config/initializers/rubyzip.rb
@@ -1,7 +1,0 @@
-# Validate entry size on extract
-# NOTE: this initializer can be removed when upgrading to rubyzip >= 2.0
-# see https://github.com/rubyzip/rubyzip/pull/403
-# see https://github.com/rubyzip/rubyzip#size-validation
-require "zip"
-
-Zip.validate_entry_sizes = true


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

After https://github.com/thepracticaldev/dev.to/pull/4915 was merged, and `rubyzip` has been upgraded to 2.0, this patch is not needed anymore.

The initializer was present to fix a possible security bug in `rubyzip` (which we weren't affected from in production anyway).
