### PR TITLE
Ensure Comment has a path when created for specs

### DIFF
--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -7,5 +7,11 @@ FactoryBot.define do
     factory :article_comment do
       association :commentable, factory: :article
     end
+
+    trait :with_path do
+      after(:create) do |comment|
+        Comments::CreateIdCodeJob.perform_now(comment.id)
+      end
+    end
   end
 end

--- a/spec/system/comments/user_edits_a_comment_spec.rb
+++ b/spec/system/comments/user_edits_a_comment_spec.rb
@@ -4,10 +4,15 @@ RSpec.describe "Editing A Comment", type: :system, js: true do
   let(:user) { create(:user) }
   let!(:article) { create(:article, show_comments: true) }
   let(:new_comment_text) { Faker::Lorem.paragraph }
-  let!(:comment) { create(:comment, commentable: article, user: user, body_markdown: Faker::Lorem.paragraph) }
+  let!(:comment) do
+    create(:comment,
+           :with_path,
+           commentable: article,
+           user: user,
+           body_markdown: Faker::Lorem.paragraph)
+  end
 
   before do
-    Notification.send_new_comment_notifications(comment)
     sign_in user
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
In this spec we are relying on the comment path in order to visit the comment page and assert that the user can edit it. This path is created in the background by a job, `Comments::CreateIdCodeJob`  which may or may not have time to run after we create a comment hence leading the spec to fail. I updated the factory with a trait that will run that job inline whenever we need the path present for a comment in a spec. There are probably other places this is needed but this is the one that was in the issue so I only tackled that. 

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/issues/4889

## Added to documentation?
- [x] no documentation needed

![and if I flake I flake gif](https://media.tenor.com/images/810d59f384546e14b4944a6c6805ea5f/tenor.gif)
