### PR TITLE
Fix Algolia sign-up link [ci skip]

### DIFF
--- a/docs/backend/algolia.md
+++ b/docs/backend/algolia.md
@@ -12,7 +12,7 @@ application.
 ## Sign up
 
 1. Go to the Algolia sign up
-   [page](https://www.algolia.com/apps/AJVD3Q9KL3/dashboard).
+   [page](https://www.algolia.com/users/sign_up).
 
 2. Choose one of the three methods of signing up: email, GitHub, or Google.
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Documentation Update

## Description

The [Algolia sign up link in the docs](https://docs.dev.to/backend/algolia/) goes to a [user's dashboard](https://www.algolia.com/apps/AJVD3Q9KL3/dashboard) and sends you to the sign-in page with an error. I updated it to go directly to the [sign-up page](https://www.algolia.com/users/sign_up) instead. 

## Related Tickets & Documents

N/A

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

N/A

## Added to documentation?

- [x] docs.dev.to
- [ ] readme
- [ ] no documentation needed
