### PR TITLE
Revert "Unescape page title. (#5246)"

### DIFF
--- a/app/views/shell/_top.html.erb
+++ b/app/views/shell/_top.html.erb
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <% title = yield(:title) %>
-    <title><%= CGI.unescapeHTML(title || "#{ApplicationConfig['COMMUNITY_NAME']} Community") %></title>
+    <title><%= title || "#{ApplicationConfig['COMMUNITY_NAME']} Community" %></title>
     <% unless internal_navigation? %>
       <meta name="last-updated" content="<%= Time.current %>">
       <meta name="user-signed-in" content="<%= user_signed_in? %>">


### PR DESCRIPTION
This reverts commit 2312d2e301c77cbb18da861e84f0086bf40248c0.

<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
The reasoning for this revert is that it is a fix for a problem that might not exist.  I had trouble reproducing the escaped ampersand locally and the title in h1 tag on article show renders properly without an escape/unescape. This might be an issue unique to the reported post and the fix should instead target the portion of the process that is escaping the title.

see discussion https://github.com/thepracticaldev/dev.to/pull/5246#issuecomment-569311248
## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/issues/5226
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
Creating a post with ampersand
![Screen Shot 2019-12-27 at 1 20 27 PM](https://user-images.githubusercontent.com/15793250/71528072-25176e80-28ac-11ea-9fe6-87546f995fc4.png)


## Added to documentation?
- [x] no documentation needed
