### PR TITLE
Asynchronously Update Algolia after a PageView Update

### DIFF
--- a/app/jobs/search/index_job.rb
+++ b/app/jobs/search/index_job.rb
@@ -3,7 +3,7 @@ module Search
     queue_as :search_index
 
     def perform(record_type, record_id)
-      raise InvalidRecordType unless %w[Comment Article User].include?(record_type)
+      raise InvalidRecordType unless %w[Comment Article User PageView].include?(record_type)
 
       record = record_type.constantize.find_by(id: record_id)
       return unless record

--- a/app/models/page_view.rb
+++ b/app/models/page_view.rb
@@ -6,7 +6,7 @@ class PageView < ApplicationRecord
 
   before_create :extract_domain_and_path
 
-  algoliasearch index_name: "UserHistory", per_environment: true, if: :belongs_to_pro_user?, enqueue: :trigger_delayed_job do
+  algoliasearch index_name: "UserHistory", per_environment: true, if: :belongs_to_pro_user?, enqueue: true do
     attributes :referrer, :user_agent, :article_tags
 
     attribute(:article_title) { article.title }
@@ -44,14 +44,6 @@ class PageView < ApplicationRecord
     distinct true
 
     customRanking ["desc(visited_at_timestamp)"]
-  end
-
-  def self.trigger_delayed_job(record, remove)
-    if remove
-      record.delay.remove_from_index!
-    else
-      record.delay.index!
-    end
   end
 
   private

--- a/app/models/page_view.rb
+++ b/app/models/page_view.rb
@@ -6,7 +6,7 @@ class PageView < ApplicationRecord
 
   before_create :extract_domain_and_path
 
-  algoliasearch index_name: "UserHistory", per_environment: true, if: :belongs_to_pro_user?, enqueue: true do
+  algoliasearch index_name: "UserHistory", per_environment: true, if: :belongs_to_pro_user?, enqueue: :trigger_index_sync do
     attributes :referrer, :user_agent, :article_tags
 
     attribute(:article_title) { article.title }
@@ -44,6 +44,14 @@ class PageView < ApplicationRecord
     distinct true
 
     customRanking ["desc(visited_at_timestamp)"]
+  end
+
+  def self.trigger_index_sync(record, remove)
+    if remove
+      Search::RemoveFromIndexJob.perform_later(algolia_index_name, record.id)
+    else
+      Search::IndexJob.perform_later("PageView", record.id)
+    end
   end
 
   private

--- a/spec/models/page_view_spec.rb
+++ b/spec/models/page_view_spec.rb
@@ -19,4 +19,18 @@ RSpec.describe PageView, type: :model do
       end
     end
   end
+
+  describe "indexing" do
+    it "indexes updated records" do
+      expect do
+        page_view.update(path: "/")
+      end.to have_enqueued_job(Search::IndexJob).exactly(:once).with("PageView", page_view.id)
+    end
+
+    it "removes deleted records" do
+      expect do
+        page_view.destroy
+      end.to have_enqueued_job(Search::RemoveFromIndexJob).exactly(:once).with(described_class.algolia_index_name, page_view.id)
+    end
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
When triggering an Algolia update it is possible to [do it asynchronously](https://github.com/algolia/algoliasearch-rails#queues--background-jobs). Here I implemented the [suggested approach for delayed_job](https://github.com/algolia/algoliasearch-rails#with-delayedjob)

Any reason why we need this done inline? It seems like asynchronously should be just fine and will save us some db hits in the controller action making it faster. 

## Added to documentation?
- [x] no documentation needed

![](https://media0.giphy.com/media/WNJAUbRAlDxrWltxim/giphy.gif)
