### PR TITLE
Replace DEPLOYMENT_SIGNATURE with HEROKU_SLUG_COMMIT

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -60,8 +60,16 @@ Rails/OutputSafety:
     - 'app/models/display_ad.rb'
     - 'app/models/message.rb'
     - 'app/views/articles/_actions.html.erb'
+    - 'app/views/articles/_sidebar.html.erb'
     - 'app/views/articles/feed.rss.builder'
     - 'app/views/articles/show.html.erb'
+    - 'app/views/layouts/_styles.html.erb'
+    - 'app/views/liquid_embeds/show.html.erb'
+    - 'app/views/pages/live.html.erb'
+    - 'app/views/pages/onboarding.html.erb'
+    - 'app/views/partnerships/index.html.erb'
+    - 'app/views/partnerships/show.html.erb'
+    - 'app/views/pro_memberships/show.html.erb'
 
 # Offense count: 25
 # Cop supports --auto-correct.
@@ -82,3 +90,5 @@ Style/GuardClause:
 # URISchemes: http, https
 Metrics/LineLength:
   Max: 380
+  Exclude:
+    - 'app/views/layouts/_styles.html.erb'

--- a/Envfile
+++ b/Envfile
@@ -29,8 +29,8 @@ variable :DEFAULT_SITE_EMAIL, :String, default: "yo@dev.to"
 variable :RACK_TIMEOUT_WAIT_TIMEOUT, :Integer, default: 100_000
 variable :RACK_TIMEOUT_SERVICE_TIMEOUT, :Integer, default: 100_000
 
-# Production related config that can be ignored
-variable :DEPLOYMENT_SIGNATURE, :String, default: "Optional"
+# Heroku release slug used to bust caches on deploys
+variable :HEROKU_SLUG_COMMIT, :String, default: "Optional"
 
 # Redis caching storage
 variable :REDIS_URL, :String, default: "redis://localhost:6379"

--- a/app/views/articles/_sidebar.html.erb
+++ b/app/views/articles/_sidebar.html.erb
@@ -1,7 +1,7 @@
 <div id="sidebar-wrapper-left" class="sidebar-wrapper sidebar-wrapper-left">
   <div class="sidebar-bg" id="sidebar-bg-left"></div>
   <div class="side-bar">
-    <% cache("main-sidebar-nav--#{user_signed_in?}-#{ApplicationConfig['DEPLOYMENT_SIGNATURE']}", expires_in: 5.days) do %>
+    <% cache("main-sidebar-nav--#{user_signed_in?}-#{ApplicationConfig['HEROKU_SLUG_COMMIT']}", expires_in: 5.days) do %>
       <%= render "articles/sidebar_nav" %>
       <div class="widget sponsorship-widget <%= "showing" unless user_signed_in? %>" id="sponsorship-widget">
         <header>

--- a/app/views/layouts/_styles.html.erb
+++ b/app/views/layouts/_styles.html.erb
@@ -1,4 +1,4 @@
-<% cache "base_inline_styles_#{@story_show}_#{@article_index}_#{@home_page}_#{@article_show}_#{view_class}_#{@notifications_index}_#{core_pages?}_#{@tags_index}_#{@reading_list_items_index}_#{@history_index}_#{ApplicationConfig['DEPLOYMENT_SIGNATURE']}_#{user_signed_in?}", expires_in: 8.hours do %>
+<% cache "base_inline_styles_#{@story_show}_#{@article_index}_#{@home_page}_#{@article_show}_#{view_class}_#{@notifications_index}_#{core_pages?}_#{@tags_index}_#{@reading_list_items_index}_#{@history_index}_#{ApplicationConfig['HEROKU_SLUG_COMMIT']}_#{user_signed_in?}", expires_in: 8.hours do %>
   <% if @story_show %>
     <style>
       <% Rails.application.config.assets.compile = true %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -98,7 +98,7 @@
       </div>
     </div>
     <% unless internal_navigation? %>
-      <% cache("footer-and-signup-modal--#{user_signed_in?}--#{ApplicationConfig['DEPLOYMENT_SIGNATURE']}", expires_in: 200.hours) do %>
+      <% cache("footer-and-signup-modal--#{user_signed_in?}--#{ApplicationConfig['HEROKU_SLUG_COMMIT']}", expires_in: 24.hours) do %>
         <%= render "layouts/footer" %>
         <%= render "layouts/signup_modal" unless user_signed_in? %>
       <% end %>

