### PR TITLE
Prepare for ENVie gem default value processing deprecation

### DIFF
--- a/Envfile
+++ b/Envfile
@@ -1,44 +1,56 @@
 # Most of the things are optional. If you need to use a
 # custom key, please create an application.yml for it
 
-enable_defaults! { ENV["RACK_ENV"] != "production" }
+SET_DEFAULTS = ! Rails.env.production?
+# or should it be ENV["RACK_ENV"] != "production" like below?
+# enable_defaults! { ENV["RACK_ENV"] != "production" }
 
 ################################################
 ############## Basic configuration #############
 ################################################
 
+def set_variable(name, data_type, default_value = nil)
+  if SET_DEFAULTS && (! default_value.nil?)
+    key = name.to_s # name will be a symbol, we need a String
+    value = default_value.to_s # default_value may be a number, we need a String
+    ENV[key] ||= value
+  end
+  variable name, data_type
+end
+
+
 # App domain + Protocol setting for development
-variable :APP_DOMAIN, :String, default: "localhost:3000"
-variable :APP_PROTOCOL, :String, default: "http://"
-variable :COMMUNITY_NAME, :String, default: "DEV(local)"
-variable :MAIN_SOCIAL_IMAGE, :String, default: "https://thepracticaldev.s3.amazonaws.com/i/6hqmcjaxbgbon8ydw93z.png"
-variable :SITE_TWITTER_HANDLE, :String, default: "tbd"
-variable :RATE_LIMIT_FOLLOW_COUNT_DAILY, :Integer, default: 500
-variable :FAVICON_URL, :String, default: "favicon.ico"
+set_variable :APP_DOMAIN, :String, "localhost:3000"
+set_variable :APP_PROTOCOL, :String, "http://"
+set_variable :COMMUNITY_NAME, :String, "DEV(local)"
+set_variable :MAIN_SOCIAL_IMAGE, :String, "https://thepracticaldev.s3.amazonaws.com/i/6hqmcjaxbgbon8ydw93z.png"
+set_variable :SITE_TWITTER_HANDLE, :String, "tbd"
+set_variable :RATE_LIMIT_FOLLOW_COUNT_DAILY, :Integer, 500
+set_variable :FAVICON_URL, :String, "favicon.ico"
 
 # Logo
-variable :LOGO_SVG, :String, default: ""
+set_variable :LOGO_SVG, :String, ""
 
 # Default staff account's id
-variable :DEVTO_USER_ID, :Integer, default: 1
+set_variable :DEVTO_USER_ID, :Integer, 1
 
 # Default site email
-variable :DEFAULT_SITE_EMAIL, :String, default: "yo@dev.to"
+set_variable :DEFAULT_SITE_EMAIL, :String, "yo@dev.to"
 
 # Service timeout length
-variable :RACK_TIMEOUT_WAIT_TIMEOUT, :Integer, default: 100_000
-variable :RACK_TIMEOUT_SERVICE_TIMEOUT, :Integer, default: 100_000
+set_variable :RACK_TIMEOUT_WAIT_TIMEOUT, :Integer, 100_000
+set_variable :RACK_TIMEOUT_SERVICE_TIMEOUT, :Integer, 100_000
 
 # Heroku release slug used to bust caches on deploys
-variable :HEROKU_SLUG_COMMIT, :String, default: "Optional"
+set_variable :HEROKU_SLUG_COMMIT, :String, "Optional"
 
 # Redis caching storage
-variable :REDIS_URL, :String, default: "redis://localhost:6379"
+set_variable :REDIS_URL, :String, "redis://localhost:6379"
 
 # Redis sessions storage
-variable :REDIS_SESSIONS_URL, :String, default: "redis://localhost:6379"
-variable :SESSION_KEY, :String, default: "_Dev_Community_Session"
-variable :SESSION_EXPIRY_SECONDS, :Integer, default: 1209600 # two weeks in seconds
+set_variable :REDIS_SESSIONS_URL, :String, "redis://localhost:6379"
+set_variable :SESSION_KEY, :String, "_Dev_Community_Session"
+set_variable :SESSION_EXPIRY_SECONDS, :Integer, 1209600 # two weeks in seconds
 
 ################################################
 ############## 3rd Party Services ##############
@@ -49,16 +61,16 @@ variable :SESSION_EXPIRY_SECONDS, :Integer, default: 1209600 # two weeks in seco
 
 # Github for github related access
 # (https://developer.github.com/v3/guides/basics-of-authentication/)
