### PR TITLE
Show Count of users followed from API

### DIFF
--- a/app/controllers/api/v0/follows_controller.rb
+++ b/app/controllers/api/v0/follows_controller.rb
@@ -8,7 +8,7 @@ module Api
         user_ids.each do |user_id|
           Users::FollowJob.perform_later(current_user.id, user_id, "User")
         end
-        render json: { outcome: "followed 50 users" }
+        render json: { outcome: "followed #{user_ids.count} users" }
       end
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
We should return the actual count of users followed rather than 50 

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media3.giphy.com/media/3ohhwDKHAAcFWXPC5q/giphy.gif)
