### PR TITLE
Use ApiController for ChatChannels and Return not_found If no Channel

### DIFF
--- a/app/controllers/api/v0/chat_channels_controller.rb
+++ b/app/controllers/api/v0/chat_channels_controller.rb
@@ -1,9 +1,9 @@
 module Api
   module V0
-    class ChatChannelsController < ApplicationController
+    class ChatChannelsController < ApiController
       def show
         @chat_channel = ChatChannel.find(params[:id])
-        raise unless @chat_channel.has_member?(current_user)
+        error_not_found unless @chat_channel.has_member?(current_user)
       end
     end
   end

--- a/spec/requests/api/v0/chat_channels_spec.rb
+++ b/spec/requests/api/v0/chat_channels_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe "Api::V0::ChatChannels", type: :request do
+  let(:user) { create(:user) }
+  let(:chat_channel) { create(:chat_channel) }
+  let(:invite_channel) { create(:chat_channel, channel_type: "invite_only") }
+
+  before { sign_in user }
+
+  describe "GET /api/chat_channels/:id" do
+    it "returns 200 if user is a member of the channel" do
+      chat_channel.add_users([user])
+      get "/api/chat_channels/#{chat_channel.id}"
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "returns a 404 if user is not a memeber of the channel" do
+      get "/api/chat_channels/#{invite_channel.id}"
+      expect(response.status).to eq(404)
+    end
+
+    it "returns a 404 if channel is not found" do
+      get "/api/chat_channels/#{invite_channel.id + 100}"
+      expect(response.status).to eq(404)
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
I noticed we were getting a very undescriptive RuntimeError from this endpoint when problems arose with the action. 
```
RuntimeError:
chat_channels_controller.rb  6 show(...)
[PROJECT_ROOT]/app/controllers/api/v0/chat_channels_controller.rb:6:in `show'
4       def show
5         @chat_channel = ChatChannel.find(params[:id])
6         raise unless @chat_channel.has_member?(current_user)
7       end
8     end
```
I updated the logic to return a not_found error in the event that the channel doesnt exist or that the user does not have access to it. I also noticed that this API controller was not using the ApiController base so I updated that. If there was a reason we were not using the ApiController let me know!

## Added to documentation?
- [x] no documentation needed

![do better gif](https://media.giphy.com/media/26gsetuXxUjaWPLA4/giphy.gif)
