### PR TITLE
Remove disable_indented_code_blocks

### DIFF
--- a/config/initializers/redcarpet.rb
+++ b/config/initializers/redcarpet.rb
@@ -2,7 +2,6 @@
   autolink: true,
   no_intra_emphasis: true,
   fenced_code_blocks: true,
-  disable_indented_code_blocks: true,
   lax_html_blocks: true,
   lax_spacing: true,
   strikethrough: true,

--- a/spec/support/fixtures/approvals/user_preview_article_body.approved.html
+++ b/spec/support/fixtures/approvals/user_preview_article_body.approved.html
@@ -107,6 +107,12 @@ the present is our past.</p>
 
 
 
+<div class="highlight"><pre class="highlight plaintext"><code>// indented codeblock should work
+function hello() {
+  console.log("hello");
+}
+</code></pre></div>
+
 <ul><li>[x] @mentions, #refs, <a href="">links</a>, <strong>formatting</strong>, and <del>tags</del> supported</li>
 <li>[x] list syntax required (any unordered or ordered list supported)</li>
 <li>[x] this is a complete item</li>

--- a/spec/support/fixtures/sample_article_template_spec.txt
+++ b/spec/support/fixtures/sample_article_template_spec.txt
@@ -61,6 +61,11 @@ function fancyAlert(arg) {
 }
 ```
 
+    // indented codeblock should work
+    function hello() {
+      console.log("hello");
+    }
+
 
 - [x] @mentions, #refs, [links](), **formatting**, and <del>tags</del> supported
 - [x] list syntax required (any unordered or ordered list supported)


### PR DESCRIPTION


<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This PR undo https://github.com/thepracticaldev/dev.to/pull/4438 and update a spec for regressions. Our reasoning is that this is a legacy markdown feature that our older articles depend on. We'll have to think of a different solution to resolve backtick in code blocks.
## Related Tickets & Documents
Resolve https://github.com/thepracticaldev/dev.to/issues/4956
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
n/a
## Added to documentation?
- [x] no documentation needed
