### PR TITLE
Return not_found Response rather than trying to authorize a nil object

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -172,6 +172,7 @@ class ArticlesController < ApplicationController
 
   def delete_confirm
     @article = current_user.articles.find_by(slug: params[:slug])
+    not_found unless @article
     authorize @article
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -262,6 +262,7 @@ class UsersController < ApplicationController
 
   def set_user
     @user = current_user
+    not_found unless @user
     authorize @user
   end
 

--- a/spec/requests/articles/articles_spec.rb
+++ b/spec/requests/articles/articles_spec.rb
@@ -158,4 +158,17 @@ RSpec.describe "Articles", type: :request do
       expect(response.body).to include("Stats for Your Article")
     end
   end
+
+  describe "GET /delete_confirm" do
+    before { sign_in user }
+
+    context "without an article" do
+      it "renders not_found" do
+        article = create(:article, user: user)
+        expect do
+          get "#{article.path}_1/delete_confirm"
+        end.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
 end

--- a/spec/requests/user/user_destroy_spec.rb
+++ b/spec/requests/user/user_destroy_spec.rb
@@ -51,27 +51,37 @@ RSpec.describe "UserDestroy", type: :request do
   describe "GET /users/confirm_destroy" do
     let(:token) { SecureRandom.hex(10) }
 
-    before do
-      sign_in user
-    end
+    context "with user signed in" do
+      before do
+        sign_in user
+      end
 
-    it "renders not_found if user doesn't have a destroy_token" do
-      expect do
+      it "renders not_found if user doesn't have a destroy_token" do
+        expect do
+          get user_confirm_destroy_path(token: token)
+        end.to raise_error(ActionController::RoutingError)
+      end
+
+      it "renders not_found if destroy_token != token" do
+        allow(Rails.cache).to receive(:read).and_return(SecureRandom.hex(8))
+        expect do
+          get user_confirm_destroy_path(token: token)
+        end.to raise_error(ActionController::RoutingError)
+      end
+
+      it "renders template if destroy_token is correct" do
+        allow(Rails.cache).to receive(:read).and_return(token)
         get user_confirm_destroy_path(token: token)
-      end.to raise_error(ActionController::RoutingError)
+        expect(response).to have_http_status(:ok)
+      end
     end
 
-    it "renders not_found if destroy_token != token" do
-      allow(Rails.cache).to receive(:read).and_return(SecureRandom.hex(8))
-      expect do
-        get user_confirm_destroy_path(token: token)
-      end.to raise_error(ActionController::RoutingError)
-    end
-
-    it "renders template if destroy_token is correct" do
-      allow(Rails.cache).to receive(:read).and_return(token)
-      get user_confirm_destroy_path(token: token)
-      expect(response).to have_http_status(:ok)
+    context "without a user" do
+      it "renders not_found" do
+        expect do
+          get user_confirm_destroy_path(token: token)
+        end.to raise_error(ActiveRecord::RecordNotFound)
+      end
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Here are a couple of places in the code where we don't check for object presence before attempting to authorize it and that can lead to this error:
```
Pundit::NotDefinedError: unable to find policy `NilClassPolicy` for `nil`
```
In both cases I think it is acceptable to return a not_found response if the object we are working with is not_found.

## Added to documentation?
- [x] no documentation needed

![kids playing hide and seek](https://thumbs.gfycat.com/FrailNeglectedGreatwhiteshark-size_restricted.gif)
