### PR TITLE
Reformat some code to break up especially long lines.

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -35,33 +35,43 @@ class ArticlesController < ApplicationController
     @article = if @tag.present? && @user&.editor_version == "v2"
                  authorize Article
                  submission_template = @tag.submission_template_customized(@user.name).to_s
-                 Article.new(body_markdown: submission_template.split("---").last.to_s.strip,
-                             cached_tag_list: @tag.name,
-                             processed_html: "",
-                             user_id: current_user&.id,
-                             title: submission_template.split("title:")[1].to_s.split("\n")[0].to_s.strip)
+                 Article.new(
+                   body_markdown: submission_template.split("---").last.to_s.strip,
+                   cached_tag_list: @tag.name,
+                   processed_html: "",
+                   user_id: current_user&.id,
+                   title: submission_template.split("title:")[1].to_s.split("\n")[0].to_s.strip,
+                 )
                elsif @tag&.submission_template.present? && @user
                  authorize Article
-                 Article.new(body_markdown: @tag.submission_template_customized(@user.name),
-                             processed_html: "",
-                             user_id: current_user&.id)
+                 Article.new(
+                   body_markdown: @tag.submission_template_customized(@user.name),
+                   processed_html: "",
+                   user_id: current_user&.id,
+                 )
                elsif @prefill.present? && @user&.editor_version == "v2"
                  authorize Article
-                 Article.new(body_markdown: @prefill.split("---").last.to_s.strip,
-                             cached_tag_list: @prefill.split("tags:")[1].to_s.split("\n")[0].to_s.strip,
-                             processed_html: "",
-                             user_id: current_user&.id,
-                             title: @prefill.split("title:")[1].to_s.split("\n")[0].to_s.strip)
+                 Article.new(
+                   body_markdown: @prefill.split("---").last.to_s.strip,
+                   cached_tag_list: @prefill.split("tags:")[1].to_s.split("\n")[0].to_s.strip,
+                   processed_html: "",
+                   user_id: current_user&.id,
+                   title: @prefill.split("title:")[1].to_s.split("\n")[0].to_s.strip,
+                 )
                elsif @prefill.present? && @user
                  authorize Article
-                 Article.new(body_markdown: @prefill,
-                             processed_html: "",
-                             user_id: current_user&.id)
+                 Article.new(
+                   body_markdown: @prefill,
+                   processed_html: "",
+                   user_id: current_user&.id,
+                 )
                elsif @tag.present?
                  skip_authorization
-                 Article.new(body_markdown: "---\ntitle: \npublished: false\ndescription: \ntags: #{@tag.name}\n---\n\n",
-                             processed_html: "",
-                             user_id: current_user&.id)
+                 Article.new(
+                   body_markdown: "---\ntitle: \npublished: false\ndescription: \ntags: #{@tag.name}\n---\n\n",
+                   processed_html: "",
+                   user_id: current_user&.id,
+                 )
                else
                  skip_authorization
                  if @user&.editor_version == "v2"

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -35,26 +35,33 @@ class ArticlesController < ApplicationController
     @article = if @tag.present? && @user&.editor_version == "v2"
                  authorize Article
                  submission_template = @tag.submission_template_customized(@user.name).to_s
-                 Article.new(body_markdown: submission_template.split("---").last.to_s.strip, cached_tag_list: @tag.name,
-                             processed_html: "", user_id: current_user&.id, title: submission_template.split("title:")[1].to_s.split("\n")[0].to_s.strip)
+                 Article.new(body_markdown: submission_template.split("---").last.to_s.strip,
+                             cached_tag_list: @tag.name,
+                             processed_html: "",
+                             user_id: current_user&.id,
+                             title: submission_template.split("title:")[1].to_s.split("\n")[0].to_s.strip)
                elsif @tag&.submission_template.present? && @user
                  authorize Article
                  Article.new(body_markdown: @tag.submission_template_customized(@user.name),
-                             processed_html: "", user_id: current_user&.id)
+                             processed_html: "",
+                             user_id: current_user&.id)
                elsif @prefill.present? && @user&.editor_version == "v2"
                  authorize Article
