### PR TITLE
Limit ALL Upload file sizes to 25 MB

### DIFF
--- a/app/uploaders/base_uploader.rb
+++ b/app/uploaders/base_uploader.rb
@@ -13,6 +13,10 @@ class BaseUploader < CarrierWave::Uploader::Base
     %w[jpg jpeg jpe gif png ico bmp dng]
   end
 
+  def size_range
+    1..10.megabytes
+  end
+
   protected
 
   # strip EXIF (and GPS) data

--- a/app/uploaders/base_uploader.rb
+++ b/app/uploaders/base_uploader.rb
@@ -14,7 +14,7 @@ class BaseUploader < CarrierWave::Uploader::Base
   end
 
   def size_range
-    1..10.megabytes
+    1..25.megabytes
   end
 
   protected


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
Currently, we only limit the file size for ProfileImage uploads. It would probably be a good idea to limit the size for all uploads. I set it to 10 MB but am open to other suggestions! 

## Added to documentation?
- [x] no documentation needed

![alt_text](https://img.gifglobe.com/grabs/blackbooks/S01E01/gif/tc0Wg0d1V2GK.gif)
