### PR TITLE
Setup dual Redis store for rolling over fragment cacheing to Redis

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -25,7 +25,7 @@ Rails.application.configure do
     REDIS_DEFAULT_EXPIRATION = 24.hours.to_i.freeze
 
     config.cache_store = :dual_rails_store, {
-      default_store: [ :redis_store, url: ENV["REDIS_URL"] + "/15", expires_in: REDIS_DEFAULT_EXPIRATION],
+      default_store: [ :memory_store ],
       redis: [ :redis_store, url: ENV["REDIS_URL"], expires_in: REDIS_DEFAULT_EXPIRATION]
     }
     config.public_file_server.headers = {

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,5 +1,3 @@
-require 'active_support/cache/dual_rails_store'
-
 def yarn_integrity_enabled?
   ENV.fetch("YARN_INTEGRITY_ENABLED", "true") == "true"
 end
@@ -27,7 +25,7 @@ Rails.application.configure do
     REDIS_DEFAULT_EXPIRATION = 24.hours.to_i.freeze
 
     config.cache_store = :dual_rails_store, {
-      default_store: [ :memory_store ],
+      default_store: [ :redis_store, url: ENV["REDIS_URL"] + "/15", expires_in: REDIS_DEFAULT_EXPIRATION],
       redis: [ :redis_store, url: ENV["REDIS_URL"], expires_in: REDIS_DEFAULT_EXPIRATION]
     }
     config.public_file_server.headers = {

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,3 +1,5 @@
+require 'active_support/cache/dual_rails_store'
+
 def yarn_integrity_enabled?
   ENV.fetch("YARN_INTEGRITY_ENABLED", "true") == "true"
 end
@@ -22,8 +24,12 @@ Rails.application.configure do
   # Enable/disable caching. By default caching is disabled.
   if Rails.root.join("tmp", "caching-dev.txt").exist?
     config.action_controller.perform_caching = true
+    REDIS_DEFAULT_EXPIRATION = 24.hours.to_i.freeze
 
-    config.cache_store = :memory_store
+    config.cache_store = :dual_rails_store, {
+      default_store: [ :memory_store ],
+      redis: [ :redis_store, url: ENV["REDIS_URL"], expires_in: REDIS_DEFAULT_EXPIRATION]
+    }
     config.public_file_server.headers = {
       "Cache-Control" => "public, max-age=#{2.days.to_i}"
     }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -106,7 +106,9 @@ Rails.application.configure do
                          password: ENV["MEMCACHIER_PASSWORD"],
                          failover: true,
                          socket_timeout: 1.5,
-                         socket_failure_delay: 0.2 } ],
+                         socket_failure_delay: 0.2,
+                         expires_in: REDIS_DEFAULT_EXPIRATION,
+                         include_connection: true } ],
     redis: [ :redis_store, url: ENV["REDIS_URL"], expires_in: REDIS_DEFAULT_EXPIRATION ]
   }
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -108,7 +108,7 @@ Rails.application.configure do
                          socket_timeout: 1.5,
                          socket_failure_delay: 0.2,
                          expires_in: REDIS_DEFAULT_EXPIRATION,
-                         include_connection: true } ],
+                         dalli_store: true } ],
     redis: [ :redis_store, url: ENV["REDIS_URL"], expires_in: REDIS_DEFAULT_EXPIRATION ]
   }
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -106,7 +106,7 @@ Rails.application.configure do
                          password: ENV["MEMCACHIER_PASSWORD"],
                          failover: true,
                          socket_timeout: 1.5,
-                         socket_failure_delay: 0.2 },
+                         socket_failure_delay: 0.2 } ],
     redis: [ :redis_store, url: ENV["REDIS_URL"], expires_in: REDIS_DEFAULT_EXPIRATION ]
   }
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -99,13 +99,16 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  config.cache_store = :dalli_store,
-                       (ENV["MEMCACHIER_SERVERS"] || "").split(","),
+  REDIS_DEFAULT_EXPIRATION = 24.hours.to_i.freeze
+  config.cache_store = :dual_rails_store, {
+    default_store: [ :dalli_store, (ENV["MEMCACHIER_SERVERS"] || "").split(","),
                        { username: ENV["MEMCACHIER_USERNAME"],
                          password: ENV["MEMCACHIER_PASSWORD"],
                          failover: true,
                          socket_timeout: 1.5,
-                         socket_failure_delay: 0.2 }
+                         socket_failure_delay: 0.2 },
+    redis: [ :redis_store, url: ENV["REDIS_URL"], expires_in: REDIS_DEFAULT_EXPIRATION ]
+  }
 
   config.app_domain = ENV["APP_DOMAIN"]
 

--- a/lib/active_support/cache/dual_rails_store.rb
+++ b/lib/active_support/cache/dual_rails_store.rb
@@ -1,6 +1,12 @@
 require 'active_support/cache'
 require 'active_support/version'
 
