### PR TITLE
Flaky Spec Fix: Ensure that article tag_list always has more than 3 tags

### DIFF
--- a/spec/models/tag_adjustment_spec.rb
+++ b/spec/models/tag_adjustment_spec.rb
@@ -74,6 +74,7 @@ RSpec.describe TagAdjustment, type: :model do
   describe "validates article tag_list" do
     it "does not allow addition on articles with 4 tags" do
       article_tags_maxed = create(:article)
+      allow(article_tags_maxed).to receive(:tag_list).and_return([1, 2, 3, 4])
       tag_adjustment = build(:tag_adjustment, user_id: admin_user.id, article_id: article_tags_maxed.id, tag_id: tag.id, tag_name: tag.name)
       expect(tag_adjustment).to be_invalid
     end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Flaky spec popped up in @rhymes recent PR this change ensures that tag list always returns with more than 3 items.
```
  1) TagAdjustment validates article tag_list does not allow addition on articles with 4 tags
     Failure/Error: expect(tag_adjustment).to be_invalid
       expected `#<TagAdjustment id: nil, adjustment_type: "addition", article_id: 378, created_at: nil, reason_for_ad... "reason 8156", status: "committed", tag_id: 1371, tag_name: "tag41", updated_at: nil, user_id: 613>.invalid?` to return true, got false
     # ./spec/models/tag_adjustment_spec.rb:78:in `block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:90:in `block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:90:in `block (2 levels) in <top (required)>'
Finished in 6 minutes 20 seconds (files took 7.13 seconds to load)
3194 examples, 1 failure
Failed examples:
rspec ./spec/models/tag_adjustment_spec.rb:75 # TagAdjustment validates article tag_list does not allow addition on articles with 4 tags
```
## Added to documentation?
- [x] no documentation needed

![alt_text](https://media2.giphy.com/media/dEdmW17JnZhiU/giphy.gif)
