### PR TITLE
Flaky Spec Fix: use match_array instead of eq to ignore ordering

### DIFF
--- a/spec/services/exporter/articles_spec.rb
+++ b/spec/services/exporter/articles_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Exporter::Articles, type: :service do
         exporter = valid_instance(user)
         result = exporter.export(slug: article.slug)
         articles = load_articles(result)
-        expect(articles.first.keys).to eq(expected_fields)
+        expect(articles.first.keys).to match_array(expected_fields)
       end
     end
 
@@ -107,7 +107,7 @@ RSpec.describe Exporter::Articles, type: :service do
         exporter = valid_instance(article.user)
         result = exporter.export
         articles = load_articles(result)
-        expect(articles.first.keys).to eq(expected_fields)
+        expect(articles.first.keys).to match_array(expected_fields)
       end
     end
   end

--- a/spec/services/exporter/comments_spec.rb
+++ b/spec/services/exporter/comments_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Exporter::Comments, type: :service do
         exporter = valid_instance(user)
         result = exporter.export(id_code: comment.id_code)
         comments = load_comments(result)
-        expect(comments.first.keys).to eq(expected_fields)
+        expect(comments.first.keys).to match_array(expected_fields)
       end
     end
 
@@ -91,7 +91,7 @@ RSpec.describe Exporter::Comments, type: :service do
         exporter = valid_instance(comment.user)
         result = exporter.export
         comments = load_comments(result)
-        expect(comments.first.keys).to eq(expected_fields)
+        expect(comments.first.keys).to match_array(expected_fields)
       end
     end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Use array_match rather than eq to ignore order.
Example of spec failure.
```
4) Exporter::Comments#export when all comments are requested returns only expected fields for the comment
     Failure/Error: expect(comments.first.keys).to eq(expected_fields)
     
       expected: ["body_markdown", "created_at", "deleted", "edited", "edited_at", "id_code", "markdown_character_count", "positive_reactions_count", "processed_html", "receive_notifications", "commentable_path"]
            got: ["edited", "created_at", "id_code", "deleted", "receive_notifications", "markdown_character_count", "edited_at", "body_markdown", "processed_html", "positive_reactions_count", "commentable_path"]
     
       (compared using ==)
     # ./spec/services/exporter/comments_spec.rb:94:in `block (4 levels) in <top (required)>'
     # ./spec/rails_helper.rb:91:in `block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:91:in `block (2 levels) in <top (required)>'
```
## Related Tickets & Documents
#4884 

## Added to documentation?
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/2YmyLa9YZIIhBCpYTo/giphy.gif)
