### PR TITLE
Create new BustCacheWorker and start sending jobs to it

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -647,6 +647,6 @@ class Article < ApplicationRecord
   end
 
   def async_bust
-    Articles::BustCacheJob.perform_later(id)
+    Articles::BustCacheWorker.perform_async(id)
   end
 end

--- a/app/workers/articles/bust_cache_worker.rb
+++ b/app/workers/articles/bust_cache_worker.rb
@@ -1,0 +1,13 @@
+module Articles
+  class BustCacheWorker
+    include Sidekiq::Worker
+
+    sidekiq_options queue: :high_priority, retry: 10
+
+    def perform(article_id, cache_buster = "CacheBuster")
+      article = Article.find_by(id: article_id)
+
+      cache_buster.constantize.bust_article(article) if article
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,6 +33,7 @@ Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
 Dir[Rails.root.join("spec/system/shared_examples/**/*.rb")].sort.each { |f| require f }
 Dir[Rails.root.join("spec/models/shared_examples/**/*.rb")].sort.each { |f| require f }
 Dir[Rails.root.join("spec/jobs/shared_examples/**/*.rb")].sort.each { |f| require f }
+Dir[Rails.root.join("spec/workers/shared_examples/**/*.rb")].sort.each { |f| require f }
 
 # Checks for pending migrations before tests are run.
 # If you are not using ActiveRecord, you can remove this line.

--- a/spec/workers/articles/bust_cache_worker_spec.rb
+++ b/spec/workers/articles/bust_cache_worker_spec.rb
@@ -5,6 +5,8 @@ class NewBuster
 end
 
 RSpec.describe Articles::BustCacheWorker, type: :worker do
+  include_examples "#enqueues_on_correct_queue", "high_priority", 1
+
   describe "#perform" do
     let(:worker) { subject }
 

--- a/spec/workers/articles/bust_cache_worker_spec.rb
+++ b/spec/workers/articles/bust_cache_worker_spec.rb
@@ -1,43 +1,43 @@
 require "rails_helper"
 
+class NewBuster
+  def self.bust_article(*); end
+end
+
 RSpec.describe Articles::BustCacheWorker, type: :worker do
   describe "#perform" do
-    let(:article) { FactoryBot.create(:article) }
-    let(:cache_buster) { double }
     let(:worker) { subject }
-    let(:buster) { "CacheBuster" }
 
-    before do
-      allow(buster).to receive(:constantize).and_return(cache_buster)
-      allow(cache_buster).to receive(:bust_article)
-    end
+    context "with article" do
+      let(:article) { double }
+      let(:article_id) { 1 }
 
-    context "with cache buster defined" do
-      it "busts cache with defined buster" do
-        new_buster = "NewBuster"
-        allow(new_buster).to receive(:constantize).and_return(cache_buster)
-        allow(cache_buster).to receive(:bust_article)
-        worker.perform(article.id, new_buster)
-        expect(cache_buster).to have_received(:bust_article).with(article)
+      before do
+        allow(Article).to receive(:find_by).with(id: article_id).and_return(article)
       end
-    end
 
-    context "without cache buster defined" do
-      it "busts cache with default" do
+      it "with cache buster defined busts cache with defined buster" do
+        allow(NewBuster).to receive(:bust_article)
+        worker.perform(article_id, "NewBuster")
+        expect(NewBuster).to have_received(:bust_article).with(article)
+      end
+
+      it "without cache buster defined busts cache with default" do
         allow(CacheBuster).to receive(:bust_article)
-        worker.perform(article.id)
+        worker.perform(article_id)
         expect(CacheBuster).to have_received(:bust_article).with(article)
       end
     end
 
     context "without article" do
       it "does not error" do
-        expect { worker.perform(nil, buster) }.not_to raise_error
+        expect { worker.perform(nil, "CacheBuster") }.not_to raise_error
       end
 
       it "does not bust cache" do
+        allow(CacheBuster).to receive(:bust_article)
         worker.perform(nil)
-        expect(cache_buster).not_to have_received(:bust_article)
+        expect(CacheBuster).not_to have_received(:bust_article)
       end
     end
   end

--- a/spec/workers/articles/bust_cache_worker_spec.rb
+++ b/spec/workers/articles/bust_cache_worker_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe Articles::BustCacheWorker, type: :worker do
+  describe "#perform" do
+    let(:article) { FactoryBot.create(:article) }
+    let(:cache_buster) { double }
+    let(:worker) { subject }
+    let(:buster) { "CacheBuster" }
+
+    before do
+      allow(buster).to receive(:constantize).and_return(cache_buster)
+      allow(cache_buster).to receive(:bust_article)
+    end
+
+    context "with cache buster defined" do
+      it "busts cache with defined buster" do
+        new_buster = "NewBuster"
+        allow(new_buster).to receive(:constantize).and_return(cache_buster)
+        allow(cache_buster).to receive(:bust_article)
+        worker.perform(article.id, new_buster)
+        expect(cache_buster).to have_received(:bust_article).with(article)
+      end
+    end
+
+    context "without cache buster defined" do
+      it "busts cache with default" do
+        allow(CacheBuster).to receive(:bust_article)
+        worker.perform(article.id)
+        expect(CacheBuster).to have_received(:bust_article).with(article)
+      end
+    end
+
+    context "without article" do
+      it "does not error" do
+        expect { worker.perform(nil, buster) }.not_to raise_error
+      end
+
+      it "does not bust cache" do
+        worker.perform(nil)
+        expect(cache_buster).not_to have_received(:bust_article)
+      end
+    end
+  end
+end

--- a/spec/workers/shared_examples/enqueues_on_correct_queue.rb
+++ b/spec/workers/shared_examples/enqueues_on_correct_queue.rb
@@ -1,0 +1,11 @@
+RSpec.shared_examples "#enqueues_on_correct_queue" do |queue_name, args|
+  describe "#perform_async" do
+    it "enqueues the job" do
+      Sidekiq::Testing.fake!
+
+      expect do
+        described_class.perform_async(args)
+      end.to change { Sidekiq::Queues[queue_name].size }.by(1)
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
This creates a new BustCacheWorker and starts sending jobs to it. Once this is deployed I will open a second PR to remove the old job code.

## Related Issue
#5305 

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media0.giphy.com/media/inVvfuomoD31K/giphy.gif)
