### PR TITLE
Record db table sizes in Datadog 

### DIFF
--- a/lib/tasks/fetch.rake
+++ b/lib/tasks/fetch.rake
@@ -123,5 +123,8 @@ task record_db_table_counts: :environment do
         table_size: estimate,
       }
     )
+    DataDogStatsClient.gauge(
+      "postgres.db_table_size", estimate, tags: { table_name: table_name }
+    )
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
I was going to remove the `Rails.logger` statement but decided not to bc it might be nice for those who want to get a community up and running but don't have Datadog right away. 

In Datadog we can use these stats to add to a public dashboard to show growth or we can use them to create alerts for ourselves.

## Related Tickets & Documents
#4925 

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media1.tenor.com/images/2ff92b094884163907368b24f25f28d6/tenor.gif?itemid=14555474)
