### PR TITLE
Add FKs to notifications_subscriptions, page_views and users_roles

### DIFF
--- a/db/migrate/20191203171558_add_missing_foreign_keys_notifications_subs_page_views_users_roles.rb
+++ b/db/migrate/20191203171558_add_missing_foreign_keys_notifications_subs_page_views_users_roles.rb
@@ -1,0 +1,7 @@
+class AddMissingForeignKeysNotificationsSubsPageViewsUsersRoles < ActiveRecord::Migration[5.2]
+  def change
+    add_foreign_key :notification_subscriptions, :users, on_delete: :cascade
+    add_foreign_key :page_views, :articles, on_delete: :cascade
+    add_foreign_key :users_roles, :users, on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_03_160028) do
+ActiveRecord::Schema.define(version: 2019_12_03_171558) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -1214,10 +1214,12 @@ ActiveRecord::Schema.define(version: 2019_12_03_160028) do
   add_foreign_key "identities", "users", on_delete: :cascade
   add_foreign_key "messages", "chat_channels"
   add_foreign_key "messages", "users"
+  add_foreign_key "notification_subscriptions", "users", on_delete: :cascade
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_access_grants", "users", column: "resource_owner_id"
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_access_tokens", "users", column: "resource_owner_id"
+  add_foreign_key "page_views", "articles", on_delete: :cascade
   add_foreign_key "push_notification_subscriptions", "users"
   add_foreign_key "sponsorships", "organizations"
   add_foreign_key "sponsorships", "users"
@@ -1226,6 +1228,7 @@ ActiveRecord::Schema.define(version: 2019_12_03_160028) do
   add_foreign_key "tag_adjustments", "users", on_delete: :cascade
   add_foreign_key "user_blocks", "users", column: "blocked_id"
   add_foreign_key "user_blocks", "users", column: "blocker_id"
+  add_foreign_key "users_roles", "users", on_delete: :cascade
   add_foreign_key "webhook_endpoints", "oauth_applications"
   add_foreign_key "webhook_endpoints", "users"
 end

--- a/spec/policies/article_policy_spec.rb
+++ b/spec/policies/article_policy_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.describe ArticlePolicy do
   subject { described_class.new(user, article) }
 
+  let!(:user) { create(:user) }
+
   let(:article) { build_stubbed(:article) }
   let(:valid_attributes) do
     %i[title body_html body_markdown main_image published
@@ -19,8 +21,6 @@ RSpec.describe ArticlePolicy do
   end
 
   context "when user is not the author" do
-    let(:user) { build_stubbed(:user) }
-
     it { is_expected.to permit_actions(%i[new create preview]) }
     it { is_expected.to forbid_actions(%i[update edit manage delete_confirm destroy]) }
 
@@ -33,7 +33,6 @@ RSpec.describe ArticlePolicy do
   end
 
   context "when user is the author" do
-    let(:user)    { build_stubbed(:user) }
     let(:article) { build_stubbed(:article, user: user) }
 
     it { is_expected.to permit_actions(%i[update edit manage new create delete_confirm destroy preview]) }

--- a/spec/policies/chat_channel_policy_spec.rb
+++ b/spec/policies/chat_channel_policy_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ChatChannelPolicy, type: :policy do
   subject { described_class.new(user, chat_channel) }
 
   let(:chat_channel) { build_stubbed(:chat_channel, channel_type: "invite_only") }
-  let(:user)         { build_stubbed(:user) }
+  let!(:user) { create(:user) }
 
   context "when user is not signed-in" do
     let(:user) { nil }

--- a/spec/policies/comment_policy_spec.rb
+++ b/spec/policies/comment_policy_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe CommentPolicy, type: :policy do
   subject(:comment_policy) { described_class.new(user, comment) }
 
-  let(:comment) { build_stubbed(:comment) }
+  let!(:comment) { create(:comment, commentable: create(:podcast_episode)) }
 
   let(:valid_attributes_for_create) do
     %i[body_markdown commentable_id commentable_type parent_id]
@@ -20,7 +20,7 @@ RSpec.describe CommentPolicy, type: :policy do
   end
 
   context "when user is not the author" do
-    let(:user) { build_stubbed(:user) }
+    let!(:user) { create(:user) }
 
     it { is_expected.to permit_actions(%i[create]) }
     it { is_expected.to forbid_actions(%i[edit update destroy delete_confirm]) }

--- a/spec/policies/follow_policy_spec.rb
+++ b/spec/policies/follow_policy_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe FollowPolicy, type: :policy do
   end
 
   context "when user is signed in" do
-    let(:user) { build_stubbed(:user) }
+    let!(:user) { create(:user) }
 
     it { is_expected.to permit_actions(%i[create]) }
 

--- a/spec/policies/github_repo_policy_spec.rb
+++ b/spec/policies/github_repo_policy_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe GithubRepoPolicy, type: :policy do
   subject { described_class.new(user, github_repo) }
 
-  let(:github_repo)      { build_stubbed(:github_repo) }
+  let_it_be(:github_repo) { create(:github_repo) }
   let(:valid_attributes) { %i[github_id_code] }
 
   context "when user is not signed in" do
@@ -13,7 +13,7 @@ RSpec.describe GithubRepoPolicy, type: :policy do
   end
 
   context "when user is not the owner" do
-    let(:user) { build_stubbed(:user) }
+    let!(:user) { create(:user) }
 
     it { is_expected.to permit_actions(%i[create]) }
     it { is_expected.to forbid_actions(%i[update]) }

--- a/spec/policies/reaction_policy_spec.rb
+++ b/spec/policies/reaction_policy_spec.rb
@@ -3,7 +3,9 @@ require "rails_helper"
 RSpec.describe ReactionPolicy do
   subject { described_class.new(user, reaction) }
 
-  let(:reaction) { build_stubbed(:reaction) }
+  let_it_be(:comment) { create(:comment, commentable: create(:article)) }
+  let_it_be(:reaction) { create(:reaction, reactable: comment) }
+  let!(:user) { create(:user) }
 
   context "when user is not signed in" do
     let(:user) { nil }
@@ -12,8 +14,6 @@ RSpec.describe ReactionPolicy do
   end
 
   context "when user is signed in" do
-    let(:user) { build_stubbed(:user) }
-
     it { is_expected.to permit_actions(%i[index create]) }
 
     context "when user is banned" do

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe UserPolicy, type: :policy do
   subject { described_class.new(user, other_user) }
 
-  let(:other_user) { build_stubbed(:user) }
+  let(:other_user) { create(:user) }
 
   context "when user is not signed-in" do
     let(:user) { nil }


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

Step 3 of 3 of adding missing foreign keys to tables, see #4960

This adds them to `notifications_subscriptions`, `page_views`, `users_roles`

(step 1 was #4994, step 2 was https://github.com/thepracticaldev/dev.to/pull/4997)

NOTE: please read the description in #4960 before merging this.