+# This class is modeled off of https://github.com/mezis/level2 and is temporary
+#
+# Any cache statement as-is will use :default_store (Memcache)
+# Any cache statement with the option only: :redis will only use Redis
+# Any cache statement with the option all: true will write to Redis and Memcache BUT will read/return the value read from Memcache.
+
 module ActiveSupport
   module Cache
     class DualRailsStore < Store

--- a/lib/active_support/cache/dual_rails_store.rb
+++ b/lib/active_support/cache/dual_rails_store.rb
@@ -1,0 +1,71 @@
+require 'active_support/cache'
+require 'active_support/version'
+
+module ActiveSupport
+  module Cache
+    class DualRailsStore < Store
+      attr_reader :stores
+
+      def initialize(store_options)
+        @stores = store_options.each_with_object({}) do |(name, options), h|
+          h[name] = ActiveSupport::Cache.lookup_store(options)
+        end
+        @options = {}
+      end
+
+      def cleanup(*args)
+        raise 'Do not clear production caches' if Rails.env.production?
+        @stores.each_value { |s| s.cleanup(*args) }
+      end
+
+      def clear(*args)
+        raise 'Do not clear production caches' if Rails.env.production?
+        @stores.each_value { |s| s.clear(*args) }
+      end
+
+      def read_multi(*names)
+        result = {}
+        @stores.each do |_name,store|
+          data = store.read_multi(*names)
+          result.merge! data
+          names -= data.keys
+        end
+        result
+      end
+
+      protected
+
+      def read_entry(key, options)
+        stores = selected_stores(options)
+        stores.each do |store|
+          entry = store.send :read_entry, key, options
+          return entry if entry.present?
+        end
+
+        return
+      end
+
+      def write_entry(key, entry, options)
+        stores = selected_stores(options)
+        stores.each do |store|
+          result = store.send(:write_entry, key, entry, options)
+          return false unless result
+        end
+      end
+
+      def delete_entry(key, options)
+        stores = selected_stores(options)
+        stores.map { |store| store.send(:delete_entry, key, options) }.all?
+      end
+
+      private
+
+      def selected_stores(options)
+        return @stores.values if options[:all]
+
+        only = options[:only] || :default_store
+        Array.wrap(@stores[only])
+      end
+    end
+  end
+end

--- a/lib/active_support/cache/dual_rails_store.rb
+++ b/lib/active_support/cache/dual_rails_store.rb
@@ -62,12 +62,12 @@ module ActiveSupport
         stores = selected_stores(options)
         stores.each do |store|
           # Ensure default expiration gets set for keys without
-          options[:expires_in] ||= options.merge(expires_in: store.options[:expires_in])
+          write_options = options.reverse_merge(expires_in: store.options[:expires_in])
 
           # Add connection to options hash for dalli_store
-          options = options.merge(connection: store.instance_variable_get(:@data)) if store.options[:dalli_store]
+          write_options = write_options.merge(connection: store.instance_variable_get(:@data)) if store.options[:dalli_store]
 
-          result = store.send(:write_entry, key, entry, options)
+          result = store.send(:write_entry, key, entry, write_options)
           return false unless result
         end
 

--- a/lib/active_support/cache/dual_rails_store.rb
+++ b/lib/active_support/cache/dual_rails_store.rb
@@ -56,6 +56,12 @@ module ActiveSupport
       def write_entry(key, entry, options)
         stores = selected_stores(options)
         stores.each do |store|
+          # Ensure default expiration gets set for keys without
+          options[:expires_in] ||= store.options[:expires_in]
+
+          # Add connection to options hash for dalli_store
+          options = options.merge(connectio: store.instance_variable_get(:@data)) if store.options[:include_connection]
+
           result = store.send(:write_entry, key, entry, options)
           return false unless result
         end

--- a/lib/active_support/cache/dual_rails_store.rb
+++ b/lib/active_support/cache/dual_rails_store.rb
@@ -60,7 +60,7 @@ module ActiveSupport
           options[:expires_in] ||= store.options[:expires_in]
 
           # Add connection to options hash for dalli_store
-          options = options.merge(connectio: store.instance_variable_get(:@data)) if store.options[:include_connection]
+          options = options.merge(connection: store.instance_variable_get(:@data)) if store.options[:include_connection]
 
           result = store.send(:write_entry, key, entry, options)
           return false unless result

--- a/lib/active_support/cache/dual_rails_store.rb
+++ b/lib/active_support/cache/dual_rails_store.rb
@@ -1,5 +1,5 @@
-require 'active_support/cache'
-require 'active_support/version'
+require "active_support/cache"
+require "active_support/version"
 
 # This class is modeled off of https://github.com/mezis/level2 and is temporary
 #
