### PR TITLE
Fix Technical Overview links [ci skip]

### DIFF
--- a/docs/technical-overview/readme.md
+++ b/docs/technical-overview/readme.md
@@ -8,7 +8,10 @@ items:
 
 We are a [Ruby on Rails](https://rubyonrails.org) web application.
 
-Our [stack](stack.md) is composed of many tools and services.
+Our [stack][stack] is composed of many tools and services.
 
 You can read more about our architecture and app's concepts here: [A few
-high-level things to know](/architecture).
+high-level things to know][architecture].
+
+[stack]: /technical-overview/stack
+[architecture]: /technical-overview/architecture


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Documentation Update

## Description

This fixes a "Page Not Found!" error on https://docs.dev.to/technical-overview/ for the "stack" and "A few high-level things to know" links.

## Related Tickets & Documents

N/A

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

N/A

## Added to documentation?

- [x] docs.dev.to
- [ ] readme
- [ ] no documentation needed
