### PR TITLE
Return ActionController::RoutingError error when Invalid Format is Requested

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,8 @@ class ApplicationController < ActionController::Base
   include ValidRequest
   include Pundit
 
+  rescue_from ActionView::MissingTemplate, with: :not_found
+
   def require_http_auth
     authenticate_or_request_with_http_basic do |username, password|
       username == ApplicationConfig["APP_NAME"] && password == ApplicationConfig["APP_PASSWORD"]

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
   include ValidRequest
   include Pundit
 
-  rescue_from ActionView::MissingTemplate, with: :not_found
+  rescue_from ActionView::MissingTemplate, with: :routing_error
 
   def require_http_auth
     authenticate_or_request_with_http_basic do |username, password|
@@ -15,6 +15,10 @@ class ApplicationController < ActionController::Base
 
   def not_found
     raise ActiveRecord::RecordNotFound, "Not Found"
+  end
+
+  def routing_error
+    raise ActionController::RoutingError, "Routing Error"
   end
 
   def not_authorized

--- a/spec/requests/articles/articles_spec.rb
+++ b/spec/requests/articles/articles_spec.rb
@@ -55,6 +55,12 @@ RSpec.describe "Articles", type: :request do
 
       it("renders empty body") { expect(response.body).to be_empty }
     end
+
+    context "when format is invalid" do
+      it "returns a 404 response" do
+        expect { get "/feed.zip" }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
   end
 
   describe "GET /feed/tag" do

--- a/spec/requests/articles/articles_spec.rb
+++ b/spec/requests/articles/articles_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe "Articles", type: :request do
 
     context "when format is invalid" do
       it "returns a 404 response" do
-        expect { get "/feed.zip" }.to raise_error(ActiveRecord::RecordNotFound)
+        expect { get "/feed.zip" }.to raise_error(ActionController::RoutingError)
       end
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
We have been seeing a lot of `ActionView::MissingTemplate` errors when people try to request invalid formats for routes. This can lead to a lot of noise in Honeybadger so I updated that error to raise an `ActiveRecord::RecordNotFound` which is ignored by default by Honeybadger

## Added to documentation?
- [x] no documentation needed

![what do you want gif](https://media.giphy.com/media/E87jjnSCANThe/200w_d.gif)
