### PR TITLE
Add a default message to badge award action

### DIFF
--- a/app/controllers/internal/badges_controller.rb
+++ b/app/controllers/internal/badges_controller.rb
@@ -8,7 +8,7 @@ class Internal::BadgesController < Internal::ApplicationController
   def award_badges
     usernames = permitted_params[:usernames].split(/\s*,\s*/)
     badge_slug = permitted_params[:badge]
-    message = permitted_params[:message_markdown]
+    message = permitted_params[:message_markdown].presence || "Congrats!"
     BadgeRewarder.award_badges(usernames, badge_slug, message)
     flash[:success] = "BadgeRewarder task ran!"
     redirect_to internal_badges_url

--- a/app/views/internal/badges/index.html.erb
+++ b/app/views/internal/badges/index.html.erb
@@ -22,12 +22,12 @@
       <div>
         <%= f.label :usernames, "Usernames (Comma Delimited)*" %>
         <br>
-        <%= f.text_area :usernames, required: true, size: "40x20" %>
+        <%= f.text_area :usernames, required: true, size: "40x10" %>
       </div>
       <div>
-        <%= f.label :message_markdown, "Message (Supports Markdown)" %>
+        <%= f.label :message_markdown, "Override Default Message (Supports Markdown)" %>
         <br>
-        <%= f.text_area :message_markdown, size: "40x20" %>
+        <%= f.text_area :message_markdown, size: "40x10" %>
       </div>
       <%= f.submit "Award Badges" %>
     <% end %>

--- a/spec/requests/internal/badges_spec.rb
+++ b/spec/requests/internal/badges_spec.rb
@@ -20,5 +20,15 @@ RSpec.describe "/internal/badges", type: :request do
         }
       end.to change { user.badges.count }.by(1).and change { user2.badges.count }.by(1)
     end
+
+    it "awards badges without a message" do
+      expect do
+        post internal_badges_award_badges_path, params: {
+          badge: badge.slug,
+          usernames: "#{user.username}, #{user2.username}",
+          message_markdown: ""
+        }
+      end.to change { user.badges.count }.by(1).and change { user2.badges.count }.by(1)
+    end
   end
 end

--- a/spec/services/notifications/new_badge_achievement/send_spec.rb
+++ b/spec/services/notifications/new_badge_achievement/send_spec.rb
@@ -2,8 +2,9 @@ require "rails_helper"
 
 RSpec.describe Notifications::NewBadgeAchievement::Send, type: :service do
   let(:badge_achievement) { create(:badge_achievement) }
+  let(:blank_badge_achievement) { create(:badge_achievement, rewarding_context_message: nil) }
 
