### PR TITLE
Return a 401 Response when Github creds are bad via the API

### DIFF
--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -35,8 +35,8 @@ class Api::V0::ApiController < ApplicationController
     render json: { error: message, status: 422 }, status: :unprocessable_entity
   end
 
-  def error_unauthorized
-    render json: { error: "unauthorized", status: 401 }, status: :unauthorized
+  def error_unauthorized(message = "unauthorized")
+    render json: { error: message, status: 401 }, status: :unauthorized
   end
 
   def error_not_found

--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -35,8 +35,8 @@ class Api::V0::ApiController < ApplicationController
     render json: { error: message, status: 422 }, status: :unprocessable_entity
   end
 
-  def error_unauthorized(message = "unauthorized")
-    render json: { error: message, status: 401 }, status: :unauthorized
+  def error_unauthorized
+    render json: { error: "unauthorized", status: 401 }, status: :unauthorized
   end
 
   def error_not_found

--- a/app/controllers/api/v0/github_repos_controller.rb
+++ b/app/controllers/api/v0/github_repos_controller.rb
@@ -1,6 +1,6 @@
 module Api
   module V0
-    class GithubReposController < ApplicationController
+    class GithubReposController < ApiController
       def index
         client = create_octokit_client
         existing_user_repos = GithubRepo.
@@ -10,6 +10,8 @@ module Api
           repo.selected = existing_user_repos.include?(repo.id)
           repo
         end
+      rescue Octokit::Unauthorized => e
+        error_unauthorized("Github Unauthorized: #{e.message}")
       end
 
       def update_or_create

--- a/app/controllers/api/v0/github_repos_controller.rb
+++ b/app/controllers/api/v0/github_repos_controller.rb
@@ -11,7 +11,7 @@ module Api
           repo
         end
       rescue Octokit::Unauthorized => e
-        error_unauthorized("Github Unauthorized: #{e.message}")
+        render json: { error: "Github Unauthorized: #{e.message}", status: 401 }, status: :unauthorized
       end
 
       def update_or_create

--- a/spec/requests/api/v0/github_repos_spec.rb
+++ b/spec/requests/api/v0/github_repos_spec.rb
@@ -19,6 +19,13 @@ RSpec.describe "Api::V0::GithubRepos", type: :request do
       get "/api/github_repos"
       expect(response).to have_http_status(:ok)
     end
+
+    it "returns 401 if github raises an unauthorized error" do
+      allow(Octokit::Client).to receive(:new).and_raise(Octokit::Unauthorized)
+      get "/api/github_repos"
+      expect(response).to have_http_status(:unauthorized)
+      expect(response.parsed_body["error"]).to include("Github Unauthorized")
+    end
   end
 
   describe "POST /api/v0/github_repos/update_or_create" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Couple things happening here:
1. Return a human readable error if Github creds do not work.
2. Have the API `GithubReposController inherit from the `ApiController` so that its behavior is consistent with the rest of the API. 

Prevents [this error](https://app.honeybadger.io/projects/66984/faults/58184430) from hitting Honeybadger
```
Octokit::Unauthorized: GET https://api.github.com/user/repos?per_page=100: 401 - Bad credentials // See: https://developer.github.com/v3
github_repos_controller.rb  9 index(...)
[PROJECT_ROOT]/app/controllers/api/v0/github_repos_controller.rb:9:in `index'
 7           where(user_id: current_user.id, featured: true).pluck(:github_id_code) #=> [1,2,3]
 8         existing_user_repos = Set.new(existing_user_repos)
 9         @repos = client.repositories.map do |repo|
10           repo.selected = existing_user_repos.include?(repo.id)
11           repo
```

Let me know if any additional auth or other cache updates need to be made with moving this over to the ApiController.

## Added to documentation?
- [x] no documentation needed

Another Honeybadger thwarted
![alt_text](https://media.giphy.com/media/NNqJnevr3nJ6/giphy.gif)
