### PR TITLE
Use find_or_create_by when updating a PageView 

### DIFF
--- a/app/controllers/page_views_controller.rb
+++ b/app/controllers/page_views_controller.rb
@@ -18,10 +18,8 @@ class PageViewsController < ApplicationMetalController
 
   def update
     if session_current_user_id
-      page_view = PageView.where(article_id: params[:id], user_id: session_current_user_id).last
-      # pageview is sometimes missing if failure on prior creation.
-      page_view ||= PageView.create(user_id: session_current_user_id, article_id: params[:id])
-      page_view.update_column(:time_tracked_in_seconds, page_view.time_tracked_in_seconds + 15)
+      page_view = PageView.find_or_create_by(article_id: params[:id], user_id: session_current_user_id)
+      page_view.update(time_tracked_in_seconds: page_view.time_tracked_in_seconds + 15)
     end
 
     head :ok


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Currently, we are seeing the following error when we try to call `update_column` on a new PageView
```
ActiveRecord::ActiveRecordError: cannot update a new record
```
To avoid this I choose to use `find_or_create_by` to help combine the find and where into a single statement and then I switched to using `update` rather than `update_column`. If anyone knows of a specific reason as to why we were using `update_column` here over `update` let me know!  

## Added to documentation?
- [x] no documentation needed

![Lets fix it sticker](https://cdn.dribbble.com/users/9953/screenshots/1785702/letsfixitbuttons.gif)
