### PR TITLE
Don't send Internal Errors to HoneyBadger

### DIFF
--- a/config/initializers/honeybadger.rb
+++ b/config/initializers/honeybadger.rb
@@ -9,14 +9,12 @@ Honeybadger.configure do |config|
   config.delayed_job.attempt_threshold = 10
 
   config.before_notify do |notice|
-    notice.halt! if notice.component&.include?("internal")
-
-    unless notice.halted?
-      notice.fingerprint = if notice.error_message&.include?("SIGTERM") && notice.component&.include?("fetch_all_rss")
-                             notice.error_message
-                           elsif notice.error_message&.include?("BANNED")
-                             "banned"
-                           end
-    end
+    notice.fingerprint = if notice.error_message&.include?("SIGTERM") && notice.component&.include?("fetch_all_rss")
+                           notice.error_message
+                         elsif notice.error_message&.include?("BANNED")
+                           "banned"
+                         elsif notice.component&.include?("internal")
+                           "internal"
+                         end
   end
 end

--- a/config/initializers/honeybadger.rb
+++ b/config/initializers/honeybadger.rb
@@ -9,10 +9,14 @@ Honeybadger.configure do |config|
   config.delayed_job.attempt_threshold = 10
 
   config.before_notify do |notice|
-    notice.fingerprint = if notice.error_message&.include?("SIGTERM") && notice.component&.include?("fetch_all_rss")
-                           notice.error_message
-                         elsif notice.error_message&.include?("BANNED")
-                           "banned"
-                         end
+    notice.halt! if notice.component&.include?("internal")
+
+    unless notice.halted?
+      notice.fingerprint = if notice.error_message&.include?("SIGTERM") && notice.component&.include?("fetch_all_rss")
+                             notice.error_message
+                           elsif notice.error_message&.include?("BANNED")
+                             "banned"
+                           end
+    end
   end
 end

--- a/spec/initializers/honeybadger_spec.rb
+++ b/spec/initializers/honeybadger_spec.rb
@@ -27,7 +27,7 @@ describe Honeybadger do
         described_class.config, component: "internal/feedback_messages"
       )
       described_class.config.before_notify_hooks.first.call(notice)
-      expect(notice.halted?).to be(true)
+      expect(notice.fingerprint).to eq("internal")
     end
   end
 end

--- a/spec/initializers/honeybadger_spec.rb
+++ b/spec/initializers/honeybadger_spec.rb
@@ -20,4 +20,14 @@ describe Honeybadger do
       expect(notice.fingerprint).to eq("banned")
     end
   end
+
+  context "when error is raised from an internal route" do
+    it "halts notification" do
+      notice = Honeybadger::Notice.new(
+        described_class.config, component: "internal/feedback_messages"
+      )
+      described_class.config.before_notify_hooks.first.call(notice)
+      expect(notice.halted?).to be(true)
+    end
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Since it is the core team and moderators that are working in the internal namespace of our application there should be no need to report errors from there to Honeybadger as we would expect those folks to report any issues themselves. I would rather use Honeybadger to report errors for frontline users that may not be able to help themselves so they have to rely on us.

OPTION 2: The other option is to group these errors under an "internal" fingerprint but then I was just going to ignore that fingerprint in HB. I thought this felt cleaner. 

Let me know what you all think! Thank you! 

[More on halting errors in HB](https://docs.honeybadger.io/lib/ruby/getting-started/ignoring-errors.html#ignore-programmatically)

## Added to documentation?
- [x] no documentation needed

![this could not be less important](https://media1.giphy.com/media/3ornjVl19PVacFaRa0/source.gif)
