### PR TITLE
Scope error message correctly for InvalidAuthenticityToken error

### DIFF
--- a/app/controllers/concerns/valid_request.rb
+++ b/app/controllers/concerns/valid_request.rb
@@ -12,7 +12,7 @@ module ValidRequest
     if request.referer.present?
       request.referer.start_with?(ApplicationConfig["APP_PROTOCOL"].to_s + ApplicationConfig["APP_DOMAIN"].to_s)
     else
-      raise ::ActionController::InvalidAuthenticityToken, NULL_ORIGIN_MESSAGE if request.origin == "null"
+      raise ::ActionController::InvalidAuthenticityToken, ::ApplicationController::NULL_ORIGIN_MESSAGE if request.origin == "null"
 
       request.origin.nil? || request.origin.gsub("https", "http") == request.base_url.gsub("https", "http")
     end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
After fixing the error scoping [another error came through](https://app.honeybadger.io/projects/66984/faults/59174341) involving the error message.
```
NameError: uninitialized constant ValidRequest::NULL_ORIGIN_MESSAGE
valid_request.rb  15 valid_request_origin?(...)
[PROJECT_ROOT]/app/controllers/concerns/valid_request.rb:15:in `valid_request_origin?'
13       request.referer.start_with?(ApplicationConfig["APP_PROTOCOL"].to_s + ApplicationConfig["APP_DOMAIN"].to_s)
14     else
15       raise ::ActionController::InvalidAuthenticityToken, NULL_ORIGIN_MESSAGE if request.origin == "null"
16 
17       request.origin.nil? || request.origin.gsub("https", "http") == request.base_url.gsub("https", "http")
```
Tested this fix in a console
```
[7] pry(main)> ApplicationController::NULL_ORIGIN_MESSAGE
=> "The browser returned a 'null' origin for a request with origin-based forgery protection turned on. This usually\nmeans you have the 'no-referrer' Referrer-Policy header enabled, or that the request came from a site that\nrefused to give its origin. This makes it impossible for Rails to verify the source of the requests. Likely the\nbest solution is to change your referrer policy to something less strict like same-origin or strict-same-origin.\nIf you cannot change the referrer policy, you can disable origin checking with the\nRails.application.config.action_controller.forgery_protection_origin_check setting.\n"
```
## Added to documentation?
- [x] no documentation needed
