### PR TITLE
use new_badge_achievement_worker instead of active job

### DIFF
--- a/app/models/badge_achievement.rb
+++ b/app/models/badge_achievement.rb
@@ -7,7 +7,7 @@ class BadgeAchievement < ApplicationRecord
 
   validates :badge_id, uniqueness: { scope: :user_id }
 
-  after_create :notify_recipient
+  after_commit :notify_recipient
   after_create :send_email_notification
   after_create :award_credits
   before_validation :render_rewarding_context_message_html

--- a/app/models/badge_achievement.rb
+++ b/app/models/badge_achievement.rb
@@ -7,7 +7,7 @@ class BadgeAchievement < ApplicationRecord
 
   validates :badge_id, uniqueness: { scope: :user_id }
 
-  after_commit :notify_recipient
+  after_create_commit :notify_recipient
   after_create :send_email_notification
   after_create :award_credits
   before_validation :render_rewarding_context_message_html

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -62,12 +62,8 @@ class Notification < ApplicationRecord
     end
 
     def send_new_badge_achievement_notification(badge_achievement)
-      Notifications::NewBadgeAchievementJob.perform_later(badge_achievement.id)
+      Notifications::NewBadgeAchievementWorker.perform_async(badge_achievement.id)
     end
-    # NOTE: this alias is temporary until the transition to ActiveJob is completed
-    # and all old DelayedJob jobs are processed by the queue workers.
-    # It can be removed after pre-existing jobs are done
-    alias send_new_badge_notification send_new_badge_achievement_notification
 
     def send_reaction_notification(reaction, receiver)
       return if reaction.skip_notification_for?(receiver)

--- a/app/workers/notifications/new_badge_achievement_worker.rb
+++ b/app/workers/notifications/new_badge_achievement_worker.rb
@@ -1,0 +1,11 @@
+module Notifications
+  class NewBadgeAchievementWorker
+    include Sidekiq::Worker
+    sidekiq_options queue: :low_priority, retry: 10
+
+    def perform(badge_achievement_id)
+      badge_achievement = BadgeAchievement.find_by(id: badge_achievement_id)
+      Notifications::NewBadgeAchievement::Send.call(badge_achievement) if badge_achievement
+    end
+  end
+end

--- a/spec/models/badge_achievement_spec.rb
+++ b/spec/models/badge_achievement_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe BadgeAchievement, type: :model do
 
   it "notifies recipients after commit" do
     allow(Notification).to receive(:send_new_badge_achievement_notification)
-    achievement.save!
+    achievement.run_callbacks(:commit)
     expect(Notification).to have_received(:send_new_badge_achievement_notification).with(achievement)
   end
 end

--- a/spec/models/badge_achievement_spec.rb
+++ b/spec/models/badge_achievement_spec.rb
@@ -17,4 +17,10 @@ RSpec.describe BadgeAchievement, type: :model do
   it "awards credits after create" do
     expect(achievement.user.credits.size).to eq(5)
   end
+
+  it "notifies recipients after commit" do
+    allow(Notification).to receive(:send_new_badge_achievement_notification)
+    achievement.save!
+    expect(Notification).to have_received(:send_new_badge_achievement_notification).with(achievement)
+  end
 end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -491,16 +491,8 @@ RSpec.describe Notification, type: :model do
 
   describe "#send_new_badge_achievement_notification" do
     it "enqueues a new badge achievement job" do
-      assert_enqueued_with(job: Notifications::NewBadgeAchievementJob, args: [badge_achievement.id]) do
+      sidekiq_assert_enqueued_with(job: Notifications::NewBadgeAchievementWorker, args: [badge_achievement.id]) do
         described_class.send_new_badge_achievement_notification(badge_achievement)
-      end
-    end
-  end
-
-  describe "#send_new_badge_notification (deprecated)" do
-    it "enqueues a new badge achievement job" do
-      assert_enqueued_with(job: Notifications::NewBadgeAchievementJob, args: [badge_achievement.id]) do
-        described_class.send_new_badge_notification(badge_achievement)
       end
     end
   end

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -309,7 +309,7 @@ RSpec.describe "NotificationsIndex", type: :request do
         sign_in user
         badge = create(:badge)
         badge_achievement = create(:badge_achievement, user: user, badge: badge)
-        perform_enqueued_jobs do
+        sidekiq_perform_enqueued_jobs do
           Notification.send_new_badge_achievement_notification(badge_achievement)
         end
         get "/notifications"

--- a/spec/system/internal/admin_awards_badges_spec.rb
+++ b/spec/system/internal/admin_awards_badges_spec.rb
@@ -40,9 +40,10 @@ RSpec.describe "Admin awards badges", type: :system do
   end
 
   it "notifies users of new badges" do
-    expect { award_two_badges }.to enqueue_job(Notifications::NewBadgeAchievementJob).
-      exactly(2).times.
-      and enqueue_job(BadgeAchievements::SendEmailNotificationJob).
-      exactly(2).times
+    assert_enqueued_jobs(2, only: BadgeAchievements::SendEmailNotificationJob) do
+      sidekiq_assert_enqueued_jobs(2) do
+        award_two_badges
+      end
+    end
   end
 end

--- a/spec/workers/notifications/new_badge_achievement_worker_spec.rb
+++ b/spec/workers/notifications/new_badge_achievement_worker_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+RSpec.describe Notifications::NewBadgeAchievementWorker, type: :worker do
+  describe "#perform" do
+    let(:badge_achievement) { create(:badge_achievement) }
+    let(:service) { Notifications::NewBadgeAchievement::Send }
+    let(:worker) { subject }
+
+    before do
+      allow(service).to receive(:call)
+    end
+
+    it "calls a service" do
+      worker.perform(badge_achievement.id)
+      expect(service).to have_received(:call).with(badge_achievement).once
+    end
+
+    it "does nothing for non-existent badge achievement" do
+      worker.perform(nil)
+      expect(service).not_to have_received(:call)
+    end
+  end
+end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [x] Refactor

## Description
Next on the list is moving the NewBadgeAchievementJob to a worker. Closely followed a previous PR here, see https://github.com/thepracticaldev/dev.to/pull/5312

I have a problem with the specs, as in my environment the spec file that fails, passes 😅 Might be some flakiness in the system?
## Related Tickets & Documents

https://github.com/thepracticaldev/dev.to/issues/5305