-variable :GITHUB_KEY, :String, default: "Optional"
-variable :GITHUB_SECRET, :String, default: "Optional"
-variable :GITHUB_TOKEN, :String, default: "Optional"
+set_variable :GITHUB_KEY, :String, "Optional"
+set_variable :GITHUB_SECRET, :String, "Optional"
+set_variable :GITHUB_TOKEN, :String, "Optional"
 
 # Twitter for normal twitter access
 # (https://developer.twitter.com/en/docs/basics/authentication/guides/access-tokens)
-variable :TWITTER_ACCESS_TOKEN, :String, default: "Optional"
-variable :TWITTER_ACCESS_TOKEN_SECRET, :String, default: "Optional"
-variable :TWITTER_KEY, :String, default: "Optional"
-variable :TWITTER_SECRET, :String, default: "Optional"
+set_variable :TWITTER_ACCESS_TOKEN, :String, "Optional"
+set_variable :TWITTER_ACCESS_TOKEN_SECRET, :String, "Optional"
+set_variable :TWITTER_KEY, :String, "Optional"
+set_variable :TWITTER_SECRET, :String, "Optional"
 
 ################################################
 ######### Optional 3rd Party Services ##########
@@ -66,147 +78,147 @@ variable :TWITTER_SECRET, :String, default: "Optional"
 
 # Honeybadger for error tracking
 # (https://docs.honeybadger.io/lib/ruby/getting-started/introduction.html)
-variable :HONEYBADGER_API_KEY, :String, default: "Optional"
-variable :HONEYBADGER_JS_API_KEY, :String, default: "Optional"
+set_variable :HONEYBADGER_API_KEY, :String, "Optional"
+set_variable :HONEYBADGER_JS_API_KEY, :String, "Optional"
 
 # Algolia for search (not optional)
 # (https://www.algolia.com/doc/)
 only_in_test = proc { ENV["RACK_ENV"] == "test" ? "test-test" : nil }
-variable :ALGOLIASEARCH_API_KEY, :String, default: only_in_test
-variable :ALGOLIASEARCH_APPLICATION_ID, :String, default: only_in_test
-variable :ALGOLIASEARCH_SEARCH_ONLY_KEY, :String, default: only_in_test
+set_variable :ALGOLIASEARCH_API_KEY, :String, only_in_test
+set_variable :ALGOLIASEARCH_APPLICATION_ID, :String, only_in_test
+set_variable :ALGOLIASEARCH_SEARCH_ONLY_KEY, :String, only_in_test
 
 # AWS for images storages
-variable :AWS_ID, :String, default: "Optional"
-variable :AWS_SECRET, :String, default: "Optional"
-variable :AWS_BUCKET_NAME, :String, default: "Optional"
+set_variable :AWS_ID, :String, "Optional"
+set_variable :AWS_SECRET, :String, "Optional"
+set_variable :AWS_BUCKET_NAME, :String, "Optional"
 
 # AWS SDK
 # (https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/setup-config.html)
-variable :AWS_DEFAULT_REGION, :String, default: "us-east-1"
-variable :AWS_SDK_KEY, :String, default: "Optional"
-variable :AWS_SDK_SECRET, :String, default: "Optional"
+set_variable :AWS_DEFAULT_REGION, :String, "us-east-1"
+set_variable :AWS_SDK_KEY, :String, "Optional"
+set_variable :AWS_SDK_SECRET, :String, "Optional"
 
 # AWS for video storage
-variable :AWS_S3_INPUT_BUCKET, :String, default: "Optional"
-variable :AWS_S3_VIDEO_ID, :String, default: "Optional"
-variable :AWS_S3_VIDEO_KEY, :String, default: "Optional"
+set_variable :AWS_S3_INPUT_BUCKET, :String, "Optional"
+set_variable :AWS_S3_VIDEO_ID, :String, "Optional"
+set_variable :AWS_S3_VIDEO_KEY, :String, "Optional"
 
 # Buffer for sending to buffer
 # (https://buffer.com/developers/api)
