### PR TITLE
Ignore delayed job and sidekiq dashboards in the service worker

### DIFF
--- a/app/views/service_worker/index.js.erb
+++ b/app/views/service_worker/index.js.erb
@@ -1,6 +1,6 @@
 // Serviceworkers file. This code gets installed in users browsers and runs code before the request is made.
 <% unless Rails.env.test? %>
-  const staticCacheName = 'static-1.1';
+  const staticCacheName = 'static-1.2';
   const expectedCaches = [
     staticCacheName
   ];
@@ -86,7 +86,6 @@
        return;
     }
     if (url.origin === location.origin) {
-      // 
       if (event.clientId === "" && // Not fetched via AJAX after page load.
         event.request.method == "GET" && // Don't fetch on POST, DELETE, etc.
         !event.request.referrer.includes('/signout_confirm') && // If this is the referrer, we instead want to flush.
@@ -102,18 +101,21 @@
         !url.href.includes('/internal') && // Don't fetch for internal dashboard.
         !url.href.includes('/future') && // Skip for /future.
         !url.href.includes('?preview=') && // Skip for /future.
+        !url.href.includes('/delayed_job') && // Skip for Delayed Job dashboard
+        !url.href.includes('/sidekiq') && // Skip for Sidekiq dashboard
         caches.match('/shell_top') && // Ensure shell_top is in the cache.
         caches.match('/shell_bottom')) { // Ensure shell_bottom is in the cache.
         event.respondWith(createPageStream(event.request)); // Respond with the stream
 
-        // Ping version endpoint to see if we should fetch new shell. 
+        // Ping version endpoint to see if we should fetch new shell.
         if (!caches.match('/async_info/shell_version')) { // Check if we have a cached shell version
           caches.open(staticCacheName)
           .then(cache => cache.addAll([
             "/async_info/shell_version",
-          ]))  
+          ]));
           return;
         }
+
         fetch('/async_info/shell_version').then(response => response.json()).then(json => {
           caches.match('/async_info/shell_version').then(cachedResponse => cachedResponse.json()).then(cacheJson => {
             if (cacheJson['version'] != json['version']) {
@@ -122,7 +124,7 @@
                 "/shell_top",
                 "/shell_bottom",
                 "/async_info/shell_version"
-              ]))
+              ]));
             }
           })
         })
@@ -136,7 +138,7 @@
         .then(cache => cache.addAll([
           "/shell_top",
           "/shell_bottom",
-        ]))
+        ]));
       }
     }
   });


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Through the gems delayed_job and sidekiq we add their respective dashboard. Sidekiq is still not part of the code but it's soon to be so I went ahead and added that exception here as well.

Closes https://github.com/thepracticaldev/dev.to/issues/5261

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Before

![Screenshot_2019-12-27 Delayed Job Web](https://user-images.githubusercontent.com/146201/71522634-d8409180-28c5-11ea-85fa-9ec1ea8be556.png)

After

![Screenshot_2019-12-27 Delayed Job Web(1)](https://user-images.githubusercontent.com/146201/71522640-db3b8200-28c5-11ea-8bb5-25f2eb9b1c8e.png)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
