### PR TITLE
Flaky Spec Fix: Check user follow count AFTER job is run

### DIFF
--- a/spec/system/user_selects_looking_for_work_spec.rb
+++ b/spec/system/user_selects_looking_for_work_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Looking For Work" do
     page.check "Looking for work"
     perform_enqueued_jobs do
       click_button("SUBMIT")
-      expect(user.follows.count).to eq(1)
     end
+    expect(user.follows.count).to eq(1)
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
I found this flaky spec after merging another flaky spec fix ironically in [this build](https://travis-ci.com/thepracticaldev/dev.to/builds/141958459). Here is my thought, the [perform_enqueued_jobs](https://api.rubyonrails.org/v5.2.3/classes/ActiveJob/TestHelper.html#method-i-perform_enqueued_jobs) will "Perform all enqueued jobs in the duration of the block." However, if we make an assertion before the end of the block then there is a chance that our job never finished. To ensure that the job finished I believe we should be making the assertion outside of that block. 

What do you all think? There are a lot of spec where we make assertions in these blocks that I think could be made more reliable by moving the assertions outside of the blocks.

## Related Tickets & Documents
#4884 

## Added to documentation?
- [x] no documentation needed

Flaky specs are like cockroaches...
![kids killing cockroaches](https://i.makeagif.com/media/11-06-2014/u6OlBY.gif)
