### PR TITLE
Ensure that we have a slug and owner before attempting Article Lookup

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -217,7 +217,7 @@ class ArticlesController < ApplicationController
 
   def set_article
     owner = User.find_by(username: params[:username]) || Organization.find_by(slug: params[:username])
-    found_article = if params[:slug]
+    found_article = if params[:slug] && owner
                       owner.articles.find_by(slug: params[:slug])
                     else
                       Article.includes(:user).find(params[:id])


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
We are seeing this error a bunch in Honeybadger from trying to lookup articles when there is no owner found. This ensures we have an owner before we try to do the lookup
```
NoMethodError: undefined method `articles' for nil:NilClass
articles_controller.rb  221 set_article(...)
[PROJECT_ROOT]/app/controllers/articles_controller.rb:221:in `set_article'
219     owner = User.find_by(username: params[:username]) || Organization.find_by(slug: params[:username])
220     found_article = if params[:slug]
221                       owner.articles.find_by(slug: params[:slug])
222                     else
223                       Article.includes(:user).find(params[:id])
```

## Added to documentation?
- [x] no documentation needed

![presence is the present gif](https://media.giphy.com/media/2ZYNGw8xgfaLRiGybX/giphy.gif)
