### PR TITLE
[WIP] Create SortableCount model for better rankable data caches

### DIFF
--- a/app/assets/stylesheets/moderators.scss
+++ b/app/assets/stylesheets/moderators.scss
@@ -7,7 +7,10 @@
   text-align: center;
   background: #d4fffe;
   h1 {
-    font-size: 4em;
+    font-size: calc(1.8em + 2vw);
+  }
+  h2 {
+    font-size: calc(0.9em + 1vw);
   }
   a {
     text-decoration: underline;
@@ -37,6 +40,19 @@
       .mod-index-hero-data-pod-number {
         font-size: calc(2.8em + 0.5vw);
       }  
+    }
+    .mod-index-hero-data-pod-change {
+      background: $black;
+      border-radius: 100px;
+      margin: 15px auto;
+      width: 110px;
+      padding: 7px 0px;
+      &.mod-index-hero-data-pod-change--positive-true {
+        color: $green;
+      }
+      &.mod-index-hero-data-pod-change--positive-false {
+        color: $red;
+      }
     }
   }
 }

--- a/app/controllers/moderations_controller.rb
+++ b/app/controllers/moderations_controller.rb
@@ -12,6 +12,7 @@ class ModerationsController < ApplicationController
     @articles = @articles.where("nth_published_by_author > 0 AND nth_published_by_author < 4 AND published_at > ?", 7.days.ago) if params[:state] == "new-authors"
     @articles = @articles.decorate
     @tag = Tag.find_by(name: params[:tag])
+    define_countables
   end
 
   def article
@@ -29,5 +30,42 @@ class ModerationsController < ApplicationController
     authorize(User, :moderation_routes?)
     @moderatable = Comment.find(params[:id_code].to_i(26))
     render template: "moderations/mod"
+  end
+
+  private
+
+  def define_countables
+    if @tag
+      @tag_counts = @tag.sortable_counts.pluck(:slug, :number)
+      @article_size = select_from_plucked_array(@tag_counts, "published_articles_this_7_days").to_i
+      @comment_size = select_from_plucked_array(@tag_counts, "comments_this_7_days").to_i
+      @reaction_size = select_from_plucked_array(@tag_counts, "reactions_this_7_days").to_i
+      @article_change = (select_from_plucked_array(@tag_counts, "published_articles_change_7_days") * 100.0 - 100).to_i
+      @comment_change = (select_from_plucked_array(@tag_counts, "comments_change_7_days") * 100.0 - 100).to_i
+      @reaction_change = (select_from_plucked_array(@tag_counts, "reactions_change_7_days") * 100.0 - 100).to_i
+    else
+      @article_size = Article.published.where("published_at > ?", 7.days.ago).size
+      @comment_size = Comment.where("created_at > ?", 7.days.ago).size
+      @reaction_size = Reaction.where("created_at > ?", 7.days.ago).size
+
+      define_changes
+    end
+  end
+
+  def select_from_plucked_array(array, slug)
+    array.select { |item| item[0] == slug }.flatten.last.to_f
+  end
+
+  def define_changes
+    prior_article_size = Article.published.where("published_at > ? AND published_at < ?", 14.days.ago, 7.days.ago).size.to_f
+    prior_article_size = 0.5 if prior_article_size.zero?
+    prior_comment_size = Comment.where("created_at > ? AND created_at < ?", 14.days.ago, 7.days.ago).size.to_f
+    prior_comment_size = 0.5 if prior_comment_size.zero?
+    prior_reaction_size = Reaction.where("created_at > ? AND created_at < ?", 14.days.ago, 7.days.ago).size.to_f
+    prior_reaction_size = 0.5 if prior_reaction_size.zero?
+
+    @article_change = (@article_size / prior_article_size * 100.0 - 100).to_i
+    @comment_change = (@comment_size / prior_comment_size * 100.0 - 100).to_i
+    @reaction_change = (@reaction_size / prior_reaction_size * 100.0 - 100).to_i
   end
 end

