### PR TITLE
Create UpdateAnalyticsWorker to replace UpdateAnalyticsJob

### DIFF
--- a/app/controllers/async_info_controller.rb
+++ b/app/controllers/async_info_controller.rb
@@ -89,6 +89,6 @@ class AsyncInfoController < ApplicationController
   private
 
   def occasionally_update_analytics
-    Articles::UpdateAnalyticsJob.perform_later(@user.id) if Rails.env.production? && rand(ApplicationConfig["GA_FETCH_RATE"]) == 1
+    Articles::UpdateAnalyticsWorker.perform_async(@user.id) if Rails.env.production? && rand(ApplicationConfig["GA_FETCH_RATE"]) == 1
   end
 end

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -21,7 +21,7 @@ class DashboardsController < ApplicationController
     @articles = target.articles.includes(:organization).sorting(params[:sort]).decorate
 
     # Updates analytics in background if appropriate
-    Articles::UpdateAnalyticsJob.perform_later(current_user.id) if @articles && ApplicationConfig["GA_FETCH_RATE"] < 50 # Rate limit concerned, sometimes we throttle down.
+    Articles::UpdateAnalyticsWorker.perform_async(current_user.id) if @articles && ApplicationConfig["GA_FETCH_RATE"] < 50 # Rate limit concerned, sometimes we throttle down.
   end
 
   def following_tags

--- a/app/workers/articles/update_analytics_worker.rb
+++ b/app/workers/articles/update_analytics_worker.rb
@@ -1,0 +1,14 @@
+module Articles
+  class UpdateAnalyticsWorker
+    include Sidekiq::Worker
+
+    sidekiq_options queue: :low_priority, retry: 5
+
+    def perform(user_id)
+      user = User.find_by(id: user_id)
+      return unless user
+
+      Articles::AnalyticsUpdater.call(user)
+    end
+  end
+end

--- a/spec/workers/articles/update_analytics_worker_spec.rb
+++ b/spec/workers/articles/update_analytics_worker_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe Articles::UpdateAnalyticsWorker, type: :worker do
+  include_examples "#enqueues_on_correct_queue", "low_priority", 1
+
+  describe "#perform" do
+    let(:worker) { subject }
+
+    before { allow(Articles::AnalyticsUpdater).to receive(:call) }
+
+    context "when user_id a real user" do
+      it "calls the service" do
+        allow(User).to receive(:find_by).and_return(456)
+        worker.perform(456)
+        expect(Articles::AnalyticsUpdater).to have_received(:call).with(456)
+      end
+    end
+
+    context "when user_id not a real user" do
+      it "does not call the service" do
+        allow(User).to receive(:find_by)
+        worker.perform(456)
+        expect(Articles::AnalyticsUpdater).not_to have_received(:call)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature
- [x] Optimization

## Description
Create UpdateAnalyticsWorker to replace UpdateAnalyticsJob. I choose to remove the optional `analytics_updater` argument since we always are using the default. I think if we need more flexibility in the future that is when we should add it. 

## Related Tickets & Documents
#5305 

## Added to documentation?
- [x] no documentation needed

![gotcha gif](https://media.tenor.com/images/961044341e3bf6d800670e0514f3ce0d/tenor.gif)
