### PR TITLE
Record counts for important db tables to help track growth

### DIFF
--- a/lib/tasks/fetch.rake
+++ b/lib/tasks/fetch.rake
@@ -111,3 +111,17 @@ end
 task fix_credits_count_cache: :environment do
   Credit.counter_culture_fix_counts only: %i[user organization]
 end
+
+task record_db_table_counts: :environment do
+  table_names = %w[users articles organizations comments podcasts classified_listings page_views]
+  table_names.each do |table_name|
+    estimate = ActiveRecord::Base.connection.execute("SELECT reltuples::bigint AS estimate FROM pg_class where relname='#{table_name}'").first["estimate"]
+    Rails.logger.info(
+      "db_table_size",
+      table_info: {
+        table_name: table_name,
+        table_size: estimate,
+      }
+    )
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
Here I am gathering the _estimated_ counts for a few key database tables. **Are there any other tables that we want to record data for?** These were the ones the seemed the most important to me. I choose not to use `.count` and instead, go with the estimate from Postgres bc doing a count can be notoriously slow especially on big tables. Trying to do it on Notifications or PageViews will lead to a timeout.  How accurate your estimate depends on how often ANALYZE is run on your postgres database. I was trying to figure that out for our add-on but gave up. It is run enough for our estimates to be pretty accurate which you can see below. 
```
irb(main):095:0> User.count
=> 294448
irb(main):097:0> ActiveRecord::Base.connection.execute("SELECT reltuples::bigint AS estimate FROM pg_class where relname='users'").first['estimate']
=> 294827

irb(main):098:0> Article.count
=> 180154
irb(main):099:0> ActiveRecord::Base.connection.execute("SELECT reltuples::bigint AS estimate FROM pg_class where relname='articles'").first['estimate']
=> 180262
```

Ideally, I want to do this in Datadog once we get it going but I think having it in Timber for now is a good start. I plan to run this rake task once a day from Heroku scheduler. 

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media3.giphy.com/media/xUNd9DLukkavmhybAs/giphy.gif)