--- a/app/jobs/tags/recount_job.rb
+++ b/app/jobs/tags/recount_job.rb
@@ -1,0 +1,51 @@
+module Tags
+  class RecountJob < ApplicationJob
+    queue_as :tag_recount
+
+    def perform(article_id)
+      article = Article.find_by(id: article_id).decorate
+      return unless article
+
+      article.cached_tag_list_array.each do |tag_name|
+        @tag = Tag.find_by(name: tag_name)
+        next unless @tag
+
+        @plucked_article_ids = Article.cached_tagged_with(@tag).pluck(:id)
+
+        count_articles
+        count_comments
+        count_reactions
+      end
+    end
+
+    def count_articles
+      articles_this_7_days_count = Article.cached_tagged_with(@tag).published.where("published_at > ?", 7.days.ago).size
+      SortableCount.find_or_create_by(countable_id: @tag.id, countable_type: "ActsAsTaggableOn::Tag", slug: "published_articles_this_7_days").update_column(:number, articles_this_7_days_count)
+      articles_prior_7_days_count = Article.cached_tagged_with(@tag).published.where("published_at > ? AND published_at < ?", 14.days.ago, 7.days.ago).size
+      SortableCount.find_or_create_by(countable_id: @tag.id, countable_type: "ActsAsTaggableOn::Tag", slug: "published_articles_prior_7_days").update_column(:number, articles_prior_7_days_count)
+      articles_prior_7_days_count = 0.5 if comments_prior_7_days_count.zero? # Guard against zero division
+      SortableCount.find_or_create_by(countable_id: @tag.id, countable_type: "ActsAsTaggableOn::Tag", slug: "published_articles_change_7_days").
+        update_column(:number, articles_this_7_days_count / articles_prior_7_days_count.to_f)
+    end
+
+    def count_comments
+      comments_this_7_days_count = Comment.where(commentable_id: @plucked_article_ids).where("created_at > ?", 7.days.ago).size
+      SortableCount.find_or_create_by(countable_id: @tag.id, countable_type: "ActsAsTaggableOn::Tag", slug: "comments_this_7_days").update_column(:number, comments_this_7_days_count)
+      comments_prior_7_days_count = Comment.where(commentable_id: @plucked_article_ids).where("created_at > ? AND created_at < ?", 14.days.ago, 7.days.ago).size
+      SortableCount.find_or_create_by(countable_id: @tag.id, countable_type: "ActsAsTaggableOn::Tag", slug: "comments_prior_7_days").update_column(:number, comments_prior_7_days_count)
+      comments_prior_7_days_count = 0.5 if comments_prior_7_days_count.zero? # Guard against zero division
+      SortableCount.find_or_create_by(countable_id: @tag.id, countable_type: "ActsAsTaggableOn::Tag", slug: "comments_change_7_days").
+        update_column(:number, comments_this_7_days_count / comments_prior_7_days_count.to_f)
+    end
+
+    def count_reactions
+      reactions_this_7_days_count = Reaction.where(reactable_id: @plucked_article_ids).where("created_at > ?", 7.days.ago).size
+      SortableCount.find_or_create_by(countable_id: @tag.id, countable_type: "ActsAsTaggableOn::Tag", slug: "reactions_this_7_days").update_column(:number, reactions_this_7_days_count)
+      reactions_prior_7_days_count = Reaction.where(reactable_id: @plucked_article_ids).where("created_at > ? AND created_at < ?", 14.days.ago, 7.days.ago).size
+      SortableCount.find_or_create_by(countable_id: @tag.id, countable_type: "ActsAsTaggableOn::Tag", slug: "reactions_prior_7_days").update_column(:number, reactions_prior_7_days_count)
+      reactions_prior_7_days_count = 0.5 if comments_prior_7_days_count.zero? # Guard against zero division
+      SortableCount.find_or_create_by(countable_id: @tag.id, countable_type: "ActsAsTaggableOn::Tag", slug: "reactions_change_7_days").
+        update_column(:number, reactions_this_7_days_count / reactions_prior_7_days_count.to_f)
+    end
+  end
+end

