### PR TITLE
Add ENV variable to flip on Redis for fragment cacheing

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -99,13 +99,19 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  config.cache_store = :dalli_store,
-                       (ENV["MEMCACHIER_SERVERS"] || "").split(","),
-                       { username: ENV["MEMCACHIER_USERNAME"],
-                         password: ENV["MEMCACHIER_PASSWORD"],
-                         failover: true,
-                         socket_timeout: 1.5,
-                         socket_failure_delay: 0.2 }
+  # TODO: Remove after cache store flip
+  if ENV['USE_REDIS']
+    DEFAULT_EXPIRATION = 24.hours.to_i.freeze
+    config.cache_store = :redis_store, ENV["REDIS_URL"], { expires_in: DEFAULT_EXPIRATION }
+  else
+    config.cache_store = :dalli_store,
+                         (ENV["MEMCACHIER_SERVERS"] || "").split(","),
+                         { username: ENV["MEMCACHIER_USERNAME"],
+                           password: ENV["MEMCACHIER_PASSWORD"],
+                           failover: true,
+                           socket_timeout: 1.5,
+                           socket_failure_delay: 0.2 }
+  end
 
   config.app_domain = ENV["APP_DOMAIN"]
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -100,7 +100,7 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   # TODO: Remove after cache store flip
-  if ENV['USE_REDIS']
+  if ENV["USE_REDIS"]
     DEFAULT_EXPIRATION = 24.hours.to_i.freeze
     config.cache_store = :redis_store, ENV["REDIS_URL"], { expires_in: DEFAULT_EXPIRATION }
   else


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature 😉
- [ ] Bug Fix
- [ ] Documentation Update

## Description
This PR adds an environment variable that will allow us to flip over to using Redis for `Rails.cache` by simply changing an ENV variable. When an ENV variable is changed in Heroku all of the dynos are restarted which is exactly what we need to happen to trigger the use of the new cache. 

## Related Tickets & Documents
#4670 

## Added to documentation?
- [x] no documentation needed
Once the switch is made and we are confident we don't need to rollback then I will issue a PR to update all relevant docs

![this is crazy gif](https://media1.giphy.com/media/WQC89Yuj3oLfsoYq8k/giphy.gif)
