### PR TITLE
Fix Algolia deserialization errors

### DIFF
--- a/app/jobs/search/index_job.rb
+++ b/app/jobs/search/index_job.rb
@@ -3,7 +3,7 @@ module Search
     queue_as :search_index
 
     def perform(record_type, record_id)
-      return unless %w[Comment Article User].include?(record_type)
+      raise InvalidRecordType unless %w[Comment Article User].include?(record_type)
 
       record = record_type.constantize.find_by(id: record_id)
       return unless record
@@ -11,4 +11,6 @@ module Search
       record.index!
     end
   end
+
+  class InvalidRecordType < StandardError; end
 end

--- a/app/jobs/search/index_job.rb
+++ b/app/jobs/search/index_job.rb
@@ -8,7 +8,7 @@ module Search
       record = record_type.constantize.find_by(id: record_id)
       return unless record
 
-      AlgoliaSearch::AlgoliaJob.perform_later(record, "index!")
+      record.index!
     end
   end
 end

--- a/app/jobs/search/index_job.rb
+++ b/app/jobs/search/index_job.rb
@@ -1,0 +1,14 @@
+module Search
+  class IndexJob < ApplicationJob
+    queue_as :search_index
+
+    def perform(record_type, record_id)
+      return unless %w[Comment Article User].include?(record_type)
+
+      record = record_type.constantize.find_by(id: record_id)
+      return unless record
+
+      AlgoliaSearch::AlgoliaJob.perform_later(record, "index!")
+    end
+  end
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -115,9 +115,9 @@ class Comment < ApplicationRecord
     return if remove
 
     if record.deleted == false
-      AlgoliaSearch::AlgoliaJob.perform_later(record, "index!")
+      Search::IndexJob.perform_later("Comment", record.id)
     else
-      AlgoliaSearch::AlgoliaJob.perform_later(record, "remove_algolia_index")
+      Search::RemoveFromIndexJob.perform_later(Comment.algolia_index_name, record.index_id)
     end
   end
 
@@ -183,11 +183,12 @@ class Comment < ApplicationRecord
     Notification.remove_all_without_delay(notifiable_ids: id, notifiable_type: "Comment")
   end
 
-  private
-
+  # public because it's used in the algolia indexing methods
   def index_id
     "comments-#{id}"
   end
+
+  private
 
   def update_notifications
     Notification.update_notifications(self)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -204,7 +204,7 @@ class User < ApplicationRecord
   def self.trigger_delayed_index(record, remove)
     return if remove
 
-    AlgoliaSearch::AlgoliaJob.perform_later(record, "index!")
+    Search::IndexJob.perform_later("User", record.id)
   end
 
   def tag_line

--- a/spec/jobs/search/index_job_spec.rb
+++ b/spec/jobs/search/index_job_spec.rb
@@ -3,11 +3,11 @@ require "jobs/shared_examples/enqueues_job"
 
 RSpec.describe Search::IndexJob, type: :job do
   it "does nothing if there is wrong record type is passed" do
-    described_class.perform_now("SuperUser", 1)
+    expect { described_class.perform_now("SuperUser", 1) }.to raise_error(Search::InvalidRecordType)
   end
 
   it "doesn't fail if a record is not found" do
-    described_class.perform_now("Comment", -1)
+    expect { described_class.perform_now("Comment", -1) }.not_to raise_error
   end
 
   it "indexes a record if everything is fine" do

--- a/spec/jobs/search/index_job_spec.rb
+++ b/spec/jobs/search/index_job_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+require "jobs/shared_examples/enqueues_job"
+
+RSpec.describe Search::IndexJob, type: :job do
+  it "does nothing if there is wrong record type is passed" do
+    described_class.perform_now("SuperUser", 1)
+  end
+
+  it "doesn't fail if a record is not found" do
+    described_class.perform_now("Comment", -1)
+  end
+
+  it "indexes a record if everything is fine" do
+    user = double
+    allow(user).to receive(:index!)
+    allow(User).to receive(:find_by).and_return(user)
+    described_class.perform_now("User", 1)
+    expect(user).to have_received(:index!)
+  end
+end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -298,8 +298,8 @@ RSpec.describe Comment, type: :model do
     context "when deleted is false" do
       it "checks auto-indexing" do
         expect do
-          create(:comment, commentable: article)
-        end.to have_enqueued_job(Search::IndexJob).once
+          comment.update(body_markdown: "hello")
+        end.to have_enqueued_job(Search::IndexJob).with("Comment", comment.id)
       end
     end
 

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -299,7 +299,7 @@ RSpec.describe Comment, type: :model do
       it "checks auto-indexing" do
         expect do
           create(:comment, commentable: article)
-        end.to have_enqueued_job.with(kind_of(described_class), "index!").on_queue("algoliasearch")
+        end.to have_enqueued_job(Search::IndexJob).once
       end
     end
 
@@ -307,7 +307,7 @@ RSpec.describe Comment, type: :model do
       it "checks auto-deindexing" do
         expect do
           comment.update(deleted: true)
-        end.to have_enqueued_job.with(kind_of(described_class), "remove_algolia_index").on_queue("algoliasearch")
+        end.to have_enqueued_job(Search::RemoveFromIndexJob).with(described_class.algolia_index_name, comment.index_id)
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -512,7 +512,7 @@ RSpec.describe User, type: :model do
 
   context "when indexing and deindexing" do
     it "triggers background auto-indexing when user is saved" do
-      expect { user.save }.to have_enqueued_job.with(user, "index!").on_queue("algoliasearch")
+      expect { user.save }.to have_enqueued_job(Search::IndexJob).with("User", user.id)
     end
 
     it "doesn't enqueue a job on destroy" do
@@ -522,7 +522,7 @@ RSpec.describe User, type: :model do
         user.save
       end
 
-      expect { user.destroy }.not_to have_enqueued_job.on_queue("algoliasearch")
+      expect { user.destroy }.not_to have_enqueued_job(Search::IndexJob)
     end
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Replaced calling `AlgoliaSearch::AlgoliaJob` with the job that accepts record ids instead of ActiveRecord objects. This should help to get rid of delayed job deserialization errors.

## Related Tickets & Documents
#3594