### PR TITLE
Fix flaky Notifications::NewFollower::Send spec

### DIFF
--- a/app/services/notifications/new_follower/send.rb
+++ b/app/services/notifications/new_follower/send.rb
@@ -38,7 +38,7 @@ module Notifications
         else
           json_data = { user: user_data(follower), aggregated_siblings: aggregated_siblings }
           notification = Notification.find_or_initialize_by(notification_params)
-          notification.notifiable_id = recent_follows.first.id
+          notification.notifiable_id = recent_follows.detect { |f| f.follower_id == @follower_id }.id
           notification.notifiable_type = "Follow"
           notification.json_data = json_data
           notification.notified_at = Time.current

--- a/app/services/notifications/new_follower/send.rb
+++ b/app/services/notifications/new_follower/send.rb
@@ -38,8 +38,18 @@ module Notifications
         else
           json_data = { user: user_data(follower), aggregated_siblings: aggregated_siblings }
           notification = Notification.find_or_initialize_by(notification_params)
-          notification.notifiable_id = recent_follows.detect { |f| f.follower_id == @follower_id }.id
+
+          # we explicitly load the correct follow, to avoid incurring in the possibility of
+          # two different follows created at the same time
+          notifiable_follow = recent_follows.detect { |f| f.follower_id == @follower_id }
+
+          # if this method is called after a ".stop_following" the follower_id won't be
+          # present, hence, we load the most recent
+          notifiable_follow ||= recent_follows.first
+
+          notification.notifiable_id = notifiable_follow.id
           notification.notifiable_type = "Follow"
+
           notification.json_data = json_data
           notification.notified_at = Time.current
           notification.read = is_read

--- a/spec/services/notifications/new_follower/send_spec.rb
+++ b/spec/services/notifications/new_follower/send_spec.rb
@@ -124,11 +124,11 @@ RSpec.describe Notifications::NewFollower::Send, type: :service do
     end
 
     context "when destroyed follow and notification exists" do
-      let_it_be(:unfollow) { user.stop_following(user2) }
-
       it "does not destroy a notification" do
         create(:notification, action: "Follow", user: user2, notifiable: follow, notified_at: 1.year.ago)
+
         expect do
+          unfollow = user.stop_following(user2)
           described_class.call(follow_data(unfollow))
         end.not_to change(Notification, :count)
       end

--- a/spec/services/notifications/new_follower/send_spec.rb
+++ b/spec/services/notifications/new_follower/send_spec.rb
@@ -124,13 +124,10 @@ RSpec.describe Notifications::NewFollower::Send, type: :service do
     end
 
     context "when destroyed follow and notification exists" do
-      let(:unfollow) { user.stop_following(user2) }
-
-      before do
-        create(:notification, action: "Follow", user: user2, notifiable: follow, notified_at: 1.year.ago)
-      end
+      let_it_be(:unfollow) { user.stop_following(user2) }
 
       it "does not destroy a notification" do
+        create(:notification, action: "Follow", user: user2, notifiable: follow, notified_at: 1.year.ago)
         expect do
           described_class.call(follow_data(unfollow))
         end.not_to change(Notification, :count)


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This fixes a timing error that caused Notifications::NewFollower::Send to sometimes fail. 

Basically the logic relies on the fact that follows never have the same exact creation date, which is not always true for tests. See the following comment for a more thorough explanation on how I tracked the bug and came up with the solution: https://github.com/thepracticaldev/dev.to/issues/5157#issuecomment-568749969

Kudos to @robbkidd https://github.com/thepracticaldev/dev.to/issues/5157#issuecomment-567612116 for the huge help in dissecting with `git bisect` !!!

## Related Tickets & Documents

Closes https://github.com/thepracticaldev/dev.to/issues/5157
