### PR TITLE
Raise an error response saying the endpoint does not support the xml format on Articles#feed.xml (#5073)

### DIFF
--- a/app/views/articles/feed.xml
+++ b/app/views/articles/feed.xml
@@ -1,0 +1,1 @@
+<errors><error>This endpoint does not support the XML format.</error></errors>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

As articulated in related issue below, currently passing `/feed.xml` breaks. As a default, `/feed` passes to an RSS formatter. Whereas XML full formatting is a future possibility, this at least for the moment raises an XML error saying this endpoint does not support XML formatting at this time. 

## Related Tickets & Documents

Raised in issue #5073 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/qCTaz2coxAJCE/giphy.gif)
