### PR TITLE
Ignore dynotype run since that is used for console access

### DIFF
--- a/datadog/prerun.sh
+++ b/datadog/prerun.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 # Disable the Datadog Agent for scheduler workers
-if [ "$DYNOTYPE" == "scheduler" ]; then
+if [ "$DYNOTYPE" == "scheduler" ] || [ "$DYNOTYPE" == "run" ]; then
   DISABLE_DATADOG_AGENT="true"
 fi


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
We don't really need to be tracking stats for the console boxes we are using in datadog. This will ignore them.

## Related Tickets & Documents
#4925 

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media0.giphy.com/media/SjNA96lBQT8YM/giphy.gif)
