### PR TITLE
Set default Fastly Rails caching back to 30 days

### DIFF
--- a/config/initializers/fastly.rb
+++ b/config/initializers/fastly.rb
@@ -1,6 +1,6 @@
 FastlyRails.configure do |c|
   c.api_key = ApplicationConfig["FASTLY_API_KEY"] # Fastly api key, required
-  c.max_age = 86_500 # time in seconds, optional, defaults to 2592000 (30 days)
+  c.max_age = 30.days.to_i # time in seconds, optional, defaults to 2592000 (30 days)
   c.service_id = ApplicationConfig["FASTLY_SERVICE_ID"] # Fastly service you will be using, required
   c.stale_if_error = 26_400
   c.purging_enabled = Rails.env.production? # No need to configure a client locally (since 0.4.0)

--- a/spec/requests/reactions_spec.rb
+++ b/spec/requests/reactions_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe "Reactions", type: :request do
   let(:user)    { create(:user) }
   let(:article) { create(:article, user_id: user.id) }
   let(:comment) { create(:comment, commentable_id: article.id) }
+  let(:max_age) { FastlyRails.configuration.max_age }
+  let(:stale_if_error) { FastlyRails.configuration.stale_if_error }
 
   describe "GET /reactions?article_id=:article_id" do
     context "when signed in" do
@@ -23,7 +25,7 @@ RSpec.describe "Reactions", type: :request do
       it "does not set Fastly cache control and surrogate control headers" do
         expect(response.headers.to_hash).not_to include(
           "Cache-Control" => "public, no-cache",
-          "Surrogate-Control" => "max-age=86500, stale-if-error=26400",
+          "Surrogate-Control" => "max-age=#{max_age}, stale-if-error=#{stale_if_error}",
         )
       end
     end
@@ -42,7 +44,7 @@ RSpec.describe "Reactions", type: :request do
       it "sets Fastly cache control and surrogate control headers" do
         expect(response.headers.to_hash).to include(
           "Cache-Control" => "public, no-cache",
-          "Surrogate-Control" => "max-age=86500, stale-if-error=26400",
+          "Surrogate-Control" => "max-age=#{max_age}, stale-if-error=#{stale_if_error}",
         )
       end
     end
@@ -66,7 +68,7 @@ RSpec.describe "Reactions", type: :request do
       it "does not set Fastly cache control and surrogate control headers" do
         expect(response.headers.to_hash).not_to include(
           "Cache-Control" => "public, no-cache",
-          "Surrogate-Control" => "max-age=86500, stale-if-error=26400",
+          "Surrogate-Control" => "max-age=#{max_age}, stale-if-error=#{stale_if_error}",
         )
       end
     end
@@ -85,7 +87,7 @@ RSpec.describe "Reactions", type: :request do
       it "sets Fastly cache control and surrogate control headers" do
         expect(response.headers.to_hash).to include(
           "Cache-Control" => "public, no-cache",
-          "Surrogate-Control" => "max-age=86500, stale-if-error=26400",
+          "Surrogate-Control" => "max-age=#{max_age}, stale-if-error=#{stale_if_error}",
         )
       end
     end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

This set Fastly's default `max-age` parameter in `Cache-Control` back to 30 days, which is the default.

If this were only used for static assets I would raise it to much more, like one year, but it's used also to dynamic responses so the default is fine. We can revisit this when we do a proper audit of how we cache with Fastly and smooth some kinks.

Recommendation from [Google Lighthouse audits on cache policy](https://developers.google.com/web/tools/lighthouse/audits/cache-policy):

> When possible, cache immutable static assets for a long time, such as a year or longer. Configure your build tool to embed a hash in your static asset filenames so that each one is unique.

