### PR TITLE
Sidekiq: add test helpers

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -75,6 +75,7 @@ RSpec.configure do |config|
   config.include Devise::Test::IntegrationHelpers, type: :request
   config.include FactoryBot::Syntax::Methods
   config.include OmniauthMacros
+  config.include SidekiqTestHelpers
 
   config.before do
     ActiveRecord::Base.observers.disable :all # <-- Turn 'em all off!

--- a/spec/support/sidekiq_test_helpers.rb
+++ b/spec/support/sidekiq_test_helpers.rb
@@ -1,0 +1,30 @@
+# Helpers for Sidekiq tests
+# modeled after <https://api.rubyonrails.org/v5.2/classes/ActiveJob/TestHelper.html>
+module SidekiqTestHelpers
+  # Asserts that the job passed in the block has been enqueued with the given arguments.
+  # check <https://api.rubyonrails.org/v5.2/classes/ActiveJob/TestHelper.html#method-i-assert_enqueued_with>
+  # for examples
+  def sidekiq_assert_enqueued_with(job: nil, args: nil, at: nil, queue: nil)
+    expected = { job: job, args: args, at: at, queue: queue }.compact
+    expected_args = Utils.prepare_args(expected)
+
+    yield
+
+    # check there's at least one job with the given args
+    matching_job = job.jobs.detect do |queued_job|
+      expected_args.all? { |key, value| value == queued_job[key] }
+    end
+
+    expect(matching_job).to be_present, "No enqueued job found with #{expected}"
+  end
+
+  class Utils
+    def self.prepare_args(args)
+      args.dup.tap do |arguments|
+        arguments[:at] = arguments[:at].to_f if arguments[:at]
+        arguments[:class] = arguments[:job].to_s
+        arguments.delete(:job)
+      end.with_indifferent_access
+    end
+  end
+end

--- a/spec/support/sidekiq_test_helpers.rb
+++ b/spec/support/sidekiq_test_helpers.rb
@@ -1,9 +1,31 @@
 # Helpers for Sidekiq tests
 # modeled after <https://api.rubyonrails.org/v5.2/classes/ActiveJob/TestHelper.html>
 module SidekiqTestHelpers
+  # Provides a store of all the enqueued jobs
+  def sidekiq_enqueued_jobs
+    Sidekiq::Worker.jobs
+  end
+
+  # Asserts that the number of enqueued jobs matches the given number.
+  # see https://api.rubyonrails.org/v5.2/classes/ActiveJob/TestHelper.html#method-i-assert_enqueued_jobs
+  def sidekiq_assert_enqueued_jobs(number, only: nil, except: nil, queue: nil)
+    if block_given?
+      original_count = Utils.enqueued_jobs_size(only: only, except: except, queue: queue)
+
+      yield
+      new_count = Utils.enqueued_jobs_size(only: only, except: except, queue: queue)
+
+      error_message = "#{number} jobs expected, but #{new_count - original_count} were enqueued"
+      expect(new_count - original_count).to eq(number), error_message
+    else
+      actual_count = Utils.enqueued_jobs_size(only: only, except: except, queue: queue)
+
+      expect(actual_count).to eq(number), "#{number} jobs expected, but #{actual_count} were enqueued"
+    end
+  end
+
   # Asserts that the job passed in the block has been enqueued with the given arguments.
-  # check <https://api.rubyonrails.org/v5.2/classes/ActiveJob/TestHelper.html#method-i-assert_enqueued_with>
-  # for examples
+  # see <https://api.rubyonrails.org/v5.2/classes/ActiveJob/TestHelper.html#method-i-assert_enqueued_with>
   def sidekiq_assert_enqueued_with(job: nil, args: nil, at: nil, queue: nil)
     expected = { job: job, args: args, at: at, queue: queue }.compact
     expected_args = Utils.prepare_args(expected)
@@ -19,12 +41,35 @@ module SidekiqTestHelpers
   end
 
   class Utils
