### PR TITLE
Customize UserContext Middleware in Timber logs

### DIFF
--- a/config/initializers/timber.rb
+++ b/config/initializers/timber.rb
@@ -19,6 +19,15 @@ config.integrations.rack.http_events.silence_request = lambda do |_rack_env, rac
   rack_request.path.match?(/^\/page_views\/\d{1,9}/)
 end
 
+config.integrations.rack.user_context.custom_user_hash = lambda do |rack_env|
+  session_user_id = rack_env["rack.session"].to_h["warden.user.user.key"]&.first&.first
+  if session_user_id
+    {
+      id: session_user_id
+    }
+  end
+end
+
 # Add additional configuration here.
 # For a full list of configuration options and their explanations see:
 # http://www.rubydoc.info/github/timberio/timber-ruby/Timber/Config


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [x] Optimization

## Description
This pull request customizes the `UserContext` middleware in Timber to pluck the user's ID from the session instead of querying a user on each request.

This means we won't have the user's name and email natively stored in logs, which is sort of a convenience, but unnecessary since we can reference that info via the ID.

This is a minor performance improvement in a lot of cases, but affects literally every request and could amount to 10-20% gains on some basic requests.

Timber docs... https://docs.timber.io/setup/languages/ruby/integrations/rack#custom_user_hash