### PR TITLE
Don't run Datadog Agent on scheduler Dynos

### DIFF
--- a/datadog/prerun.sh
+++ b/datadog/prerun.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Disable the Datadog Agent for scheduler workers
+if [ "$DYNOTYPE" == "scheduler" ]; then
+  DISABLE_DATADOG_AGENT="true"
+fi


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix
- [x] Optimization

## Description
Datadog charges on a by host basis and since the schedulers only run once a few times a day I dont think it is worth it to track them in Datadog. Furthermore, with moving to Sidekiq, eventually, we might be able to get off Scheduler completely.  

[Here are the Datadog docs on prerun scripts](https://docs.datadoghq.com/agent/basic_agent_usage/heroku/#prerun-script). Looks like you just put it in the expected file path and it just works 🤷

## Related Tickets & Documents
#4925 

## Added to documentation?
- [x] no documentation needed

![alt_text](gif_link)
