### PR TITLE
Update initializer and locales to doorkeeper 5.2.2

### DIFF
--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 Doorkeeper.configure do
-  # Change the ORM that doorkeeper will use (needs plugins)
+  # Change the ORM that doorkeeper will use (requires ORM extensions installed).
+  # Check the list of supported ORMs here: https://github.com/doorkeeper-gem/doorkeeper#orms
   orm :active_record
 
   # This block will be called to check whether the resource owner is authenticated or not.
@@ -9,7 +10,7 @@ Doorkeeper.configure do
     # raise "Please configure doorkeeper resource_owner_authenticator block located in #{__FILE__}"
     # Put your resource owner authentication logic here.
     # Example implementation:
-    #   User.find_by_id(session[:user_id]) || redirect_to(new_user_session_url)
+    #   User.find_by(id: session[:user_id]) || redirect_to(new_user_session_url)
     current_user || warden.authenticate!(scope: :user)
   end
 
@@ -40,18 +41,18 @@ Doorkeeper.configure do
   #
   # enforce_content_type
 
-  # Authorization Code expiration time (default 10 minutes).
+  # Authorization Code expiration time (default: 10 minutes).
   #
   # authorization_code_expires_in 10.minutes
 
-  # Access token expiration time (default 2 hours).
-  # If you want to disable expiration, set this to nil.
+  # Access token expiration time (default: 2 hours).
+  # If you want to disable expiration, set this to `nil`.
   #
   # access_token_expires_in 2.hours
 
   # Assign custom TTL for access tokens. Will be used instead of access_token_expires_in
   # option if defined. In case the block returns `nil` value Doorkeeper fallbacks to
-  # `access_token_expires_in` configuration option value. If you really need to issue a
+  # +access_token_expires_in+ configuration option value. If you really need to issue a
   # non-expiring access token (which is not recommended) then you need to return
   # Float::INFINITY from this block.
   #
@@ -66,12 +67,13 @@ Doorkeeper.configure do
   # end
 
   # Use a custom class for generating the access token.
-  # See https://github.com/doorkeeper-gem/doorkeeper#custom-access-token-generator
+  # See https://doorkeeper.gitbook.io/guides/configuration/other-configurations#custom-access-token-generator
   #
   # access_token_generator '::Doorkeeper::JWT'
 
-  # The controller Doorkeeper::ApplicationController inherits from.
-  # Defaults to ActionController::Base.
+  # The controller +Doorkeeper::ApplicationController+ inherits from.
+  # Defaults to +ActionController::Base+ unless +api_only+ is set, which changes the default to
+  # +ActionController::API+. The return value of this option must be a stringified class name.
   # See https://doorkeeper.gitbook.io/guides/configuration/other-configurations#custom-base-controller
   #
   base_controller "ApplicationController"
@@ -129,11 +131,10 @@ Doorkeeper.configure do
   #
   # hash_application_secrets using: '::Doorkeeper::SecretStoring::BCrypt'
 
-  # When the above option is enabled,
-  # and a hashed token or secret is not found,
-  # you can allow to fall back to another strategy.
-  # For users upgrading doorkeeper and wishing to enable hashing,
-  # you will probably want to enable the fallback to plain tokens.
+  # When the above option is enabled, and a hashed token or secret is not found,
+  # you can allow to fall back to another strategy. For users upgrading
+  # doorkeeper and wishing to enable hashing, you will probably want to enable
+  # the fallback to plain tokens.
   #
   # This will ensure that old access tokens and secrets
   # will remain valid even if the hashing above is enabled.
@@ -142,8 +143,8 @@ Doorkeeper.configure do
 
   # Issue access tokens with refresh token (disabled by default), you may also
   # pass a block which accepts `context` to customize when to give a refresh
-  # token or not. Similar to `custom_access_token_expires_in`, `context` has
-  # the properties:
+  # token or not. Similar to +custom_access_token_expires_in+, `context` has
+  # the following properties:
   #
   # `client` - the OAuth client application (see Doorkeeper::OAuth::Client)
   # `grant_type` - the grant type of the request (see Doorkeeper::OAuth)
@@ -152,7 +153,7 @@ Doorkeeper.configure do
   use_refresh_token
 
   # Provide support for an owner to be assigned to each registered application (disabled by default)
-  # Optional parameter confirmation: true (default false) if you want to enforce ownership of
+  # Optional parameter confirmation: true (default: false) if you want to enforce ownership of
   # a registered application
   # NOTE: you must also run the rails g doorkeeper:application_owner generator
   # to provide the necessary support
@@ -161,22 +162,22 @@ Doorkeeper.configure do
 
   # Define access token scopes for your provider
   # For more information go to
