### PR TITLE
Default return all user notifications if filter is unknown

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -60,6 +60,8 @@ class NotificationsController < ApplicationController
       @user.notifications.for_published_articles
     elsif params[:filter].to_s.casecmp("comments").zero?
       @user.notifications.for_comments.or(@user.notifications.for_mentions)
+    else
+      @user.notifications
     end
   end
 

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -422,5 +422,13 @@ RSpec.describe "NotificationsIndex", type: :request do
         expect(response.body).to include "made a new post:"
       end
     end
+
+    context "when filter is unknown" do
+      it "returns all notifications for user" do
+        sign_in user
+        expect(user).to have_received(:notifications).and_call_original
+        expect { get "/notifications/feed" }.not_to raise_error
+      end
+    end
   end
 end

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -424,9 +424,8 @@ RSpec.describe "NotificationsIndex", type: :request do
     end
 
     context "when filter is unknown" do
-      it "returns all notifications for user" do
+      it "does not raise an error" do
         sign_in user
-        expect(user).to have_received(:notifications).and_call_original
         expect { get "/notifications/feed" }.not_to raise_error
       end
     end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Fixes the issue we are seeing where `:filter` gets set to the value `feed` and ends up returning nil for `filtered_notifications`. I updated that behavior to simply return all user notifications. We should figure out where that feed value is getting set but I thought this solution was very safe and easy to implement so I went with this. 
```
NoMethodError: undefined method `includes' for nil:NilClass

notifications_controller.rb  29 index(...)
[PROJECT_ROOT]/app/controllers/notifications_controller.rb:29:in `index'
27                      end
28 
29     @notifications = @notifications.includes(:notifiable).without_past_aggregations.order(notified_at: :desc)
30 
31     # if offset based pagination is invoked by the frontend code, we filter out all earlier ones
```

## Added to documentation?
- [x] no documentation needed

![I dont get it](https://media0.giphy.com/media/l1IY5eFHkrr8J3H1u/giphy.gif)
