### PR TITLE
Nokogiri::HTML should receive the body, not the response object

### DIFF
--- a/app/services/medium_article_retrieval_service.rb
+++ b/app/services/medium_article_retrieval_service.rb
@@ -10,8 +10,8 @@ class MediumArticleRetrievalService
   end
 
   def call
-    html = HTTParty.get(url)
-    page = Nokogiri::HTML(html)
+    response = HTTParty.get(url)
+    page = Nokogiri::HTML(response.body)
 
     title = page.at("meta[name='title']")["content"]
     reading_time = page.at("meta[name='twitter:data1']")["value"]

--- a/spec/services/medium_article_retrieval_service_spec.rb
+++ b/spec/services/medium_article_retrieval_service_spec.rb
@@ -13,13 +13,11 @@ RSpec.describe MediumArticleRetrievalService, type: :service, vcr: {} do
     }
   end
 
-  context "when valid medium url" do
+  context "when the medium url is valid" do
     let(:medium_url) { "https://medium.com/@edisonywh/my-ruby-journey-hooking-things-up-91d757e1c59c" }
 
     it "returns a valid response" do
       VCR.use_cassette("medium") do
-        html = HTTParty.get(medium_url)
-        stub_request(:get, medium_url).to_return(body: html.body, status: 200)
         expect(described_class.call(medium_url)).to include(expected_response)
       end
     end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This fixes the following warning:

> MediumArticleRetrievalService
  when valid medium url
[DEPRECATION] HTTParty will no longer override `response#nil?`. This functionality will be removed in future versions. Please, add explicit check `response.body.nil? || response.body.empty?`. For more info refer to: https://github.com/jnunemaker/httparty/issues/568
/gems/ruby-2.6.5/gems/nokogiri-1.10.7/lib/nokogiri/html/document.rb:199:in `parse'
    returns a valid response

also removes a useless HTTP call and stub in the spec