@@ -20,18 +20,20 @@ module ActiveSupport
       end
 
       def cleanup(*args)
-        raise 'Do not clear production caches' if Rails.env.production?
+        raise "Do not clear production caches" if Rails.env.production?
+
         @stores.each_value { |s| s.cleanup(*args) }
       end
 
       def clear(*args)
-        raise 'Do not clear production caches' if Rails.env.production?
+        raise "Do not clear production caches" if Rails.env.production?
+
         @stores.each_value { |s| s.clear(*args) }
       end
 
       def read_multi(*names)
         result = {}
-        @stores.each do |_name,store|
+        @stores.each do |_name, store|
           data = store.read_multi(*names)
           result.merge! data
           names -= data.keys
@@ -48,7 +50,7 @@ module ActiveSupport
           return entry if entry.present?
         end
 
-        return
+        nil
       end
 
       def write_entry(key, entry, options)

--- a/lib/active_support/cache/dual_rails_store.rb
+++ b/lib/active_support/cache/dual_rails_store.rb
@@ -85,6 +85,8 @@ module ActiveSupport
         return @stores.values if options[:all]
 
         only = options[:only] || :default_store
+        raise 'Store not found!' unless @stores[only]
+
         Array.wrap(@stores[only])
       end
     end

--- a/lib/active_support/cache/dual_rails_store.rb
+++ b/lib/active_support/cache/dual_rails_store.rb
@@ -62,7 +62,7 @@ module ActiveSupport
         stores = selected_stores(options)
         stores.each do |store|
           # Ensure default expiration gets set for keys without
-          options[:expires_in] ||= store.options[:expires_in]
+          options[:expires_in] ||= options.merge(expires_in: store.options[:expires_in])
 
           # Add connection to options hash for dalli_store
           options = options.merge(connection: store.instance_variable_get(:@data)) if store.options[:dalli_store]
@@ -85,7 +85,7 @@ module ActiveSupport
         return @stores.values if options[:all]
 
         only = options[:only] || :default_store
-        raise 'Store not found!' unless @stores[only]
+        raise "Store not found!" unless @stores[only]
 
         Array.wrap(@stores[only])
       end

--- a/lib/active_support/cache/dual_rails_store.rb
+++ b/lib/active_support/cache/dual_rails_store.rb
@@ -46,11 +46,11 @@ module ActiveSupport
       def read_entry(key, options)
         stores = selected_stores(options)
         stores.each do |store|
-          if store.options[:dalli_store]
-            entry = store.instance_variable_get(:@data).get(key, options)
-          else
-            entry = store.send :read_entry, key, options
-          end
+          entry = if store.options[:dalli_store]
+                    store.instance_variable_get(:@data).get(key, options)
+                  else
+                    store.send :read_entry, key, options
+                  end
 
           return entry if entry.present?
         end

--- a/spec/lib/active_support/cache/dual_rails_store_spec.rb
+++ b/spec/lib/active_support/cache/dual_rails_store_spec.rb
@@ -65,6 +65,10 @@ RSpec.describe ActiveSupport::Cache::DualRailsStore, type: :lib do
       dual_store.clear
       expect(dual_store.read("foo")).to be_nil
     end
+
+    it "raises an error for an unknown store" do
+      expect { dual_store.write("foo", "bar", only: :foo) }.to raise_error("Store not found!")
+    end
   end
 
   describe "storage" do

--- a/spec/lib/active_support/cache/dual_rails_store_spec.rb
+++ b/spec/lib/active_support/cache/dual_rails_store_spec.rb
@@ -4,10 +4,12 @@ RSpec.describe ActiveSupport::Cache::DualRailsStore, type: :lib do
   subject do
     ActiveSupport::Cache.lookup_store :dual_rails_store,
                                       default_store: [
-                                        :memory_store, { size: 10.megabytes }
+                                        :memory_store,
+                                        { size: 10.megabytes },
                                       ],
                                       second_store: [
-                                        :memory_store, { size: 5.megabytes }
+                                        :redis_store,
+                                        { size: 5.megabytes, expires_in: 200 },
                                       ]
   end
 
@@ -49,6 +51,13 @@ RSpec.describe ActiveSupport::Cache::DualRailsStore, type: :lib do
     it "honors expiration" do
       dual_store.write("foo", "bar", expires_in: 0)
       expect(dual_store.read("foo")).to be_nil
+    end
+
+    it "honors default expiration" do
+      dual_store.write("foo", "bar")
+      ttl = second_store.data.ttl("foo")
+      expect(ttl).to be < 201
+      expect(ttl).to be > 0
     end
 
     it "can #clear" do

