### PR TITLE
Add Index to Notifications created_at

### DIFF
--- a/db/migrate/20191226202114_add_created_at_index_to_notifications.rb
+++ b/db/migrate/20191226202114_add_created_at_index_to_notifications.rb
@@ -1,0 +1,7 @@
+class AddCreatedAtIndexToNotifications < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :notifications, :created_at, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_23_202251) do
+ActiveRecord::Schema.define(version: 2019_12_26_202114) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -569,6 +569,7 @@ ActiveRecord::Schema.define(version: 2019_12_23_202251) do
     t.boolean "read", default: false
     t.datetime "updated_at", null: false
     t.integer "user_id"
+    t.index ["created_at"], name: "index_notifications_on_created_at"
     t.index ["json_data"], name: "index_notifications_on_json_data", using: :gin
     t.index ["notifiable_id"], name: "index_notifications_on_notifiable_id"
     t.index ["notifiable_type"], name: "index_notifications_on_notifiable_type"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
Was trying to run the [new code](https://github.com/thepracticaldev/dev.to/pull/5180) for removing notifications in a console and was still getting timeouts. I discovered we don't have an index on created_at which would be extremely helpful for our `<` queries. 

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

![alt_text](https://media0.giphy.com/media/25OzfT9LjNhkRdvvJJ/giphy.gif)