-    def self.prepare_args(args)
-      args.dup.tap do |arguments|
-        arguments[:at] = arguments[:at].to_f if arguments[:at]
-        arguments[:class] = arguments[:job].to_s
-        arguments.delete(:job)
-      end.with_indifferent_access
+    class << self
+      def enqueued_jobs_size(only: nil, except: nil, queue: nil)
+        validate_option(only: only, except: except)
+
+        Sidekiq::Worker.jobs.count do |job|
+          job_class = job.fetch("class")
+          if only
+            next false unless Array(only).include?(job_class.constantize)
+          elsif except
+            next false if Array(except).include?(job_class.constantize)
+          end
+          if queue
+            next false unless queue.to_s == job.fetch("queue")
+          end
+          true
+        end
+      end
+
+      def validate_option(only: nil, except: nil)
+        raise ArgumentError, "Cannot specify both `:only` and `:except` options." if only && except
+      end
+
+      def prepare_args(args)
+        args.dup.tap do |arguments|
+          arguments[:at] = arguments[:at].to_f if arguments[:at]
+          arguments[:class] = arguments[:job].to_s
+          arguments.delete(:job)
+        end.with_indifferent_access
+      end
     end
   end
 end

--- a/spec/support/sidekiq_test_helpers.rb
+++ b/spec/support/sidekiq_test_helpers.rb
@@ -2,12 +2,14 @@
 # modeled after <https://api.rubyonrails.org/v5.2/classes/ActiveJob/TestHelper.html>
 module SidekiqTestHelpers
   # Provides a store of all the enqueued jobs
-  def sidekiq_enqueued_jobs
+  def sidekiq_enqueued_jobs(queue: nil)
+    return Sidekiq::Queues[queue.to_s] if queue
+
     Sidekiq::Worker.jobs
   end
 
   # Asserts that the number of enqueued jobs matches the given number.
-  # see https://api.rubyonrails.org/v5.2/classes/ActiveJob/TestHelper.html#method-i-assert_enqueued_jobs
+  # see <https://api.rubyonrails.org/v5.2/classes/ActiveJob/TestHelper.html#method-i-assert_enqueued_jobs>
   def sidekiq_assert_enqueued_jobs(number, only: nil, except: nil, queue: nil)
     if block_given?
       original_count = Utils.enqueued_jobs_size(only: only, except: except, queue: queue)
@@ -38,6 +40,12 @@ module SidekiqTestHelpers
     end
 
     expect(matching_job).to be_present, "No enqueued job found with #{expected}"
+  end
+
+  # Asserts that no jobs have been enqueued.
+  # see <https://api.rubyonrails.org/v5.2/classes/ActiveJob/TestHelper.html#method-i-assert_no_enqueued_jobs>
+  def sidekiq_assert_no_enqueued_jobs(only: nil, except: nil, &block)
+    sidekiq_assert_enqueued_jobs(0, only: only, except: except, &block)
   end
 
   class Utils

--- a/spec/support/sidekiq_test_helpers.rb
+++ b/spec/support/sidekiq_test_helpers.rb
@@ -1,5 +1,6 @@
 # Helpers for Sidekiq tests
 # modeled after <https://api.rubyonrails.org/v5.2/classes/ActiveJob/TestHelper.html>
+# NOTE: contains code adapted from <https://github.com/rails/rails/blob/ac30e389ecfa0e26e3d44c1eda8488ddf63b3ecc/activejob/lib/active_job/test_helper.rb>
 module SidekiqTestHelpers
   # Provides a store of all the enqueued jobs
   def sidekiq_enqueued_jobs(queue: nil)


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR adds some test helpers modeled after [ActiveJob::TestHelper](https://api.rubyonrails.org/v5.2/classes/ActiveJob/TestHelper.html) in Rails.

Those purely "rspeccy" are missing, mostly because I didn't want to go down the RSpec rabbit hole (I admit I find RSpec too "magic" and never fully understood how it works :D). If anyone wants to add them, please be my guest.

I didn't convert all `ActiveJob` test helpers, only those that I found that are used in the codebase.

All helpers are prefixed with `sidekiq_` to avoid name clashing with those in `ActiveJob`, maybe when the transition is finished we can remove the prefix, or not.

I tested all helpers manually :)

## Related Tickets & Documents

#5305 
