### PR TITLE
Use block to reset cache_store to Redis for view cacheing

### DIFF
--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -199,18 +199,20 @@
     <%= render "articles/full_comment_area" %>
   </div>
 
-  <% cache("article-bottom-content-#{@article.id}", expires_in: 18.hours) do %>
-    <% @classic_article = Suggester::Articles::Classic.new(@article, not_ids: [@article.id]).get.first %>
-    <% if @classic_article %>
-      <%= render "additional_content_boxes/article_box",
-                 article: @classic_article,
-                 classification: "classic",
-                 classification_text: "Classic DEV Post from #{@classic_article.readable_publish_date}",
-                 follow_cue: "Follow <a href='#{@classic_article.user.path}'>@#{@classic_article.user.username}</a> to see more of their posts in your feed." %>
+  <% use_redis_cache do %>
+    <% cache("article-bottom-content-#{@article.id}", expires_in: 18.hours) do %>
+      <% @classic_article = Suggester::Articles::Classic.new(@article, not_ids: [@article.id]).get.first %>
+      <% if @classic_article %>
+        <%= render "additional_content_boxes/article_box",
+                   article: @classic_article,
+                   classification: "classic",
+                   classification_text: "Classic DEV Post from #{@classic_article.readable_publish_date}",
+                   follow_cue: "Follow <a href='#{@classic_article.user.path}'>@#{@classic_article.user.username}</a> to see more of their posts in your feed." %>
+      <% end %>
+      <div id="additional-content-area" data-article-id="<%= @article.id %>,<%= @classic_article&.id %>"></div>
+      <% suggested_articles = ArticleSuggester.new(@article).articles(max: 4) %>
+      <%= render "articles/bottom_content", articles: suggested_articles %>
     <% end %>
-    <div id="additional-content-area" data-article-id="<%= @article.id %>,<%= @classic_article&.id %>"></div>
-    <% suggested_articles = ArticleSuggester.new(@article).articles(max: 4) %>
-    <%= render "articles/bottom_content", articles: suggested_articles %>
   <% end %>
 </div>
 

--- a/config/initializers/redis_rails.rb
+++ b/config/initializers/redis_rails.rb
@@ -11,3 +11,15 @@ RedisRailsCache = if Rails.env.test?
                   else
                     ActiveSupport::Cache::RedisCacheStore.new(url: redis_url, expires_in: DEFAULT_EXPIRATION)
                   end
+
+module ActionView
+  module Helpers #:nodoc:
+    module CacheHelper
+      def use_redis_cache
+        controller.cache_store = RedisRailsCache
+        yield
+        controller.cache_store = Rails.cache
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
I added a helper that will allow us to switch to using the Redis cache when we want to for view cacheing. This works by setting the `controller.cache_store` to the Redis store, running the block and then resetting it back to Memcache. What does everyone think of this approach?

## Related Tickets & Documents
#4670 

## Added to documentation?
- [x] no documentation needed

![keep trying gif](https://media3.giphy.com/media/3o7TKCFii3mAz693Ko/giphy.gif)
