### PR TITLE
Allow language-xxx class detection on pre tags in ReverseMarkdown

### DIFF
--- a/app/lib/reverse_markdown/converters/custom_pre.rb
+++ b/app/lib/reverse_markdown/converters/custom_pre.rb
@@ -25,11 +25,17 @@ module ReverseMarkdown
 
       def language(node)
         lang = language_from_highlight_class(node)
-        lang || language_from_confluence_class(node)
+        lang ||= language_from_language_class(node)
+        lang ||= language_from_confluence_class(node)
+        lang
       end
 
       def language_from_highlight_class(node)
         node.parent["class"].to_s[/highlight-([a-zA-Z0-9]+)/, 1]
+      end
+
+      def language_from_language_class(node)
+        node["class"].to_s[/language-([a-zA-Z0-9]+)/, 1]
       end
 
       def language_from_confluence_class(node)

--- a/spec/lib/reverse_markdown/converters/custom_pre_spec.rb
+++ b/spec/lib/reverse_markdown/converters/custom_pre_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+# require "nokogiri"
+
+RSpec.describe ReverseMarkdown::Converters::CustomPre, type: :lib do
+  def create_custom_pre
+    ReverseMarkdown.config.github_flavored = true
+    described_class.new
+  end
+
+  describe "#convert" do
+    it "detects languages from language-prefixed classnames" do
+      node = Nokogiri::HTML('<pre class="language-js"></pre>').search("pre")[0]
+      result = create_custom_pre.convert(node)
+      expect(result.split[0]).to eq("```js")
+    end
+
+    it "detects languages from highlight-prefixed classnames on the parent element" do
+      node = Nokogiri::HTML('<div class="highlight-ruby"><pre></pre></div>').search("pre")[0]
+      result = create_custom_pre.convert(node)
+      expect(result.split[0]).to eq("```ruby")
+    end
+
+    it "detects languages from confluence-style classnames" do
+      node = Nokogiri::HTML('<pre class="brush:html;"></pre>').search("pre")[0]
+      result = create_custom_pre.convert(node)
+      expect(result.split[0]).to eq("```html")
+    end
+  end
+end

--- a/spec/lib/reverse_markdown/converters/custom_pre_spec.rb
+++ b/spec/lib/reverse_markdown/converters/custom_pre_spec.rb
@@ -1,5 +1,4 @@
 require "rails_helper"
-# require "nokogiri"
 
 RSpec.describe ReverseMarkdown::Converters::CustomPre, type: :lib do
   def create_custom_pre


### PR DESCRIPTION
Solves thepracticaldev/dev.to#5298

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

See thepracticaldev/dev.to#5298 - allows detecting `<pre class="language-js">` as a language definition for code. 

## Related Tickets & Documents

thepracticaldev/dev.to#5298 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

N/A 

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

