### PR TITLE
Clearing reading list item list on archive status toggle.

### DIFF
--- a/app/javascript/readingList/readingList.jsx
+++ b/app/javascript/readingList/readingList.jsx
@@ -111,6 +111,8 @@ export class ReadingList extends Component {
       totalCount: totalCount - 1,
     });
 
+    // Clear Algolia cache so it actually searches on toggleStatusView
+    t.state.index.clearCache();
     // hide the snackbar in a few moments
     setTimeout(() => {
       t.setState({ archiving: false });


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [✅] Bug Fix
- [ ] Documentation Update

## Description
I believe the cached search results from Algolia were causing the reading list status views to not properly update.

## Related Tickets & Documents
[Algolia's documentation about clearing cache](https://www.algolia.com/doc/api-client/advanced/cache-browser-only/javascript/?language=javascript)
#3217 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
N/A

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [✅] no documentation needed
