### PR TITLE
Group SIGTERM fetch_all_rss rake task Honeybadger Errors

### DIFF
--- a/config/initializers/honeybadger.rb
+++ b/config/initializers/honeybadger.rb
@@ -1,8 +1,15 @@
+# Can be used to implement more programatic error handling
+# https://docs.honeybadger.io/lib/ruby/getting-started/ignoring-errors.html#ignore-programmatically
+
 Honeybadger.configure do |config|
-  # Can be used to implement more programatic error handling
-  # https://docs.honeybadger.io/lib/ruby/getting-started/ignoring-errors.html#ignore-programmatically
   config.api_key = ApplicationConfig["HONEYBADGER_API_KEY"]
   config.revision = ApplicationConfig["HEROKU_SLUG_COMMIT"]
   config.exceptions.ignore += [Pundit::NotAuthorizedError, ActiveRecord::RecordNotFound]
   config.request.filter_keys += %w[authorization]
+
+  config.before_notify do |notice|
+    if notice.error_message&.include?("SIGTERM") && notice.component&.include?("fetch_all_rss")
+      notice.fingerprint = notice.error_message
+    end
+  end
 end

--- a/spec/initializers/honeybadger_spec.rb
+++ b/spec/initializers/honeybadger_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+describe Honeybadger do
+  context "when a fetch_all_rss SIGTERM error is raised" do
+    it "sets fingerprint to error_message" do
+      notice = Honeybadger::Notice.new(
+        described_class.config, error_message: "SignalException: SIGTERM", component: "rake fetch_all_rss"
+      )
+      described_class.config.before_notify_hooks.first.call(notice)
+      expect(notice.fingerprint).to eq(notice.error_message)
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Currently, we are seeing a lot of `SignalException: SIGTERM` errors from our `rake fetch_all_rss` job. I suspect these might be memory related but until we get a chance to dive in further we should group all of these errors together to avoid extra noise. Because the SIGTERM signal is received at different points in the code execution the backtraces for these errors are all different which causes them not to be grouped correctly. 

If you want to read more about how Honeybadger groups its errors checkout these [fingerprinting docs](https://docs.honeybadger.io/lib/ruby/getting-started/customizing-error-grouping.html).

## Added to documentation?
- [x] no documentation needed

![we are all in this together now](https://media1.giphy.com/media/MiDTxuorxMSFa/giphy.gif)
