### PR TITLE
Disable Sidekiq web sessions to make it work with Redis sessions

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,3 +1,8 @@
+require "sidekiq/web"
+# Sidekiq sessions don't play well with Redis based sessions and Devise
+# <https://github.com/mperham/sidekiq/wiki/Monitoring#sessions-being-lost>
+Sidekiq::Web.set :sessions, false
+
 Sidekiq.configure_server do |config|
   sidekiq_url = ApplicationConfig["REDIS_SIDEKIQ_URL"] || ApplicationConfig["REDIS_URL"]
   config.redis = { url: sidekiq_url }


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Right now when I try to view the Sidekiq dashboard I get a runtime error. I dug a little bit and found out that it has issues - https://github.com/redis-store/redis-rails/issues/34 - with the combo `redis-rails` and `devise`, which is what we use for sessions.

Since we rely on Devise to guard the access, we don't need Sidekiq sessions

## Related Tickets & Documents

- [Sidekiq Monitoring: sessions being lost](https://github.com/mperham/sidekiq/wiki/Monitoring#sessions-being-lost)
- [ Not sharing session with sidekiq web-ui](https://github.com/redis-store/redis-rails/issues/34)
- [Allow to disable sessions](https://github.com/mperham/sidekiq/pull/3183)

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Before

![Screenshot_2019-12-27 RuntimeError at ](https://user-images.githubusercontent.com/146201/71526770-aedd3100-28d8-11ea-9e59-edbda67180c4.png)

After

![Screenshot_2019-12-27  DEVELOPMENT  Sidekiq](https://user-images.githubusercontent.com/146201/71526792-be5c7a00-28d8-11ea-82ad-69a808ea53cc.png)

