### PR TITLE
Change from after_create to after_create_commit

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -27,7 +27,7 @@ class Comment < ApplicationRecord
   after_destroy  :after_destroy_actions
   before_destroy :before_destroy_actions
   after_create   :send_email_notification, if: :should_send_email_notification?
-  after_create   :create_first_reaction
+  after_create_commit :create_first_reaction
   after_create   :send_to_moderator
   before_save    :set_markdown_character_count, if: :body_markdown
   before_create  :adjust_comment_parent_based_on_depth


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Running this code on `after_create` creates a situation where the `where` clause in the sidekiq worker cannot yet find the data because the record can’t be seen by other database connections, like the one Sidekiq is using, until the database transaction is committed, which happens a little later.

Basically `after_create` runs before the transaction is actually final and this creates a little race condition.

More info here: https://www.justinweiss.com/articles/a-couple-callback-gotchas-and-a-rails-5-fix/

I think this wasn't a problem for Delayed Job because it always happened after at least one other DB transaction to create the job in the first place.