--- a/app/jobs/tags/recount_job.rb
+++ b/app/jobs/tags/recount_job.rb
@@ -23,7 +23,7 @@ module Tags
       SortableCount.find_or_create_by(countable_id: @tag.id, countable_type: "ActsAsTaggableOn::Tag", slug: "published_articles_this_7_days").update_column(:number, articles_this_7_days_count)
       articles_prior_7_days_count = Article.cached_tagged_with(@tag).published.where("published_at > ? AND published_at < ?", 14.days.ago, 7.days.ago).size
       SortableCount.find_or_create_by(countable_id: @tag.id, countable_type: "ActsAsTaggableOn::Tag", slug: "published_articles_prior_7_days").update_column(:number, articles_prior_7_days_count)
-      articles_prior_7_days_count = 0.5 if comments_prior_7_days_count.zero? # Guard against zero division
+      articles_prior_7_days_count = 0.5 if articles_prior_7_days_count.zero? # Guard against zero division
       SortableCount.find_or_create_by(countable_id: @tag.id, countable_type: "ActsAsTaggableOn::Tag", slug: "published_articles_change_7_days").
         update_column(:number, articles_this_7_days_count / articles_prior_7_days_count.to_f)
     end
@@ -43,7 +43,7 @@ module Tags
       SortableCount.find_or_create_by(countable_id: @tag.id, countable_type: "ActsAsTaggableOn::Tag", slug: "reactions_this_7_days").update_column(:number, reactions_this_7_days_count)
       reactions_prior_7_days_count = Reaction.where(reactable_id: @plucked_article_ids).where("created_at > ? AND created_at < ?", 14.days.ago, 7.days.ago).size
       SortableCount.find_or_create_by(countable_id: @tag.id, countable_type: "ActsAsTaggableOn::Tag", slug: "reactions_prior_7_days").update_column(:number, reactions_prior_7_days_count)
-      reactions_prior_7_days_count = 0.5 if comments_prior_7_days_count.zero? # Guard against zero division
+      reactions_prior_7_days_count = 0.5 if reactions_prior_7_days_count.zero? # Guard against zero division
       SortableCount.find_or_create_by(countable_id: @tag.id, countable_type: "ActsAsTaggableOn::Tag", slug: "reactions_change_7_days").
         update_column(:number, reactions_this_7_days_count / reactions_prior_7_days_count.to_f)
     end

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -20,7 +20,7 @@ class Reaction < ApplicationRecord
 
   before_save :assign_points
   after_save :index_to_algolia
-  after_save :update_reactable, :bust_reactable_cache, :touch_user, :async_bust
+  after_save :update_reactable, :bust_reactable_cache, :touch_user, :async_bust, :recount_tag_data
   before_destroy :update_reactable_without_delay, unless: :destroyed_by_association
   before_destroy :bust_reactable_cache_without_delay
   before_destroy :remove_algolia
@@ -102,6 +102,10 @@ class Reaction < ApplicationRecord
 
   def update_reactable_without_delay
     Reactions::UpdateReactableJob.perform_now(id)
+  end
+
+  def recount_tag_data
+    Tags::RecountJob.perform_later(reactable_id) if reactable_type == "Article"
   end
 
   def reading_time

--- a/app/models/sortable_count.rb
+++ b/app/models/sortable_count.rb
@@ -1,0 +1,13 @@
+class SortableCount < ApplicationRecord
+  belongs_to :countable, polymorphic: true
+
+  validates :slug, uniqueness: { scope: %i[countable_id countable_type] }
+
+  before_save :apply_title_if_none
+
+  private
+
+  def apply_title_if_none
+    self.title = slug.titleize if title.blank?
+  end
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -19,6 +19,7 @@ class Tag < ActsAsTaggableOn::Tag
 
   belongs_to :badge, optional: true
   has_one :sponsorship, as: :sponsorable, inverse_of: :sponsorable, dependent: :destroy
