### PR TITLE
Rails 5.2 features: enable cache versioning (recyclable keys)

### DIFF
--- a/config/initializers/new_framework_defaults_5_2.rb
+++ b/config/initializers/new_framework_defaults_5_2.rb
@@ -8,7 +8,7 @@
 
 # Make Active Record use stable #cache_key alongside new #cache_version method.
 # This is needed for recyclable cache keys.
-# Rails.application.config.active_record.cache_versioning = true
+Rails.application.config.active_record.cache_versioning = true
 
 # Use AES-256-GCM authenticated encryption for encrypted cookies.
 # Also, embed cookie expiry in signed or encrypted cookies for increased security.


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Among the notable Rails 5.2 features is the ability to recycle cache keys, aka cache versioning. It is supported by all builtin cache stores and now that we've migrated to Redis and are using the builtin `:redis_cache_store` - https://github.com/thepracticaldev/dev.to/blob/ee8fd7cbc22f2edaced8163b4eabb192ebde5849/config/environments/production.rb#L106 - we can effectively enable this feature.

This will get us one step closer to Rails 5.2 defaults and help transitioning to Rails 6

**NOTE: this does NOT generate cache misses, nor it generates new keys, it just helps with a smarter invalidation**

**What does this feature do?**

Adds efficiency to cache invalidation by separating the cache key from the cache version. 

> With the new method of cache versioning, the keys stay consistent, but the cache_version is stored inside the cache entry and manually checked when pulling an entry from the cache

**Are there any issues?**

The issues are related to `:dalli_store` that doesn't support cache versioning, but we've migrated away from that

**Other useful info**

Model objects have a [.cache_key_with_version](https://api.rubyonrails.org/v5.2/classes/ActiveRecord/Integration.html#method-i-cache_key_with_version) method that could be useful when we do low level caching around the code (as an alternative to explicitly join `.updated_at`) which I just found out about, it's already available even with cache versioning disabled.

## Related Tickets & Documents

- [Cache Invalidation Complexity: Rails 5.2 and Dalli Cache Store](https://www.schneems.com/2018/10/17/cache-invalidation-complexity-rails-52-and-dalli-cache-store/) this explains what cache versioning is and how it benefits Rails builtin caching logic

- [Rails 5.2 guides: Low-Level caching](https://guides.rubyonrails.org/v5.2/caching_with_rails.html#low-level-caching) an example on how to use `cache_key_with_version`, see also this example:

```ruby
[1] pry(main)> User.last.cache_key_with_version
=> "users/11-20191231095247258085"
[2] pry(main)> x = "users/11-20191231095247258085"
[3] pry(main)> u = User.last
[4] pry(main)> u.touch
[5] pry(main)> u.reload.cache_key_with_version
=> "users/11-20200102101249941793"
[6] pry(main)> u.reload.cache_key_with_version == x
=> false
```

(note: this is already present, because now the cache key embeds the version, enabling cache versioning is related to how the caching is invalidated, not to the presence or absence of this method)
