### PR TITLE
Migrate Articles/BustMultipleCachesJob to Sidekiq

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -476,7 +476,7 @@ class Article < ApplicationRecord
     end
     # perform busting cache in chunks in case there're a lot of articles
     (article_ids.uniq.sort - [id]).each_slice(10) do |ids|
-      Articles::BustMultipleCachesJob.perform_later(ids)
+      Articles::BustMultipleCachesWorker.perform_async(ids)
     end
   end
 

--- a/app/workers/articles/bust_multiple_caches_worker.rb
+++ b/app/workers/articles/bust_multiple_caches_worker.rb
@@ -1,0 +1,13 @@
+module Articles
+  class BustMultipleCachesWorker
+    include Sidekiq::Worker
+    sidekiq_options queue: :low_priority, retry: 10
+
+    def perform(article_ids)
+      Article.select(:id, :path).where(id: article_ids).find_each do |article|
+        CacheBuster.bust(article.path)
+        CacheBuster.bust("#{article.path}?i=i")
+      end
+    end
+  end
+end

--- a/spec/models/article_destroy_spec.rb
+++ b/spec/models/article_destroy_spec.rb
@@ -20,10 +20,9 @@ RSpec.describe Article, type: :model do
     let!(:org_user_article) { create(:article, user: user, organization: organization) }
 
     it "queues BustCacheJob with user and organization article_ids" do
-      expect do
+      sidekiq_assert_enqueued_with(job: Articles::BustMultipleCachesWorker, args: [[user_article.id, org_user_article.id, org_article.id].sort]) do
         article.destroy
-      end.to have_enqueued_job(Articles::BustMultipleCachesJob).exactly(:once).
-        with([user_article.id, org_user_article.id, org_article.id].sort)
+      end
     end
   end
 end

--- a/spec/workers/articles/bust_multiple_caches_worker_spec.rb
+++ b/spec/workers/articles/bust_multiple_caches_worker_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe Articles::BustMultipleCachesWorker, type: :worker do
+  describe "#perform" do
+    let(:article) { create(:article) }
+    let(:path) { article.path }
+    let(:worker) { subject }
+
+    it "busts cache" do
+      allow(CacheBuster).to receive(:bust)
+
+      worker.perform([article.id])
+
+      expect(CacheBuster).to have_received(:bust).with(path).once
+      expect(CacheBuster).to have_received(:bust).with(path + "?i=i").once
+    end
+  end
+end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
In order to move all the jobs to Sidekiq, this commit creates a new
Articles/BustMultipleCachesWorker using Sidekiq based on the
Articles/BustMultipleCachesJob (this one is not removed until we know
that any job on this one will be performed).

## Related Tickets & Documents
Related to: #5305

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
