### PR TITLE
API: Return an empty result set instead of 404 in case users are not available

### DIFF
--- a/app/controllers/api/v0/users_controller.rb
+++ b/app/controllers/api/v0/users_controller.rb
@@ -10,13 +10,14 @@ module Api
           @users = User.where(username: usernames)
           return
         end
+
         if params[:state] == "follow_suggestions"
           @users = Suggester::Users::Recent.new(current_user).suggest
         elsif params[:state] == "sidebar_suggestions"
           given_tag = params[:tag]
           @users = Suggester::Users::Sidebar.new(current_user, given_tag).suggest.sample(3)
         else
-          error_not_found
+          @users = User.none
         end
       end
 

--- a/spec/requests/api/v0/users_spec.rb
+++ b/spec/requests/api/v0/users_spec.rb
@@ -6,11 +6,10 @@ RSpec.describe "Api::V0::Users", type: :request do
   end
 
   describe "GET /api/users" do
-    it "returns not found status if state is not present" do
-      user = create(:user)
-      sign_in user
+    it "returns no users if state is not present" do
       get api_users_path, params: {}
-      expect(response.status).to eq(404)
+      expect(response).to have_http_status(:success)
+      expect(json_response).to be_empty
     end
   end
 


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

A common response in collection endpoint with REST APIs is to return an empty result set when the requested params end up in an empty result. The reason for this is that the resource itself exists (the collection always exists), it just is empty.

Also, all other collections return no values, not 404.

For more rationale: https://stackoverflow.com/a/13367198/4186181

Basically the difference is:

- if I ask for ID 1 and ID 1 is not present in the DB then `404 Not Found` because the resource does not exist and will never exist
- if I ask for a collection of items (filtered or not), the resource (the collection) exists, it's just it contains nothing, hence `200 OK` with no result

## Related Tickets & Documents

See https://github.com/thepracticaldev/dev.to/pull/5192