-                 Article.new(body_markdown: @prefill.split("---").last.to_s.strip, cached_tag_list: @prefill.split("tags:")[1].to_s.split("\n")[0].to_s.strip,
-                             processed_html: "", user_id: current_user&.id, title: @prefill.split("title:")[1].to_s.split("\n")[0].to_s.strip)
+                 Article.new(body_markdown: @prefill.split("---").last.to_s.strip,
+                             cached_tag_list: @prefill.split("tags:")[1].to_s.split("\n")[0].to_s.strip,
+                             processed_html: "",
+                             user_id: current_user&.id,
+                             title: @prefill.split("title:")[1].to_s.split("\n")[0].to_s.strip)
                elsif @prefill.present? && @user
                  authorize Article
                  Article.new(body_markdown: @prefill,
-                             processed_html: "", user_id: current_user&.id)
+                             processed_html: "",
+                             user_id: current_user&.id)
                elsif @tag.present?
                  skip_authorization
-                 Article.new(
-                   body_markdown: "---\ntitle: \npublished: false\ndescription: \ntags: #{@tag.name}\n---\n\n",
-                   processed_html: "", user_id: current_user&.id
-                 )
+                 Article.new(body_markdown: "---\ntitle: \npublished: false\ndescription: \ntags: #{@tag.name}\n---\n\n",
+                             processed_html: "",
+                             user_id: current_user&.id)
                else
                  skip_authorization
                  if @user&.editor_version == "v2"
@@ -62,7 +69,8 @@ class ArticlesController < ApplicationController
                  else
                    Article.new(
                      body_markdown: "---\ntitle: \npublished: false\ndescription: \ntags: \n---\n\n",
-                     processed_html: "", user_id: current_user&.id
+                     processed_html: "",
+                     user_id: current_user&.id,
                    )
                  end
                end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -150,7 +150,10 @@ class CommentsController < ApplicationController
     @comment = Comment.find(params[:id_code].to_i(26))
     authorize @comment
     @notification_subscription = NotificationSubscription.find_or_initialize_by(
-      user_id: @comment.user_id, notifiable_id: @comment.id, notifiable_type: "Comment", config: "all_comments",
+      user_id: @comment.user_id,
+      notifiable_id: @comment.id,
+      notifiable_type: "Comment",
+      config: "all_comments",
     )
     render :settings
   end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -149,7 +149,9 @@ class CommentsController < ApplicationController
   def settings
     @comment = Comment.find(params[:id_code].to_i(26))
     authorize @comment
-    @notification_subscription = NotificationSubscription.find_or_initialize_by(user_id: @comment.user_id, notifiable_id: @comment.id, notifiable_type: "Comment", config: "all_comments")
+    @notification_subscription = NotificationSubscription.find_or_initialize_by(
+      user_id: @comment.user_id, notifiable_id: @comment.id, notifiable_type: "Comment", config: "all_comments",
+    )
     render :settings
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -104,14 +104,20 @@ class UsersController < ApplicationController
   end
 
   def onboarding_update
-    current_user.assign_attributes(params[:user].permit(:summary, :location, :employment_title, :employer_name, :last_onboarding_page)) if params[:user]
+    if params[:user]
+      current_user.assign_attributes(params[:user].permit(:summary, :location, :employment_title, :employer_name, :last_onboarding_page))
+    end
     current_user.saw_onboarding = true
     authorize User
     render_update_response
   end
 
   def onboarding_checkbox_update
-    current_user.assign_attributes(params[:user].permit(:checked_code_of_conduct, :checked_terms_and_conditions, :email_membership_newsletter, :email_digest_periodic)) if params[:user]
+    if params[:user]
+      current_user.assign_attributes(params[:user].permit(
+                                       :checked_code_of_conduct, :checked_terms_and_conditions, :email_membership_newsletter, :email_digest_periodic
+                                     ))
+    end
     current_user.saw_onboarding = true
     authorize User
     render_update_response

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -105,7 +105,8 @@ class UsersController < ApplicationController
 
   def onboarding_update
     if params[:user]
-      current_user.assign_attributes(params[:user].permit(:summary, :location, :employment_title, :employer_name, :last_onboarding_page))
+      permitted_params = %i[summary location employment_title employer_name last_onboarding_page]
+      current_user.assign_attributes(params[:user].permit(permitted_params))
     end
     current_user.saw_onboarding = true
     authorize User
@@ -114,7 +115,10 @@ class UsersController < ApplicationController
 
   def onboarding_checkbox_update
     if params[:user]
