### PR TITLE
Change RateLimitCheckerJob to RateLimitCheckerWorker and Move to Sidekiq

### DIFF
--- a/app/labor/rate_limit_checker.rb
+++ b/app/labor/rate_limit_checker.rb
@@ -45,7 +45,7 @@ class RateLimitChecker
   end
 
   def ping_admins
-    RateLimitCheckerJob.perform_later(user.id, action)
+    RateLimitCheckerWorker.perform_async(user.id, action)
   end
 
   private

--- a/app/workers/rate_limit_checker_worker.rb
+++ b/app/workers/rate_limit_checker_worker.rb
@@ -1,5 +1,6 @@
-class RateLimitCheckerJob < ApplicationJob
-  queue_as :rate_limit_checker
+class RateLimitCheckerWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: :default, retry: 10
 
   def perform(user_id, action)
     user = User.find_by(id: user_id)

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -5,5 +5,7 @@ Sidekiq::Web.set :sessions, false
 
 Sidekiq.configure_server do |config|
   sidekiq_url = ApplicationConfig["REDIS_SIDEKIQ_URL"] || ApplicationConfig["REDIS_URL"]
+  # On Heroku this configuration is overridden and Sidekiq will point at the redis
+  # instance given by the ENV variable REDIS_PROVIDER
   config.redis = { url: sidekiq_url }
 end

--- a/spec/labor/rate_limit_checker_spec.rb
+++ b/spec/labor/rate_limit_checker_spec.rb
@@ -21,10 +21,10 @@ RSpec.describe RateLimitChecker, type: :labor do
     end
 
     it "triggers ping admin when too many comments" do
-      allow(RateLimitCheckerJob).to receive(:perform_later)
+      allow(RateLimitCheckerWorker).to receive(:perform_async)
       create_list(:comment, 10, user_id: user.id, commentable_id: article.id)
       described_class.new(user).limit_by_action("comment_creation")
-      expect(RateLimitCheckerJob).to have_received(:perform_later).with(user.id, "comment_creation")
+      expect(RateLimitCheckerWorker).to have_received(:perform_async).with(user.id, "comment_creation")
     end
 
     it "returns false if allowed comment" do

--- a/spec/workers/rate_limit_checker_worker_spec.rb
+++ b/spec/workers/rate_limit_checker_worker_spec.rb
@@ -1,23 +1,16 @@
 require "rails_helper"
 
-RSpec.describe RateLimitCheckerJob, type: :job do
-  include_examples "#enqueues_job", "rate_limit_checker", 2
-
-  describe "#perform_later" do
+RSpec.describe RateLimitCheckerWorker, type: :worker do
+  describe "#perform" do
     let(:user) { create(:user) }
     let(:service) { PingAdmins }
+    let(:worker) { subject }
 
     before { allow(service).to receive(:call) }
 
-    it "enqueues the job" do
-      expect do
-        described_class.perform_later(user.id)
-      end.to have_enqueued_job.with(user.id).on_queue("rate_limit_checker")
-    end
-
     it "calls a service" do
       perform_enqueued_jobs do
-        described_class.perform_now(user.id, "test")
+        worker.perform(user.id, "test")
 
         expect(service).to have_received(:call).with(user, "test").once
       end
@@ -25,7 +18,7 @@ RSpec.describe RateLimitCheckerJob, type: :job do
 
     it "does nothing for non-existent user" do
       perform_enqueued_jobs do
-        described_class.perform_now(nil, "test")
+        worker.perform(nil, "test")
 
         expect(service).not_to have_received(:call)
       end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature
- [x] Optimization

## Description
This PR is what I plan to use to lay the foundation for what a Sidekiq worker rollover should look like. For this job, since it is not executed a lot I choose to cut straight over and remove the old worker in the same PR. This moves the RateLimitCheckerJob to Sidekiq and renames it.

I believe tracking the progress of the move will be easier with the rename and it allows us to move jobs over and keep old job classes for those that run frequently and we may need to allow queues to drain. 

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media.giphy.com/media/kDOJyIXIMqY4zEAqc8/giphy.gif)
