### PR TITLE
Flaky Spec Fix: Ensure model properties in factories are unique

### DIFF
--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -1,7 +1,9 @@
 FactoryBot.define do
+  sequence(:title) { |n| "#{Faker::Book.title}#{n}" }
+
   factory :article do
     transient do
-      title { Faker::Book.title + " #{rand(1000)}" }
+      title { generate :title }
       published { true }
       date { "01/01/2015" }
       tags { Faker::Hipster.words(number: 4).join(", ") }

--- a/spec/factories/badges.rb
+++ b/spec/factories/badges.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   image_path = Rails.root.join("spec/support/fixtures/images/image1.jpeg")
 
   factory :badge do
-    title       { Faker::Book.title + " #{rand(1000)}" }
+    sequence(:title) { |n| "#{Faker::Book.title}-#{n}" }
     description { Faker::Lorem.sentence }
     badge_image { Rack::Test::UploadedFile.new(image_path, "image/jpeg") }
   end

--- a/spec/factories/chat_channels.rb
+++ b/spec/factories/chat_channels.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :chat_channel do
     channel_type { "open" }
-    slug { rand(10_000_000_000).to_s }
+    sequence(:slug) { |n| "slug-#{n}" }
   end
 
   trait :workshop do

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :collection do
     user
-    slug { "word-#{rand(10_000)}" }
+    sequence(:slug) { |n| "slug-#{n}" }
   end
 
   trait :with_articles do

--- a/spec/factories/github_repos.rb
+++ b/spec/factories/github_repos.rb
@@ -1,13 +1,16 @@
 FactoryBot.define do
+  sequence(:github_id_code) { |n| n }
+  sequence(:url) { |n| "#{Faker::Internet.url}#{n}" }
+
   factory :github_repo do
     user
     name               { Faker::Book.title }
-    url                { Faker::Internet.url }
+    url                { generate :url }
     description        { Faker::Book.title }
     language           { Faker::Book.title }
     bytes_size         { rand(100_000) }
     watchers_count     { rand(100_000) }
-    github_id_code     { rand(100_000) }
+    github_id_code     { generate :github_id_code }
     stargazers_count   { rand(100_000) }
     featured { true }
     fork { false }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
We have a lot of properties of models that are expected to be unique. In order to generate some of these, we are relying on random numbers which could theoretically end up being the same. To ensure uniqueness I have changed a few of these attributes to use the [sequence function offered by factory bot](https://github.com/thoughtbot/factory_bot/blob/master/GETTING_STARTED.md#sequences). 

## Related Tickets & Documents
#4884 

## Added to documentation?
- [x] no documentation needed

![checkmate gin and yathzee my friend scrubs gif](https://media0.giphy.com/media/TM3pQSg2TGGac/source.gif)
