### PR TITLE
Handle Missing article_id When Loading additional_content_boxes

### DIFF
--- a/app/controllers/additional_content_boxes_controller.rb
+++ b/app/controllers/additional_content_boxes_controller.rb
@@ -4,6 +4,11 @@ class AdditionalContentBoxesController < ApplicationController
   before_action :set_cache_control_headers, only: [:index]
 
   def index
+    if params[:article_id].blank?
+      render json: { error: "Article ID missing", status: 422 }, status: :unprocessable_entity
+      return
+    end
+
     article_ids = params[:article_id].split(",")
     @article = Article.find(article_ids[0])
     @suggested_articles = Suggester::Articles::Classic.

--- a/app/controllers/additional_content_boxes_controller.rb
+++ b/app/controllers/additional_content_boxes_controller.rb
@@ -4,10 +4,7 @@ class AdditionalContentBoxesController < ApplicationController
   before_action :set_cache_control_headers, only: [:index]
 
   def index
-    if params[:article_id].blank?
-      render json: { error: "Article ID missing", status: 422 }, status: :unprocessable_entity
-      return
-    end
+    return head :unprocessable_entity if params[:article_id].blank?
 
     article_ids = params[:article_id].split(",")
     @article = Article.find(article_ids[0])

--- a/spec/requests/additional_content_boxes_spec.rb
+++ b/spec/requests/additional_content_boxes_spec.rb
@@ -31,5 +31,10 @@ RSpec.describe "AdditionalContentBoxes", type: :request do
       get "/additional_content_boxes?article_id=#{regular_article.id}&state=include_sponsors"
       expect(response.body).to include CGI.escapeHTML(boosted_sugg.title)
     end
+
+    it "returns 422 status if article_id is missing" do
+      get "/additional_content_boxes"
+      expect(response.status).to eq(422)
+    end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This PR solves [this error](https://app.honeybadger.io/projects/66984/faults/59183991) that occurs when an article_id is missing:
```
NoMethodError: undefined method `split' for nil:NilClass
additional_content_boxes_controller.rb  7 index(...)
[PROJECT_ROOT]/app/controllers/additional_content_boxes_controller.rb:7:in `index'
5 
6   def index
7     article_ids = params[:article_id].split(",")
8     @article = Article.find(article_ids[0])
9     @suggested_articles = Suggester::Articles::Classic.
```
If we don't return a 200 then [we wont render the additional content boxes](https://github.com/thepracticaldev/dev.to/blob/master/app/assets/javascripts/initializers/initializeAdditionalContentBoxes.js#L30)

This seemed like a straightforward fix but let me know if I missed anything. There might be more at play here than I am realizing

## Added to documentation?
- [x] no documentation needed
