### PR TITLE
Improve twitter card caching

### DIFF
--- a/app/views/social_previews/article.html.erb
+++ b/app/views/social_previews/article.html.erb
@@ -132,7 +132,9 @@
     </div>
     <div class="badge-images">
       <% @tag_badges.each do |badge| %>
-        <img src="<%= badge.badge_image_url %>" style="transform: rotate(<%= rand(-6..6) %>deg);" />
+        <%# Use a seed in Random so we don't break cache on every render %>
+        <% not_so_rand = Random.new(badge.id + @article.id) %>
+        <img src="<%= badge.badge_image_url %>" style="transform: rotate(<%= not_so_rand.rand(-6..6) %>deg);" />
       <% end %>
       <img src="https://thepracticaldev.s3.amazonaws.com/i/bh2wmpcltaybu1xsnico.png" />
     </div>

--- a/app/views/social_previews/comment.html.erb
+++ b/app/views/social_previews/comment.html.erb
@@ -125,7 +125,9 @@
     </div>
     <div class="badge-images">
       <% @tag_badges.each do |badge| %>
-        <img src="<%= badge.badge_image_url %>" style="transform: rotate(<%= rand(-6..6) %>deg);" />
+        <%# Use a seed in Random so we don't break cache on every render %>
+        <% not_so_rand = Random.new(badge.id + @comment.id) %>
+        <img src="<%= badge.badge_image_url %>" style="transform: rotate(<%= not_so_rand.rand(-6..6) %>deg);" />
       <% end %>
       <img src="https://thepracticaldev.s3.amazonaws.com/i/bh2wmpcltaybu1xsnico.png" />
     </div>

--- a/app/views/social_previews/user.html.erb
+++ b/app/views/social_previews/user.html.erb
@@ -118,7 +118,9 @@
     </div>
     <div class="badge-images">
       <% @tag_badges.each do |badge| %>
-        <img src="<%= badge.badge_image_url %>" style="transform: rotate(<%= rand(-6..6) %>deg);" />
+        <%# Use a seed in Random so we don't break cache on every render %>
+        <% not_so_rand = Random.new(badge.id + @user.id) %>
+        <img src="<%= badge.badge_image_url %>" style="transform: rotate(<%= not_so_rand.rand(-6..6) %>deg);" />
       <% end %>
       <img src="https://thepracticaldev.s3.amazonaws.com/i/bh2wmpcltaybu1xsnico.png" />
     </div>

--- a/spec/requests/social_previews_spec.rb
+++ b/spec/requests/social_previews_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.describe "SocialPreviews", type: :request do
   let(:user) { create(:user) }
-  let(:tag) { create(:tag) }
+  let(:tag) { create(:tag, badge: create(:badge)) }
   let(:organization) { create(:organization) }
-  let(:article) { create(:article, user_id: user.id) }
+  let(:article) { create(:article, user_id: user.id, tags: tag.name) }
   let(:comment) { create(:comment, user_id: user.id, commentable_id: article.id) }
   let(:image_url) { "https://hcti.io/v1/image/6c52de9d-4d37-4008-80f8-67155589e1a1" }
   let(:listing) { create(:classified_listing, user_id: user.id, category: "cfp") }

--- a/spec/requests/social_previews_spec.rb
+++ b/spec/requests/social_previews_spec.rb
@@ -55,6 +55,8 @@ RSpec.describe "SocialPreviews", type: :request do
     end
 
     it "renders consistent HTML between requests" do
+      create(:badge_achievement, user: user)
+
       # We use the HTML for caching. It needs to be deterministic (if data is unchanged, the HTML should be the same)
       get "/social_previews/user/#{user.id}"
       first_request_body = response.body


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [X] Optimization
- [ ] Documentation Update

## Description
Fixing the twitter card caching ⚡️ ⚡️ 

The tests weren't catching this because article/user didn't have Badges in the tests.

Updated to make the badge rotation `not_so_random`. Aka, they are still random and look cool. But don't change each render. Making the caching way more efficient.

## 🎄 