### PR TITLE
Fix title_with_timeframe and Update rake task to not use return

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -26,10 +26,6 @@ module ApplicationHelper
   end
 
   def title_with_timeframe(page_title:, timeframe:, content_for: false)
-    if timeframe.blank?
-      return content_for ? title(page_title) : page_title
-    end
-
     sub_titles = {
       "week" => "Top posts this week",
       "month" => "Top posts this month",
@@ -37,6 +33,10 @@ module ApplicationHelper
       "infinity" => "All posts",
       "latest" => "Latest posts"
     }
+
+    if timeframe.blank? || sub_titles[timeframe].blank?
+      return content_for ? title(page_title) : page_title
+    end
 
     title_text = "#{page_title} - #{sub_titles.fetch(timeframe)}"
     content_for ? title(title_text) : title_text

--- a/lib/tasks/fetch.rake
+++ b/lib/tasks/fetch.rake
@@ -50,9 +50,9 @@ task github_repo_fetch_all: :environment do
 end
 
 task send_email_digest: :environment do
-  return if Time.current.wday < 3
-
-  EmailDigest.send_periodic_digest_email
+  if Time.current.wday >= 3
+    EmailDigest.send_periodic_digest_email
+  end
 end
 
 task award_badges: :environment do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This PR fixes 2 Honeybadger errors:
Having an invalid timeframe when loading a title for an article.
```
ActionView::Template::Error: key not found: "foobar"
application_helper.rb  41 fetch(...)
[PROJECT_ROOT]/app/helpers/application_helper.rb:41:in `fetch'
39     }
40 
41     title_text = "#{page_title} - #{sub_titles.fetch(timeframe)}"
42     content_for ? title(title_text) : title_text
43   end
```
Trying to return from a rake task:
```
LocalJumpError: unexpected return
fetch.rake  53 block in <main>(...)
[PROJECT_ROOT]/lib/tasks/fetch.rake:53:in `block in <main>'
51 
52 task send_email_digest: :environment do
53   return if Time.current.wday < 3
54 
55   EmailDigest.send_periodic_digest_email
```

## Added to documentation?
- [x] no documentation needed

Nothing to do with the PR but its Xmas eve!!!!
![alt_text](https://media1.tenor.com/images/b12475f2ebb5844571dc318ad76757d3/tenor.gif?itemid=13286666)
