### PR TITLE
Don't serviceworker cache ?preview= requests

### DIFF
--- a/app/views/service_worker/index.js.erb
+++ b/app/views/service_worker/index.js.erb
@@ -101,6 +101,7 @@
         !url.href.includes('/admin') && // Don't fetch for administrate dashboard.
         !url.href.includes('/internal') && // Don't fetch for internal dashboard.
         !url.href.includes('/future') && // Skip for /future.
+        !url.href.includes('?preview=') && // Skip for /future.
         caches.match('/shell_top') && // Ensure shell_top is in the cache.
         caches.match('/shell_bottom')) { // Ensure shell_bottom is in the cache.
         event.respondWith(createPageStream(event.request)); // Respond with the stream


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This skips serviceworkers on article preview pages, which is sort of a hack because the serviceworker ignores the `3xx` status code we'd expect when redirecting to this page after making an update. However, this conflicts with the patch we have in our edge cache which ignores `3xx` responses in order to ensure we beat any race conditions.

This strikes me as the only overly problematic situation so this fix should help. We should work to ultimately find a better longterm solution for this and similar service worker gotchas.