-variable :BUFFER_ACCESS_TOKEN, :String, default: "Optional"
-variable :BUFFER_FACEBOOK_ID, :String, default: "Optional"
-variable :BUFFER_LINKEDIN_ID, :String, default: "Optional"
-variable :BUFFER_PROFILE_ID, :Integer, default: 0
-variable :BUFFER_TWITTER_ID, :String, default: "Optional"
-variable :BUFFER_LISTINGS_PROFILE, :String, default: "Optional"
+set_variable :BUFFER_ACCESS_TOKEN, :String, "Optional"
+set_variable :BUFFER_FACEBOOK_ID, :String, "Optional"
+set_variable :BUFFER_LINKEDIN_ID, :String, "Optional"
+set_variable :BUFFER_PROFILE_ID, :Integer, 0
+set_variable :BUFFER_TWITTER_ID, :String, "Optional"
+set_variable :BUFFER_LISTINGS_PROFILE, :String, "Optional"
 
 # Cloudinary for image resizing and cache??
 # (https://cloudinary.com/documentation/rails_integration)
-variable :CLOUDINARY_API_KEY, :String, default: "Optional"
-variable :CLOUDINARY_API_SECRET, :String, default: "Optional"
-variable :CLOUDINARY_CLOUD_NAME, :String, default: "Optional"
-variable :CLOUDINARY_SECURE, :String, default: "Optional"
+set_variable :CLOUDINARY_API_KEY, :String, "Optional"
+set_variable :CLOUDINARY_API_SECRET, :String, "Optional"
+set_variable :CLOUDINARY_CLOUD_NAME, :String, "Optional"
+set_variable :CLOUDINARY_SECURE, :String, "Optional"
 
 # HTML/CSS to Image for generating social preview images
 # (https://docs.htmlcsstoimage.com/example-code/ruby)
-variable :HCTI_API_USER_ID, :String, default: "Optional"
-variable :HCTI_API_KEY, :String, default: "Optional"
+set_variable :HCTI_API_USER_ID, :String, "Optional"
+set_variable :HCTI_API_KEY, :String, "Optional"
 
 # Dacast for streaming
 # (https://www.dacast.com/video-api-documentation/)
-variable :DACAST_STREAM_CODE, :String, default: "Optional"
+set_variable :DACAST_STREAM_CODE, :String, "Optional"
 
 # Fastly for edge caching
 # (https://docs.fastly.com/api/)
-variable :FASTLY_API_KEY, :String, default: "Optional"
-variable :FASTLY_SERVICE_ID, :String, default: "Optional"
+set_variable :FASTLY_API_KEY, :String, "Optional"
+set_variable :FASTLY_SERVICE_ID, :String, "Optional"
 
 # Honeycomb for monitoring and observability
 # (https://www.honeycomb.io/)
-variable :HONEYCOMB_API_KEY, :String, default: ""
+set_variable :HONEYCOMB_API_KEY, :String, ""
 
 # Google analytic
 # (https://developers.google.com/analytics/devguides/reporting/core/v4)
-variable :GA_SERVICE_ACCOUNT_JSON, :String, default: "Optional"
-variable :GA_TRACKING_ID, :String, default: "Optional"
-variable :GA_OPTIMIZE_ID, :String, default: "Optional"
-variable :GA_VIEW_ID, :String, default: "Optional"
-variable :GA_FETCH_RATE, :Integer, default: 25
+set_variable :GA_SERVICE_ACCOUNT_JSON, :String, "Optional"
+set_variable :GA_TRACKING_ID, :String, "Optional"
+set_variable :GA_OPTIMIZE_ID, :String, "Optional"
+set_variable :GA_VIEW_ID, :String, "Optional"
+set_variable :GA_FETCH_RATE, :Integer, 25
 
 # Mailchimp for mails
 # (https://mailchimp.com/developer/)
-variable :MAILCHIMP_API_KEY, :String, default: "Optional-valid"
-variable :MAILCHIMP_NEWSLETTER_ID, :String, default: "Optional"
-variable :MAILCHIMP_SUSTAINING_MEMBERS_ID, :String, default: "Optional"
-variable :MAILCHIMP_TAG_MODERATORS_ID, :String, default: "Optional"
-variable :MAILCHIMP_COMMUNITY_MODERATORS_ID, :String, default: "Optional"
+set_variable :MAILCHIMP_API_KEY, :String, "Optional-valid"
+set_variable :MAILCHIMP_NEWSLETTER_ID, :String, "Optional"
+set_variable :MAILCHIMP_SUSTAINING_MEMBERS_ID, :String, "Optional"
+set_variable :MAILCHIMP_TAG_MODERATORS_ID, :String, "Optional"
+set_variable :MAILCHIMP_COMMUNITY_MODERATORS_ID, :String, "Optional"
 
 # Email digest frequency
