### PR TITLE
Fix flaky delete spec by setting timestamp in the future and Decrease Notification Counts

### DIFF
--- a/spec/services/bulk_sql_delete_spec.rb
+++ b/spec/services/bulk_sql_delete_spec.rb
@@ -7,7 +7,7 @@ describe BulkSqlDelete, type: :service do
       WHERE notifications.id IN (
         SELECT notifications.id
         FROM notifications
-        WHERE created_at < '#{Time.zone.now}'
+        WHERE created_at < '#{2.hours.from_now}'
         LIMIT 1
       )
     SQL
@@ -18,20 +18,16 @@ describe BulkSqlDelete, type: :service do
 
   describe "#delete_in_batches" do
     it "logs batch deletion" do
-      create_list :notification, 5
-      allow(logger).to receive(:info).exactly(6).times.with(
-        hash_including(:tag, :statement, :duration, :rows_deleted),
-      )
+      create_list :notification, 3
+      allow(logger).to receive(:info)
       described_class.delete_in_batches(sql)
-      expect(logger).to have_received(:info).exactly(6).times.with(
+      expect(logger).to have_received(:info).exactly(4).times.with(
         hash_including(:tag, :statement, :duration, :rows_deleted),
       )
     end
 
     it "logs errors that occur" do
-      allow(logger).to receive(:error).with(
-        hash_including(:tag, :statement, :exception_message, :backtrace),
-      )
+      allow(logger).to receive(:error)
       # rubocop:disable RSpec/AnyInstance
       allow_any_instance_of(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter).to receive(:exec_delete).and_raise("broken")
       # rubocop:enable RSpec/AnyInstance
@@ -43,8 +39,8 @@ describe BulkSqlDelete, type: :service do
     end
 
     it "deletes all records in batches" do
-      create_list :notification, 10
-      expect { described_class.delete_in_batches(sql) }.to change(Notification, :count).from(10).to(0)
+      create_list :notification, 5
+      expect { described_class.delete_in_batches(sql) }.to change(Notification, :count).from(5).to(0)
     end
   end
 end

--- a/spec/services/bulk_sql_delete_spec.rb
+++ b/spec/services/bulk_sql_delete_spec.rb
@@ -7,7 +7,7 @@ describe BulkSqlDelete, type: :service do
       WHERE notifications.id IN (
         SELECT notifications.id
         FROM notifications
-        WHERE created_at < '#{2.hours.from_now}'
+        WHERE created_at < '#{Time.zone.now}'
         LIMIT 1
       )
     SQL
@@ -18,7 +18,7 @@ describe BulkSqlDelete, type: :service do
 
   describe "#delete_in_batches" do
     it "logs batch deletion" do
-      create_list :notification, 3
+      create_list :notification, 3, created_at: 1.month.ago
       allow(logger).to receive(:info)
       described_class.delete_in_batches(sql)
       expect(logger).to have_received(:info).exactly(4).times.with(
@@ -39,7 +39,7 @@ describe BulkSqlDelete, type: :service do
     end
 
     it "deletes all records in batches" do
-      create_list :notification, 5
+      create_list :notification, 5, created_at: 1.month.ago
       expect { described_class.delete_in_batches(sql) }.to change(Notification, :count).from(5).to(0)
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix
- [x] Optimization

## Description
Set timestamp in the future so Notifications created are for sure destroyed and decrease the counts to make it a smidge faster. 

## Added to documentation?
- [x] no documentation needed

All good now
![alt_text](https://media1.tenor.com/images/069be69908e522f929c221e3692ea274/tenor.gif?itemid=5650557)
