### PR TITLE
Add missing fks to api_secrets, listings and identities

### DIFF
--- a/db/migrate/20191203160028_add_missing_foreign_keys_api_secrets_listings_identities.rb
+++ b/db/migrate/20191203160028_add_missing_foreign_keys_api_secrets_listings_identities.rb
@@ -1,0 +1,7 @@
+class AddMissingForeignKeysApiSecretsListingsIdentities < ActiveRecord::Migration[5.2]
+  def change
+    add_foreign_key :api_secrets, :users, on_delete: :cascade
+    add_foreign_key :classified_listings, :users, on_delete: :cascade
+    add_foreign_key :identities, :users, on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_03_114809) do
+ActiveRecord::Schema.define(version: 2019_12_03_160028) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -1204,11 +1204,14 @@ ActiveRecord::Schema.define(version: 2019_12_03_114809) do
     t.index ["user_id"], name: "index_webhook_endpoints_on_user_id"
   end
 
+  add_foreign_key "api_secrets", "users", on_delete: :cascade
   add_foreign_key "audit_logs", "users"
   add_foreign_key "badge_achievements", "badges"
   add_foreign_key "badge_achievements", "users"
   add_foreign_key "chat_channel_memberships", "chat_channels"
   add_foreign_key "chat_channel_memberships", "users"
+  add_foreign_key "classified_listings", "users", on_delete: :cascade
+  add_foreign_key "identities", "users", on_delete: :cascade
   add_foreign_key "messages", "chat_channels"
   add_foreign_key "messages", "users"
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"

--- a/spec/models/identity_spec.rb
+++ b/spec/models/identity_spec.rb
@@ -5,7 +5,15 @@ RSpec.describe Identity, type: :model do
   it { is_expected.to validate_presence_of(:uid) }
   it { is_expected.to validate_presence_of(:provider) }
   it { is_expected.to validate_uniqueness_of(:uid).scoped_to(:provider) }
-  it { is_expected.to validate_uniqueness_of(:user_id).scoped_to(:provider) }
+
+  it do
+    # rubocop:disable RSpec/NamedSubject
+    # see <https://github.com/thoughtbot/shoulda-matchers/issues/682>
+    subject.user = create(:user)
+    expect(subject).to validate_uniqueness_of(:user_id).scoped_to(:provider)
+    # rubocop:enable RSpec/NamedSubject
+  end
+
   it { is_expected.to validate_inclusion_of(:provider).in_array(%w[github twitter]) }
   it { is_expected.to serialize(:auth_data_dump) }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

Step 2 of 3 of adding missing foreign keys to tables, see #4960

This adds them to `api_secrets`, `classified_listings`, `identities`

(step 1 was https://github.com/thepracticaldev/dev.to/pull/4994)

NOTE: please read the description in #4960 before merging this.
