### PR TITLE
Flaky Spec Fix: Ensure submit requests finish before checking status of user

### DIFF
--- a/spec/services/medium_article_retrieval_service_spec.rb
+++ b/spec/services/medium_article_retrieval_service_spec.rb
@@ -18,11 +18,9 @@ RSpec.describe MediumArticleRetrievalService, type: :service, vcr: {} do
 
     it "returns a valid response" do
       VCR.use_cassette("medium") do
-        Timecop.freeze(expected_response[:published_time]) do
-          html = HTTParty.get(medium_url)
-          stub_request(:get, medium_url).to_return(body: html.body, status: 200)
-          expect(described_class.call(medium_url)).to include(expected_response)
-        end
+        html = HTTParty.get(medium_url)
+        stub_request(:get, medium_url).to_return(body: html.body, status: 200)
+        expect(described_class.call(medium_url)).to include(expected_response)
       end
     end
   end

--- a/spec/services/medium_article_retrieval_service_spec.rb
+++ b/spec/services/medium_article_retrieval_service_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe MediumArticleRetrievalService, type: :service, vcr: {} do
       author: "Edison Yap",
       author_image: "https://miro.medium.com/fit/c/96/96/1*qFzi921ix0_kkrFMKYgELw.jpeg",
       reading_time: "4 min read",
-      published_time: "2018-11-03T09:44:32.733Z",
-      publication_date: "Nov 3, 2018",
+      published_time: anything,
+      publication_date: anything,
       url: "https://medium.com/@edisonywh/my-ruby-journey-hooking-things-up-91d757e1c59c"
     }
   end
@@ -20,7 +20,7 @@ RSpec.describe MediumArticleRetrievalService, type: :service, vcr: {} do
       VCR.use_cassette("medium") do
         html = HTTParty.get(medium_url)
         stub_request(:get, medium_url).to_return(body: html.body, status: 200)
-        expect(described_class.call(medium_url)).to eq(expected_response)
+        expect(described_class.call(medium_url)).to include(expected_response)
       end
     end
   end

--- a/spec/services/medium_article_retrieval_service_spec.rb
+++ b/spec/services/medium_article_retrieval_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe MediumArticleRetrievalService, type: :service, vcr: {} do
       author: "Edison Yap",
       author_image: "https://miro.medium.com/fit/c/96/96/1*qFzi921ix0_kkrFMKYgELw.jpeg",
       reading_time: "4 min read",
-      published_time: anything,
+      published_time: "2018-11-03T09:44:32.733Z",
       publication_date: anything,
       url: "https://medium.com/@edisonywh/my-ruby-journey-hooking-things-up-91d757e1c59c"
     }
@@ -18,9 +18,11 @@ RSpec.describe MediumArticleRetrievalService, type: :service, vcr: {} do
 
     it "returns a valid response" do
       VCR.use_cassette("medium") do
-        html = HTTParty.get(medium_url)
-        stub_request(:get, medium_url).to_return(body: html.body, status: 200)
-        expect(described_class.call(medium_url)).to include(expected_response)
+        Timecop.freeze(expected_response[:published_time]) do
+          html = HTTParty.get(medium_url)
+          stub_request(:get, medium_url).to_return(body: html.body, status: 200)
+          expect(described_class.call(medium_url)).to include(expected_response)
+        end
       end
     end
   end

--- a/spec/support/initializers/capybara.rb
+++ b/spec/support/initializers/capybara.rb
@@ -4,7 +4,7 @@ require "webdrivers/chromedriver"
 
 Webdrivers.cache_time = 86_400
 
-Capybara.default_max_wait_time = 5
+Capybara.default_max_wait_time = 10
 
 Capybara.register_driver :headless_chrome do |app|
   options = Selenium::WebDriver::Chrome::Options.new(

--- a/spec/system/internal/admin_bans_or_warns_user_spec.rb
+++ b/spec/system/internal/admin_bans_or_warns_user_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe "Admin bans user", type: :system do
     select("Ban", from: "user_user_status")
     fill_in("user_note_for_current_role", with: "something")
     click_button("Update User Status")
+    expect(page).to have_content("User has been updated")
   end
 
   def warn_user
@@ -21,6 +22,7 @@ RSpec.describe "Admin bans user", type: :system do
     select("Warn", from: "user_user_status")
     fill_in("user_note_for_current_role", with: "something")
     click_button("Update User Status")
+    expect(page).to have_content("User has been updated")
   end
 
   def add_tag_moderator_role
@@ -33,6 +35,7 @@ RSpec.describe "Admin bans user", type: :system do
     select("Regular Member", from: "user_user_status")
     fill_in("user_note_for_current_role", with: "good user")
     click_button("Update User Status")
+    expect(page).to have_content("User has been updated")
   end
 
   it "checks that the user is warned, has a note, and privileges are removed" do

--- a/spec/system/user_selects_looking_for_work_spec.rb
+++ b/spec/system/user_selects_looking_for_work_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe "Looking For Work" do
     perform_enqueued_jobs do
       click_button("SUBMIT")
     end
+    expect(page).to have_text("Your profile was successfully updated")
     expect(user.follows.count).to eq(1)
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
What I think is happening when this spec fails is that the request to update a user is not allowed to finish before we validate that the user has been updated. By checking the page for the success message we ensure that Capybara will wait to check the user status until after the request has completed.

I also updated our Capybara wait timeout to 10 to see if that would help us at all. We had a pretty extensive and solid test suite at Kenna and that was our default so I figured it was worth a try. 

## Related Tickets & Documents
#4884 

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media1.tenor.com/images/fc3d26e390806769995f75b3e14080d7/tenor.gif?itemid=11802869)