-  # https://github.com/doorkeeper-gem/doorkeeper/wiki/Using-Scopes
+  # https://doorkeeper.gitbook.io/guides/ruby-on-rails/scopes
   #
   default_scopes :public, :read_articles
   # optional_scopes :write, :update
 
-  # Define scopes_by_grant_type to restrict only certain scopes for grant_type
+  # Allows to restrict only certain scopes for grant_type.
   # By default, all the scopes will be available for all the grant types.
   #
   # Keys to this hash should be the name of grant_type and
   # values should be the array of scopes for that grant type.
-  # Note: scopes should be from configured_scopes(i.e. deafult or optional)
+  # Note: scopes should be from configured_scopes (i.e. default or optional)
   #
   # scopes_by_grant_type password: [:write], client_credentials: [:update]
 
   # Forbids creating/updating applications with arbitrary scopes that are
-  # not in configuration, i.e. `default_scopes` or `optional_scopes`.
+  # not in configuration, i.e. +default_scopes+ or +optional_scopes+.
   # (disabled by default)
   #
   # enforce_configured_scopes
@@ -196,15 +197,6 @@ Doorkeeper.configure do
   # for more information on customization
   #
   # access_token_methods :from_bearer_authorization, :from_access_token_param, :from_bearer_param
-
-  # Change the native redirect uri for client apps
-  # When clients register with the following redirect uri, they won't be redirected to
-  # any server and the authorizationcode will be displayed within the provider
-  # The value can be any string. Use nil to disable this feature. When disabled, clients
-  # must providea valid URL
-  # (Similar behaviour: https://developers.google.com/accounts/docs/OAuth2InstalledApp#choosingredirecturi)
-  #
-  # native_redirect_uri 'urn:ietf:wg:oauth:2.0:oob'
 
   # Forces the usage of the HTTPS protocol in non-native redirect uris (enabled
   # by default in non-development environments). OAuth2 delegates security in
@@ -247,7 +239,7 @@ Doorkeeper.configure do
   # is invalid, expired, revoked or has invalid scopes.
   #
   # If you want to render error response yourself (i.e. rescue exceptions),
-  # set  handle_auth_errors to `:raise` and rescue Doorkeeper::Errors::InvalidToken
+  # set +handle_auth_errors+ to `:raise` and rescue Doorkeeper::Errors::InvalidToken
   # or following specific errors:
   #
   #   Doorkeeper::Errors::TokenForbidden, Doorkeeper::Errors::TokenExpired,
@@ -291,6 +283,37 @@ Doorkeeper.configure do
   #
   # grant_flows %w[authorization_code client_credentials]
 
+  # Allows to customize OAuth grant flows that +each+ application support.
+  # You can configure a custom block (or use a class respond to `#call`) that must
+  # return `true` in case Application instance supports requested OAuth grant flow
+  # during the authorization request to the server. This configuration +doesn't+
+  # set flows per application, it only allows to check if application supports
+  # specific grant flow.
+  #
+  # For example you can add an additional database column to `oauth_applications` table,
+  # say `t.array :grant_flows, default: []`, and store allowed grant flows that can
+  # be used with this application there. Then when authorization requested Doorkeeper
+  # will call this block to check if specific Application (passed with client_id and/or
+  # client_secret) is allowed to perform the request for the specific grant type
+  # (authorization, password, client_credentials, etc).
+  #
+  # Example of the block:
+  #
+  #   ->(flow, client) { client.grant_flows.include?(flow) }
+  #
+  # In case this option invocation result is `false`, Doorkeeper server returns
+  # :unauthorized_client error and stops the request.
+  #
+  # @param allow_grant_flow_for_client [Proc] Block or any object respond to #call
+  # @return [Boolean] `true` if allow or `false` if forbid the request
+  #
+  # allow_grant_flow_for_client do |grant_flow, client|
+  #   # `grant_flows` is an Array column with grant
+  #   # flows that application supports
+  #
+  #   client.grant_flows.include?(grant_flow)
+  # end
+
   # Hook into the strategies' request & response life-cycle in case your
   # application needs advanced customization or logging:
   #
@@ -306,7 +329,7 @@ Doorkeeper.configure do
   # or add any other functionality.
   #
   # before_successful_authorization do |controller|
-  #   Rails.logger.info(params.inspect)
+  #   Rails.logger.info(controller.request.params.inspect)
   # end
   #
   # after_successful_authorization do |controller|
@@ -324,7 +347,61 @@ Doorkeeper.configure do
   #   client.superapp? or resource_owner.admin?
   # end
 
