### PR TITLE
Cache data on /mod

### DIFF
--- a/app/assets/stylesheets/moderators.scss
+++ b/app/assets/stylesheets/moderators.scss
@@ -7,7 +7,10 @@
   text-align: center;
   background: #d4fffe;
   h1 {
-    font-size: 4em;
+    font-size: calc(1.8em + 2vw);
+  }
+  h2 {
+    font-size: calc(0.9em + 1vw);
   }
   a {
     text-decoration: underline;
@@ -38,6 +41,9 @@
         font-size: calc(2.8em + 0.5vw);
       }  
     }
+  }
+  .mod-index-hero-sub {
+    font-size: 0.9em;
   }
 }
 

--- a/app/controllers/moderations_controller.rb
+++ b/app/controllers/moderations_controller.rb
@@ -11,7 +11,7 @@ class ModerationsController < ApplicationController
     @articles = @articles.cached_tagged_with(params[:tag]) if params[:tag].present?
     @articles = @articles.where("nth_published_by_author > 0 AND nth_published_by_author < 4 AND published_at > ?", 7.days.ago) if params[:state] == "new-authors"
     @articles = @articles.decorate
-    @tag = Tag.find_by(name: params[:tag])
+    @tag = Tag.find_by(name: params[:tag]) || not_found if params[:tag].present?
   end
 
   def article

--- a/app/views/moderations/index.html.erb
+++ b/app/views/moderations/index.html.erb
@@ -12,29 +12,34 @@
     }
   </style>
   <% end %>
-  <div class="mod-index-hero">
-    <h1><%= "#" + @tag.name.titleize if @tag %> Moderators</h1>
-    <h2>We build the <%= ApplicationConfig["COMMUNITY_NAME"] %> Community</h2>
-    <div class="mod-index-hero-data-pod">
-      <div class="mod-index-hero-data-pod-number">
-        <%= number_with_delimiter(@tag ? Article.cached_tagged_with(@tag).published.where("published_at > ?", 7.days.ago).size : Article.published.where("published_at > ?", 7.days.ago).size) %>
+  <% cache("mod-data-header-#{params[:tag]}", expires_in: 6.hours) do %>
+    <div class="mod-index-hero">
+      <h1><%= "#" + @tag.name.titleize if @tag %> Moderators</h1>
+      <h2>We build the <%= ApplicationConfig["COMMUNITY_NAME"] %> Community</h2>
+      <div class="mod-index-hero-data-pod">
+        <div class="mod-index-hero-data-pod-number">
+          <%= number_with_delimiter(@tag ? Article.cached_tagged_with(@tag).published.where("published_at > ?", 7.days.ago).size : Article.published.where("published_at > ?", 7.days.ago).size) %>
+        </div>
+        Posts This Week
       </div>
-      Posts This Week
-    </div>
-    <% plucked_article_ids = Article.cached_tagged_with(@tag).pluck(:id) if @tag %>
-    <div class="mod-index-hero-data-pod">
-      <div class="mod-index-hero-data-pod-number">
-        <%= number_with_delimiter(@tag ? Comment.where(commentable_id: plucked_article_ids ).where("created_at > ?", 7.days.ago).size : Comment.where("created_at > ?", 7.days.ago).size) %>
+      <% plucked_article_ids = Article.cached_tagged_with(@tag).pluck(:id) if @tag %>
+      <div class="mod-index-hero-data-pod">
+        <div class="mod-index-hero-data-pod-number">
+          <%= number_with_delimiter(@tag ? Comment.where(commentable_id: plucked_article_ids ).where("created_at > ?", 7.days.ago).size : Comment.where("created_at > ?", 7.days.ago).size) %>
+        </div>
+        Comments This Week
       </div>
-      Comments This Week
-    </div>
-    <div class="mod-index-hero-data-pod">
-      <div class="mod-index-hero-data-pod-number">
-        <%= number_with_delimiter(@tag ? Reaction.where(reactable_id: plucked_article_ids ).where("created_at > ?", 7.days.ago).size : Reaction.where("created_at > ?", 7.days.ago).size)  %>
+      <div class="mod-index-hero-data-pod">
+        <div class="mod-index-hero-data-pod-number">
+          <%= number_with_delimiter(@tag ? Reaction.where(reactable_id: plucked_article_ids ).where("created_at > ?", 7.days.ago).size : Reaction.where("created_at > ?", 7.days.ago).size)  %>
+        </div>
+        Reactions This Week
       </div>
-      Reactions This Week
+      <div class="mod-index-hero-sub">
+        <em>Data as of <%= Time.current %></em>
+      </div>
     </div>
-  </div>
+  <% end %>
   <div class="mod-index-header">
     <div class="mod-index-header-top-filters">
       <a href="<%= request.path %>" class="<%= "mod-index-top-filter-link--active" if params[:state].blank? %>">Base Feed</a>

--- a/spec/requests/moderations_spec.rb
+++ b/spec/requests/moderations_spec.rb
@@ -68,5 +68,9 @@ RSpec.describe "Moderations", type: :request do
       get "/mod/#{article.tags.first}"
       expect(response.body).to include("#" + article.tags.first.name.titleize)
     end
+
+    it "returns not found for inapprpriate tags" do
+      expect { get "/mod/dsdsdsweweedsdseweww" }.to raise_exception(ActiveRecord::RecordNotFound)
+    end
   end
 end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
While we wait on other ways to display counts, this caches the queries on `/mod` which are currently _just a bit_ too expensive. I'm sure there are better queries than what we have to begin with, but this is probably a solid choice either way. This data doesn't need to be ultra fresh, and the performance win should be really helpful for making this page really usable.