### PR TITLE
Correctly Define InvalidAuthenticityToken error in helper module

### DIFF
--- a/app/controllers/concerns/valid_request.rb
+++ b/app/controllers/concerns/valid_request.rb
@@ -12,7 +12,7 @@ module ValidRequest
     if request.referer.present?
       request.referer.start_with?(ApplicationConfig["APP_PROTOCOL"].to_s + ApplicationConfig["APP_DOMAIN"].to_s)
     else
-      raise InvalidAuthenticityToken, NULL_ORIGIN_MESSAGE if request.origin == "null"
+      raise ::ActionController::InvalidAuthenticityToken, NULL_ORIGIN_MESSAGE if request.origin == "null"
 
       request.origin.nil? || request.origin.gsub("https", "http") == request.base_url.gsub("https", "http")
     end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This error is getting incorrectly scoped to this module which then means we see an [uninitialized constant error](https://app.honeybadger.io/projects/66984/faults/58946304). I looked up the full path for the error and then made sure to add the leading `::` to make sure it wasn't scoped to the module. 
```
NameError: uninitialized constant ValidRequest::InvalidAuthenticityToken
valid_request.rb  15 valid_request_origin?(...)
[PROJECT_ROOT]/app/controllers/concerns/valid_request.rb:15:in `valid_request_origin?'
13       request.referer.start_with?(ApplicationConfig["APP_PROTOCOL"].to_s + ApplicationConfig["APP_DOMAIN"].to_s)
14     else
15       raise InvalidAuthenticityToken, NULL_ORIGIN_MESSAGE if request.origin == "null"
16 
17       request.origin.nil? || request.origin.gsub("https", "http") == request.base_url.gsub("https", "http")
```
## Added to documentation?
- [x] no documentation needed

![alt_text](https://media3.giphy.com/media/QP77kEChx16M0x5lv6/giphy.gif)