+  has_many :sortable_counts, as: :countable, inverse_of: :countable, dependent: :destroy
 
   mount_uploader :profile_image, ProfileImageUploader
   mount_uploader :social_image, ProfileImageUploader

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -49,6 +49,7 @@ class User < ApplicationRecord
   has_many :access_tokens, class_name: "Doorkeeper::AccessToken", foreign_key: :resource_owner_id, inverse_of: :resource_owner, dependent: :delete_all
   has_many :webhook_endpoints, class_name: "Webhook::Endpoint", foreign_key: :user_id, inverse_of: :user, dependent: :delete_all
   has_many :user_blocks
+  has_many :sortable_counts, as: :countable, inverse_of: :countable, dependent: :destroy
   has_one :pro_membership, dependent: :destroy
 
   mount_uploader :profile_image, ProfileImageUploader

--- a/app/views/moderations/index.html.erb
+++ b/app/views/moderations/index.html.erb
@@ -1,4 +1,9 @@
-<% title "Moderate" %>
+<% if @tag %>
+  <% title "Moderate ##{@tag.name}" %>
+<% else %>
+  <% title "Moderate" %>
+
+<% end %>
 
 <% if current_user&.trusted %>
   <% if @tag %>
@@ -17,22 +22,30 @@
     <h2>We build the <%= ApplicationConfig["COMMUNITY_NAME"] %> Community</h2>
     <div class="mod-index-hero-data-pod">
       <div class="mod-index-hero-data-pod-number">
-        <%= number_with_delimiter(@tag ? Article.cached_tagged_with(@tag).published.where("published_at > ?", 7.days.ago).size : Article.published.where("published_at > ?", 7.days.ago).size) %>
+        <%= number_with_delimiter(@article_size) %>
       </div>
       Posts This Week
+      <div class="mod-index-hero-data-pod-change mod-index-hero-data-pod-change--positive-<%= @article_change.positive? %>" title="Change in posts since last week">
+        <%= sprintf("%+d", @article_change) %>%
+      </div>
     </div>
-    <% plucked_article_ids = Article.cached_tagged_with(@tag).pluck(:id) if @tag %>
     <div class="mod-index-hero-data-pod">
       <div class="mod-index-hero-data-pod-number">
-        <%= number_with_delimiter(@tag ? Comment.where(commentable_id: plucked_article_ids ).where("created_at > ?", 7.days.ago).size : Comment.where("created_at > ?", 7.days.ago).size) %>
+        <%= number_with_delimiter(@comment_size) %>
       </div>
       Comments This Week
+      <div class="mod-index-hero-data-pod-change mod-index-hero-data-pod-change--positive-<%= @comment_change.positive? %>" title="Change in comments since last week">
+        <%= sprintf("%+d", @comment_change) %>%
+      </div>
     </div>
     <div class="mod-index-hero-data-pod">
       <div class="mod-index-hero-data-pod-number">
-        <%= number_with_delimiter(@tag ? Reaction.where(reactable_id: plucked_article_ids ).where("created_at > ?", 7.days.ago).size : Reaction.where("created_at > ?", 7.days.ago).size)  %>
+        <%= number_with_delimiter(@reaction_size)  %>
       </div>
       Reactions This Week
+      <div class="mod-index-hero-data-pod-change mod-index-hero-data-pod-change--positive-<%= @reaction_change.positive? %>" title="Change in reactions since last week">
+        <%= sprintf("%+d", @reaction_change) %>%
+      </div>
     </div>
   </div>
   <div class="mod-index-header">

--- a/db/migrate/20191230190517_create_sortable_counts.rb
+++ b/db/migrate/20191230190517_create_sortable_counts.rb
@@ -1,0 +1,16 @@
+class CreateSortableCounts < ActiveRecord::Migration[5.2]
+  def change
+    create_table :sortable_counts do |t|
+      t.bigint :countable_id, null: false
+      t.string :countable_type, null: false
+      t.string :slug, null: false
+      t.string :title, null: false
+      t.float :number, null: false, default: 0
+      t.timestamps
+    end
+    add_index :sortable_counts, :countable_id
+    add_index :sortable_counts, :countable_type
+    add_index :sortable_counts, :number
+    add_index :sortable_counts, :slug
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_27_114543) do
+ActiveRecord::Schema.define(version: 2019_12_30_190517) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -880,6 +880,20 @@ ActiveRecord::Schema.define(version: 2019_12_27_114543) do
     t.text "value"
     t.string "var", null: false
     t.index ["var"], name: "index_site_configs_on_var", unique: true
