### PR TITLE
Add theme selector to user settings

### DIFF
--- a/app/assets/stylesheets/minimal.scss
+++ b/app/assets/stylesheets/minimal.scss
@@ -31,6 +31,7 @@
 @import 'item-list';
 @import 'color-picker';
 @import 'moderators';
+@import 'theme-selector';
 
 @import 'ltags/LiquidTags';
 

--- a/app/assets/stylesheets/theme-selector.scss
+++ b/app/assets/stylesheets/theme-selector.scss
@@ -1,0 +1,151 @@
+.theme-selector--default {
+  --theme-background: #f9f9fa;
+  --theme-color: #0a0a0a;
+  --theme-top-bar-background: #fdf9f3;
+  --theme-top-bar-search-background: #e8e7e7;
+  --theme-container-background: #fff;
+  --theme-container-border: 1px solid #d6d6d6;
+}
+
+.theme-selector--night-theme {
+  --theme-background: #0d1219;
+  --theme-color: #fff;
+  --theme-top-bar-background: #1c2938;
+  --theme-top-bar-search-background: #424a54;
+  --theme-container-background: #202c3d;
+  --theme-container-border: 1px solid #141d26;
+}
+
+.theme-selector--pink-theme {
+  --theme-background: #FFF7F9;
+  --theme-color: #0a0a0a;
+  --theme-top-bar-background: #ff4983;
+  --theme-top-bar-search-background: #FFF7F9;
+  --theme-container-background: #fff;
+  --theme-container-border: 1px solid #ff4983;
+}
+
+.theme-selector--minimal-light-theme {
+  --theme-background: #fcfcfc;
+  --theme-color: #0a0a0a;
+  --theme-top-bar-background: #ffffff;
+  --theme-top-bar-search-background: #f4f5f7;
+  --theme-container-background: #fff;
+  --theme-container-border: 1px solid #d6d6d6;
+}
+
+.theme-selector--ten-x-hacker-theme {
+  --theme-background: #0a0a0a;
+  --theme-color: #42ff87;
+  --theme-top-bar-background: #1c1c1c;
+  --theme-top-bar-search-background: #0a0a0a;
+  --theme-container-background: #0a0a0a;
+  --theme-container-border: 1px solid #42ff87;
+}
+
+.theme-selector {
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  border: var(--theme-container-border);
+  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23);
+  transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
+  margin: 15px;
+  width: 192px;
+  height: 108px;
+  border-radius: 10px;
+  padding: 0 !important;
+}
+
+.theme-selector:hover,
+.theme-selector:focus {
+  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.25), 0 10px 10px rgba(0, 0, 0, 0.22);
+}
+
+.theme-selector * {
+  pointer-events: none;
+}
+
+.theme-selector__radio:focus~.theme-selector__outline {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  border: 1px solid #4D90FE;
+  transform: scale(1.1);
+}
+
+.theme-selector__radio,
+.theme-selector__indicatior {
+  position: absolute;
+  opacity: 0;
+}
+
+.theme-selector__indicatior {
+  height: 1em;
+  width: 1em;
+  top: 0.5em;
+  right: 0.5em;
+  border-radius: 1em;
+  background: green;
+  border: 0.1em solid darkgreen;
+
+}
+
+.theme-selector__nav {
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  height: 20px;
+  width: 192px;
+  background: var(--theme-top-bar-background);
+  border-bottom: var(--theme-container-border);
+  border-radius: 10px 10px 0 0;
+}
+
+.theme-selector__search {
+  width: 32%;
+  height: 12px;
+  background: var(--theme-top-bar-search-background);
+  border-radius: 2px;
+}
+
+.theme-selector__body {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 88px;
+  width: 192px;
+  background: var(--theme-background);
+  border-radius: 0 0 10px 10px;
+}
+
+.theme-selector__col,
+.theme-selector__col--center {
+  width: 20%;
+  height: 85%;
+  background: var(--theme-container-background);
+  border-radius: 2px;
+  border: var(--theme-container-border);
+}
+
+.theme-selector__col--center {
+  text-align: center;
+  color: var(--theme-color);
+  width: 35%;
+  background: var(--theme-background);
+  border: none;
+  margin: 0 10px;
+}
+
+.theme-selector__posts {
+  height: calc(100% - 18px);
+  background: var(--theme-container-background);
+  border: var(--theme-container-border);
+  border-radius: 2px;
+}
+
+.theme-selector__radio:checked+.theme-selector__indicatior {
+  opacity: 1;
+}

--- a/app/views/users/_misc.html.erb
+++ b/app/views/users/_misc.html.erb
@@ -40,8 +40,11 @@
 <%= form_for(@user, html: { id: nil }) do |f| %>
   <div class="sub-field">
     <%= f.label :config_theme, "Site Theme" %>
-    <%= f.select(:config_theme, options_for_select(["default", "night theme", "minimal light theme", "pink theme", "ten x hacker theme"], @user.config_theme.tr("_", " "))) %>
-    <sub><em>Default is light style.</em></sub>
+    <div class="theme-selector-field">
+      <% ["default", "night theme", "minimal light theme", "pink theme", "ten x hacker theme"].each do |theme| %>
+        <%= render partial: "theme_selector", locals: { f: f, theme: theme } %>
+      <% end %>
+    </div>
   </div>
   <div class="sub-field">
     <%= f.label :config_font, "Base Post Font" %>
@@ -50,7 +53,7 @@
   </div>
   <div class="sub-field">
     <%= f.label :config_navbar, "Site Navbar" %>
-    <%= f.select(:config_navbar, options_for_select(["default", "static"], @user.config_navbar.tr("_", " "))) %>
+    <%= f.select(:config_navbar, options_for_select(%w[default static], @user.config_navbar.tr("_", " "))) %>
     <sub><em>Default is fixed.</em></sub>
   </div>
   <div class="field">

--- a/app/views/users/_theme_selector.html.erb
+++ b/app/views/users/_theme_selector.html.erb
@@ -1,0 +1,16 @@
+<label class="theme-selector theme-selector--<%= theme.tr(" ", "-") %>">
+  <%= f.radio_button :config_theme, theme, checked: @user.config_theme.tr("_", " ") == theme, class: "theme-selector__radio" %>
+  <div class="theme-selector__indicatior"></div>
+  <div class="theme-selector__outline"></div>
+  <div class="theme-selector__nav">
+    <div class="theme-selector__search"></div>
+  </div>
+  <div class="theme-selector__body">
+    <div class="theme-selector__col"></div>
+    <div class="theme-selector__col--center">
+      ~ ~ ~ ~ ~
+      <div class="theme-selector__posts"></div>
+    </div>
+    <div class="theme-selector__col"></div>
+  </div>
+</label>


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [x] Feature

## Description

Add a theme selector to user settings which displays what the theme looks like. Thanks @Link2Twenty for the cool mock-up :)

## Related Tickets & Documents

Fixes #2158 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![theme-selector](https://user-images.githubusercontent.com/9089551/70875418-b3c6ea00-1f94-11ea-97d4-5e5ae8b6a856.gif)

## Added to documentation?

- [x] no documentation needed