-variable :PERIODIC_EMAIL_DIGEST_MAX, :Integer, default: 0
-variable :PERIODIC_EMAIL_DIGEST_MIN, :Integer, default: 2
+set_variable :PERIODIC_EMAIL_DIGEST_MAX, :Integer, 0
+set_variable :PERIODIC_EMAIL_DIGEST_MIN, :Integer, 2
 
 # Pusher for DEV Connect/notfications
 # (https://pusher.com/docs)
-variable :PUSHER_APP_ID, :String, default: "Optional"
-variable :PUSHER_CLUSTER, :String, default: "Optional"
-variable :PUSHER_KEY, :String, default: "Optional"
-variable :PUSHER_SECRET, :String, default: "Optional"
-variable :PUSHER_BEAMS_ID, :String, default: "Optional"
-variable :PUSHER_BEAMS_KEY, :String, default: "Optional"
+set_variable :PUSHER_APP_ID, :String, "Optional"
+set_variable :PUSHER_CLUSTER, :String, "Optional"
+set_variable :PUSHER_KEY, :String, "Optional"
+set_variable :PUSHER_SECRET, :String, "Optional"
+set_variable :PUSHER_BEAMS_ID, :String, "Optional"
+set_variable :PUSHER_BEAMS_KEY, :String, "Optional"
 
 # Google recaptcha
 # (https://developers.google.com/recaptcha/intro)
-variable :RECAPTCHA_SECRET, :String, default: "Optional"
-variable :RECAPTCHA_SITE, :String, default: "Optional"
+set_variable :RECAPTCHA_SECRET, :String, "Optional"
+set_variable :RECAPTCHA_SITE, :String, "Optional"
 
 # Slack for customer alerts
 # (https://api.slack.com/)
-variable :SLACK_CHANNEL, :String, default: ""
-variable :SLACK_WEBHOOK_URL, :String, default: ""
+set_variable :SLACK_CHANNEL, :String, ""
+set_variable :SLACK_WEBHOOK_URL, :String, ""
 
 # Stripe for payment system
 # (https://stripe.com/docs/api)
-variable :STRIPE_PUBLISHABLE_KEY, :String, default: "Optional"
-variable :STRIPE_SECRET_KEY, :String, default: "Optional"
-variable :STRIPE_CANCELLATION_SECRET, :String, default: "Optional"
+set_variable :STRIPE_PUBLISHABLE_KEY, :String, "Optional"
+set_variable :STRIPE_SECRET_KEY, :String, "Optional"
+set_variable :STRIPE_CANCELLATION_SECRET, :String, "Optional"
 
 # For video calling in DEV Connect
 # (https://www.twilio.com/docs/video)
-variable :TWILIO_ACCOUNT_SID, :String, default: "Optional"
-variable :TWILIO_VIDEO_API_KEY, :String, default: "Optional"
-variable :TWILIO_VIDEO_API_SECRET, :String, default: "Optional"
+set_variable :TWILIO_ACCOUNT_SID, :String, "Optional"
+set_variable :TWILIO_VIDEO_API_KEY, :String, "Optional"
+set_variable :TWILIO_VIDEO_API_SECRET, :String, "Optional"
 
 # For Twitch live stream integration
 # (https://dev.twitch.tv/docs)
-variable :TWITCH_CLIENT_ID, :String, default: "Optional"
-variable :TWITCH_CLIENT_SECRET, :String, default: "Optional"
-variable :TWITCH_WEBHOOK_SECRET, :String, default: "Optional"
+set_variable :TWITCH_CLIENT_ID, :String, "Optional"
+set_variable :TWITCH_CLIENT_SECRET, :String, "Optional"
+set_variable :TWITCH_WEBHOOK_SECRET, :String, "Optional"
 
 # Trending tags on home page
-variable :TRENDING_TAGS, :String, default: "git,beginners"
+set_variable :TRENDING_TAGS, :String, "git,beginners"
 
 # For calling the Stack Exchange API
 # (https://api.stackexchange.com/docs)
-variable :STACK_EXCHANGE_APP_KEY, :String, default: ""
+set_variable :STACK_EXCHANGE_APP_KEY, :String, ""
 
 ##### Legacy test related env vars ######
-variable :FACEBOOK_PIXEL_ID, :String, default: "Optional"
-variable :SMARTY_STREETS_WEB_KEY, :String, default: "Optional"
+set_variable :FACEBOOK_PIXEL_ID, :String, "Optional"
+set_variable :SMARTY_STREETS_WEB_KEY, :String, "Optional"
 
 group :production do
-  variable :SECRET_KEY_BASE, :String
+  set_variable :SECRET_KEY_BASE, :String
 
   # Timber
   # (https://docs.timber.io/)
