### PR TITLE
Handle a case when lambda client returns an empty result

### DIFF
--- a/app/labor/function_caller.rb
+++ b/app/labor/function_caller.rb
@@ -11,7 +11,8 @@ class FunctionCaller
 
   def call
     response = aws_lambda_client.invoke(function_name: function_name, payload: payload)
-    JSON.parse(JSON.parse(response.payload.as_json[0])["body"])["message"]
+    payload_json = response.payload.as_json[0]
+    payload_json ? JSON.parse(JSON.parse(payload_json)["body"])["message"] : nil
   end
 
   private

--- a/spec/labor/function_caller_spec.rb
+++ b/spec/labor/function_caller_spec.rb
@@ -3,7 +3,8 @@ require "rails_helper"
 RSpec.describe FunctionCaller, type: :labor do
   let(:payload) { { user_id: 1, name: "hello" } }
   let(:dummy_client) { double }
-  let(:result) { OpenStruct.new(payload: [{ body: { message: "hi" }.to_json }.to_json]) }
+  let(:result_struct) { Struct.new(:payload, keyword_init: true) }
+  let(:result) { result_struct.new(payload: [{ body: { message: "hi" }.to_json }.to_json]) }
 
   before do
     allow(dummy_client).to receive(:invoke).and_return(result)
@@ -17,5 +18,12 @@ RSpec.describe FunctionCaller, type: :labor do
   it "returns parsed value" do
     value = described_class.call("some_function", payload, dummy_client)
     expect(value).to eq("hi")
+  end
+
+  it "doesn't fail when payload is empty" do
+    empty_result = result_struct.new(payload: [nil])
+    empty_client = double
+    allow(empty_client).to receive(:invoke).and_return(empty_result)
+    expect(described_class.call("some_function", payload, empty_client)).to be_nil
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Sometimes aws lambda client returns an empty result which leads to `Comments::CalculateScoreJob` failure. This pr handles this case.
I also changed the `FunctionCaller` spec to use `Struct` instead of `OpenStruct`.