### PR TITLE
Separate chat channel unopened status from Algolia

### DIFF
--- a/app/assets/stylesheets/chat.scss
+++ b/app/assets/stylesheets/chat.scss
@@ -798,11 +798,12 @@
 }
 
 .chatchanneltabbutton {
-  width: 93%;
+  width: calc(95% - 2px);
   border: none;
   background: transparent;
   padding: 3px 0px;
   margin-bottom: -5px 0;
+  box-sizing: border-box;
   @include themeable(color,
     theme-color,
     $black);
@@ -817,7 +818,7 @@
 
 .chatchanneltab {
   display: inline-block;
-  width: 90%;
+  width: 100%;
   margin-bottom: 5px;
   background: inherit;
   text-align: start;
@@ -829,6 +830,7 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  box-sizing: border-box;
 
   @media screen and (min-width: 550px) {
     font-size: 13px;

--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -207,6 +207,10 @@ body.night-theme, body.ten-x-hacker-theme {
   .partner-image-light-mode {
     display: none !important;
   }
+
+  .not-dark-theme-text-compatible {
+    @include themeable-important(color, theme-secondary-color, white);
+  }
 }
 
 // Alternate base fonts

--- a/app/controllers/chat_channels_controller.rb
+++ b/app/controllers/chat_channels_controller.rb
@@ -7,6 +7,9 @@ class ChatChannelsController < ApplicationController
     if params[:state] == "unopened"
       authorize ChatChannel
       render_unopened_json_response
+    elsif params[:state] == "unopened_ids"
+      authorize ChatChannel
+      render_unopened_ids_response
     elsif params[:state] == "pending"
       authorize ChatChannel
       render_pending_json_response
@@ -132,6 +135,12 @@ class ChatChannelsController < ApplicationController
                                    []
                                  end
     render "index.json"
+  end
+
+  def render_unopened_ids_response
+    @unopened_ids = ChatChannelMembership.where(user_id: session_current_user_id).includes(:chat_channel).
+      where(has_unopened_messages: true).pluck(:chat_channel_id)
+    render json: { unopened_ids: @unopened_ids }
   end
 
   def render_channels_html

--- a/app/javascript/chat/__tests__/__snapshots__/message.test.jsx.snap
+++ b/app/javascript/chat/__tests__/__snapshots__/message.test.jsx.snap
@@ -33,7 +33,7 @@ exports[`<Message /> should render and test snapshot 1`] = `
         class="message__info"
       >
         <span
-          class="chatmessagebody__username"
+          class="chatmessagebody__username not-dark-theme-text-compatible"
           style={
             Object {
               "color": "#00FFFF",

--- a/app/javascript/chat/__tests__/channels.test.jsx
+++ b/app/javascript/chat/__tests__/channels.test.jsx
@@ -78,6 +78,7 @@ const getChannels = (mod, chatChannels) => (
     incomingVideoCallChannelIds={[]} // no incoming calls
     activeChannelId={12345}
     chatChannels={chatChannels}
+    unopenedChannelIds={[]}
     handleSwitchChannel={fakeSwitchChannel}
     channelsLoaded
     filterQuery=""

--- a/app/javascript/chat/actions.js
+++ b/app/javascript/chat/actions.js
@@ -137,6 +137,16 @@ export function getChannels(
   });
 }
 
+export function getUnopenedChannelIds(successCb) {
+  fetch('/chat_channels?state=unopened_ids', {
+    credentials: 'same-origin',
+  })
+    .then(response => response.json())
+    .then(json => {
+      successCb(json.unopened_ids);
+    });
+}
+
 export function getTwilioToken(videoChannelName, successCb, failureCb) {
   fetch(`/twilio_tokens/${videoChannelName}`, {
     Accept: 'application/json',

--- a/app/javascript/chat/channels.jsx
+++ b/app/javascript/chat/channels.jsx
@@ -6,6 +6,7 @@ import ConfigImage from 'images/three-dots.svg';
 const Channels = ({
   activeChannelId,
   chatChannels,
+  unopenedChannelIds,
   handleSwitchChannel,
   expanded,
   filterQuery,
@@ -14,10 +15,7 @@ const Channels = ({
 }) => {
   const channels = chatChannels.map(channel => {
     const isActive = parseInt(activeChannelId, 10) === channel.chat_channel_id;
-    const lastOpened = channel.last_opened_at;
-    const isUnopened =
-      new Date(channel.channel_last_message_at) > new Date(lastOpened) &&
-      channel.channel_messages_count > 0;
+    const isUnopened = !isActive && unopenedChannelIds.includes(channel.chat_channel_id)
     let newMessagesIndicator = isUnopened ? 'new' : 'old';
     if (incomingVideoCallChannelIds.indexOf(channel.chat_channel_id) > -1) {
       newMessagesIndicator = 'video';
@@ -114,6 +112,7 @@ const Channels = ({
 Channels.propTypes = {
   activeChannelId: PropTypes.number.isRequired,
   chatChannels: PropTypes.arrayOf(PropTypes.objectOf()).isRequired,
+  unopenedChannelIds: PropTypes.arrayOf().isRequired,
   handleSwitchChannel: PropTypes.func.isRequired,
   expanded: PropTypes.bool.isRequired,
   filterQuery: PropTypes.string.isRequired,

--- a/app/javascript/chat/message.jsx
+++ b/app/javascript/chat/message.jsx
@@ -59,7 +59,7 @@ const Message = ({
       >
         <div className="message__info__actions">
           <div className="message__info">
-            <span className="chatmessagebody__username" style={spanStyle}>
+            <span className="chatmessagebody__username not-dark-theme-text-compatible" style={spanStyle}>
               <a
                 className="chatmessagebody__username--link"
                 href={`/${user}`}

--- a/spec/requests/chat_channels_spec.rb
+++ b/spec/requests/chat_channels_spec.rb
@@ -50,6 +50,26 @@ RSpec.describe "ChatChannels", type: :request do
     end
   end
 
+  describe "get /chat_channels?state=unopened_ids" do
+    it "returns unopened chat channel ids" do
+      direct_channel.add_users [user]
+      user.chat_channel_memberships.each { |m| m.update(has_unopened_messages: true) }
+      sign_in user
+      get "/chat_channels?state=unopened_ids"
+      expect(response.body).to include(direct_channel.id.to_s)
+      expect(response.body).to include("unopened_ids")
+    end
+
+    it "does not return chat channel ids if not signed in" do
+      direct_channel.add_users [user]
+      user.chat_channel_memberships.each { |m| m.update(has_unopened_messages: true) }
+      sign_out user
+      expect do
+        get "/chat_channels?state=unopened_ids"
+      end.to raise_error(Pundit::NotAuthorizedError)
+    end
+  end
+
   describe "get /chat_channels?state=pending" do
     it "returns pending channels" do
       ChatChannelMembership.create(chat_channel_id: invite_channel.id, user_id: user.id, status: "pending")


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Currently we fetch chat channels on load of `/connect` via Algolia, which means things are fast and the search engine for channel list is also very fast and compatible.

But since Algolia is async, we sometimes run into problems with not properly displaying the "opened" quality of chat channels.

This PR addresses it by breaking things out and offering a separate endpoint to handle the open status.

Using Algolia in this manner is really not ideal in general. The instant search part is great, but everything else is more trouble than it's worth I think. We can seek to change this approach gradually. For now this addresses the biggest source of pain.