### PR TITLE
Fix #5072: Remove unnecessary reaction call

### DIFF
--- a/app/assets/javascripts/initializers/initializeAllFollowButts.js
+++ b/app/assets/javascripts/initializers/initializeAllFollowButts.js
@@ -9,7 +9,6 @@ function initializeAllFollowButts() {
 
 function initializeFollowButt(butt) {
   var user = userData();
-  var deviceWidth = window.innerWidth > 0 ? window.innerWidth : screen.width;
   var buttInfo = JSON.parse(butt.dataset.info);
   var userStatus = document
     .getElementsByTagName('body')[0]

--- a/app/assets/javascripts/initializers/initializeReadingListIcons.js
+++ b/app/assets/javascripts/initializers/initializeReadingListIcons.js
@@ -14,7 +14,7 @@ function initializeReadingListIcons() {
 
 // set SAVE or SAVED articles buttons
 function setReadingListButtonsState() {
-  var readingListButtons = document.getElementsByClassName('bookmark-engage');
+  var readingListButtons = document.getElementsByClassName('bookmark-button');
   Array.from(readingListButtons).forEach(highlightButton);
 }
 
@@ -150,7 +150,7 @@ function isReadingListButtonHoverTarget(element) {
 
   return (
     (element.tagName === 'BUTTON' &&
-      classList.contains('bookmark-engage') &&
+      classList.contains('bookmark-button') &&
       classList.contains('selected')) ||
     (element.tagName === 'SPAN' && classList.contains('bm-success'))
   );

--- a/app/assets/javascripts/utilities/buildArticleHTML.js.erb
+++ b/app/assets/javascripts/utilities/buildArticleHTML.js.erb
@@ -77,12 +77,12 @@ function buildArticleHTML(article) {
     }
     var saveButton = '';
     if (article.class_name === "Article") {
-      saveButton = '<button type="button" class="article-engagement-count bookmark-engage" data-reactable-id="'+article.id+'">\
+      saveButton = '<button type="button" class="article-engagement-count engage-button bookmark-button" data-reactable-id="'+article.id+'">\
                       <span class="bm-initial">SAVE</span>\
                       <span class="bm-success">SAVED</span>\
                     </button>'
     } else if (article.class_name === "User") {
-      saveButton = '<button type="button" style="width: 122px" class="article-engagement-count bookmark-engage follow-action-button"\
+      saveButton = '<button type="button" style="width: 122px" class="article-engagement-count engage-button follow-action-button"\
                        data-info=\'{"id":'+article.id+',"className":"User"}\' data-follow-action-button>\
                        &nbsp;\
                     </button>'

--- a/app/assets/stylesheets/articles.scss
+++ b/app/assets/stylesheets/articles.scss
@@ -772,7 +772,7 @@
       &.reactions-count {
         left: 20px;
       }
-      &.bookmark-engage {
+      &.engage-button {
         right: 12px;
         border: 2px solid transparent;
         border-radius: 3px;
@@ -809,7 +809,7 @@
         margin-top: -38px;
         bottom: auto;
         z-index: 10;
-        &.bookmark-engage {
+        &.engage-button {
           margin-top: -39px;
         }
       }

--- a/app/assets/stylesheets/more-articles.scss
+++ b/app/assets/stylesheets/more-articles.scss
@@ -184,7 +184,7 @@
         }
       }
     }
-    .bookmark-engage {
+    .engage-button {
       font-family: $helvetica-condensed;
       background: darken($purple, 26%);
       color: white;

--- a/app/views/articles/_single_story.html.erb
+++ b/app/views/articles/_single_story.html.erb
@@ -57,7 +57,7 @@
   </a>
   <button
     type="button"
-    class="article-engagement-count bookmark-engage"
+    class="article-engagement-count engage-button bookmark-button"
     data-reactable-id="<%= story.id %>"
     aria-label="Save to reading list"
     title="Save to reading list">

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -136,7 +136,7 @@
             </a>
             <button
               type="button"
-              class="article-engagement-count bookmark-engage featured-engagement-count"
+              class="article-engagement-count engage-button bookmark-button featured-engagement-count"
               data-reactable-id="<%= @featured_story.id %>"
               aria-label="Save to reading list"
               title="Save to reading list">


### PR DESCRIPTION
What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Inside the [search result page](https://dev.to/search?q=test&filters=class_name:User), when you select to search by people on the sidebar and click the button to follow someone, it was erroneously triggering a reaction ajax request, thus not having the `reactable_id`:

![Group](https://user-images.githubusercontent.com/1292945/70876204-7adc4480-1f97-11ea-9b72-e524d361b409.png)
_If you click any of those follow buttons you'll see the failed ajax request on console._

It gets called because all buttons with the `bookmark-engage` class get that event assigned to it. And the follow buttons use that class too, probably only to have the same styling. 

There are many ways to solve this problem, I've updated the CSS classes in a way those buttons have a common styling class `.engage-button` to look the same. Then, the event for the "reactions" is only added to the existing `.bookmark-button` class and the following buttons won't use it anymore.

The request for following/unfollowing the person still occurs as usually.

## Related Tickets & Documents
- Fixes https://github.com/thepracticaldev/dev.to/issues/5072