### PR TITLE
Handle missing commentable for user_is_commentable_author? check

### DIFF
--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -64,6 +64,6 @@ class CommentPolicy < ApplicationPolicy
   end
 
   def user_is_commentable_author?
-    record.commentable.user_id == user.id
+    record.commentable.present? && record.commentable.user_id == user.id
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Fixes the [error that occurs](https://app.honeybadger.io/projects/66984/faults/59014101) when commentable no longer exists for a comment. 
```
Honeybadger Style Backtrace
Rails Style Backtrace
NoMethodError: undefined method `user_id' for nil:NilClass
comment_policy.rb  67 user_is_commentable_author?(...)
[PROJECT_ROOT]/app/policies/comment_policy.rb:67:in `user_is_commentable_author?'
65 
66   def user_is_commentable_author?
67     record.commentable.user_id == user.id
68   end
69 end
```
## Added to documentation?
- [x] no documentation needed

![alt_text](https://media.giphy.com/media/d4eIPsWSWHLpK/giphy.gif)
