### PR TITLE
Switch external redis_store to Rails supported redis_cache_store

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -103,7 +103,7 @@ Rails.application.configure do
   redis_url = ENV["REDISCLOUD_URL"]
   redis_url ||= ApplicationConfig["REDIS_URL"]
   DEFAULT_EXPIRATION = 24.hours.to_i.freeze
-  config.cache_store = :redis_store, redis_url, { expires_in: DEFAULT_EXPIRATION }
+  config.cache_store = :redis_cache_store, { url: redis_url, expires_in: DEFAULT_EXPIRATION }
 
   config.app_domain = ENV["APP_DOMAIN"]
 


### PR DESCRIPTION


<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

`redis_store` was initially introduced to switch sessions from the cookie store to Redis in https://github.com/thepracticaldev/dev.to/pull/4004. When we introduced a dual cache store in https://github.com/thepracticaldev/dev.to/pull/4991 we forgot to use the builtin Rails cache store - [ActiveSupport::Cache::RedisCacheStore](https://guides.rubyonrails.org/caching_with_rails.html#activesupport-cache-rediscachestore) - and instead kept using the external [ActiveSupport::Cache::RedisStore] which comes from the `redis-activesupport` gem included by `redis-rails`.

The gem `redis-activesupport` contains this disclaimer:

> Rails 5.2.0 includes a Redis cache store out of the box, so you don't really need this anymore if you're generating a new Rails application. We are no longer accepting new features for this gem, only pull requests for security and compatibility fixes will be accepted.

Other reasons to use the Rails builtin cache store, other than being supported and developed are the following:

- supports and uses `hiredis` as a client if installed:

https://github.com/rails/rails/blob/22483b86a6c779743b30e2f23bb46accfbf96b28/activesupport/lib/active_support/cache/redis_cache_store.rb#L12-L14

- supports compressions for keys over 1kb (that can be configured)

- is evolved with Rails itself

I've also tried to write ERB caches with `redis_store` and read them with `redis_cache_store` without any issue.

## Related Tickets & Documents

- https://github.com/redis-store/redis-activesupport/blob/v5.2.0/lib/active_support/cache/redis_store.rb and its test https://github.com/redis-store/redis-activesupport/blob/v5.2.0/test/active_support/cache/redis_store_test.rb

- Rails's redis cache store https://github.com/rails/rails/blob/v5.2.4/activesupport/lib/active_support/cache/redis_cache_store.rb and its test https://github.com/rails/rails/blob/v5.2.4/activesupport/test/cache/stores/redis_cache_store_test.rb
