### PR TITLE
Change the way that id_code was created 

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -247,7 +247,7 @@ class Comment < ApplicationRecord
   end
 
   def create_id_code
-    Comments::CreateIdCodeJob.perform_later(id)
+    update_column(:id_code, id.to_s(26))
   end
 
   def touch_user

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -248,6 +248,14 @@ RSpec.describe Comment, type: :model do
   end
 
   context "when callbacks are triggered after create" do
+    it "creates an id code" do
+      comment = build(:comment, user: user, commentable: article)
+
+      comment.save
+
+      expect(comment.reload.id_code).to eq(comment.id.to_s(26))
+    end
+
     it "enqueue a worker to create the first reaction" do
       comment = build(:comment, user: user, commentable: article)
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The column id_code was created with a job in an after create a callback,
that was replaced by an inline creation of the attribute

## Related Tickets & Documents

#5305 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
