### PR TITLE
Group all BANNED errors in Honeybadger

### DIFF
--- a/config/initializers/honeybadger.rb
+++ b/config/initializers/honeybadger.rb
@@ -8,8 +8,10 @@ Honeybadger.configure do |config|
   config.request.filter_keys += %w[authorization]
 
   config.before_notify do |notice|
-    if notice.error_message&.include?("SIGTERM") && notice.component&.include?("fetch_all_rss")
-      notice.fingerprint = notice.error_message
-    end
+    notice.fingerprint = if notice.error_message&.include?("SIGTERM") && notice.component&.include?("fetch_all_rss")
+                           notice.error_message
+                         elsif notice.error_message&.include?("BANNED")
+                           "banned"
+                         end
   end
 end

--- a/spec/initializers/honeybadger_spec.rb
+++ b/spec/initializers/honeybadger_spec.rb
@@ -10,4 +10,14 @@ describe Honeybadger do
       expect(notice.fingerprint).to eq(notice.error_message)
     end
   end
+
+  context "when BANNED error is raised" do
+    it "sets fingerprint to banned" do
+      notice = Honeybadger::Notice.new(
+        described_class.config, error_message: "RuntimeError: BANNED"
+      )
+      described_class.config.before_notify_hooks.first.call(notice)
+      expect(notice.fingerprint).to eq("banned")
+    end
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
If a banned user logs in we will `raise 'BANNED'` from our Application controller. Since the users may be trying to access different routes this error will end up with different stack traces and won't be grouped appropriately in HB.

## Added to documentation?
- [x] no documentation needed

![ban ban ban ban gif](https://media2.giphy.com/media/Vh2c84FAPVyvvjZJNM/giphy.gif)
