### PR TITLE
Don't Alert Honeybadger until Right before a job is going to fail

### DIFF
--- a/config/initializers/honeybadger.rb
+++ b/config/initializers/honeybadger.rb
@@ -6,6 +6,7 @@ Honeybadger.configure do |config|
   config.revision = ApplicationConfig["HEROKU_SLUG_COMMIT"]
   config.exceptions.ignore += [Pundit::NotAuthorizedError, ActiveRecord::RecordNotFound]
   config.request.filter_keys += %w[authorization]
+  config.delayed_job.attempt_threshold = 10
 
   config.before_notify do |notice|
     notice.fingerprint = if notice.error_message&.include?("SIGTERM") && notice.component&.include?("fetch_all_rss")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Currently every time a Delayed Job fails it reports the error to Honeybadger which is unnecessary since the vast majority of those jobs retry without an issue. We should only report an error when a job runs out of retry attempts. [Documentation for this option](https://docs.honeybadger.io/lib/ruby/gem-reference/configuration.html), scroll to the bottom.

## Added to documentation?
- [x] no documentation needed

![shhhhhh gif](https://media0.giphy.com/media/B46OnS3oGxk5y/giphy.gif)
