### PR TITLE
Use find_or_create_by to avoid duplicate records

### DIFF
--- a/app/controllers/poll_skips_controller.rb
+++ b/app/controllers/poll_skips_controller.rb
@@ -2,7 +2,7 @@ class PollSkipsController < ApplicationController
   before_action :authenticate_user!, only: %i[create]
 
   def create
-    @poll_skip = PollSkip.create(poll_id: poll_skips_params[:poll_id], user_id: current_user.id)
+    @poll_skip = PollSkip.find_or_create_by(poll_id: poll_skips_params[:poll_id], user_id: current_user.id)
     @poll = Poll.find(poll_skips_params[:poll_id])
     render json: { voting_data: @poll.voting_data,
                    poll_id: poll_skips_params[:poll_id].to_i,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Recently got a HB(Honeybadger) when trying to create a duplicate record here thanks to our db constraints so I updated this code to be find_or_create_by to avoid that issue.
```
ActiveRecord::RecordNotUnique: PG::UniqueViolation: ERROR: duplicate key value violates unique constraint 
```
## Added to documentation?
- [x] no documentation needed

![there can only be one gif](https://media2.giphy.com/media/5rjEsJnmsUF2CxGg5e/giphy.gif)
