### PR TITLE
Only Update page_views When They Are Valid (ie created)

### DIFF
--- a/app/controllers/page_views_controller.rb
+++ b/app/controllers/page_views_controller.rb
@@ -19,7 +19,9 @@ class PageViewsController < ApplicationMetalController
   def update
     if session_current_user_id
       page_view = PageView.find_or_create_by(article_id: params[:id], user_id: session_current_user_id)
-      page_view.update_column(:time_tracked_in_seconds, page_view.time_tracked_in_seconds + 15)
+      unless page_view.new_record?
+        page_view.update_column(:time_tracked_in_seconds, page_view.time_tracked_in_seconds + 15)
+      end
     end
 
     head :ok

--- a/app/controllers/page_views_controller.rb
+++ b/app/controllers/page_views_controller.rb
@@ -18,7 +18,7 @@ class PageViewsController < ApplicationMetalController
 
   def update
     if session_current_user_id
-      page_view = PageView.find_or_create_by(article_id: params[:id], user_id: session_current_user_id)
+      page_view = PageView.order("created_at DESC").find_or_create_by(article_id: params[:id], user_id: session_current_user_id)
       unless page_view.new_record?
         page_view.update_column(:time_tracked_in_seconds, page_view.time_tracked_in_seconds + 15)
       end

--- a/spec/requests/page_views_spec.rb
+++ b/spec/requests/page_views_spec.rb
@@ -91,11 +91,14 @@ RSpec.describe "PageViews", type: :request do
       end
 
       it "updates a new page view time on page by 15" do
-        post "/page_views", params: {
-          article_id: article.id
-        }
+        post "/page_views", params: { article_id: article.id }
         put "/page_views/" + article.id.to_s
         expect(PageView.last.time_tracked_in_seconds).to eq(30)
+      end
+
+      it "does not update an invalid page view" do
+        invalid_id = article.id + 100
+        expect { put "/page_views/" + invalid_id.to_s }.not_to raise_error
       end
     end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
OK, folks, I have finally figured it out! This endpoint will raise this error `ActiveRecord::ActiveRecordError: cannot update a new record` when we attempt to make a PageView that is not valid. For example a page view for an article that does not exist. In the event that this happens we should skip attempting to update the page_view.

Why `new_record?` instead of a `valid?` check? The reason I went with the new_record over valid is that valid would have hit the database to validate the Article and User AGAIN. Since we already did that when we attempted to make the PageView we may as well skip that and trust that if the page view is a new record it could not persist bc it is invalid. 

## Added to documentation?
- [x] no documentation needed

![victory gif](https://media0.giphy.com/media/lnlAifQdenMxW/giphy.gif)
