### PR TITLE
Added API related extensions to the recommended VS Code extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,6 +6,8 @@
     "msjsdiag.debugger-for-chrome",
     "msjsdiag.debugger-for-edge",
     "rebornix.ruby",
-    "MS-vsliveshare.vsliveshare-pack"
+    "MS-vsliveshare.vsliveshare-pack",
+    "42Crunch.vscode-openapi",
+    "philosowaffle.openapi-designer"
   ]
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [x] Code Editor Tooling

## Description

This adds the [OpenAPI (Swagger) Editor](https://marketplace.visualstudio.com/items?itemName=42Crunch.vscode-openapi) and [openapi-designer](https://marketplace.visualstudio.com/items?itemName=philosowaffle.openapi-designer) VS Code extensions to the recommended VS Code extensions to install. The [API documentation](https://docs.dev.to/contributing_api/#running-and-editing-the-docs-locally) recommends these extension when working with the API locally.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![Cat as a Mighty Morphin Power Ranger](https://media.giphy.com/media/l0ExmW4lfkvT1ScLK/giphy.gif)
