### PR TITLE
Fix unique constraint violation on notifications create

### DIFF
--- a/app/services/notifications/notifiable_action/send.rb
+++ b/app/services/notifications/notifiable_action/send.rb
@@ -34,7 +34,15 @@ module Notifications
             notified_at: Time.current,
           )
         end
-        Notification.import! notifications
+        conflict_target = %i[notifiable_id notifiable_type user_id]
+        conflict_target << :action if action.present?
+        index_predicate = "action IS#{action.present? ? ' NOT ' : ' '}NULL"
+        Notification.import! notifications,
+                             on_duplicate_key_update: {
+                               conflict_target: conflict_target,
+                               index_predicate: index_predicate,
+                               columns: %i[json_data notified_at read]
+                             }
       end
 
       private

--- a/spec/services/notifications/notifiable_action/send_spec.rb
+++ b/spec/services/notifications/notifiable_action/send_spec.rb
@@ -48,4 +48,10 @@ RSpec.describe Notifications::NotifiableAction::Send, type: :service do
     described_class.call(article, "Published")
     expect(Notification.count).to eq 0
   end
+
+  it "doesn't fail if the notification already exists" do
+    notification = create(:notification, user: user2, action: "Published", notifiable: article)
+    result = described_class.call(article, "Published")
+    expect(result.ids).to include(notification.id)
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Sometimes duplicate notifications could be attempted to be created in `Notifications::NotifiableAction::Send`. In this pr I specified `on_duplicate_key_update` option so that the existing records would be updated instead of failing with unique constraint violation.