### PR TITLE
Return not_found Response If Video's Related Article is Not Found

### DIFF
--- a/app/controllers/video_states_controller.rb
+++ b/app/controllers/video_states_controller.rb
@@ -18,9 +18,14 @@ class VideoStatesController < ApplicationController
     request_json = JSON.parse(request.raw_post, symbolize_names: true)
     message_json = JSON.parse(request_json[:Message], symbolize_names: true)
     @article = Article.find_by(video_code: message_json[:input][:key])
-    @article.update(video_state: "COMPLETED") # Only is called on completion
-    NotifyMailer.video_upload_complete_email(@article).deliver
-    render json: { message: "Video state updated" }
+
+    if @article
+      @article.update(video_state: "COMPLETED") # Only is called on completion
+      NotifyMailer.video_upload_complete_email(@article).deliver
+      render json: { message: "Video state updated" }
+    else
+      render json: { message: "Related article not found" }, status: :not_found
+    end
   end
 
   def valid_user

--- a/spec/requests/video_states_update_spec.rb
+++ b/spec/requests/video_states_update_spec.rb
@@ -21,8 +21,7 @@ RSpec.describe "VideoStatesUpdate", type: :request do
     end
 
     it "returns not_found if video article is not found" do
-      input = JSON.unparse(input: { key: article.video_code })
-      article.destroy
+      input = JSON.unparse(input: { key: "abc" })
       post "/video_states?key=#{authorized_user.secret}",
            params: { Message: input }.to_json
       expect(response).to have_http_status(:not_found)

--- a/spec/requests/video_states_update_spec.rb
+++ b/spec/requests/video_states_update_spec.rb
@@ -19,5 +19,14 @@ RSpec.describe "VideoStatesUpdate", type: :request do
            params: { input: { key: article.video_code } }
       expect(response).to have_http_status(:unprocessable_entity)
     end
+
+    it "returns not_found if video article is not found" do
+      input = JSON.unparse(input: { key: article.video_code })
+      article.destroy
+      post "/video_states?key=#{authorized_user.secret}",
+           params: { Message: input }.to_json
+      expect(response).to have_http_status(:not_found)
+      expect(response.parsed_body["message"]).to eq("Related article not found")
+    end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
There are times when we can't find the article in this action. I am not sure why but the quick fix is to handle that not_found case. 
```
NoMethodError: undefined method `update' for nil:NilClass
video_states_controller.rb  21 create(...)
[PROJECT_ROOT]/app/controllers/video_states_controller.rb:21:in `create'
19     message_json = JSON.parse(request_json[:Message], symbolize_names: true)
20     @article = Article.find_by(video_code: message_json[:input][:key])
21 >>> @article.update(video_state: "COMPLETED") # Only is called on completion
22     NotifyMailer.video_upload_complete_email(@article).deliver
23     render json: { message: "Video state updated" }
```

## Added to documentation?
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![404 gif](https://cdn.dribbble.com/users/1607264/screenshots/6904551/page404animation.gif)