-  # WWW-Authenticate Realm (default "Doorkeeper").
+  # Configure custom constraints for the Token Introspection request.
+  # By default this configuration option allows to introspect a token by another
+  # token of the same application, OR to introspect the token that belongs to
+  # authorized client (from authenticated client) OR when token doesn't
+  # belong to any client (public token). Otherwise requester has no access to the
+  # introspection and it will return response as stated in the RFC.
+  #
+  # Block arguments:
+  #
+  # @param token [Doorkeeper::AccessToken]
+  #   token to be introspected
+  #
+  # @param authorized_client [Doorkeeper::Application]
+  #   authorized client (if request is authorized using Basic auth with
+  #   Client Credentials for example)
+  #
+  # @param authorized_token [Doorkeeper::AccessToken]
+  #   Bearer token used to authorize the request
+  #
+  # In case the block returns `nil` or `false` introspection responses with 401 status code
+  # when using authorized token to introspect, or you'll get 200 with { "active": false } body
+  # when using authorized client to introspect as stated in the
+  # RFC 7662 section 2.2. Introspection Response.
+  #
+  # Using with caution:
+  # Keep in mind that these three parameters pass to block can be nil as following case:
+  #  `authorized_client` is nil if and only if `authorized_token` is present, and vice versa.
+  #  `token` will be nil if and only if `authorized_token` is present.
+  # So remember to use `&` or check if it is present before calling method on
+  # them to make sure you doesn't get NoMethodError exception.
+  #
+  # You can define your custom check:
+  #
+  # allow_token_introspection do |token, authorized_client, authorized_token|
+  #   if authorized_token
+  #     # customize: require `introspection` scope
+  #     authorized_token.application == token&.application ||
+  #       authorized_token.scopes.include?("introspection")
+  #   elsif token.application
+  #     # `protected_resource` is a new database boolean column, for example
+  #     authorized_client == token.application || authorized_client.protected_resource?
+  #   else
+  #     # public token (when token.application is nil, token doesn't belong to any application)
+  #     true
+  #   end
+  # end
+  #
+  # Or you can completely disable any token introspection:
+  #
+  # allow_token_introspection false
+  #
+  # If you need to block the request at all, then configure your routes.rb or web-server
+  # like nginx to forbid the request.
+
+  # WWW-Authenticate Realm (default: "Doorkeeper").
   #
   # realm "Doorkeeper"
 end

--- a/config/locales/doorkeeper.en.yml
+++ b/config/locales/doorkeeper.en.yml
@@ -11,6 +11,7 @@ en:
             redirect_uri:
               fragment_present: 'cannot contain a fragment.'
               invalid_uri: 'must be a valid URI.'
+              unspecified_scheme: 'must specify a scheme.'
               relative_uri: 'must be an absolute URI.'
               secured_uri: 'must be an HTTPS/SSL URI.'
               forbidden_uri: 'is forbidden by the server.'
@@ -37,7 +38,6 @@ en:
         confidential: 'Application will be used where the client secret can be kept confidential. Native mobile apps and Single Page Apps are considered non-confidential.'
         redirect_uri: 'Use one line per URI'
         blank_redirect_uri: "Leave it blank if you configured your provider to use Client Credentials, Resource Owner Password Credentials or any other grant type that doesn't require redirect URI."
-        native_redirect_uri: 'Use %{native_redirect_uri} if you want to add localhost URIs for development purposes'
         scopes: 'Separate scopes with spaces. Leave blank to use the default scopes.'
       edit:
         title: 'Edit application'
@@ -92,7 +92,11 @@ en:
     errors:
       messages:
         # Common error messages
-        invalid_request: 'The request is missing a required parameter, includes an unsupported parameter value, or is otherwise malformed.'
+        invalid_request:
+          unknown: 'The request is missing a required parameter, includes an unsupported parameter value, or is otherwise malformed.'
+          missing_param: 'Missing required parameter: %{value}.'
+          not_support_pkce: 'Invalid code_verifier parameter. Server does not support pkce.'
+          request_not_authorized: 'Request need to be authorized. Required parameter for authorizing request is missing or invalid.'
         invalid_redirect_uri: "The requested redirect uri is malformed or doesn't match client redirect URI."
         unauthorized_client: 'The client is not authorized to perform this request using this method.'
         access_denied: 'The resource owner or authorization server denied the request.'


### PR DESCRIPTION
# What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [x] Documentation Update

## Description

After reading the changelog for https://github.com/thepracticaldev/dev.to/pull/4990 I realized there are quite a few new features/options in doorkeeper 5.2.2 (all disabled by default).

This updates the initializer code and incorporates some new locale strings the new doorkeepers needs for error messaging.

I ran `rails g doorkeeper:install` and merged the changes

No new features have been enabled or existing features have been changed, it just updates the files.
