### PR TITLE
Ensure remember_user_token is present for Fastly with Specs

### DIFF
--- a/app/controllers/async_info_controller.rb
+++ b/app/controllers/async_info_controller.rb
@@ -11,7 +11,7 @@ class AsyncInfoController < ApplicationController
       }
       return
     end
-    if cookies[:remember_user_token].blank?
+    if remember_user_token.blank?
       current_user.remember_me = true
       current_user.remember_me!
       remember_me(current_user)
@@ -71,7 +71,11 @@ class AsyncInfoController < ApplicationController
     #{current_user&.articles_count}__
     #{current_user&.pro?}__
     #{current_user&.blocking_others_count}__
-    #{cookies[:remember_user_token]}"
+    #{remember_user_token}"
+  end
+
+  def remember_user_token
+    cookies[:remember_user_token]
   end
 
   private

--- a/spec/requests/async_info_spec.rb
+++ b/spec/requests/async_info_spec.rb
@@ -1,6 +1,12 @@
 require "rails_helper"
 
 RSpec.describe "AsyncInfo", type: :request do
+  let(:controller_instance) { AsyncInfoController.new }
+
+  before do
+    allow(AsyncInfoController).to receive(:new).and_return(controller_instance)
+  end
+
   describe "GET /async_info/base_data" do
     context "when not logged-in" do
       before { get "/async_info/base_data" }
@@ -14,13 +20,24 @@ RSpec.describe "AsyncInfo", type: :request do
       end
     end
 
-    context "when logged int" do
+    context "when logged in" do
       it "returns token and user" do
-        allow(cookies).to receive(:[]).with(:remember_user_token).and_return(nil)
+        allow(controller_instance).to receive(:remember_user_token).and_return(nil)
         sign_in create(:user)
         get "/async_info/base_data"
         expect(response.body).to include("token", "user")
       end
+    end
+  end
+
+  describe "#remember_user_token" do
+    # We require the remember_user_token key bc we also use it for caching in Fastly
+    # If this key changes, Fastly needs to be updated
+    it "requires remember_user_token cookie to be present" do
+      get "/async_info/base_data"
+      token = "a_token"
+      controller.send("cookies")[:remember_user_token] = "a_token"
+      expect(controller.remember_user_token).to eq(token)
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Documentation Update (in the sense that I added a comment to the specs)

## Description
When we cache views in Fastly we use the `remember_user_token` to help us do it. If this key changes then we need to update how we do our Fastly caching. To avoid having this key change unexpectedly, I have added a spec. I also cleaned up the spec above which was actually not stubbing the cookies correctly. 

## Added to documentation?
- [x] no documentation needed

![safety first gif](https://media.giphy.com/media/1k03DWas9bfbYcbb33/giphy.gif)
