### PR TITLE
Clear Sidekiq jobs between tests

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -78,6 +78,8 @@ RSpec.configure do |config|
 
   config.before do
     ActiveRecord::Base.observers.disable :all # <-- Turn 'em all off!
+
+    Sidekiq::Worker.clear_all # worker jobs shouldn't linger around between tests
   end
 
   config.after do


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Sidekiq doesn't clear the jobs queue between tests, tests should be isolated and thus the job queue should be empty between each test.

This should be merged ASAP because a lot of Sidekiq worker specs will rely on counting the number of jobs in a specific queue, without this counts will likely be off in many cases, see also the failing build here https://travis-ci.com/thepracticaldev/dev.to/builds/142775786

Part of #5305 
