### PR TITLE
Add ability to open /new in connect sidecar

### DIFF
--- a/app/javascript/chat/chat.jsx
+++ b/app/javascript/chat/chat.jsx
@@ -523,6 +523,14 @@ export default class Chat extends Component {
         .trigger('client-initiatevideocall', {
           channelId: activeChannelId,
         });
+    } else if (message.startsWith('/new')) {
+      this.setActiveContentState(activeChannelId, {
+        type_of: 'loading-post',
+      });
+      this.setActiveContent({
+        path: '/new',
+        type_of: 'article'
+      })
     } else if (message.startsWith('/github')) {
       const args = message.split('/github ')[1].trim();
       this.setActiveContentState(activeChannelId, { type_of: 'github', args });

--- a/app/javascript/src/utils/getUnopenedChannels.jsx
+++ b/app/javascript/src/utils/getUnopenedChannels.jsx
@@ -149,6 +149,10 @@ function manageChannel(json) {
 }
 
 export default function getUnopenedChannels() {
+  if (window.frameElement) {
+    // We don't want this triggered within context of iframe.
+    return;
+  }
   render(
     <UnopenedChannelNotice
       unopenedChannels={[]}

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -52,12 +52,12 @@ class Message < ApplicationRecord
     doc = Nokogiri::HTML(html)
     doc.css("a").each do |anchor|
       if article = rich_link_article(anchor)
-        html += "<a href='#{article.path}'
+        html += "<a href='#{article.current_state_path}'
         class='chatchannels__richlink'
           target='_blank' data-content='sidecar-article'>
             #{"<div class='chatchannels__richlinkmainimage' style='background-image:url(" + cl_path(article.main_image) + ")' data-content='sidecar-article' ></div>" if article.main_image.present?}
           <h1 data-content='sidecar-article'>#{article.title}</h1>
-          <h4 data-content='sidecar-article'><img src='#{ProfileImage.new(article.cached_user).get(90)}' /> #{article.cached_user.name}・#{article.readable_publish_date}</h4>
+          <h4 data-content='sidecar-article'><img src='#{ProfileImage.new(article.cached_user).get(90)}' /> #{article.cached_user.name}・#{article.readable_publish_date || 'Draft Post'}</h4>
           </a>".html_safe
       elsif tag = rich_link_tag(anchor)
         html += "<a href='/t/#{tag.name}'


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Adds the `/new` trigger which opens up a sidecar with the `/new` composer.

This is a simple PR which makes use of the iframe sidecar.

Also tacked on some functionality to ensure the "you received a message" banner doesn't show up _within_ the iframe context and some fix to ensure unpublished posts can be shared with their appropriate password.

![compose-in-connect](https://user-images.githubusercontent.com/3102842/71361506-26b9fd00-2561-11ea-994a-89e57c9b9029.gif)
