### PR TITLE
Add missing foreign keys between tables

### DIFF
--- a/db/migrate/20191128111048_add_missing_foreign_keys.rb
+++ b/db/migrate/20191128111048_add_missing_foreign_keys.rb
@@ -1,0 +1,13 @@
+class AddMissingForeignKeys < ActiveRecord::Migration[5.2]
+  def change
+    add_foreign_key :api_secrets, :users, on_delete: :cascade
+    add_foreign_key :classified_listings, :users, on_delete: :cascade
+    add_foreign_key :identities, :users, on_delete: :cascade
+    add_foreign_key :notification_subscriptions, :users, on_delete: :cascade
+    add_foreign_key :page_views, :articles, on_delete: :nullify
+    add_foreign_key :tag_adjustments, :users, on_delete: :cascade
+    add_foreign_key :tag_adjustments, :articles, on_delete: :cascade
+    add_foreign_key :tag_adjustments, :tags, on_delete: :cascade
+    add_foreign_key :users_roles, :users, on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_06_102826) do
+ActiveRecord::Schema.define(version: 2019_11_28_111048) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -1204,22 +1204,31 @@ ActiveRecord::Schema.define(version: 2019_11_06_102826) do
     t.index ["user_id"], name: "index_webhook_endpoints_on_user_id"
   end
 
+  add_foreign_key "api_secrets", "users", on_delete: :cascade
   add_foreign_key "audit_logs", "users"
   add_foreign_key "badge_achievements", "badges"
   add_foreign_key "badge_achievements", "users"
   add_foreign_key "chat_channel_memberships", "chat_channels"
   add_foreign_key "chat_channel_memberships", "users"
+  add_foreign_key "classified_listings", "users", on_delete: :cascade
+  add_foreign_key "identities", "users", on_delete: :cascade
   add_foreign_key "messages", "chat_channels"
   add_foreign_key "messages", "users"
+  add_foreign_key "notification_subscriptions", "users", on_delete: :cascade
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_access_grants", "users", column: "resource_owner_id"
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_access_tokens", "users", column: "resource_owner_id"
+  add_foreign_key "page_views", "articles", on_delete: :nullify
   add_foreign_key "push_notification_subscriptions", "users"
   add_foreign_key "sponsorships", "organizations"
   add_foreign_key "sponsorships", "users"
+  add_foreign_key "tag_adjustments", "articles", on_delete: :cascade
+  add_foreign_key "tag_adjustments", "tags", on_delete: :cascade
+  add_foreign_key "tag_adjustments", "users", on_delete: :cascade
   add_foreign_key "user_blocks", "users", column: "blocked_id"
   add_foreign_key "user_blocks", "users", column: "blocker_id"
+  add_foreign_key "users_roles", "users", on_delete: :cascade
   add_foreign_key "webhook_endpoints", "oauth_applications"
   add_foreign_key "webhook_endpoints", "users"
 end

--- a/spec/models/identity_spec.rb
+++ b/spec/models/identity_spec.rb
@@ -5,7 +5,15 @@ RSpec.describe Identity, type: :model do
   it { is_expected.to validate_presence_of(:uid) }
   it { is_expected.to validate_presence_of(:provider) }
   it { is_expected.to validate_uniqueness_of(:uid).scoped_to(:provider) }
-  it { is_expected.to validate_uniqueness_of(:user_id).scoped_to(:provider) }
+
+  it do
+    # rubocop:disable RSpec/NamedSubject
+    # see <https://github.com/thoughtbot/shoulda-matchers/issues/682>
+    subject.user = create(:user)
+    expect(subject).to validate_uniqueness_of(:user_id).scoped_to(:provider)
+    # rubocop:enable RSpec/NamedSubject
+  end
+
   it { is_expected.to validate_inclusion_of(:provider).in_array(%w[github twitter]) }
   it { is_expected.to serialize(:auth_data_dump) }
 

--- a/spec/policies/article_policy_spec.rb
+++ b/spec/policies/article_policy_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.describe ArticlePolicy do
   subject { described_class.new(user, article) }
 
