### PR TITLE
Destroy Related Comments when an Article is destroyed

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -22,7 +22,7 @@ class Article < ApplicationRecord
   counter_culture :user
   counter_culture :organization
 
-  has_many :comments, as: :commentable, inverse_of: :commentable
+  has_many :comments, as: :commentable, inverse_of: :commentable, dependent: :destroy
   has_many :profile_pins, as: :pinnable, inverse_of: :pinnable
   has_many :buffer_updates, dependent: :destroy
   has_many :notifications, as: :notifiable, inverse_of: :notifiable, dependent: :delete_all

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Article, type: :model do
     it { is_expected.to belong_to(:user) }
     it { is_expected.to belong_to(:organization).optional }
     it { is_expected.to belong_to(:collection).optional.touch(true) }
-    it { is_expected.to have_many(:comments) }
+    it { is_expected.to have_many(:comments).dependent(:destroy) }
     it { is_expected.to have_many(:reactions).dependent(:destroy) }
     it { is_expected.to have_many(:notifications).dependent(:delete_all) }
     it { is_expected.to have_many(:notification_subscriptions).dependent(:destroy) }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
After looking at some Honeybadger errors I noticed that we do not clean up Article comments when an Article is destroyed. I can't think of any reason why we would want to keep them so I added `dependent: :destroy` to the has_many polymorphic relationship

TODO: Following this we need to clean up all orphan Article comments. 

## Added to documentation?
- [x] no documentation needed

![I will destroy you gif](https://media2.giphy.com/media/hrkAVI0b6yYW0zJDiQ/giphy.gif)
