### PR TITLE
Add Sidekiq Monitoring for Datadog and Honeybadger

### DIFF
--- a/config/initializers/datadog_apm.rb
+++ b/config/initializers/datadog_apm.rb
@@ -7,6 +7,7 @@ Datadog.configure do |c|
   c.tracer partial_flush: true
   c.tracer priority_sampling: true
   c.use :delayed_job
+  c.use :sidekiq
   c.use :redis
   c.use :rails
   c.use :http

--- a/config/initializers/honeybadger.rb
+++ b/config/initializers/honeybadger.rb
@@ -11,6 +11,7 @@ Honeybadger.configure do |config|
   ]
   config.request.filter_keys += %w[authorization]
   config.delayed_job.attempt_threshold = 10
+  config.sidekiq.attempt_threshold = 10
 
   config.before_notify do |notice|
     notice.fingerprint = if notice.error_message&.include?("SIGTERM") && notice.component&.include?("fetch_all_rss")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
- Track Sidekiq jobs in Datadog
- Only return Sidekiq errors to Honeybadger after the 10 retry or once the job has exhausted retries

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media3.giphy.com/media/XBc87mmaSnFgCUnA59/giphy.gif)