+  let!(:user) { create(:user) }
+
   let(:article) { build_stubbed(:article) }
   let(:valid_attributes) do
     %i[title body_html body_markdown main_image published
@@ -19,8 +21,6 @@ RSpec.describe ArticlePolicy do
   end
 
   context "when user is not the author" do
-    let(:user) { build_stubbed(:user) }
-
     it { is_expected.to permit_actions(%i[new create preview]) }
     it { is_expected.to forbid_actions(%i[update edit manage delete_confirm destroy]) }
 
@@ -33,7 +33,6 @@ RSpec.describe ArticlePolicy do
   end
 
   context "when user is the author" do
-    let(:user)    { build_stubbed(:user) }
     let(:article) { build_stubbed(:article, user: user) }
 
     it { is_expected.to permit_actions(%i[update edit manage new create delete_confirm destroy preview]) }

--- a/spec/policies/chat_channel_policy_spec.rb
+++ b/spec/policies/chat_channel_policy_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ChatChannelPolicy, type: :policy do
   subject { described_class.new(user, chat_channel) }
 
   let(:chat_channel) { build_stubbed(:chat_channel, channel_type: "invite_only") }
-  let(:user)         { build_stubbed(:user) }
+  let!(:user) { create(:user) }
 
   context "when user is not signed-in" do
     let(:user) { nil }

--- a/spec/policies/comment_policy_spec.rb
+++ b/spec/policies/comment_policy_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe CommentPolicy, type: :policy do
   subject(:comment_policy) { described_class.new(user, comment) }
 
-  let(:comment) { build_stubbed(:comment) }
+  let!(:comment) { create(:comment, commentable: create(:podcast_episode)) }
 
   let(:valid_attributes_for_create) do
     %i[body_markdown commentable_id commentable_type parent_id]
@@ -20,7 +20,7 @@ RSpec.describe CommentPolicy, type: :policy do
   end
 
   context "when user is not the author" do
-    let(:user) { build_stubbed(:user) }
+    let!(:user) { create(:user) }
 
     it { is_expected.to permit_actions(%i[create]) }
     it { is_expected.to forbid_actions(%i[edit update destroy delete_confirm]) }

--- a/spec/policies/follow_policy_spec.rb
+++ b/spec/policies/follow_policy_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.describe FollowPolicy, type: :policy do
   subject { described_class.new(user, Follow) }
 
+  let_it_be(:user) { create(:user) }
+
   context "when user is not signed in" do
     let(:user) { nil }
 
@@ -10,8 +12,6 @@ RSpec.describe FollowPolicy, type: :policy do
   end
 
   context "when user is signed in" do
-    let(:user) { build_stubbed(:user) }
-
     it { is_expected.to permit_actions(%i[create]) }
 
     context "when user is banned" do

--- a/spec/policies/github_repo_policy_spec.rb
+++ b/spec/policies/github_repo_policy_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe GithubRepoPolicy, type: :policy do
   subject { described_class.new(user, github_repo) }
 
-  let(:github_repo)      { build_stubbed(:github_repo) }
+  let_it_be(:github_repo) { create(:github_repo) }
   let(:valid_attributes) { %i[github_id_code] }
 
   context "when user is not signed in" do
@@ -13,7 +13,7 @@ RSpec.describe GithubRepoPolicy, type: :policy do
   end
 
   context "when user is not the owner" do
-    let(:user) { build_stubbed(:user) }
+    let!(:user) { create(:user) }
 
     it { is_expected.to permit_actions(%i[create]) }
     it { is_expected.to forbid_actions(%i[update]) }

--- a/spec/policies/reaction_policy_spec.rb
+++ b/spec/policies/reaction_policy_spec.rb
@@ -3,7 +3,9 @@ require "rails_helper"
 RSpec.describe ReactionPolicy do
   subject { described_class.new(user, reaction) }
 
-  let(:reaction) { build_stubbed(:reaction) }
+  let_it_be(:comment) { create(:comment, commentable: create(:article)) }
+  let_it_be(:reaction) { create(:reaction, reactable: comment) }
+  let!(:user) { create(:user) }
 
   context "when user is not signed in" do
     let(:user) { nil }
@@ -12,8 +14,6 @@ RSpec.describe ReactionPolicy do
   end
 
   context "when user is signed in" do
-    let(:user) { build_stubbed(:user) }
-
     it { is_expected.to permit_actions(%i[index create]) }
 
     context "when user is banned" do

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe UserPolicy, type: :policy do
   subject { described_class.new(user, other_user) }
 
-  let(:other_user) { build_stubbed(:user) }
+  let!(:other_user) { create(:user) }
 
   context "when user is not signed-in" do
     let(:user) { nil }


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

The goals of having good referential integrity (expressed by adding foreign keys) are:

- protecting data: we delegate a lot of the logic to Rails right now but in the future data might entering the DB from sources outside the web app
- easier deletion and cleanup: by linking tables with each other we can rely on the DB to efficiently delete data and set rules on cascading if necessary
- as a byproduct it will also alert us of data violations and latent sequencing problems we possibly have (this change also alerted me of some data violations in specs that I've fixed)

I checked which tables that had relations withing ActiveRecord/Rails were missing it on the DB level and added them.

**DISCLAIMER**: this migration is likely to fail at the first attempt. Since some of these columns can be nullified as of now, there can be that we have dead rows on referencing tables (eg. "api keys that don't belong to any users", effectively useless in the DB).

**HOW TO PROCEED**:

- for each table listed in the migration we should run a query like this to check if there are any dead rows:

```sql
SELECT COUNT(*) FROM "api_secrets" left join users as association_table on association_table.id = api_secrets.user_id WHERE "api_secrets"."user_id" IS NOT NULL AND (association_table.id is null);
```

- if the query checking the values returns something greater than 0 it means that we have rows in the related table (`api_secrets` in this example) that do not correspond to any valid referenced rows (ie. in this case there would be api secrets that point to users that have been removed)

- if the query checking the values returns 0, the foreign key is safe to add

**WHAT TO DO IF THERE ARE DEAD ROWS**:

- the obvious response here is to manually delete them:

```sql
BEGIN;
-- SELECT user_id FROM "api_secrets" left join users as association_table on association_table.id = api_secrets.user_id WHERE "api_secrets"."user_id" IS NOT NULL AND (association_table.id is null)
DELETE FROM api_secrets WHERE user_id IN (SELECT user_id FROM "api_secrets" left join users as association_table on association_table.id = api_secrets.user_id WHERE "api_secrets"."user_id" IS NOT NULL AND (association_table.id is null));
COMMIT;
```

After all dead rows are gone, this PR can be safely merged.

I could write a script to delete dead rows via SQL but I think it's safer with manual intervention.

**ADDENDUM**: I wrote the foreign key for `page_views -> users` to not destroy page views, because that's what happens right now at the Rails level. Is this behavior correct or they should be destroyed too?
