### PR TITLE
Reading list count becomes "empty" when selecting a tag

### DIFF
--- a/app/javascript/searchableItemList/searchableItemList.js
+++ b/app/javascript/searchableItemList/searchableItemList.js
@@ -102,12 +102,13 @@ export function search(query, { page, tags, statusView }) {
   }
   index.search(query, filters).then(result => {
     // append new items at the end
-    const allItems = page === undefined ? result.hits : [...items, ...result.hits];
+    const allItems =
+      page === undefined ? result.hits : [...items, ...result.hits];
     component.setState({
       query,
       page: newPage,
       items: result.hits,
-      totalCount: allItems,
+      totalCount: allItems.length,
       // show the button if the number of items is lower than the number
       // of available results
       showLoadMoreButton: allItems.length < result.nbHits,


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Fixes #5272 

From the issue: "This is probably a regression because I know it used to work, but apparently the count of articles in the reading list takes the value empty when selecting a tag. The same happens when unselecting the tag or going to the archive. The only way to restore the count is to do a full refresh of the page"

## Related Tickets & Documents
#5272 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
N/A

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![Kid sitting at computer gives a thumbs up](https://media.giphy.com/media/XreQmk7ETCak0/giphy.gif)
