### PR TITLE
Modify page view recount rate in page_views_controller

### DIFF
--- a/app/controllers/page_views_controller.rb
+++ b/app/controllers/page_views_controller.rb
@@ -30,7 +30,7 @@ class PageViewsController < ApplicationMetalController
   private
 
   def update_article_page_views
-    return if Rails.env.production? && rand(8) != 1 # We don't need to update the article page views every time.
+    return if Rails.env.production? && rand(15) != 1 # We don't need to update the article page views every time.
 
     @article = Article.find(page_view_params[:article_id])
     new_page_views_count = @article.page_views.sum(:counts_for_number_of_views)
@@ -44,7 +44,7 @@ class PageViewsController < ApplicationMetalController
   end
 
   def update_organic_page_views
-    return if Rails.env.production? && rand(20) != 1 # We need to do this operation only once in a while.
+    return if Rails.env.production? && rand(100) != 1 # We need to do this operation only once in a while.
 
     page_views_from_google_com = @article.page_views.where(referrer: "https://www.google.com/")
 
@@ -53,10 +53,10 @@ class PageViewsController < ApplicationMetalController
 
     organic_count_past_week_count = page_views_from_google_com.
       where("created_at > ?", 1.week.ago).sum(:counts_for_number_of_views)
-    @article.update_column(:organic_page_views_past_week_count, organic_count_past_week_count) if organic_count_past_week_count > @article.organic_page_views_past_week_count
+    @article.update_column(:organic_page_views_past_week_count, organic_count_past_week_count)
 
     organic_count_past_month_count = page_views_from_google_com.
       where("created_at > ?", 1.month.ago).sum(:counts_for_number_of_views)
-    @article.update_column(:organic_page_views_past_month_count, organic_count_past_month_count) if organic_count_past_month_count > @article.organic_page_views_past_month_count
+    @article.update_column(:organic_page_views_past_month_count, organic_count_past_month_count)
   end
 end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update
- [x] Optimization

## Description
This oft-hit endpoint doesn't need to result in a re-count _quite_ as often as it does, especially with the organic pageviews count.

Also found a logical problem where we were only updating the "past week" and "past month" counts for organic pageviews if they incremented, which is wrong for this one.