--- a/app/views/liquid_embeds/show.html.erb
+++ b/app/views/liquid_embeds/show.html.erb
@@ -1,4 +1,4 @@
-<% cache "liquid_tag_styles_#{ApplicationConfig['DEPLOYMENT_SIGNATURE']}", expires_in: 8.hours do #TODO: Render specific ltag class instead of everything %>
+<% cache "liquid_tag_styles_#{ApplicationConfig['HEROKU_SLUG_COMMIT']}", expires_in: 8.hours do #TODO: Render specific ltag class instead of everything %>
   <style><%= Rails.application.assets["ltags/LiquidTags.scss"].to_s.html_safe %></style>
 <% end %>
 <% begin %>

--- a/app/views/pages/live.html.erb
+++ b/app/views/pages/live.html.erb
@@ -20,7 +20,7 @@
 <meta name="twitter:image:src" content="https://thepracticaldev.s3.amazonaws.com/i/bqzj1pwho9e0jicqo44s.png">
 
 <style>
-  <% cache "live-page-css-#{ApplicationConfig['DEPLOYMENT_SIGNATURE']}", expires_in: 1.hour do %>
+  <% cache "live-page-css-#{ApplicationConfig['HEROKU_SLUG_COMMIT']}", expires_in: 1.hour do %>
   <%= Rails.application.assets["live.css"].to_s.html_safe %>
   <% end %>
 </style>

--- a/app/views/pages/onboarding.html.erb
+++ b/app/views/pages/onboarding.html.erb
@@ -1,7 +1,7 @@
-<% title "Welcome to #{ApplicationConfig["COMMUNITY_NAME"]}" %>
+<% title "Welcome to #{ApplicationConfig['COMMUNITY_NAME']}" %>
 
 <style>
-  <% cache "onboarding-css-#{ApplicationConfig['DEPLOYMENT_SIGNATURE']}", expires_in: 10.hours do %>
+  <% cache "onboarding-css-#{ApplicationConfig['HEROKU_SLUG_COMMIT']}", expires_in: 10.hours do %>
     <%= Rails.application.assets["onboarding.css"].to_s.html_safe %>
     <%= Rails.application.assets["preact/onboarding-modal.css"].to_s.html_safe %>
   <% end %>

--- a/app/views/partnerships/index.html.erb
+++ b/app/views/partnerships/index.html.erb
@@ -1,7 +1,7 @@
 <% title "Partnerships and Sponsors" %>
 
 <style>
-  <% cache "partnership-org-section-credits-#{ApplicationConfig['DEPLOYMENT_SIGNATURE']}", expires_in: 10.hours do %>
+  <% cache "partnership-org-section-credits-#{ApplicationConfig['HEROKU_SLUG_COMMIT']}", expires_in: 10.hours do %>
     <%= Rails.application.assets["partnerships.css"].to_s.html_safe %>
   <% end %>
 </style>

--- a/app/views/partnerships/show.html.erb
+++ b/app/views/partnerships/show.html.erb
@@ -1,7 +1,7 @@
 <% title "#{params[:option].titleize} Overview" %>
 
 <style>
-  <% cache "partnership-org-section-credits-#{ApplicationConfig['DEPLOYMENT_SIGNATURE']}", expires_in: 10.hours do %>
+  <% cache "partnership-org-section-credits-#{ApplicationConfig['HEROKU_SLUG_COMMIT']}", expires_in: 10.hours do %>
     <%= Rails.application.assets["partnerships.css"].to_s.html_safe %>
   <% end %>
 </style>

--- a/app/views/pro_memberships/show.html.erb
+++ b/app/views/pro_memberships/show.html.erb
@@ -1,7 +1,7 @@
 <% title "Pro Membership" %>
 
 <style>
-  <% cache "partnership-org-section-credits-#{ApplicationConfig['DEPLOYMENT_SIGNATURE']}", expires_in: 10.hours do %>
+  <% cache "partnership-org-section-credits-#{ApplicationConfig['HEROKU_SLUG_COMMIT']}", expires_in: 10.hours do %>
     <%= Rails.application.assets["partnerships.css"].to_s.html_safe %>
   <% end %>
 </style>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
The original intent of DEPLOYMENT_SIGNATURE was to bust these caches on a new deploy. However, the feature never got fully implemented so currently the DEPLOYMENT_SIGNATURE just stays the same always. To fix this we can use HEROKU_SLUG_COMMIT which is an ENV variable that Heroku provides to us and can be used to bust these caches on deploy.

## Added to documentation?
- [x] no documentation needed

![could I have your autograph from space jam](https://media2.giphy.com/media/5uOr03yvkeyTS/giphy.gif)
