### PR TITLE
Fix event propagation for click on tag rules in editor

### DIFF
--- a/app/javascript/article-form/elements/__tests__/__snapshots__/tags.test.jsx.snap
+++ b/app/javascript/article-form/elements/__tests__/__snapshots__/tags.test.jsx.snap
@@ -132,3 +132,14 @@ Object {
   "showingRulesForTag": null,
 }
 `;
+
+exports[`<Tags /> skips the click handler if className is articleform__tagsoptionrulesbutton 1`] = `
+Object {
+  "additionalTags": Array [],
+  "cursorIdx": 0,
+  "prevLen": 0,
+  "searchResults": Array [],
+  "selectedIndex": -1,
+  "showingRulesForTag": null,
+}
+`;

--- a/app/javascript/article-form/elements/__tests__/tags.test.jsx
+++ b/app/javascript/article-form/elements/__tests__/tags.test.jsx
@@ -43,6 +43,26 @@ describe('<Tags />', () => {
       });
   });
 
+  it('skips the click handler if className is articleform__tagsoptionrulesbutton', () => {
+    // eslint-disable-next-line no-underscore-dangle
+    const component = preactRender(
+      <Tags
+        defaultValue=""
+        onInput={jest.fn()}
+        classPrefix="articleform"
+        maxTags={4}
+      />,
+      document.body,
+      document.body.firstElementChild,
+    )._component;
+
+    component.handleTagClick({
+      target: { className: 'articleform__tagsoptionrulesbutton' },
+    });
+    expect(component.state).toMatchSnapshot();
+    expect(component.state.searchResults).toEqual([]);
+  });
+
   it('selects tag when you click on it', () => {
     // eslint-disable-next-line no-underscore-dangle
     const component = preactRender(
@@ -56,7 +76,10 @@ describe('<Tags />', () => {
       document.body.firstElementChild,
     )._component;
 
-    component.handleTagClick({ target: { dataset: { content: 'git' } } });
+    component.handleTagClick({
+      target: {},
+      currentTarget: { dataset: { content: 'git' } },
+    });
     expect(component.state).toMatchSnapshot();
   });
 
@@ -77,7 +100,10 @@ describe('<Tags />', () => {
     input.value = 'java,javascript,linux';
     input.selectionStart = 2;
 
-    component.handleTagClick({ target: { dataset: { content: 'git' } } });
+    component.handleTagClick({
+      target: {},
+      currentTarget: { dataset: { content: 'git' } },
+    });
     expect(component.state).toMatchSnapshot();
   });
 

--- a/app/javascript/shared/components/tags.jsx
+++ b/app/javascript/shared/components/tags.jsx
@@ -225,9 +225,14 @@ class Tags extends Component {
     if (e.target.className === 'articleform__tagsoptionrulesbutton') {
       return;
     }
+
     const input = document.getElementById('tag-input');
     input.focus();
-    this.insertTag(e.target.dataset.content);
+
+    // the rules container (__tagoptionrow) is the real target of the event,
+    // by using currentTarget we let the event propagation work
+    // from the inner rules box as well (__tagrules)
+    this.insertTag(e.currentTarget.dataset.content);
   };
 
   handleInput = e => {
@@ -326,8 +331,8 @@ class Tags extends Component {
         if (listing === true) {
           const { additionalTags } = this.state;
           const { category } = this.props;
-          const additionalItems = (additionalTags[category] || []).filter(
-            t => t.includes(query),
+          const additionalItems = (additionalTags[category] || []).filter(t =>
+            t.includes(query),
           );
           const resultsArray = content.hits;
           additionalItems.forEach(t => {


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This fixes an error in which clicking on the inner rules box would insert `undefined` as a tag, instead of the tag itself.

## Related Tickets & Documents

Closes https://github.com/thepracticaldev/dev.to/issues/5277

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![tags](https://user-images.githubusercontent.com/146201/71573442-3054df00-2ae4-11ea-8220-46d04fffbcf2.gif)
