### PR TITLE
Fix podcast episode validation error

### DIFF
--- a/app/services/podcasts/create_episode.rb
+++ b/app/services/podcasts/create_episode.rb
@@ -25,8 +25,11 @@ module Podcasts
         Rails.logger.error("not a valid date: #{e}")
       end
       ep.body = item.body
-      ep.save!
-      ep
+      import_result = PodcastEpisode.import! [ep], on_duplicate_key_update: {
+        conflict_target: %i[media_url],
+        columns: %i[title slug subtitle summary website_url published_at reachable media_url https body]
+      }
+      PodcastEpisode.find(import_result.ids.first)
     end
 
     private

--- a/spec/services/podcasts/create_episode_spec.rb
+++ b/spec/services/podcasts/create_episode_spec.rb
@@ -70,4 +70,19 @@ RSpec.describe Podcasts::CreateEpisode, type: :service do
       expect(episode.reachable).to be true
     end
   end
+
+  context "when attempting to create duplicate episodes" do
+    let(:rss_item) { RSS::Parser.parse("spec/support/fixtures/podcasts/developertea.rss", false).items.first }
+    let(:item) { Podcasts::EpisodeRssItem.from_item(rss_item) }
+    let!(:episode) { create(:podcast_episode, media_url: item.link) }
+
+    before do
+      stub_request(:head, item.enclosure_url).to_return(status: 200)
+    end
+
+    it "updates existing episode" do
+      new_episode = described_class.call(podcast.id)
+      expect(new_episode.id).to eq(episode.id)
+    end
+  end
 end

--- a/spec/services/podcasts/create_episode_spec.rb
+++ b/spec/services/podcasts/create_episode_spec.rb
@@ -74,15 +74,20 @@ RSpec.describe Podcasts::CreateEpisode, type: :service do
   context "when attempting to create duplicate episodes" do
     let(:rss_item) { RSS::Parser.parse("spec/support/fixtures/podcasts/developertea.rss", false).items.first }
     let(:item) { Podcasts::EpisodeRssItem.from_item(rss_item) }
-    let!(:episode) { create(:podcast_episode, media_url: item.link) }
+    let!(:episode) { create(:podcast_episode, title: "outdated title", media_url: item.enclosure_url) }
 
     before do
       stub_request(:head, item.enclosure_url).to_return(status: 200)
     end
 
     it "updates existing episode" do
-      new_episode = described_class.call(podcast.id)
+      new_episode = described_class.call(podcast.id, item)
       expect(new_episode.id).to eq(episode.id)
+    end
+
+    it "updates columns" do
+      new_episode = described_class.call(podcast.id, item)
+      expect(new_episode.title).to eq(item.title)
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
`Podcasts::CreateEpisode` can potentially be called more than once with the same arguments. E.g. it can be created when the previous job hasn't finished yet. In this case the job will fail with a validation error. This pr uses `import!` from `activerecord-import` gem so that the service object would perform upsert (`ON CONFLICT DO UPDATE`).