### PR TITLE
Migrate delayed job that calculates comment score to sidekiq

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -21,7 +21,7 @@ class Comment < ApplicationRecord
   validates :user_id, presence: true
 
   after_create   :after_create_checks
-  after_save     :calculate_score
+  after_commit   :calculate_score
   after_save     :bust_cache
   after_save     :synchronous_bust
   after_destroy  :after_destroy_actions
@@ -238,7 +238,7 @@ class Comment < ApplicationRecord
   end
 
   def calculate_score
-    Comments::CalculateScoreJob.perform_later(id)
+    Comments::CalculateScoreWorker.perform_async(id)
   end
 
   def after_create_checks

--- a/app/workers/comments/calculate_score_worker.rb
+++ b/app/workers/comments/calculate_score_worker.rb
@@ -12,7 +12,7 @@ module Comments
       spaminess_rating = BlackBox.calculate_spaminess(comment)
 
       comment.update_columns(score: score, spaminess_rating: spaminess_rating)
-      comment.root.save unless comment.is_root?
+      comment.root.save! unless comment.is_root?
     end
   end
 end

--- a/app/workers/comments/calculate_score_worker.rb
+++ b/app/workers/comments/calculate_score_worker.rb
@@ -1,0 +1,18 @@
+module Comments
+  class CalculateScoreWorker
+    include Sidekiq::Worker
+
+    sidekiq_options queue: :medium_priority
+
+    def perform(comment_id)
+      comment = Comment.find_by(id: comment_id)
+      return unless comment
+
+      score = BlackBox.comment_quality_score(comment)
+      spaminess_rating = BlackBox.calculate_spaminess(comment)
+
+      comment.update_columns(score: score, spaminess_rating: spaminess_rating)
+      comment.root.save unless comment.is_root?
+    end
+  end
+end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -256,6 +256,14 @@ RSpec.describe Comment, type: :model do
       end.to change(Comments::CreateFirstReactionWorker.jobs, :size).by(1)
     end
 
+    it "enqueues a worker to calculate comment score" do
+      comment = build(:comment, user: user, commentable: article)
+
+      expect do
+        comment.save
+      end.to change(Comments::CalculateScoreWorker.jobs, :size).by(1)
+    end
+
     it "touches user updated_at" do
       user.updated_at = 1.month.ago
       user.save

--- a/spec/workers/comments/calculate_score_worker_spec.rb
+++ b/spec/workers/comments/calculate_score_worker_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+RSpec.describe Comments::CalculateScoreWorker, type: :worker do
+  include_examples "#enqueues_on_correct_queue", "medium_priority", 1
+
+  describe "#perform" do
+    let(:worker) { subject }
+
+    context "with comment" do
+      let_it_be(:article) { create(:article) }
+      let_it_be(:comment) { create(:comment, commentable: article) }
+
+      before do
+        allow(BlackBox).to receive(:comment_quality_score).and_return(7)
+        allow(BlackBox).to receive(:calculate_spaminess).and_return(99)
+      end
+
+      it "updates score and spaminess_rating", :aggregate_failures do
+        worker.perform(comment.id)
+
+        comment.reload
+        expect(comment.score).to be(7)
+        expect(comment.spaminess_rating).to be(99)
+      end
+
+      it "calls save on the root comment when given a descendant comment" do
+        child_comment = double
+        root_comment = double
+
+        allow(root_comment).to receive(:save)
+        allow(child_comment).to receive(:update_columns)
+        allow(child_comment).to receive(:is_root?).and_return(false)
+        allow(child_comment).to receive(:root).and_return(root_comment)
+        allow(Comment).to receive(:find_by).with(id: 1).and_return(child_comment)
+
+        worker.perform(1)
+
+        expect(child_comment).to have_received(:is_root?)
+        expect(child_comment).to have_received(:root)
+        expect(root_comment).to have_received(:save)
+      end
+
+      it "does not call save on the root comment" do
+        root_comment = double
+
+        allow(root_comment).to receive(:save)
+        allow(root_comment).to receive(:update_columns)
+        allow(root_comment).to receive(:is_root?).and_return(true)
+        allow(root_comment).to receive(:root).and_return(root_comment)
+        allow(Comment).to receive(:find_by).with(id: 1).and_return(root_comment)
+
+        worker.perform(1)
+
+        expect(root_comment).to have_received(:is_root?)
+        expect(root_comment).not_to have_received(:root)
+        expect(root_comment).not_to have_received(:save)
+      end
+    end
+
+    context "without comment" do
+      it "does not break" do
+        expect { worker.perform(nil) }.not_to raise_error
+      end
+    end
+  end
+end

--- a/spec/workers/comments/calculate_score_worker_spec.rb
+++ b/spec/workers/comments/calculate_score_worker_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Comments::CalculateScoreWorker, type: :worker do
         child_comment = double
         root_comment = double
 
-        allow(root_comment).to receive(:save)
+        allow(root_comment).to receive(:save!)
         allow(child_comment).to receive(:update_columns)
         allow(child_comment).to receive(:is_root?).and_return(false)
         allow(child_comment).to receive(:root).and_return(root_comment)
@@ -37,7 +37,7 @@ RSpec.describe Comments::CalculateScoreWorker, type: :worker do
 
         expect(child_comment).to have_received(:is_root?)
         expect(child_comment).to have_received(:root)
-        expect(root_comment).to have_received(:save)
+        expect(root_comment).to have_received(:save!)
       end
 
       it "does not call save on the root comment" do


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

This creates a sidekiq version of the delayed job that calculates comment score and spaminess rating. The delayed job version will be removed and it's associated reference will be updated in a follow up PR.

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/issues/5305

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

P.S: My first PR for an open source project! =) 

![giphy (1)](https://user-images.githubusercontent.com/2251508/71855922-60861a00-30b0-11ea-98a0-66c79ed03346.gif)

