### PR TITLE
Check if an organization is present when creating a reaction

### DIFF
--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -78,6 +78,6 @@ class ReactionsController < ApplicationController
   private
 
   def organization_article?(reaction)
-    reaction.reactable_type == "Article" && reaction.reactable.organization_id
+    reaction.reactable_type == "Article" && reaction.reactable.organization.present?
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Sometimes an organization related to an article gets destroyed but the article remains. In those cases when someone reacts to the Article we should not attempt to send notifications to the missing organization. Fixes [this honeybadger](https://app.honeybadger.io/projects/66984/faults/58887009):
```
NoMethodError: undefined method `id' for nil:NilClass
notification.rb  163 reaction_notification_attributes(...)
[PROJECT_ROOT]/app/models/notification.rb:163:in `reaction_notification_attributes'
161         reactable_user_id: reaction.reactable.user_id
162       }
163       receiver_data = { klass: receiver.class.name, id: receiver.id }
164       [reactable_data, receiver_data]
165     end
```
## Added to documentation?
- [x] no documentation needed

![alt_text](https://media.tenor.com/images/fa2e94e3d890184f667cf9d0a381a213/tenor.gif)
