### PR TITLE
Change create first reaction job to worker

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -259,7 +259,7 @@ class Comment < ApplicationRecord
   end
 
   def create_first_reaction
-    Comments::CreateFirstReactionJob.perform_later(id)
+    Comments::CreateFirstReactionWorker.perform_async(id, user_id)
   end
 
   def after_destroy_actions

--- a/app/workers/comments/create_first_reaction_worker.rb
+++ b/app/workers/comments/create_first_reaction_worker.rb
@@ -1,0 +1,18 @@
+module Comments
+  class CreateFirstReactionWorker
+    include Sidekiq::Worker
+
+    sidekiq_options queue: :high_priority, retry: 10
+
+    def perform(comment_id, user_id)
+      return unless Comment.where(id: comment_id).exists?
+
+      Reaction.create(
+        user_id: user_id,
+        reactable_id: comment_id,
+        reactable_type: "Comment",
+        category: "like",
+      )
+    end
+  end
+end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -249,8 +249,6 @@ RSpec.describe Comment, type: :model do
 
   context "when callbacks are triggered after create" do
     it "enqueue a worker to create the first reaction" do
-      Sidekiq::Testing.fake!
-
       comment = build(:comment, user: user, commentable: article)
 
       expect do

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -247,6 +247,18 @@ RSpec.describe Comment, type: :model do
     end
   end
 
+  context "when callbacks are triggered after create" do
+    it "enqueue a worker to create the first reaction" do
+      Sidekiq::Testing.fake!
+
+      comment = build(:comment, user: user, commentable: article)
+
+      expect do
+        comment.save
+      end.to change(Comments::CreateFirstReactionWorker.jobs, :size).by(1)
+    end
+  end
+
   context "when callbacks are triggered before save" do
     it "generates character count before saving" do
       comment.save

--- a/spec/workers/comments/create_first_reaction_worker_spec.rb
+++ b/spec/workers/comments/create_first_reaction_worker_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe Comments::CreateFirstReactionWorker, type: :worker do
+  include_examples "#enqueues_on_correct_queue", "high_priority", 1
+
+  describe "#perform_now" do
+    let(:worker) { subject }
+
+    context "with comment" do
+      let_it_be(:article) { create(:article) }
+      let_it_be(:comment) { create(:comment, commentable: article) }
+
+      it "creates a first reaction" do
+        expect do
+          worker.perform(comment.id, comment.user_id)
+        end.to change(comment.reactions, :count).by(1)
+      end
+
+      it "creates a like reaction" do
+        worker.perform(comment.id, comment.user_id)
+
+        expect(comment.reactions.last.category).to eq("like")
+      end
+    end
+
+    context "without comment" do
+      it "does not break" do
+        expect { worker.perform(nil, nil) }.not_to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Add a new sidekiq class with migrated code from creating first reaction
job. Add some missing specs on the comment, and refactor existing specs
for the job.

## Related Tickets & Documents

#5305 

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed