### PR TITLE
Add another check to the function caller to avoid exceptions

### DIFF
--- a/app/labor/function_caller.rb
+++ b/app/labor/function_caller.rb
@@ -12,7 +12,8 @@ class FunctionCaller
   def call
     response = aws_lambda_client.invoke(function_name: function_name, payload: payload)
     payload_json = response.payload.as_json[0]
-    payload_json ? JSON.parse(JSON.parse(payload_json)["body"])["message"] : nil
+    body = payload_json ? JSON.parse(payload_json)["body"] : nil
+    body ? JSON.parse(body)["message"] : nil
   end
 
   private

--- a/spec/labor/function_caller_spec.rb
+++ b/spec/labor/function_caller_spec.rb
@@ -26,4 +26,11 @@ RSpec.describe FunctionCaller, type: :labor do
     allow(empty_client).to receive(:invoke).and_return(empty_result)
     expect(described_class.call("some_function", payload, empty_client)).to be_nil
   end
+
+  it "doesn't fail when payload is empty and is a hash" do
+    empty_result = result_struct.new(payload: [{}.to_json])
+    empty_client = double
+    allow(empty_client).to receive(:invoke).and_return(empty_result)
+    expect(described_class.call("some_function", payload, empty_client)).to be_nil
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Sometimes aws lambda client returns an empty result which leads to `Comments::CalculateScoreJob` failure. I started fixing it in #5248 but I still see failing jobs once in a while. I added another check to fix this issue.
