### PR TITLE
Create less data for Notification.fast_destroy_old_notifications spec

### DIFF
--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -519,15 +519,17 @@ RSpec.describe Notification, type: :model do
   end
 
   describe "#fast_destroy_old_notifications" do
+    let_it_be(:notifications) { create_list(:notification, 3) }
+
     it "bulk deletes notifications older than 4 months by default" do
-      create_list :notification, 5
-      described_class.last.update(created_at: 5.months.ago)
+      notifications.last.update(created_at: 5.months.ago)
       expect { described_class.fast_destroy_old_notifications }.to change(described_class, :count).by(-1)
     end
 
     it "bulk deletes notifications older than a given timestamp" do
-      create_list :notification, 5
-      expect { described_class.fast_destroy_old_notifications(Time.zone.now) }.to change(described_class, :count).by(-5)
+      expect do
+        described_class.fast_destroy_old_notifications(Time.current)
+      end.to change(described_class, :count).by(-notifications.size)
     end
   end
 end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

While refactoring model specs I learned that one of the keys to keeping them fast is to create as few data as possible for a test to complete.

Instead of creating 10 notifications here we only create 3.
