### PR TITLE
Dont Raise Error For Incorrect Liquid Tags

### DIFF
--- a/app/labor/markdown_parser.rb
+++ b/app/labor/markdown_parser.rb
@@ -18,10 +18,10 @@ class MarkdownParser
     sanitized_content = sanitize_rendered_markdown(html)
     begin
       parsed_liquid = Liquid::Template.parse(sanitized_content)
-    rescue StandardError => e
-      raise StandardError, e.message
+      html = markdown.render(parsed_liquid.render)
+    rescue Liquid::SyntaxError => e
+      html = e.message
     end
-    html = markdown.render(parsed_liquid.render)
     html = remove_nested_linebreak_in_list(html)
     html = prefix_all_images(html)
     html = wrap_all_images_in_links(html)
@@ -97,6 +97,8 @@ class MarkdownParser
       tags << node.class if node.class.superclass.to_s == LiquidTagBase.to_s
     end
     tags.uniq
+  rescue Liquid::SyntaxError
+    []
   end
 
   def prefix_all_images(html, width = 880)

--- a/spec/labor/markdown_parser_spec.rb
+++ b/spec/labor/markdown_parser_spec.rb
@@ -195,9 +195,9 @@ RSpec.describe MarkdownParser, type: :labor do
   end
 
   context "when provided with liquid tags" do
-    it "raises error if liquid tag was used incorrectly" do
+    it "does not raises error if liquid tag was used incorrectly" do
       bad_ltag = "{% #{random_word} %}"
-      expect { generate_and_parse_markdown(bad_ltag) }.to raise_error(StandardError)
+      expect { generate_and_parse_markdown(bad_ltag) }.not_to raise_error(StandardError)
     end
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Rather than raising an error that will propagate all the way up to our error reporting service, lets simply alert the user that a liquid tag failed to render and allow them to fix it themselves. Obviously this leads to a little bit of a different user experience so I am interested in what people think. 
**Current Flow: User puts in an invalid tag**
Preview
![Screen Shot 2019-12-11 at 4 52 58 PM](https://user-images.githubusercontent.com/1813380/70667570-d2488080-1c36-11ea-8c4a-4443f4850ee1.png)
Save Attempt just hangs
![Screen Shot 2019-12-11 at 4 53 08 PM](https://user-images.githubusercontent.com/1813380/70667571-d2488080-1c36-11ea-9099-f49f755bd286.png)

**NEW Flow**
Preview error examples:
![Screen Shot 2019-12-11 at 4 50 58 PM](https://user-images.githubusercontent.com/1813380/70667564-d1afea00-1c36-11ea-8722-dd2fbfc5a68f.png)
![Screen Shot 2019-12-11 at 4 51 14 PM](https://user-images.githubusercontent.com/1813380/70667566-d2488080-1c36-11ea-95d7-d0906bf57ff0.png)
Save Attempt either raises an error to the user
![Screen Shot 2019-12-11 at 4 51 48 PM](https://user-images.githubusercontent.com/1813380/70720122-dae19b00-1cb8-11ea-8c13-9bb77cd9559e.png)
OR saves the error message as the html 
![Screen Shot 2019-12-11 at 4 52 11 PM](https://user-images.githubusercontent.com/1813380/70667569-d2488080-1c36-11ea-8ebd-3e33057fc0b7.png)

## Added to documentation?
- [x] no documentation needed