-      current_user.assign_attributes(params[:user].permit(:checked_code_of_conduct, :checked_terms_and_conditions, :email_membership_newsletter, :email_digest_periodic))
+      permitted_params = %i[
+        checked_code_of_conduct checked_terms_and_conditions email_membership_newsletter email_digest_periodic
+      ]
+      current_user.assign_attributes(params[:user].permit(permitted_params))
     end
 
     current_user.saw_onboarding = true

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -114,10 +114,9 @@ class UsersController < ApplicationController
 
   def onboarding_checkbox_update
     if params[:user]
-      current_user.assign_attributes(params[:user].permit(
-                                       :checked_code_of_conduct, :checked_terms_and_conditions, :email_membership_newsletter, :email_digest_periodic
-                                     ))
+      current_user.assign_attributes(params[:user].permit(:checked_code_of_conduct, :checked_terms_and_conditions, :email_membership_newsletter, :email_digest_periodic))
     end
+
     current_user.saw_onboarding = true
     authorize User
     render_update_response

--- a/app/services/notifications/new_follower/send.rb
+++ b/app/services/notifications/new_follower/send.rb
@@ -24,15 +24,19 @@ module Notifications
         recent_follows = Follow.where(followable_type: followable_type, followable_id: followable_id).
           where("created_at > ?", 24.hours.ago).order("created_at DESC")
 
-        notification_params = build_notification_params
+        notification_params = { action: "Follow" }
+        if followable_type == "User"
+          notification_params[:user_id] = followable_id
+        elsif followable_type == "Organization"
+          notification_params[:organization_id] = followable_id
+        end
 
-        aggregated_sibling_ids = User.where(id: recent_follows.select(:follower_id))
-        aggregated_siblings_hashes = aggregated_sibling_ids.map { |follower| user_data(follower) }
-
-        if aggregated_siblings_hashes.empty?
+        followers = User.where(id: recent_follows.select(:follower_id))
+        aggregated_siblings = followers.map { |follower| user_data(follower) }
+        if aggregated_siblings.size.zero?
           notification = Notification.find_by(notification_params)&.destroy
         else
-          json_data = { user: user_data(follower), aggregated_siblings: aggregated_siblings_hashes }
+          json_data = { user: user_data(follower), aggregated_siblings: aggregated_siblings }
           notification = Notification.find_or_initialize_by(notification_params)
           notification.notifiable_id = recent_follows.first.id
           notification.notifiable_type = "Follow"
@@ -47,18 +51,6 @@ module Notifications
       private
 
       attr_reader :followable_id, :followable_type, :follower_id, :is_read
-
-      # Builds a hash used to search for or create the notification of
-      # follows of the user or organization.
-      def build_notification_params
-        notification_params = { action: "Follow" }
-        if followable_type == "User"
-          notification_params[:user_id] = followable_id
-        elsif followable_type == "Organization"
-          notification_params[:organization_id] = followable_id
-        end
-        notification_params
-      end
 
       def follower
         User.find(follower_id)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
As I was browsing the controller code, I saw some especially long lines that were too long to fit on my 13" laptop screen. In addition to accommodating narrower screens:

* some of the changes put key/value pairs on their own lines, which speeds up visual scanning
* `if`'s that were especially far right on the line will even be off the screen on some screens, but even when not, because of their placement, might easily be missed. (My personal preference would be to go even farther than this, but I realize I'm an outlier on this.)

I am now marking this WIP because Rubocop forced the text to the right, making it worse than before; should I revert that change, or do we want to reconsider Rubocop config settings?

<img width="900" alt="rubocop-onboarding-checkbox-update" src="https://user-images.githubusercontent.com/28410/70535771-35330c80-1b90-11ea-8c3e-8f324d202e57.png">


## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Old:

<img width="1366" alt="article-new" src="https://user-images.githubusercontent.com/28410/70535233-43ccf400-1b8f-11ea-9a38-b4a0f69c1efc.png">

New:
<img width="1392" alt="new-articles-controller" src="https://user-images.githubusercontent.com/28410/70535969-86430080-1b90-11ea-9835-086884196c67.png">


Old:

<img width="798" alt="onboarding-checkbox-update" src="https://user-images.githubusercontent.com/28410/70535420-a58d5e00-1b8f-11ea-8396-1c082519e02b.png">

New:

(See note above about Rubocop changes.)


## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x ] no documentation needed
