### PR TITLE
Return 422 if params are missing when creating an article via the API

### DIFF
--- a/app/controllers/api/v0/articles_controller.rb
+++ b/app/controllers/api/v0/articles_controller.rb
@@ -85,16 +85,16 @@ module Api
           :title, :body_markdown, :published, :series,
           :main_image, :canonical_url, :description, tags: []
         ]
-        allowed_params << :organization_id if params["article"]["organization_id"] && allowed_to_change_org_id?
+        allowed_params << :organization_id if params.dig("article", "organization_id") && allowed_to_change_org_id?
         params.require(:article).permit(allowed_params)
       end
 
       def allowed_to_change_org_id?
         potential_user = @article&.user || @user
-        if @article.nil? || OrganizationMembership.exists?(user: potential_user, organization_id: params["article"]["organization_id"])
-          OrganizationMembership.exists?(user: potential_user, organization_id: params["article"]["organization_id"])
+        if @article.nil? || OrganizationMembership.exists?(user: potential_user, organization_id: params.dig("article", "organization_id"))
+          OrganizationMembership.exists?(user: potential_user, organization_id: params.dig("article", "organization_id"))
         elsif potential_user == @user
-          potential_user.org_admin?(params["article"]["organization_id"]) ||
+          potential_user.org_admin?(params.dig("article", "organization_id")) ||
             @user.any_admin?
         end
       end

--- a/spec/requests/api/v0/articles_spec.rb
+++ b/spec/requests/api/v0/articles_spec.rb
@@ -587,6 +587,14 @@ RSpec.describe "Api::V0::Articles", type: :request do
         end.to change(Article, :count).by(1)
         expect(Article.find(json_response["id"]).description).to eq("yooo" * 20 + "y...")
       end
+
+      it "does not raise an error if article params are missing" do
+        headers = { "api-key" => api_secret.secret, "content-type" => "application/json" }
+        expect do
+          post api_articles_path, params: {}.to_json, headers: headers
+        end.not_to raise_error
+        expect(response.status).to eq(422)
+      end
     end
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Instead of raising a 500, let's return a usable error to the user when they are trying to create an article through the API. While I was here I changed the other hash traversals to arrays as well since I think it looks cleaner and avoids those pesky `NoMethodError: undefined method `[]' for nil:NilClass` errors

## Added to documentation?
- [x] no documentation needed

![another one bites the dust errors](https://media.tenor.com/images/2636e0cf91b27bf175922847ea51aa97/tenor.gif)
