### PR TITLE
Move navbar rendering JS inline

### DIFF
--- a/app/assets/javascripts/initializers/initNotifications.js
+++ b/app/assets/javascripts/initializers/initNotifications.js
@@ -47,44 +47,16 @@ function fetchNotificationsCount() {
     document.getElementById('notifications-container') == null &&
     checkUserLoggedIn()
   ) {
-    var xmlhttp;
-    if (window.XMLHttpRequest) {
-      xmlhttp = new XMLHttpRequest();
-    } else {
-      xmlhttp = new ActiveXObject('Microsoft.XMLHTTP');
+    // Prefetch notifications page
+    if (instantClick) {
+      InstantClick.removeExpiredKeys('force');
+      setTimeout(function() {
+        InstantClick.preload(
+          document.getElementById('notifications-link').href,
+          'force',
+        );
+      }, 30);
     }
-    xmlhttp.onreadystatechange = function() {
-      if (xmlhttp.readyState == XMLHttpRequest.DONE) {
-        var count = xmlhttp.response;
-        if (isNaN(count)) {
-          document
-            .getElementById('notifications-number')
-            .classList.remove('showing');
-        } else if (count != '0' && count != undefined && count != '') {
-          document.getElementById('notifications-number').innerHTML =
-            xmlhttp.response;
-          document
-            .getElementById('notifications-number')
-            .classList.add('showing');
-          if (instantClick) {
-            InstantClick.removeExpiredKeys('force');
-            setTimeout(function() {
-              InstantClick.preload(
-                document.getElementById('notifications-link').href,
-                'force',
-              );
-            }, 30);
-          }
-        } else {
-          document
-            .getElementById('notifications-number')
-            .classList.remove('showing');
-        }
-      }
-    };
-
-    xmlhttp.open('GET', '/notifications/counts', true);
-    xmlhttp.send();
   }
 }
 

--- a/app/views/layouts/_top_bar.html.erb
+++ b/app/views/layouts/_top_bar.html.erb
@@ -37,4 +37,52 @@
       <%= render "layouts/nav_menu" %>
     </div>
   </nav>
+  <% if user_signed_in? %>
+    <script async>
+      // Here we have some scripts we want to get working on before
+      // waiting for the page to stream in.
+
+      // Load the current user's pic as quickly as it's available
+      var currentUser = localStorage.getItem('current_user')
+      var navProfilePic = document.getElementById('nav-profile-image')
+      if (currentUser && navProfilePic) {
+        navProfilePic.src = JSON.parse(currentUser).profile_image_90;
+      }
+
+      // Load notifications count as quickly as it's available.
+      if (
+        document.getElementById('notifications-container') == null
+      ) {
+        var xmlhttp;
+        if (window.XMLHttpRequest) {
+          xmlhttp = new XMLHttpRequest();
+        } else {
+          xmlhttp = new ActiveXObject('Microsoft.XMLHTTP');
+        }
+        xmlhttp.onreadystatechange = function() {
+          if (xmlhttp.readyState == XMLHttpRequest.DONE) {
+            var count = xmlhttp.response;
+            if (isNaN(count)) {
+              document
+                .getElementById('notifications-number')
+                .classList.remove('showing');
+            } else if (count != '0' && count != undefined && count != '') {
+              document.getElementById('notifications-number').innerHTML =
+                xmlhttp.response;
+              document
+                .getElementById('notifications-number')
+                .classList.add('showing');
+            } else {
+              document
+                .getElementById('notifications-number')
+                .classList.remove('showing');
+            }
+          }
+        };
+
+        xmlhttp.open('GET', '/notifications/counts', true);
+        xmlhttp.send();
+      }
+    </script>
+  <% end %>
 </div>


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
This moves some of the code for displaying user profile pic and notifications count into an inline `script` tag so that it can be stored in the shell and run as soon as this code shows up on the site.

Avoids flash of black for users visiting the site. We can add any other relevant code here if we see fit.

<img width="171" alt="Screen Shot 2019-12-16 at 2 16 53 PM" src="https://user-images.githubusercontent.com/3102842/70935681-b7975280-200e-11ea-9bc5-647812dd203a.png">

This will speed up rendering of user info regardless of serviceworkers, but is primarily effective for the serviceworker context.