### PR TITLE
Add rake task to reward tag badges weekly

### DIFF
--- a/lib/tasks/fetch.rake
+++ b/lib/tasks/fetch.rake
@@ -63,6 +63,13 @@ task award_badges: :environment do
   BadgeRewarder.award_streak_badge(16)
 end
 
+task award_weekly_tag_badges: :environment do
+  # Should only run once per week (via Heroku Scheduler) on Thursday.
+  return if Time.current.wday != 4
+
+  BadgeRewarder.award_tag_badges
+end
+
 # rake award_top_seven_badges["ben jess peter mac liana andy"]
 task :award_top_seven_badges, [:arg1] => :environment do |_t, args|
   usernames = args[:arg1].split(" ")
@@ -93,8 +100,8 @@ task award_contributor_badges_from_github: :environment do
 end
 
 task remove_old_html_variant_data: :environment do
-  HtmlVariantTrial.where("created_at < ?", 1.week.ago).destroy_all
-  HtmlVariantSuccess.where("created_at < ?", 1.week.ago).destroy_all
+  HtmlVariantTrial.where("created_at < ?", 2.weeks.ago).destroy_all
+  HtmlVariantSuccess.where("created_at < ?", 2.weeks.ago).destroy_all
   HtmlVariant.find_each do |html_variant|
     html_variant.calculate_success_rate! if html_variant.html_variant_successes.any?
   end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This adds a rake task to automatically reward tag badges every Thursday (when accompanied by a daily Heroku scheduler).

Currently I've been doing this myself and a robot could do it much better.

I also changed the period where we clean old data for HTML Variants while I was here. 1 week is a bit too erratic for data, even if we're looking to keep things recent and fresh.

After this is merged we then add the Heroku scheduler.