--- a/spec/lib/active_support/cache/dual_rails_store_spec.rb
+++ b/spec/lib/active_support/cache/dual_rails_store_spec.rb
@@ -1,0 +1,107 @@
+require "rails_helper"
+
+RSpec.describe ActiveSupport::Cache::DualRailsStore, type: :lib do
+  subject do
+    ActiveSupport::Cache.lookup_store :dual_rails_store,
+                                      default_store: [
+                                        :memory_store, { size: 10.megabytes }
+                                      ],
+                                      second_store: [
+                                        :memory_store, { size: 5.megabytes }
+                                      ]
+  end
+
+  let(:dual_store) { subject }
+  let(:default_store) { subject.stores.values.first }
+  let(:second_store) { subject.stores.values.last }
+
+  describe "#initialized" do
+    it "does not raise an error" do
+      expect { dual_store }.not_to raise_error
+    end
+
+    it "sets stores instance variable" do
+      expect(dual_store.stores.count).to eq(2)
+    end
+  end
+
+  describe "cache behavior" do
+    it "can #write" do
+      expect(dual_store.write("foo", "bar")).to be_truthy
+    end
+
+    it "can #read" do
+      dual_store.write("foo", "bar")
+      expect(dual_store.read("foo")).to eq("bar")
+    end
+
+    it "can #delete" do
+      dual_store.write("foo", "bar")
+      dual_store.delete("foo")
+      expect(dual_store.read("foo")).to be_nil
+    end
+
+    it "can #fetch" do
+      expect(dual_store.fetch("foo") { "bar" }).to eq("bar")
+      expect(dual_store.fetch("foo") { "qux" }).to eq("bar")
+    end
+
+    it "honors expiration" do
+      dual_store.write("foo", "bar", expires_in: 0)
+      expect(dual_store.read("foo")).to be_nil
+    end
+
+    it "can #clear" do
+      dual_store.write("foo", "bar")
+      dual_store.clear
+      expect(dual_store.read("foo")).to be_nil
+    end
+  end
+
+  describe "storage" do
+    it "writes to all stores with all option" do
+      dual_store.write("foo", "bar", all: true)
+      expect(default_store.read("foo")).to eq("bar")
+      expect(second_store.read("foo")).to eq("bar")
+    end
+
+    it "reads from the default store" do
+      default_store.write("foo", "bar1")
+      second_store.write("foo", "bar2")
+      expect(dual_store.read("foo")).to eq("bar1")
+    end
+
+    it "can read from the bottom store" do
+      second_store.write("foo", "bar2")
+      expect(dual_store.read("foo", only: :second_store)).to eq("bar2")
+    end
+  end
+
+  describe ":only restrictions" do
+    it "only writes to the selected store" do
+      dual_store.write("foo", "bar", only: :second_store)
+      expect(default_store.read("foo")).to be_nil
+      expect(second_store.read("foo")).to eq("bar")
+    end
+
+    it "only reads the selected store" do
+      default_store.write("foo", "bar1", only: :default_store)
+      second_store.write("foo", "bar2", only: :second_store)
+      expect(dual_store.read("foo", only: :default_store)).to eq("bar1")
+      expect(dual_store.read("foo", only: :second_store)).to eq("bar2")
+    end
+  end
+
+  describe "#read_multi" do
+    before do
+      dual_store.write("a", "a1", only: :default_store)
+      dual_store.write("a", "a2", only: :second_store)
+      dual_store.write("b", "b1", only: :default_store)
+      dual_store.write("c", "c2", only: :second_store)
+    end
+
+    it "mass-reads data from each store" do
+      expect(dual_store.read_multi("a", "b", "c", "d")).to eq("a" => "a1", "b" => "b1", "c" => "c2")
+    end
+  end
+end

--- a/spec/lib/active_support/cache/dual_rails_store_spec.rb
+++ b/spec/lib/active_support/cache/dual_rails_store_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe ActiveSupport::Cache::DualRailsStore, type: :lib do
     end
 
     it "honors default expiration" do
-      dual_store.write("foo", "bar")
+      dual_store.write("foo", "bar", all: true)
       ttl = second_store.data.ttl("foo")
       expect(ttl).to be < 201
       expect(ttl).to be > 0


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
This new cache store, `dual_rails_store` will allow us to continue to write to Memcache while moving over keys to Redis at our own pace. I modeled this class off of a [gem I found for dual caches](https://github.com/mezis/level2) except I updated it for our purposes. 

* Any cache statement as-is will use Memcache 
* Any cache statement with the option `only: redis` will only use Redis
* Any cache statement with the option `all: true` will write to Redis and Memcache but will read/return the value read from Memcache.

What does everyone think of this approach? I like that we can continue to roll over keys at our own pace and that we can back populate any keys we deem a higher risk to roll over. 

## Related Tickets & Documents
#4670 

## Added to documentation?
- [x] no documentation needed

![maybe that will work gif](https://media1.tenor.com/images/63f988e6b715c4d94b830b07d9ecb396/tenor.gif?itemid=13407671)
