### PR TITLE
Fix gitpod setup

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -1,8 +1,6 @@
 FROM gitpod/workspace-postgres
-# The below variable is to be modified to trigger a Dockerfile rebuild (this is in YYYY-MM-DD format)
-ENV IMAGE_BUILD_DATE=2019-11-3
 
 # Install Ruby
-COPY .ruby-version /tmp
-RUN bash -lc "rvm install ruby-$(cat /tmp/.ruby-version)" \
+ENV RUBY_VERSION=2.6.5
+RUN bash -lc "rvm install ruby-$RUBY_VERSION && rvm use ruby-$RUBY_VERSION --default" \
  && rm -f /tmp/*

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@
     <img src="https://www.codetriage.com/thepracticaldev/dev.to/badges/users.svg" alt="CodeTriage badge">
   </a>
   <img src="https://flat.badgen.net/dependabot/thepracticaldev/dev.to?icon=dependabot" alt="Dependabot Badge" />
+  <a href="https://gitpod.io/from-referrer/">
+    <img src="https://img.shields.io/badge/setup-automated-blue?logo=gitpod"/>
+  </a>
 </p>
 
 Welcome to the [dev.to](https://dev.to) codebase. We are so excited to have you.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

The setup for gitpod was not working since the last ruby version update.
This PR fixes it by also making the version being the default used one.

I have simplified the config, to not rely on the `.ruby_version` file as we have to update the dockerfile anyhow. So Instead of adding a strange UPDATE marker I believe just including the ruby version again is simpler for anyone trying to understand the setup.

Also, while at it I added the setup|automated badge to the readme.

## Added to documentation?

- [ ] docs.dev.to
- [x] readme
- [ ] no documentation needed