### PR TITLE
[WIP] Remove test guard from protect_from_forgery in ApplicationMetalController

### DIFF
--- a/app/controllers/application_metal_controller.rb
+++ b/app/controllers/application_metal_controller.rb
@@ -7,7 +7,7 @@ class ApplicationMetalController < ActionController::Metal
   # ActionController modules which may not be used in each controller can go in
   # the specific controller.
 
-  protect_from_forgery with: :exception, prepend: true unless Rails.env.test?
+  protect_from_forgery with: :exception, prepend: true
 
   include SessionCurrentUser
   include ValidRequest


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

We shouldn't need a guard to `protect_from_forgery`, we don't in the `ApplicationController`. 

This might also affect system and e2e tests that rely on CSRF tokens being present
