### PR TITLE
Raise ActiveRecord::RecordNotFound if Org is Not Found

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -79,6 +79,7 @@ class OrganizationsController < ApplicationController
 
   def set_organization
     @organization = Organization.find_by(id: organization_params[:id])
+    not_found unless @organization
     authorize @organization
   end
 end

--- a/spec/requests/organizations_update_spec.rb
+++ b/spec/requests/organizations_update_spec.rb
@@ -30,4 +30,11 @@ RSpec.describe "OrganizationsUpdate", type: :request do
     put "/organizations/#{org_id}", params: { organization: { id: org_id, text_color_hex: "#111111" } }
     expect(Organization.last.profile_updated_at).to be > 2.minutes.ago
   end
+
+  it "returns not_found if organization is missing" do
+    invalid_id = org_id + 100
+    expect do
+      put "/organizations/#{invalid_id}", params: { organization: { id: invalid_id, text_color_hex: "#111111" } }
+    end.to raise_error(ActiveRecord::RecordNotFound)
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Rather than erroring out like below by trying to authorize nil we should raise an ActiveRecord::RecordNotFound error instead
```
Pundit::NotDefinedError: unable to find policy `NilClassPolicy` for `nil`
organizations_controller.rb  82 set_organization(...)
[PROJECT_ROOT]/app/controllers/organizations_controller.rb:82:in `set_organization'
80   def set_organization
81     @organization = Organization.find_by(id: organization_params[:id])
82     authorize @organization
83   end
84 end
```

## Added to documentation?
- [x] no documentation needed

![not allowed](https://media2.giphy.com/media/2kRm4LlDGGQlIpzkNk/giphy.gif)
