### PR TITLE
Remove Unnecessary Fragment Cacheing

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -62,6 +62,8 @@ Rails/OutputSafety:
     - 'app/views/articles/_actions.html.erb'
     - 'app/views/articles/feed.rss.builder'
     - 'app/views/articles/show.html.erb'
+    - 'app/views/giveaways/new.html.erb'
+    - 'app/views/liquid_embeds/show.html.erb'
 
 # Offense count: 25
 # Cop supports --auto-correct.

--- a/app/views/giveaways/new.html.erb
+++ b/app/views/giveaways/new.html.erb
@@ -20,9 +20,7 @@
 <% end %>
 
 <style>
-  <% cache("giveaways-page-cache", expires_in: 30.minutes) do %>
   <%= Rails.application.assets["giveaways.css"].to_s.html_safe %>
-  <% end %>
 </style>
 
 <div class="giveaway-header" style="background-image:url(https://res.cloudinary.com/practicaldev/image/upload/c_scale,f_auto,fl_progressive,q_80,w_1000/v1487774090/stickers_e0antp.png)">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -83,9 +83,7 @@
         <%= yield(:audio) %>
       </div>
     <% end %>
-    <% cache("application-top-bar--#{user_signed_in?}--#{internal_navigation?}", expires_in: 100.hours) do %>
-      <%= render "layouts/top_bar" unless internal_navigation? %>
-    <% end %>
+    <%= render "layouts/top_bar" unless internal_navigation? %>
     <div id="message-notice"></div>
     <div id="page-content" class="universal-page-content-wrapper <%= view_class %>" data-current-page="<%= current_page %>">
       <% if flash[:global_notice] %>

--- a/app/views/liquid_embeds/show.html.erb
+++ b/app/views/liquid_embeds/show.html.erb
@@ -1,6 +1,4 @@
-<% cache "liquid_tag_styles_#{ApplicationConfig['DEPLOYMENT_SIGNATURE']}", expires_in: 8.hours do #TODO: Render specific ltag class instead of everything %>
-  <style><%= Rails.application.assets["ltags/LiquidTags.scss"].to_s.html_safe %></style>
-<% end %>
+<style><%= Rails.application.assets["ltags/LiquidTags.scss"].to_s.html_safe %></style>
 <% begin %>
   <% @liquid_node = Liquid::Template.parse("{% #{params[:embeddable]} #{params[:args]} %}").root.nodelist.first %>
   <%= @liquid_node.render({}) %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
I removed these 3 external fragment caches because from as far as I could tell none of the fragments being cached were making any external calls and therefore cacheing them seemed a little pointless. Let me know what you think and if I missed something!

## Related Tickets & Documents
#4670 

## Added to documentation?
- [x] no documentation needed

![maybe](https://media.giphy.com/media/21I909B1Us5hsGiupn/giphy.gif)
