### PR TITLE
Skip serviceworker logic for Twitter iOS referrals

### DIFF
--- a/app/views/service_worker/index.js.erb
+++ b/app/views/service_worker/index.js.erb
@@ -81,6 +81,10 @@
 
   self.addEventListener('fetch', event => {
     const url = new URL(event.request.url);
+    if (/iPhone|CriOS|iPad/i.test(navigator.userAgent) && event.request.referrer.includes('t.co')) {
+       // Twitter on iOS seems to cause problems
+       return;
+    }
     if (url.origin === location.origin) {
       // 
       if (event.clientId === "" && // Not fetched via AJAX after page load.
@@ -96,6 +100,7 @@
         !url.href.includes('/shell_') && // Don't fetch for shell.
         !url.href.includes('/admin') && // Don't fetch for administrate dashboard.
         !url.href.includes('/internal') && // Don't fetch for internal dashboard.
+        !url.href.includes('/future') && // Skip for /future.
         caches.match('/shell_top') && // Ensure shell_top is in the cache.
         caches.match('/shell_bottom')) { // Ensure shell_bottom is in the cache.
         event.respondWith(createPageStream(event.request)); // Respond with the stream
@@ -106,7 +111,7 @@
           .then(cache => cache.addAll([
             "/async_info/shell_version",
           ]))  
-          return
+          return;
         }
         fetch('/async_info/shell_version').then(response => response.json()).then(json => {
           caches.match('/async_info/shell_version').then(cachedResponse => cachedResponse.json()).then(cacheJson => {


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
I've been having issues with the Twitter in-app browser for iOS. Multiple visits to DEV in the same Twitter session causes the browser to hang and just stop working. It seems highly likely that this is related to serviceworkers. I'm not entirely sure what the problem might be or that it is definitely fixable in this way, but it's worth a shot to get this working properly. Shouldn't affect much else.

It's unlikely this would affect Android due to the better serviceworker support. Haven't discovered problems in other iOS apps yet. We may get to the bottom of it, we may forever have this hack in. Who knows?

Also added a condition for `/future` which also has issues with serviceworkers due to our other redirect hacks in place.