### PR TITLE
Change MentionJob to MentionWorker and move to sidekiq

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -86,7 +86,7 @@ class Notification < ApplicationRecord
     def send_mention_notification(mention)
       return if mention.mentionable_type == "User" && UserBlock.blocking?(mention.mentionable_id, mention.user_id)
 
-      Notifications::MentionJob.perform_later(mention.id)
+      Notifications::MentionWorker.perform_async(mention.id)
     end
 
     def send_welcome_notification(receiver_id)

--- a/app/workers/notifications/mention_worker.rb
+++ b/app/workers/notifications/mention_worker.rb
@@ -1,0 +1,11 @@
+module Notifications
+  class MentionWorker
+    include Sidekiq::Worker
+    sidekiq_options queue: :high_priority, retry: 10
+
+    def perform(mention_id)
+      mention = Mention.find_by(id: mention_id)
+      Notifications::NewMention::Send.call(mention) if mention
+    end
+  end
+end

--- a/app/workers/notifications/mention_worker.rb
+++ b/app/workers/notifications/mention_worker.rb
@@ -1,7 +1,7 @@
 module Notifications
   class MentionWorker
     include Sidekiq::Worker
-    sidekiq_options queue: :high_priority, retry: 10
+    sidekiq_options queue: :low_priority, retry: 10
 
     def perform(mention_id)
       mention = Mention.find_by(id: mention_id)

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -344,12 +344,11 @@ RSpec.describe "NotificationsIndex", type: :request do
           body_markdown: "@#{user.username}",
         )
       end
+      let(:mention) { create(:mention, mentionable: comment, user: user) }
 
       before do
-        comment
-        perform_enqueued_jobs do
-          Mention.create_all(comment)
-          Notification.send_mention_notification(Mention.first)
+        Sidekiq::Testing.inline! do
+          Notification.send_mention_notification(mention)
         end
         sign_in user
         get "/notifications"

--- a/spec/workers/notifications/mention_worker_spec.rb
+++ b/spec/workers/notifications/mention_worker_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+RSpec.describe Notifications::MentionWorker, type: :worker do
+  describe "#perform" do
+    let(:mention) { create(:mention, mentionable: create(:comment, commentable: create(:article))) }
+    let(:service) { Notifications::NewMention::Send }
+    let(:worker) { subject }
+
+    before do
+      allow(service).to receive(:call)
+    end
+
+    it "calls a service" do
+      perform_enqueued_jobs do
+        worker.perform(mention.id)
+
+        expect(service).to have_received(:call).with(mention).once
+      end
+    end
+
+    it "does nothing for non-existent mention " do
+      perform_enqueued_jobs do
+        worker.perform(nil)
+
+        expect(service).not_to have_received(:call)
+      end
+    end
+  end
+end

--- a/spec/workers/notifications/mention_worker_spec.rb
+++ b/spec/workers/notifications/mention_worker_spec.rb
@@ -10,19 +10,13 @@ RSpec.describe Notifications::MentionWorker, type: :worker do
     end
 
     it "calls a service" do
-      perform_enqueued_jobs do
-        worker.perform(mention.id)
-
-        expect(service).to have_received(:call).with(mention).once
-      end
+      worker.perform(mention.id)
+      expect(service).to have_received(:call).with(mention).once
     end
 
     it "does nothing for non-existent mention " do
-      perform_enqueued_jobs do
-        worker.perform(nil)
-
-        expect(service).not_to have_received(:call)
-      end
+      worker.perform(nil)
+      expect(service).not_to have_received(:call)
     end
   end
 end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [x] Refactor

## Description
I followed the PR [here: ](https://github.com/thepracticaldev/dev.to/pull/5302)
This creates a new MentionWorker and starts sending jobs to it from the Notification model. Once this is deployed, I will open a second PR to remove the old code.

Starting small, if this looks good, i can tackle more of the Notification jobs :)
## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/issues/5305

## Added to documentation?

- [x] no documentation needed