-  def expected_json_data
+  def expected_json_data(badge_achievement)
     {
       user: Notifications.user_data(badge_achievement.user),
       badge_achievement: {
@@ -25,8 +26,10 @@ RSpec.describe Notifications::NewBadgeAchievement::Send, type: :service do
   end
 
   it "creates a notification for the badge achievement user" do
-    notification = described_class.call(badge_achievement)
-    expect(notification.user).to eq(badge_achievement.user)
+    notification = described_class.call(blank_badge_achievement)
+    expect(notification.user).to eq(blank_badge_achievement.user)
+    json_data = notification.json_data.to_json
+    expect(JSON.parse(json_data)).to eq(JSON.parse(expected_json_data(blank_badge_achievement)))
   end
 
   it "creates a notification for the badge achievement" do
@@ -43,6 +46,6 @@ RSpec.describe Notifications::NewBadgeAchievement::Send, type: :service do
   it "creates a notification with the proper json data" do
     notification = described_class.call(badge_achievement)
     json_data = notification.json_data.to_json
-    expect(JSON.parse(json_data)).to eq(JSON.parse(expected_json_data))
+    expect(JSON.parse(json_data)).to eq(JSON.parse(expected_json_data(badge_achievement)))
   end
 end

--- a/spec/system/internal/admin_awards_badges_spec.rb
+++ b/spec/system/internal/admin_awards_badges_spec.rb
@@ -4,9 +4,10 @@ RSpec.describe "Admin awards badges", type: :system do
   let(:admin) { create(:user, :super_admin) }
   let(:user) { create(:user) }
   let(:user2) { create(:user) }
+  let(:badges) { Badge.all.map { |b| CGI.escapeHTML(b.title) } }
 
   def submit_form
-    find(:xpath, "//option[contains(text(), \"#{Badge.last.title}\")]").select_option
+    find(:xpath, "//option[contains(text(), \"#{badges.last}\")]").select_option
     fill_in "usernames", with: "#{user.username}, #{user2.username}"
     fill_in "message_markdown", with: "He who controls the spice controls the universe."
     click_on "Award Badges"
@@ -23,13 +24,19 @@ RSpec.describe "Admin awards badges", type: :system do
   end
 
   it "lists the badges" do
-    Badge.all.each do |b|
-      expect(page).to have_content(b.title)
+    badges.each do |badge|
+      expect(page).to have_content(badge)
     end
   end
 
   it "awards badges" do
-    expect { submit_form }.to change { user.badges.count }.by(1).and change { user2.badges.count }.by(1)
+    expect { submit_form }.to change { user.badges.count }.by(1).
+      and change { user2.badges.count }.by(1).
+      and change(enqueued_jobs, :size).by_at_least(1)
     expect(page).to have_content("BadgeRewarder task ran!")
+
+    visit "/#{user.username}/"
+
+    expect(page).to have_link(href: "/badge/#{Badge.last.slug}")
   end
 end

--- a/spec/system/internal/admin_awards_badges_spec.rb
+++ b/spec/system/internal/admin_awards_badges_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe "Admin awards badges", type: :system do
   let(:admin) { create(:user, :super_admin) }
   let(:user) { create(:user) }
   let(:user2) { create(:user) }
-  let(:badges) { Badge.all.map { |b| CGI.escapeHTML(b.title) } }
+  let(:badges) { Badge.pluck(:title) }
 
-  def submit_form
+  def award_two_badges
     find(:xpath, "//option[contains(text(), \"#{badges.last}\")]").select_option
     fill_in "usernames", with: "#{user.username}, #{user2.username}"
     fill_in "message_markdown", with: "He who controls the spice controls the universe."
@@ -30,13 +30,19 @@ RSpec.describe "Admin awards badges", type: :system do
   end
 
   it "awards badges" do
-    expect { submit_form }.to change { user.badges.count }.by(1).
-      and change { user2.badges.count }.by(1).
-      and change(enqueued_jobs, :size).by_at_least(1)
+    expect { award_two_badges }.to change { user.badges.count }.by(1).
+      and change { user2.badges.count }.by(1)
     expect(page).to have_content("BadgeRewarder task ran!")
 
     visit "/#{user.username}/"
 
     expect(page).to have_link(href: "/badge/#{Badge.last.slug}")
+  end
+
+  it "notifies users of new badges" do
+    expect { award_two_badges }.to enqueue_job(Notifications::NewBadgeAchievementJob).
+      exactly(2).times.
+      and enqueue_job(BadgeAchievements::SendEmailNotificationJob).
+      exactly(2).times
   end
 end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Add a default message to badge award action

Because:
 - The only badges routinely awarded manually use the same message
 - Right now, unfriendly/unsafe UI can result in an error notification

The only badges that are currently awarded manually (afaik) have the
message "Congrats!!!" so for the time being, if a message is not
supplied to the UI, it will simply use the "Congrats!!!" message as a
default.

That being said, I'm not totally convinced this message won't work for
the long term. Generally, if we are awarding badges by hand, I'd imagine
we'd want a specific message explaining why we are doing that, or just
be okay with "Congrats!"

After talking with Peter about it, the longer term goal should be to
move badge messages into the database so they can be modified in the app
and not hardcoded. That also make sense regarding the effort to
genericize the app eventually.

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed