### PR TITLE
Ignore ActiveRecord::QueryCanceled errors in Honeybadger

### DIFF
--- a/config/initializers/honeybadger.rb
+++ b/config/initializers/honeybadger.rb
@@ -4,7 +4,11 @@
 Honeybadger.configure do |config|
   config.api_key = ApplicationConfig["HONEYBADGER_API_KEY"]
   config.revision = ApplicationConfig["HEROKU_SLUG_COMMIT"]
-  config.exceptions.ignore += [Pundit::NotAuthorizedError, ActiveRecord::RecordNotFound]
+  config.exceptions.ignore += [
+    Pundit::NotAuthorizedError,
+    ActiveRecord::RecordNotFound,
+    ActiveRecord::QueryCanceled,
+  ]
   config.request.filter_keys += %w[authorization]
   config.delayed_job.attempt_threshold = 10
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
We get a lot of `ActiveRecord::QueryCanceled` errors in Honeybadger due to PG timeouts. We are not really concerned with these when they occur occasionally, we are more concerned if we suddenly see a large spike in them. For this reason, I choose to ignore this error in Honeybadger and instead set up an alert for it through our logging service Timber. Now if we see more than 200 of these errors in under 100 seconds we will be alerted via slack.
![Screen Shot 2019-12-18 at 11 27 38 AM](https://user-images.githubusercontent.com/1813380/71108887-a6268580-2189-11ea-99e5-8dbbc3f7dc32.png)

## Added to documentation?
- [x] no documentation needed

![minion alert gif](https://media.tenor.com/images/0d09cb07f10e3fc3502c15197b42b378/tenor.gif)