### PR TITLE
Handle missing commentable In Social Preview

### DIFF
--- a/app/controllers/social_previews_controller.rb
+++ b/app/controllers/social_previews_controller.rb
@@ -40,7 +40,7 @@ class SocialPreviewsController < ApplicationController
 
   def comment
     @comment = Comment.find(params[:id])
-    @tag_badges = Badge.where(id: Tag.where(name: @comment.commentable.decorate.cached_tag_list_array).pluck(:badge_id))
+    @tag_badges = Badge.where(id: Tag.where(name: @comment.commentable&.decorate&.cached_tag_list_array).pluck(:badge_id))
 
     set_respond
   end

--- a/app/views/social_previews/comment.html.erb
+++ b/app/views/social_previews/comment.html.erb
@@ -113,10 +113,10 @@
     <% elsif @comment.title.size < 50 %>
       <% font_size = 8.3 %>
     <% else %>
-      <% font_size = 15 - ((((@comment.title).size**0.92) + 85) / 16) %>
+      <% font_size = 15 - (((@comment.title.size**0.92) + 85) / 16) %>
     <% end %>
     <div class="title-area">
-      <h2>re: <%= @comment.commentable.title %></h2>
+      <h2>re: <%= @comment.commentable&.title %></h2>
       <h1 style="font-size:<%= font_size %>vw;"><%= @comment.title %></h1>
     </div>
     <div class="preview-user">


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
By design, we don't require comments to have a related commentable entity. The reason for this is because the comment first and foremost belongs to a user and we still want them to be able to access that comment even if what they were commenting on is removed. For this reason, we need to handle the situation where commentable is not present rather than assume it always is and end up with errors like this:
```
NoMethodError: undefined method `decorate' for nil:NilClass
social_previews_controller.rb  43 comment(...)
[PROJECT_ROOT]/app/controllers/social_previews_controller.rb:43:in `comment'
41   def comment
42     @comment = Comment.find(params[:id])
43     @tag_badges = Badge.where(id: Tag.where(name: @comment.commentable.decorate.cached_tag_list_array).pluck(:badge_id))
44 
45     set_respond
```

## Added to documentation?
- [x] no documentation needed

Me trying to make it through all these Honeybadgers
![one after the other](https://media2.giphy.com/media/l4pTgKSq2LDffuUIo/giphy.gif)
