### PR TITLE
Add canonical url to posts even if internal nav

### DIFF
--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -36,9 +36,11 @@
   <% end %>
 <% end %>
 
+<% if internal_navigation? %>
     <link rel="canonical" href="<%= @article.canonical_url.presence || "https://#{ApplicationConfig['APP_DOMAIN']}#{@article.path}" %>" />
-<% unless internal_navigation? %>
+<% else %>
   <%= content_for :page_meta do %>
+    <link rel="canonical" href="<%= @article.canonical_url.presence || "https://#{ApplicationConfig['APP_DOMAIN']}#{@article.path}" %>" />
     <meta name="description" content="<%= @article.description || "An article from the community" %>">
     <meta name="keywords" content="software development, inclusive, community, engineering, <%= @article.cached_tag_list %>">
 

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -36,13 +36,9 @@
   <% end %>
 <% end %>
 
-<% if !internal_navigation? %>
+    <link rel="canonical" href="<%= @article.canonical_url.presence || "https://#{ApplicationConfig['APP_DOMAIN']}#{@article.path}" %>" />
+<% unless internal_navigation? %>
   <%= content_for :page_meta do %>
-    <% if @article.canonical_url.present? %>
-      <link rel="canonical" href="<%= @article.canonical_url %>" />
-    <% else %>
-      <link rel="canonical" href="https://dev.to<%= @article.path %>" />
-    <% end %>
     <meta name="description" content="<%= @article.description || "An article from the community" %>">
     <meta name="keywords" content="software development, inclusive, community, engineering, <%= @article.cached_tag_list %>">
 

--- a/spec/requests/stories_show_spec.rb
+++ b/spec/requests/stories_show_spec.rb
@@ -107,6 +107,18 @@ RSpec.describe "StoriesShow", type: :request do
       get "/#{middle_username}/#{article.slug}"
       expect(response.body).to redirect_to("/#{user.username}/#{article.slug}")
     end
+
+    it "renders canonical url when exists" do
+      article = create(:article, with_canonical_url: true)
+      get article.path
+      expect(response.body).to include('"canonical" href="' + article.canonical_url.to_s + '"')
+    end
+
+    it "shodoes not render canonical url when not on article model" do
+      article = create(:article, with_canonical_url: false)
+      get article.path
+      expect(response.body).not_to include('"canonical" href="' + article.canonical_url.to_s + '"')
+    end
   end
 
   describe "GET /:username (org)" do


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Includes canonical URL even in the "internal" version of the page, which we now render for all cases where serviceworkers run the show.

The "machine readable" version still includes the canonical in the head. The user-readable version where service workers are turned on includes it streamed into the body.

This was never "technically" broken, but fixes confusion here:

closes https://github.com/thepracticaldev/dev.to/issues/5156