### PR TITLE
Fixing microdata main entity reference

### DIFF
--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -80,7 +80,7 @@
     <% if @article.video_state == "PROGRESSING" %>
       <h1 style="text-align:center;">⏳ Video Transcoding In Progress ⏳</h1>
     <% end %>
-    <article itemscope itemtype="http://schema.org/Article" itemprop="mainEntityOfPage">
+    <article itemscope itemtype="http://schema.org/Article" itemprop="mainEntity">
       <meta itemprop="url" content="https://dev.to<%= @article.path %>">
       <meta itemprop="image" content="<%= article_social_image_url(@article) %>">
       <div itemprop="publisher" itemscope itemtype="https://schema.org/Organization">

--- a/app/views/users/_profile_header.html.erb
+++ b/app/views/users/_profile_header.html.erb
@@ -10,7 +10,7 @@
 
   <% end %>
 </style>
-<div class="user-profile-header" style="<%= user_colors_style(@user) %>" itemscope itemtype="http://schema.org/Person" itemprop="mainEntityOfPage">
+<div class="user-profile-header" style="<%= user_colors_style(@user) %>" itemscope itemtype="http://schema.org/Person" itemprop="mainEntity">
   <meta itemprop="url" content="https://dev.to/<%= @user.username %>">
   <div class="user-profile-header-container">
     <div class="profile-pic-wrapper">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -24,7 +24,7 @@
     }
     <% end %>
   </style>
-  <div class="user-profile-header" style="<%= user_colors_style(@user) %>" itemscope itemtype="http://schema.org/Person" itemprop="mainEntityOfPage">
+  <div class="user-profile-header" style="<%= user_colors_style(@user) %>" itemscope itemtype="http://schema.org/Person" itemprop="mainEntity">
     <meta itemprop="url" content="https://dev.to/<%= @user.username %>">
     <div class="user-profile-header-container">
       <div class="profile-pic-wrapper">


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

Currently across a number of pages, there is use of [schema.org](https://schema.org) microdata (all those "itemprop" attributes etc). There are 3 references where there is use of the "mainEntityOfPage" item property however it is incorrectly used.

A ["mainEntityOfPage"](https://schema.org/mainEntityOfPage) isn't to say that this is the main entity of _this_ page, it is to say that this thing (person or article etc) is the main entity described _somewhere else_. A "mainEntityOfPage" needs to be a URL or ["CreativeWork"](https://schema.org/CreativeWork) and while an "Article" extends "CreativeWork", "Person" on the user profile page doesn't.

There is an inverse property to this, ["mainEntity"](https://schema.org/mainEntity), which is what I think you were wanting to use. It is used to say that this thing (person or article etc) is the main entity of _this_ page. A "mainEntity" can be absolutely any "Thing" so it is valid for use with a "Person".

## Related Tickets & Documents

- https://webmasters.stackexchange.com/a/87982/18454
- https://stackoverflow.com/a/34467088/1676444
- https://schema.org/mainEntityOfPage
- https://schema.org/mainEntity