+  end
+
+  create_table "sortable_counts", force: :cascade do |t|
+    t.bigint "countable_id", null: false
+    t.string "countable_type", null: false
+    t.datetime "created_at", null: false
+    t.float "number", default: 0.0, null: false
+    t.string "slug", null: false
+    t.string "title", null: false
+    t.datetime "updated_at", null: false
+    t.index ["countable_id"], name: "index_sortable_counts_on_countable_id"
+    t.index ["countable_type"], name: "index_sortable_counts_on_countable_type"
+    t.index ["number"], name: "index_sortable_counts_on_number"
+    t.index ["slug"], name: "index_sortable_counts_on_slug"
   end
 
   create_table "sponsorships", force: :cascade do |t|

--- a/spec/jobs/tags/recount_job_spec.rb
+++ b/spec/jobs/tags/recount_job_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe Tags::RecountJob do
+  include_examples "#enqueues_job", "tag_recount", 1
+
+  describe "#perform_now" do
+    let(:article) { create(:article) }
+    let(:tag) { Tag.find_by(name: article.decorate.cached_tag_list_array.first) }
+
+    before do
+      described_class.perform_now(article.id)
+    end
+
+    it "counts articles" do
+      expect(tag.sortable_counts.size).to be(6)
+      expect(tag.sortable_counts.first.slug).to eq("published_articles_this_7_days")
+    end
+
+    it "counts comments" do
+      expect(tag.sortable_counts.size).to be(6)
+      expect(tag.sortable_counts.where(slug: "comments_this_7_days").size).to be(1)
+    end
+
+    it "counts reactions" do
+      expect(tag.sortable_counts.size).to eq(6)
+      expect(tag.sortable_counts.where(slug: "reactions_this_7_days").size).to be(1)
+    end
+  end
+end

--- a/spec/models/sortable_count_spec.rb
+++ b/spec/models/sortable_count_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe SortableCount, type: :model do
   let(:article) { create(:article, featured: true) }
 
   it "creates title" do
-    count = described_class.find_or_create_by(countable_id: article.id, countable_type: "Article", slug: "published_articles_this_7_days").update_column(:number, 1)
+    count = described_class.find_or_create_by(countable_id: article.id, countable_type: "Article", slug: "published_articles_this_7_days")
+    count.update_column(:number, 1)
     expect(count.title).to eq("Published Articles This 7 Days")
   end
 end

--- a/spec/models/sortable_count_spec.rb
+++ b/spec/models/sortable_count_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.describe SortableCount, type: :model do
+  let(:article) { create(:article, featured: true) }
+
+  it "creates title" do
+    count = described_class.find_or_create_by(countable_id: article.id, countable_type: "Article", slug: "published_articles_this_7_days").update_column(:number, 1)
+    expect(count.title).to eq("Published Articles This 7 Days")
+  end
+end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

This PR adds a table called `sortable_counts` which is a model designed to hold a "countable" thing.

This starts with creating sortable counts for tags. These can be extended via `has_many` relationship to store lots of rankable data for organization and performance.

This is related to #4825, #4939, etc. I think it's a pretty scalable solution for some of what we might want to do along these lines. I'm not totally sure about all this though.

This doesn't really make use of the "sortable" part, but is the first screen which makes use of this sort of data:

<img width="1619" alt="Screen Shot 2019-12-30 at 7 21 44 PM" src="https://user-images.githubusercontent.com/3102842/71605772-a172b180-2b39-11ea-9a28-0b324fa4f87e.png">
