### PR TITLE
Setup Sidekiq queues for different priority jobs

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,7 @@
+:queues:
+  - ["default", 1]
+  - ["low_priority", 10]
+  - ["medium_priority", 100]
+  - ["high_priority", 1000]
+  - ["scheduler", 1000]
+  - ["mailers", 1000]


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)
- [x] Feature

## Description
Before we start rolling over jobs we need to set up a few more [Sidekiq queues](https://github.com/mperham/sidekiq/wiki/Advanced-Options#queues).  Next to each queue is a number that represents its importance. The higher the number the more important the queue is and the fast those jobs will be executed. The numbers are actually a ratio. In the event that every queue is full we will execute 1000 `high_priority` jobs for every 100 `medium_priority`, every 10 `low_priority` etc.

This is a similar setup we had at Kenna plus a couple more actually based on worker volume. For now, I didn't include those but we can add a couple more depending on how it all balances out. Queue balancing is an art and usually involves monitoring things as they get moved over and then making tweaks.

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media2.giphy.com/media/MSCxjkeWkwCZNgpgMi/giphy.gif)