-  variable :SEND_LOGS_TO_TIMBER, :String  # Defaults to true in production, false in development
-  variable :TIMBER, :String  # Only required if above is "true" or unset
+  set_variable :SEND_LOGS_TO_TIMBER, :String  # Defaults to true in production, false in development
+  set_variable :TIMBER, :String  # Only required if above is "true" or unset
 
   # Sendgrid
   # (https://sendgrid.com/docs/API_Reference/api_v3.html)
-  variable :SENDGRID_USERNAME_ACCEL, :String
-  variable :SENDGRID_PASSWORD_ACCEL, :String
+  set_variable :SENDGRID_USERNAME_ACCEL, :String
+  set_variable :SENDGRID_PASSWORD_ACCEL, :String
 
   # Heroku
-  variable :HEROKU_APP_URL, :String  # practicaldev.herokuapp.com
+  set_variable :HEROKU_APP_URL, :String  # practicaldev.herokuapp.com
 end

--- a/Envfile
+++ b/Envfile
@@ -84,12 +84,7 @@ set_variable :HONEYBADGER_JS_API_KEY, :String, "Optional"
 # Algolia for search (not optional)
 # (https://www.algolia.com/doc/)
 #
-# I'm changing the following line:
-# only_in_test = proc { ENV["RACK_ENV"] == "test" ? "test-test" : nil }
-# to:
 only_in_test = (ENV["RACK_ENV"] == "test" ? "test-test" : nil)
-# Is there a reason this computation needs to be deferred as a Proc?
-#
 set_variable :ALGOLIASEARCH_API_KEY, :String, only_in_test
 set_variable :ALGOLIASEARCH_APPLICATION_ID, :String, only_in_test
 set_variable :ALGOLIASEARCH_SEARCH_ONLY_KEY, :String, only_in_test

--- a/Envfile
+++ b/Envfile
@@ -12,9 +12,8 @@ SET_DEFAULTS = ! Rails.env.production?
 def set_variable(name, data_type, default_value = nil)
   if SET_DEFAULTS && (! default_value.nil?)
     key = name.to_s # name will be a symbol, we need a String
-    unless ENV.has_key?(key)
-      ENV[key] = default_value.to_s # default_value may be a number, we need a String
-    end
+    value = default_value.to_s # default_value may be a number, we need a String
+    ENV[key] ||= value
   end
   variable name, data_type
 end

--- a/Envfile
+++ b/Envfile
@@ -83,7 +83,13 @@ set_variable :HONEYBADGER_JS_API_KEY, :String, "Optional"
 
 # Algolia for search (not optional)
 # (https://www.algolia.com/doc/)
-only_in_test = proc { ENV["RACK_ENV"] == "test" ? "test-test" : nil }
+#
+# I'm changing the following line:
+# only_in_test = proc { ENV["RACK_ENV"] == "test" ? "test-test" : nil }
+# to:
+only_in_test = (ENV["RACK_ENV"] == "test" ? "test-test" : nil)
+# Is there a reason this computation needs to be deferred as a Proc?
+#
 set_variable :ALGOLIASEARCH_API_KEY, :String, only_in_test
 set_variable :ALGOLIASEARCH_APPLICATION_ID, :String, only_in_test
 set_variable :ALGOLIASEARCH_SEARCH_ONLY_KEY, :String, only_in_test

--- a/Envfile
+++ b/Envfile
@@ -12,8 +12,9 @@ SET_DEFAULTS = ! Rails.env.production?
 def set_variable(name, data_type, default_value = nil)
   if SET_DEFAULTS && (! default_value.nil?)
     key = name.to_s # name will be a symbol, we need a String
-    value = default_value.to_s # default_value may be a number, we need a String
-    ENV[key] ||= value
+    unless ENV.has_key?(key)
+      ENV[key] = default_value.to_s # default_value may be a number, we need a String
+    end
   end
   variable name, data_type
 end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Response to Gem Deprecation

## Description

I'm not certain this approach is satisfactory, but implementing it moves the default setting out of ENVie and does not change the success or failure of the unit tests.

Previously, a default parameter was passed to ENVie to manage. I changed this to modify ENV itself if there was no non-nil value and if the environment was not production (please see comment in code regarding that condition).

Whereas a numeric default value was passed to ENVie as a number, I am setting the ENV value to the string representation of the number. The data type is passed to ENVie, and I am assuming it will handle any necessary conversions.

## Related Tickets & Documents

Issue #5152 

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
