### PR TITLE
Fixes glitch tag full screen button

### DIFF
--- a/app/views/liquids/_glitch.html.erb
+++ b/app/views/liquids/_glitch.html.erb
@@ -1,8 +1,8 @@
 <div class="glitch-embed-wrap" style="height: 450px; width: 100%;margin: 1em auto 1.3em">
   <iframe
-    sandbox="allow-same-origin allow-scripts allow-forms allow-top-navigation-by-user-activation"
+    sandbox="allow-same-origin allow-scripts allow-forms allow-top-navigation-by-user-activation allow-popups"
     src="https://glitch.com/embed/#!/embed/<%= id %>?<%= query %>"
     alt="<%= id %> on glitch"
-    style="height: 100%; width: 100%; border: 0;margin:0;padding:0" 
+    style="height: 100%; width: 100%; border: 0;margin:0;padding:0"
     loading="lazy"></iframe>
 </div>


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Fixes the Glitch tag issue with the full screen button.

Glitch liquid tag opens a ``_blank`` page when full screen is clicked, so it was necessary to ``allow-popups`` in the iframe. 

## Related Tickets & Documents

Fixes #253 

## Added to documentation?

- [x] no documentation needed
