### PR TITLE
Switch back to update_column For Improved PageView Performance

### DIFF
--- a/app/controllers/page_views_controller.rb
+++ b/app/controllers/page_views_controller.rb
@@ -19,7 +19,7 @@ class PageViewsController < ApplicationMetalController
   def update
     if session_current_user_id
       page_view = PageView.find_or_create_by(article_id: params[:id], user_id: session_current_user_id)
-      page_view.update(time_tracked_in_seconds: page_view.time_tracked_in_seconds + 15)
+      page_view.update_column(:time_tracked_in_seconds, page_view.time_tracked_in_seconds + 15)
     end
 
     head :ok


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
When we switched to using update the hit to performance from calling the AR callback chain was larger than we thought it would be since this model has only a single `before_create` callback. This PR goes back to using `update_column` which when I tested with `find_or_create_by` in a console did not error out, so we will see what happens!

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

![must go faster gif](https://media1.giphy.com/media/7XsFGzfP6WmC4/giphy.gif)
