### PR TITLE
Restore 30 days as the default value for Fastly's cache

### DIFF
--- a/config/initializers/fastly.rb
+++ b/config/initializers/fastly.rb
@@ -1,6 +1,6 @@
 FastlyRails.configure do |c|
   c.api_key = ApplicationConfig["FASTLY_API_KEY"] # Fastly api key, required
-  c.max_age = 1.day.to_i # time in seconds, optional, defaults to 2592000 (30 days)
+  c.max_age = 30.days.to_i # time in seconds, optional, defaults to 2592000 (30 days)
   c.service_id = ApplicationConfig["FASTLY_SERVICE_ID"] # Fastly service you will be using, required
   c.stale_if_error = 26_400
   c.purging_enabled = Rails.env.production? # No need to configure a client locally (since 0.4.0)


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

With https://github.com/thepracticaldev/dev.to/pull/4996 we switched Fastly's default cache's duration to 30 days, somehow https://github.com/thepracticaldev/dev.to/pull/5020 changed it to 1 day, this PR restores the value to 30 days.

See https://github.com/thepracticaldev/dev.to/pull/4996 for the rationale behind having 30 days but basically: assets are versioned, so they can be tagged with a long lifespan. 

Let me know if I'm missing something here

## Related Tickets & Documents

- https://github.com/thepracticaldev/dev.to/pull/4996
- https://github.com/thepracticaldev/dev.to/pull/5020
