### PR TITLE
Rails 5.2 features: document why we can't enable some of them just yet

### DIFF
--- a/config/initializers/new_framework_defaults_5_2.rb
+++ b/config/initializers/new_framework_defaults_5_2.rb
@@ -6,6 +6,11 @@
 #
 # Read the Guide for Upgrading Ruby on Rails for more info on each option.
 
+# NOTE: we can't enable this just yet because it likely requires a flushing on the whole cache
+# due to how the new cache keys are generated. This is intended to improve and optimize caching
+# strategies by Rails but since we use "dalli_store" we can't enable this without flushing the cache.
+# This won't be a problem when we'll have switched to "redis_cache_store"
+# see <https://blog.heroku.com/cache-invalidation-rails-5-2-dalli-store>
 # Make Active Record use stable #cache_key alongside new #cache_version method.
 # This is needed for recyclable cache keys.
 # Rails.application.config.active_record.cache_versioning = true
@@ -31,6 +36,10 @@ Rails.application.config.action_controller.default_protect_from_forgery = true
 # 'f' after migrating old data.
 # Rails.application.config.active_record.sqlite3.represent_boolean_as_integer = true
 
+# NOTE: we can't enable this just yet, because it changes how "ActiveSupport::Digest.hexdigest"
+# generates digests, which in turn is used by "ActionView::Digestor", which in turn is used by the
+# see <https://github.com/rails/rails/blob/5-2-stable/actionview/lib/action_view/digestor.rb> and
+# <https://github.com/rails/rails/blob/5-2-stable/actionview/lib/action_view/helpers/cache_helper.rb#L227>
 # Use SHA-1 instead of MD5 to generate non-sensitive digests, such as the ETag header.
 # Rails.application.config.active_support.use_sha1_digests = true
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Documentation Update

## Description

I've added some notes about why we can't enable some of the Rails 5.2 features in `config/initializers/new_framework_defaults_5_2.rb` just yet:

1. `Rails.application.config.active_record.cache_versioning` changes how cache keys are generated, there's a [nice explanation](https://blog.heroku.com/cache-invalidation-rails-5-2-dalli-store) by Heroku. TLDR; this can be enabled when we'll have migrated all the caching to Redis

2. `Rails.application.config.active_support.use_sha1_digests` changes the algorithm that generates digests when a virtual path is used, I don't know for sure if we indeed are hitting that internal Rails feature but it requires an audit and thorough testing, because it could result in unexpected cache misses

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
