### PR TITLE
Return not_found response if we cant return users via the api

### DIFF
--- a/app/controllers/api/v0/users_controller.rb
+++ b/app/controllers/api/v0/users_controller.rb
@@ -16,6 +16,8 @@ module Api
           given_tag = params[:tag]
           @users = Suggester::Users::Sidebar.new(current_user, given_tag).suggest.sample(3)
         end
+
+        error_not_found
       end
 
       def show

--- a/app/controllers/api/v0/users_controller.rb
+++ b/app/controllers/api/v0/users_controller.rb
@@ -15,9 +15,9 @@ module Api
         elsif params[:state] == "sidebar_suggestions"
           given_tag = params[:tag]
           @users = Suggester::Users::Sidebar.new(current_user, given_tag).suggest.sample(3)
+        else
+          error_not_found
         end
-
-        error_not_found
       end
 
       def show

--- a/spec/requests/api/v0/users_spec.rb
+++ b/spec/requests/api/v0/users_spec.rb
@@ -5,6 +5,15 @@ RSpec.describe "Api::V0::Users", type: :request do
     JSON.parse(response.body)
   end
 
+  describe "GET /api/users" do
+    it "returns not found status if state is not present" do
+      user = create(:user)
+      sign_in user
+      get api_users_path, params: {}
+      expect(response.status).to eq(404)
+    end
+  end
+
   describe "GET /api/users/me" do
     it "requires request to be authenticated" do
       get me_api_users_path


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
If none of these if statements can be executed then return a not_found response for the users index API.

## Added to documentation?
- [x] no documentation needed

![bug being run over by giant vehicle with treads](https://media2.giphy.com/media/l2SqdZWSwDrkyHiKc/giphy.gif)
