### PR TITLE
Move from env variables to SiteConfig

### DIFF
--- a/Envfile
+++ b/Envfile
@@ -11,19 +11,6 @@ enable_defaults! { ENV["RACK_ENV"] != "production" }
 variable :APP_DOMAIN, :String, default: "localhost:3000"
 variable :APP_PROTOCOL, :String, default: "http://"
 variable :COMMUNITY_NAME, :String, default: "DEV(local)"
-variable :MAIN_SOCIAL_IMAGE, :String, default: "https://thepracticaldev.s3.amazonaws.com/i/6hqmcjaxbgbon8ydw93z.png"
-variable :SITE_TWITTER_HANDLE, :String, default: "tbd"
-variable :RATE_LIMIT_FOLLOW_COUNT_DAILY, :Integer, default: 500
-variable :FAVICON_URL, :String, default: "favicon.ico"
-
-# Logo
-variable :LOGO_SVG, :String, default: ""
-
-# Default staff account's id
-variable :DEVTO_USER_ID, :Integer, default: 1
-
-# Default site email
-variable :DEFAULT_SITE_EMAIL, :String, default: "yo@dev.to"
 
 # Service timeout length
 variable :RACK_TIMEOUT_WAIT_TIMEOUT, :Integer, default: 100_000
@@ -134,20 +121,10 @@ variable :HONEYCOMB_API_KEY, :String, default: ""
 variable :GA_SERVICE_ACCOUNT_JSON, :String, default: "Optional"
 variable :GA_TRACKING_ID, :String, default: "Optional"
 variable :GA_OPTIMIZE_ID, :String, default: "Optional"
-variable :GA_VIEW_ID, :String, default: "Optional"
-variable :GA_FETCH_RATE, :Integer, default: 25
 
 # Mailchimp for mails
 # (https://mailchimp.com/developer/)
 variable :MAILCHIMP_API_KEY, :String, default: "Optional-valid"
-variable :MAILCHIMP_NEWSLETTER_ID, :String, default: "Optional"
-variable :MAILCHIMP_SUSTAINING_MEMBERS_ID, :String, default: "Optional"
-variable :MAILCHIMP_TAG_MODERATORS_ID, :String, default: "Optional"
-variable :MAILCHIMP_COMMUNITY_MODERATORS_ID, :String, default: "Optional"
-
-# Email digest frequency
-variable :PERIODIC_EMAIL_DIGEST_MAX, :Integer, default: 0
-variable :PERIODIC_EMAIL_DIGEST_MIN, :Integer, default: 2
 
 # Pusher for DEV Connect/notfications
 # (https://pusher.com/docs)

--- a/Envfile
+++ b/Envfile
@@ -11,6 +11,19 @@ enable_defaults! { ENV["RACK_ENV"] != "production" }
 variable :APP_DOMAIN, :String, default: "localhost:3000"
 variable :APP_PROTOCOL, :String, default: "http://"
 variable :COMMUNITY_NAME, :String, default: "DEV(local)"
+variable :MAIN_SOCIAL_IMAGE, :String, default: "https://thepracticaldev.s3.amazonaws.com/i/6hqmcjaxbgbon8ydw93z.png"
+variable :SITE_TWITTER_HANDLE, :String, default: "tbd"
+variable :RATE_LIMIT_FOLLOW_COUNT_DAILY, :Integer, default: 500
+variable :FAVICON_URL, :String, default: "favicon.ico"
+
+# Logo
+variable :LOGO_SVG, :String, default: ""
+
+# Default staff account's id
+variable :DEVTO_USER_ID, :Integer, default: 1
+
+# Default site email
+variable :DEFAULT_SITE_EMAIL, :String, default: "yo@dev.to"
 
 # Service timeout length
 variable :RACK_TIMEOUT_WAIT_TIMEOUT, :Integer, default: 100_000
@@ -121,10 +134,20 @@ variable :HONEYCOMB_API_KEY, :String, default: ""
 variable :GA_SERVICE_ACCOUNT_JSON, :String, default: "Optional"
 variable :GA_TRACKING_ID, :String, default: "Optional"
 variable :GA_OPTIMIZE_ID, :String, default: "Optional"
+variable :GA_VIEW_ID, :String, default: "Optional"
+variable :GA_FETCH_RATE, :Integer, default: 25
 
 # Mailchimp for mails
 # (https://mailchimp.com/developer/)
 variable :MAILCHIMP_API_KEY, :String, default: "Optional-valid"
+variable :MAILCHIMP_NEWSLETTER_ID, :String, default: "Optional"
+variable :MAILCHIMP_SUSTAINING_MEMBERS_ID, :String, default: "Optional"
+variable :MAILCHIMP_TAG_MODERATORS_ID, :String, default: "Optional"
+variable :MAILCHIMP_COMMUNITY_MODERATORS_ID, :String, default: "Optional"
+
+# Email digest frequency
+variable :PERIODIC_EMAIL_DIGEST_MAX, :Integer, default: 0
+variable :PERIODIC_EMAIL_DIGEST_MIN, :Integer, default: 2
 
 # Pusher for DEV Connect/notfications
 # (https://pusher.com/docs)

--- a/app/black_box/google_analytics.rb
+++ b/app/black_box/google_analytics.rb
@@ -56,7 +56,7 @@ class GoogleAnalytics
 
   def make_report_request(filters_expression_string, metrics_string)
     ReportRequest.new(
-      view_id: ApplicationConfig["GA_VIEW_ID"],
+      view_id: SiteConfig.ga_view_id,
       filters_expression: filters_expression_string,
       metrics: [Metric.new(expression: metrics_string)],
       dimensions: [Dimension.new(name: "ga:segment")],

--- a/app/controllers/api_secrets_controller.rb
+++ b/app/controllers/api_secrets_controller.rb
@@ -23,7 +23,7 @@ class ApiSecretsController < ApplicationController
     if @secret.destroy
       flash[:notice] = "Your API Key has been revoked."
     else
-      flash[:error] = "An error occurred. Please try again or send an email to: #{ApplicationConfig['DEFAULT_SITE_EMAIL']}"
+      flash[:error] = "An error occurred. Please try again or send an email to: #{SiteConfig.default_site_email}"
     end
 
     redirect_back(fallback_location: root_path)

--- a/app/controllers/async_info_controller.rb
+++ b/app/controllers/async_info_controller.rb
@@ -89,6 +89,8 @@ class AsyncInfoController < ApplicationController
   private
 
   def occasionally_update_analytics
-    Articles::UpdateAnalyticsWorker.perform_async(@user.id) if Rails.env.production? && rand(ApplicationConfig["GA_FETCH_RATE"]) == 1
+    return unless Rails.env.production? && rand(SiteConfig.ga_fetch_rate) == 1
+
+    Articles::UpdateAnalyticsWorker.perform_async(@user.id)
   end
 end

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -21,7 +21,7 @@ class DashboardsController < ApplicationController
     @articles = target.articles.includes(:organization).sorting(params[:sort]).decorate
 
     # Updates analytics in background if appropriate
-    Articles::UpdateAnalyticsWorker.perform_async(current_user.id) if @articles && ApplicationConfig["GA_FETCH_RATE"] < 50 # Rate limit concerned, sometimes we throttle down.
+    Articles::UpdateAnalyticsWorker.perform_async(current_user.id) if @articles && SiteConfig.ga_fetch_rate < 50 # Rate limit concerned, sometimes we throttle down.
   end
 
   def following_tags

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -99,7 +99,7 @@ class PagesController < ApplicationController
 
   def latest_published_thread(tag_name)
     Article.published.
-      where(user_id: ApplicationConfig["DEVTO_USER_ID"]).
+      where(user_id: SiteConfig.staff_user_id).
       order("published_at ASC").
       tagged_with(tag_name).last
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -98,7 +98,7 @@ class UsersController < ApplicationController
 
       flash[:settings_notice] = "Your #{provider.capitalize} account was successfully removed."
     else
-      flash[:error] = "An error occurred. Please try again or send an email to: #{ApplicationConfig['DEFAULT_SITE_EMAIL']}"
+      flash[:error] = "An error occurred. Please try again or send an email to: #{SiteConfig.default_site_email}"
     end
     redirect_to "/settings/#{@tab}"
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -137,8 +137,8 @@ module ApplicationHelper
   end
 
   def logo_svg
-    if ApplicationConfig["LOGO_SVG"].present?
-      ApplicationConfig["LOGO_SVG"].html_safe
+    if SiteConfig.logo_svg.present?
+      SiteConfig.logo_svg.html_safe
     else
       inline_svg_tag("devplain.svg", class: "logo", size: "20% * 20%", aria: true, title: "App logo")
     end

--- a/app/labor/email_logic.rb
+++ b/app/labor/email_logic.rb
@@ -52,8 +52,8 @@ class EmailLogic
 
   def get_days_until_next_email
     # Relies on hyperbolic tangent function to model the frequency of the digest email
-    max_day = ApplicationConfig["PERIODIC_EMAIL_DIGEST_MAX"].to_i
-    min_day = ApplicationConfig["PERIODIC_EMAIL_DIGEST_MIN"].to_i
+    max_day = SiteConfig.periodic_email_digest_max
+    min_day = SiteConfig.periodic_email_digest_min
     result = max_day * (1 - Math.tanh(2 * @open_percentage))
     result = result.round
     result < min_day ? min_day : result

--- a/app/labor/error_message_cleaner.rb
+++ b/app/labor/error_message_cleaner.rb
@@ -7,7 +7,7 @@ class ErrorMessageCleaner
 
   def clean
     if error_message.include? "expected key while parsing a block mapping at line"
-      "There was a problem parsing the front-matter YAML. Perhaps you need to escape a quote or a colon or something. Email #{ApplicationConfig['DEFAULT_SITE_EMAIL']} if you are having trouble."
+      "There was a problem parsing the front-matter YAML. Perhaps you need to escape a quote or a colon or something. Email #{SiteConfig.default_site_email} if you are having trouble."
     else
       error_message
     end

--- a/app/labor/mailchimp_bot.rb
+++ b/app/labor/mailchimp_bot.rb
@@ -19,7 +19,7 @@ class MailchimpBot
     # attempt to update email if user changed email addresses
     success = false
     begin
-      gibbon.lists(ApplicationConfig["MAILCHIMP_NEWSLETTER_ID"]).members(target_md5_email).upsert(
+      gibbon.lists(SiteConfig.mailchimp_newsletter_id).members(target_md5_email).upsert(
         body: {
           email_address: user.email,
           status: user.email_newsletter ? "subscribed" : "unsubscribed",
@@ -52,7 +52,7 @@ class MailchimpBot
     success = false
     status = user.email_community_mod_newsletter ? "subscribed" : "unsubscribed"
     begin
-      gibbon.lists(ApplicationConfig["MAILCHIMP_COMMUNITY_MODERATORS_ID"]).members(target_md5_email).upsert(
+      gibbon.lists(SiteConfig.mailchimp_community_moderators_id).members(target_md5_email).upsert(
         body: {
           email_address: user.email,
           status: status,
@@ -79,7 +79,7 @@ class MailchimpBot
     tags = user.roles.where(name: "tag_moderator").map { |tag| Tag.find(tag.resource_id).name }
     status = user.email_tag_mod_newsletter ? "subscribed" : "unsubscribed"
     begin
-      gibbon.lists(ApplicationConfig["MAILCHIMP_TAG_MODERATORS_ID"]).members(target_md5_email).upsert(
+      gibbon.lists(SiteConfig.mailchimp_tag_moderators_id).members(target_md5_email).upsert(
         body: {
           email_address: user.email,
           status: status,
@@ -103,7 +103,7 @@ class MailchimpBot
   def unsub_sustaining_member
     return unless user.tag_moderator?
 
-    gibbon.lists(ApplicationConfig["MAILCHIMP_TAG_MODERATORS_ID"]).members(target_md5_email).update(
+    gibbon.lists(SiteConfig.mailchimp_tag_moderators_id).members(target_md5_email).update(
       body: {
         status: "unsubscribed"
       },
@@ -113,7 +113,7 @@ class MailchimpBot
   def unsub_community_mod
     return unless user.has_role?(:trusted)
 
-    gibbon.lists(ApplicationConfig["MAILCHIMP_COMMUNITY_MODERATORS_ID"]).members(target_md5_email).update(
+    gibbon.lists(SiteConfig.mailchimp_community_moderators_id).members(target_md5_email).update(
       body: {
         status: "unsubscribed"
       },
@@ -123,7 +123,7 @@ class MailchimpBot
   def unsub_tag_mod
     return unless a_sustaining_member?
 
-    gibbon.lists(ApplicationConfig["MAILCHIMP_SUSTAINING_MEMBERS_ID"]).members(target_md5_email).update(
+    gibbon.lists(SiteConfig.mailchimp_sustaining_members_id).members(target_md5_email).update(
       body: {
         status: "unsubscribed"
       },
@@ -133,7 +133,7 @@ class MailchimpBot
   def unsubscribe_all_newsletters
     success = false
     begin
-      gibbon.lists(ApplicationConfig["MAILCHIMP_NEWSLETTER_ID"]).members(target_md5_email).update(
+      gibbon.lists(SiteConfig.mailchimp_newsletter_id).members(target_md5_email).update(
         body: {
           status: "unsubscribed"
         },

--- a/app/labor/rate_limit_checker.rb
+++ b/app/labor/rate_limit_checker.rb
@@ -2,7 +2,7 @@ class RateLimitChecker
   attr_reader :user, :action
 
   def self.daily_account_follow_limit
-    ApplicationConfig["RATE_LIMIT_FOLLOW_COUNT_DAILY"]
+    SiteConfig.rate_limit_follow_count_daily
   end
 
   def initialize(user = nil)

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,5 +1,5 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "DEV Community <#{ApplicationConfig['DEFAULT_SITE_EMAIL']}>"
+  default from: "DEV Community <#{SiteConfig.default_site_email}>"
   layout "mailer"
   default template_path: ->(mailer) { "mailers/#{mailer.class.name.underscore}" }
 

--- a/app/mailers/digest_mailer.rb
+++ b/app/mailers/digest_mailer.rb
@@ -1,5 +1,5 @@
 class DigestMailer < ApplicationMailer
-  default from: "DEV Digest <#{ApplicationConfig['DEFAULT_SITE_EMAIL']}>"
+  default from: "DEV Digest <#{SiteConfig.default_site_email}>"
 
   def digest_email(user, articles)
     @user = user

--- a/app/mailers/pro_membership_mailer.rb
+++ b/app/mailers/pro_membership_mailer.rb
@@ -1,5 +1,5 @@
 class ProMembershipMailer < ApplicationMailer
-  default from: "DEV Pro Memberships <#{ApplicationConfig['DEFAULT_SITE_EMAIL']}>"
+  default from: "DEV Pro Memberships <#{SiteConfig.default_site_email}>"
 
   def expiring_membership(pro_membership, expiration_date)
     @pro_membership = pro_membership

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -33,7 +33,7 @@ class Organization < ApplicationRecord
             format: { with: /\A[a-zA-Z0-9\-_]+\Z/ },
             length: { in: 2..18 },
             exclusion: { in: ReservedWords.all,
-                         message: "%<value>s is a reserved word. Contact #{ApplicationConfig['DEFAULT_SITE_EMAIL']} for help registering your organization." }
+                         message: "%<value>s is a reserved word. Contact #{SiteConfig.default_site_email} for help registering your organization." }
   validates :url, url: { allow_blank: true, no_local: true, schemes: %w[https http] }
   validates :secret, uniqueness: { allow_blank: true }
   validates :location, :email, :company_size, length: { maximum: 64 }

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -9,9 +9,9 @@ class SiteConfig < RailsSettings::Base
   cache_prefix { "v1" }
 
   # staff account
-  field :staff_user_id, type: :integer, default: 1 # will replace DEVTO_USER_ID
+  field :staff_user_id, type: :integer, default: 1
   field :default_site_email, type: :string, default: "yo@dev.to"
-  field :social_networks_handle, type: :string, default: "thepracticaldev" # will replace SITE_TWITTER_HANDLE
+  field :social_networks_handle, type: :string, default: "thepracticaldev"
 
   # images
   field :main_social_image, type: :string, default: "https://thepracticaldev.s3.amazonaws.com/i/6hqmcjaxbgbon8ydw93z.png"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -146,7 +146,7 @@ class User < ApplicationRecord
   validate  :validate_feed_url, if: :feed_url_changed?
   validate  :unique_including_orgs_and_podcasts, if: :username_changed?
 
-  scope :dev_account, -> { find_by(id: ApplicationConfig["DEVTO_USER_ID"]) }
+  scope :dev_account, -> { find_by(id: SiteConfig.staff_user_id) }
 
   after_create :send_welcome_notification
   after_save  :bust_cache

--- a/app/views/articles/_sidebar.html.erb
+++ b/app/views/articles/_sidebar.html.erb
@@ -32,11 +32,11 @@
           <h4>key links</h4>
         </header>
         <div class="widget-body">
-          <a href="https://twitter.com/<%= ApplicationConfig["SITE_TWITTER_HANDLE"] %>" target="_blank" rel="noopener"><img src="<%= asset_path("twitter-logo.svg") %>" alt="Twitter logo" class="social-icon" /></a>
-          <a href="https://github.com/<%= ApplicationConfig["SITE_TWITTER_HANDLE"] %>" target="_blank" rel="noopener"><img src="<%= asset_path("github-logo.svg") %>" alt="GitHub logo" class="social-icon" /></a>
-          <a href="https://instagram.com/<%= ApplicationConfig["SITE_TWITTER_HANDLE"] %>" target="_blank" rel="noopener"><img src="<%= asset_path("instagram-logo.svg") %>" alt="Instagram logo" class="social-icon" /></a>
-          <a href="https://facebook.com/<%= ApplicationConfig["SITE_TWITTER_HANDLE"] %>" target="_blank" rel="noopener"><img src="<%= asset_path("facebook-logo.svg") %>" alt="Facebook logo" class="social-icon" /></a>
-          <a href="https://twitch.tv/<%= ApplicationConfig["SITE_TWITTER_HANDLE"] %>" target="_blank" rel="noopener"><img src="<%= asset_path("twitch-logo.svg") %>" alt="Twitch logo" class="social-icon" /></a>
+          <a href="https://twitter.com/<%= SiteConfig.social_networks_handle %>" target="_blank" rel="noopener"><img src="<%= asset_path("twitter-logo.svg") %>" alt="Twitter logo" class="social-icon" /></a>
+          <a href="https://github.com/<%= SiteConfig.social_networks_handle %>" target="_blank" rel="noopener"><img src="<%= asset_path("github-logo.svg") %>" alt="GitHub logo" class="social-icon" /></a>
+          <a href="https://instagram.com/<%= SiteConfig.social_networks_handle %>" target="_blank" rel="noopener"><img src="<%= asset_path("instagram-logo.svg") %>" alt="Instagram logo" class="social-icon" /></a>
+          <a href="https://facebook.com/<%= SiteConfig.social_networks_handle %>" target="_blank" rel="noopener"><img src="<%= asset_path("facebook-logo.svg") %>" alt="Facebook logo" class="social-icon" /></a>
+          <a href="https://twitch.tv/<%= SiteConfig.social_networks_handle %>" target="_blank" rel="noopener"><img src="<%= asset_path("twitch-logo.svg") %>" alt="Twitch logo" class="social-icon" /></a>
         </div>
         <div class="side-footer">
           <a href="/about">About</a>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -12,14 +12,14 @@
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://dev.to<%= request.path %>" />
   <meta property="og:title" content="<%= title_with_timeframe(page_title: community_qualified_name, timeframe: params[:timeframe]) %>" />
-  <meta property="og:image" content="<%= ApplicationConfig["MAIN_SOCIAL_IMAGE"] %>">
+  <meta property="og:image" content="<%= SiteConfig.main_social_image %>">
   <meta property="og:description" content="Where programmers share ideas and help each other grow." />
   <meta property="og:site_name" content="<%= community_qualified_name %>" />
 
-  <meta name="twitter:site" content="@<%= ApplicationConfig["SITE_TWITTER_HANDLE"] %>">
+  <meta name="twitter:site" content="@<%= SiteConfig.social_networks_handle %>">
   <meta name="twitter:title" content="<%= title_with_timeframe(page_title: community_qualified_name, timeframe: params[:timeframe]) %>">
   <meta name="twitter:description" content="Where programmers share ideas, experiences, and help each other grow.">
-  <meta name="twitter:image:src" content="<%= ApplicationConfig["MAIN_SOCIAL_IMAGE"] %>">
+  <meta name="twitter:image:src" content="<%= SiteConfig.main_social_image %>">
   <meta name="twitter:card" content="summary_large_image">
   <%= auto_discovery_link_tag(:rss, "https://dev.to/feed", title: "#{ApplicationConfig['COMMUNITY_NAME']} RSS Feed") %>
 <% end %>

--- a/app/views/articles/manage.html.erb
+++ b/app/views/articles/manage.html.erb
@@ -11,12 +11,12 @@
         <h3 class="manage-page-success"><%= flash[:pins_success] %></h3>
       <% end %>
       <h2>Tools:</h2>
-      <p><strong>Suggest a Tweet:</strong> Help get your post in front of more developers by suggesting a tweet that <a href="https://twitter.com/<%= ApplicationConfig["SITE_TWITTER_HANDLE"] %>">@<%= ApplicationConfig["SITE_TWITTER_HANDLE"] %></a> editors can use.
+      <p><strong>Suggest a Tweet:</strong> Help get your post in front of more developers by suggesting a tweet that <a href="https://twitter.com/<%= SiteConfig.social_networks_handle %>">@<%= SiteConfig.social_networks_handle %></a> editors can use.
       <p><strong>Experience Level of Post:</strong> The best target dev experience level— a <em>gentle</em> indicator to help show the post to the people who will benefit the most.
       <h2>Tips:</h2>
       <ol>
         <li>
-          Make your own tweet about the post, describing personally why you wrote it or why people might find it useful. <a href="https://twitter.com/<%= ApplicationConfig["SITE_TWITTER_HANDLE"] %>">@<%= ApplicationConfig["SITE_TWITTER_HANDLE"] %></a> may retweet you.
+          Make your own tweet about the post, describing personally why you wrote it or why people might find it useful. <a href="https://twitter.com/<%= SiteConfig.social_networks_handle %>">@<%= SiteConfig.social_networks_handle %></a> may retweet you.
         </li>
         <li>
           Share to link aggregators such as <a href="https://www.reddit.com/">Reddit</a>. Try to choose the most topic-specific subreddits, such as <a href="https://www.reddit.com/r/javascript">/r/javascript</a> instead of <a href="https://www.reddit.com/r/programming">/r/programming</a>. <em>Warning: jerks and trolls may be lurking.</em>

--- a/app/views/articles/search/_meta.html.erb
+++ b/app/views/articles/search/_meta.html.erb
@@ -6,12 +6,12 @@
 <meta property="og:type" content="website" />
 <meta property="og:url" content="DEV => Search Results" />
 <meta property="og:title" content="The DEV Community" />
-<meta property="og:image" content="<%= ApplicationConfig["MAIN_SOCIAL_IMAGE"] %>">
+<meta property="og:image" content="<%= SiteConfig.main_social_image %>">
 <meta property="og:description" content="Where programmers share ideas and help each other grow." />
 <meta property="og:site_name" content="The DEV Community" />
 
-<meta name="twitter:site" content="@<%= ApplicationConfig["SITE_TWITTER_HANDLE"] %>">
+<meta name="twitter:site" content="@<%= SiteConfig.social_networks_handle %>">
 <meta name="twitter:title" content="DEV => Search Results">
 <meta name="twitter:description" content="Where programmers share ideas, experiences, and help each other grow.">
-<meta name="twitter:image:src" content="<%= ApplicationConfig["MAIN_SOCIAL_IMAGE"] %>">
+<meta name="twitter:image:src" content="<%= SiteConfig.main_social_image %>">
 <meta name="twitter:card" content="summary_large_image">

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -49,7 +49,7 @@
     <meta property="og:title" content="<%= @article.title %>" />
     <meta property="og:description" content="<%= @article.description || "An article from the community" %>" />
     <meta property="og:site_name" content="<%= community_qualified_name %>" />
-    <meta name="twitter:site" content="@<%= ApplicationConfig["SITE_TWITTER_HANDLE"] %>">
+    <meta name="twitter:site" content="@<%= SiteConfig.social_networks_handle %>">
     <meta name="twitter:creator" content="@<%= @user.twitter_username %>">
     <meta name="twitter:title" content="<%= @article.title %>">
     <meta name="twitter:description" content="<%= @article.description || "An article from the community" %>">

--- a/app/views/articles/tags/_meta.html.erb
+++ b/app/views/articles/tags/_meta.html.erb
@@ -13,7 +13,7 @@
 <meta property="og:description" content="<%= @tag.capitalize %> content on dev.to" />
 <meta property="og:site_name" content="The DEV Community" />
 
-<meta name="twitter:site" content="@<%= ApplicationConfig["SITE_TWITTER_HANDLE"] %>">
+<meta name="twitter:site" content="@<%= SiteConfig.social_networks_handle %>">
 <meta name="twitter:creator" content="@<%= @tag.capitalize %>">
 <meta name="twitter:title" content="<%= title_with_timeframe(page_title: @tag.capitalize, timeframe: params[:timeframe]) %>">
 <meta name="twitter:description" content="<%= @tag.capitalize %> content on dev.to">
@@ -23,7 +23,7 @@
   <meta property="og:image" content="<%= tag_social_preview_url(@tag_model, format: :png) %>">
   <meta name="twitter:image:src" content="<%= tag_social_preview_url(@tag_model, format: :png) %>">
 <% else %>
-  <meta property="og:image" content="<%= ApplicationConfig["MAIN_SOCIAL_IMAGE"] %>">
-  <meta name="twitter:image:src" content="<%= ApplicationConfig["MAIN_SOCIAL_IMAGE"] %>">
+  <meta property="og:image" content="<%= SiteConfig.main_social_image %>">
+  <meta name="twitter:image:src" content="<%= SiteConfig.main_social_image %>">
   <meta name="twitter:card" content="summary_large_image">
 <% end %>

--- a/app/views/classified_listings/index.html.erb
+++ b/app/views/classified_listings/index.html.erb
@@ -22,7 +22,7 @@
     <meta name="twitter:description" content="Where programmers share ideas, experiences, and help each other grow.">
     <meta name="twitter:image:src" content="https://thepracticaldev.s3.amazonaws.com/i/sa3xjflbtvt9zw0xpan5.png">
   <% end %>
-  <meta name="twitter:site" content="@<%= ApplicationConfig["SITE_TWITTER_HANDLE"] %>">
+  <meta name="twitter:site" content="@<%= SiteConfig.social_networks_handle %>">
   <meta name="twitter:card" content="summary_large_image">
 <% end %>
 

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -12,7 +12,7 @@
   <meta property="og:title" content="Discussion of <%= @commentable.title %>" />
   <meta property="og:description" content="<%= @commentable.description || "A DEV Comment" %>" />
   <meta property="og:site_name" content="The DEV Community" />
-  <meta name="twitter:site" content="@<%= ApplicationConfig["SITE_TWITTER_HANDLE"] %>">
+  <meta name="twitter:site" content="@<%= SiteConfig.social_networks_handle %>">
   <meta name="twitter:creator" content="@<%= @user.twitter_username %>">
   <meta name="twitter:title" content="<%= @commentable.title %>">
   <meta name="twitter:description" content="<%= @commentable.description || "A DEV Comment" %>">

--- a/app/views/devise/shared/_authorization_error.html.erb
+++ b/app/views/devise/shared/_authorization_error.html.erb
@@ -25,6 +25,6 @@
       <%= flash[:alert] %>
       <br>
     <% end %>
-    Please try again below, or contact <a href="mailto:<%= ApplicationConfig["DEFAULT_SITE_EMAIL"] %>"><%= ApplicationConfig["DEFAULT_SITE_EMAIL"] %></a> if this persists.
+    Please try again below, or contact <a href="mailto:<%= SiteConfig.default_site_email %>"><%= SiteConfig.default_site_email %></a> if this persists.
   </div>
 <% end %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -10,7 +10,7 @@
   <meta property="og:description" content="Talks and workshops designed to help community members level up." />
   <meta property="og:site_name" content="The Practical Dev" />
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:site" content="@<%= ApplicationConfig["SITE_TWITTER_HANDLE"] %>">
+  <meta name="twitter:site" content="@<%= SiteConfig.social_networks_handle %>">
   <meta name="twitter:title" content="dev.to | Events">
   <meta property="og:description" content="Talks and workshops designed to help community members level up." />
   <meta name="twitter:image:src" content="https://thepracticaldev.s3.amazonaws.com/i/bhavxzyx2e7bdsyvysve.jpg">

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -10,19 +10,19 @@
   <% if @event.cover_image.present? %>
     <meta property="og:image" content="<%= @event.cover_image_url %>" />
   <% else %>
-    <meta property="og:image" content="<%= ApplicationConfig["MAIN_SOCIAL_IMAGE"] %>" />
+    <meta property="og:image" content="<%= SiteConfig.main_social_image %>" />
   <% end %>
   <meta property="og:description" content="<%= truncate(strip_tags(@event.description_html), length: 140) %>" />
   <meta property="og:site_name" content="The Practical Dev" />
 
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:site" content="@<%= ApplicationConfig["SITE_TWITTER_HANDLE"] %>">
+  <meta name="twitter:site" content="@<%= SiteConfig.social_networks_handle %>">
   <meta name="twitter:title" content="<%= truncate(strip_tags(@event.title), length: 70) %>">
   <meta property="og:description" content="<%= truncate(strip_tags(@event.description_html), length: 140) %>" />
   <% if @event.cover_image.present? %>
     <meta name="twitter:image:src" content="<%= @event.cover_image_url %>">
   <% else %>
-    <meta name="twitter:image:src" content="<%= ApplicationConfig["MAIN_SOCIAL_IMAGE"] %>">
+    <meta name="twitter:image:src" content="<%= SiteConfig.main_social_image %>">
   <% end %>
 <% end %>
 

--- a/app/views/feedback_messages/index.html.erb
+++ b/app/views/feedback_messages/index.html.erb
@@ -9,7 +9,7 @@
     <h2>Thank you for your report.</h2>
     <h3><a href="/">Return to home page</a></h3>
     <p>
-      Questions? Send an email to <a href="mailto:<%= ApplicationConfig["DEFAULT_SITE_EMAIL"] %>"><%= ApplicationConfig["DEFAULT_SITE_EMAIL"] %></a>
+      Questions? Send an email to <a href="mailto:<%= SiteConfig.default_site_email %>"><%= SiteConfig.default_site_email %></a>
     </p>
   </div>
 </div>

--- a/app/views/history/index.html.erb
+++ b/app/views/history/index.html.erb
@@ -13,7 +13,7 @@
   <meta property="og:site_name" content="<%= community_qualified_name %>" />
 
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:site" content="@<%= ApplicationConfig["SITE_TWITTER_HANDLE"] %>">
+  <meta name="twitter:site" content="@<%= SiteConfig.social_networks_handle %>">
   <meta name="twitter:title" content="History - <%= community_qualified_name %>">
   <meta name="twitter:description" content="Page views history for <%= community_qualified_name %>">
 <% end %>

--- a/app/views/internal/articles/_individual_article.html.erb
+++ b/app/views/internal/articles/_individual_article.html.erb
@@ -188,7 +188,7 @@
                 <% if article.user.twitter_username? %>&#013{ author: @<%= article.user.twitter_username %> } #DEVCommunity<% end %>
               </textarea>
             </div>
-            <button class="btn btn-primary mb-2">🦅 Tweet to @<%= ApplicationConfig["SITE_TWITTER_HANDLE"] %></button>
+            <button class="btn btn-primary mb-2">🦅 Tweet to @<%= SiteConfig.social_networks_handle %></button>
           <% end %>
 
           <% if (article.decorate.cached_tag_list_array & Tag.bufferized_tags).any? %>

--- a/app/views/layouts/internal.html.erb
+++ b/app/views/layouts/internal.html.erb
@@ -8,7 +8,7 @@
   <meta name="description" content="">
   <meta name="author" content="">
   <%= csrf_meta_tags %>
-  <%= favicon_link_tag ApplicationConfig["FAVICON_URL"] %>
+  <%= favicon_link_tag SiteConfig.favicon_url %>
   <title><%= controller_name.titleize %></title>
 
   <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js" integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n" crossorigin="anonymous"></script>

--- a/app/views/mailers/notify_mailer/account_deleted_email.html.erb
+++ b/app/views/mailers/notify_mailer/account_deleted_email.html.erb
@@ -7,7 +7,7 @@
 </p>
 
 <p>
-  Contact us at <a href="mailto:<%= ApplicationConfig["DEFAULT_SITE_EMAIL"] %>"><%= ApplicationConfig["DEFAULT_SITE_EMAIL"] %></a> if there is anything more we can help with. 😊
+  Contact us at <a href="mailto:<%= SiteConfig.default_site_email %>"><%= SiteConfig.default_site_email %></a> if there is anything more we can help with. 😊
 </p>
 
 <p>

--- a/app/views/mailers/notify_mailer/account_deleted_email.text.erb
+++ b/app/views/mailers/notify_mailer/account_deleted_email.text.erb
@@ -1,6 +1,6 @@
 Hi <%= @name %>, your account has been successfully deleted.
 
-Contact us at <%= ApplicationConfig["DEFAULT_SITE_EMAIL"] %> if there is anything more we can help with.
+Contact us at <%= SiteConfig.default_site_email %> if there is anything more we can help with.
 
 Thanks,
 The DEV Team

--- a/app/views/mailers/notify_mailer/account_deletion_requested_email.html.erb
+++ b/app/views/mailers/notify_mailer/account_deletion_requested_email.html.erb
@@ -8,7 +8,7 @@
 </p>
 
 <p>
-  Contact us at <a href="mailto:<%= ApplicationConfig["DEFAULT_SITE_EMAIL"] %>"><%= ApplicationConfig["DEFAULT_SITE_EMAIL"] %></a> if there is anything more we can help with. 😊
+  Contact us at <a href="mailto:<%= SiteConfig.default_site_email %>"><%= SiteConfig.default_site_email %></a> if there is anything more we can help with. 😊
 </p>
 
 <p>

--- a/app/views/mailers/notify_mailer/account_deletion_requested_email.txt.erb
+++ b/app/views/mailers/notify_mailer/account_deletion_requested_email.txt.erb
@@ -1,6 +1,6 @@
 Hi <%= @name %>,
 Your account deletion was requested. Please, visit this page: <%= user_request_destroy_url(@token) %> to destroy your account. The link will expire in 12 hours.
-Contact us at <%= ApplicationConfig["DEFAULT_SITE_EMAIL"] %> if there is anything more we can help with.
+Contact us at <%= SiteConfig.default_site_email %> if there is anything more we can help with.
 
 Thanks,
 The DEV Team

--- a/app/views/moderations/index.html.erb
+++ b/app/views/moderations/index.html.erb
@@ -85,7 +85,7 @@
     <h1 style="text-align: center">DEV Mods</h1>
     <div class="body">
       <p>We periodically award some DEV members with heightened privileges to help moderate the community.</p>
-      <p>Email <a href="mailto:<%= ApplicationConfig["DEFAULT_SITE_EMAIL"] %>"><%= ApplicationConfig["DEFAULT_SITE_EMAIL"] %></a> if you'd like to be considered right away.</p>
+      <p>Email <a href="mailto:<%= SiteConfig.default_site_email %>"><%= SiteConfig.default_site_email %></a> if you'd like to be considered right away.</p>
       <% if !user_signed_in? %>
         <p><em>P.S. You are not currently signed in.</em></p>
       <% end %>

--- a/app/views/moderations/mod.html.erb
+++ b/app/views/moderations/mod.html.erb
@@ -110,7 +110,7 @@
     <% if @moderatable.last_buffered.blank? %>
       <div class="tag-mod-form">
         <%= form_for(BufferUpdate.new) do |f| %>
-          <h2>Suggest a Tweet for @<%= ApplicationConfig["SITE_TWITTER_HANDLE"] %></h2>
+          <h2>Suggest a Tweet for @<%= SiteConfig.social_networks_handle %></h2>
           <%= f.hidden_field :article_id, value: @moderatable.id %>
           <%= f.text_area :body_text, maxlength: 220, placeholder: "Can be a TLDR of the post, an interesting quote from the post, or bullet points from topics covered in the post, etc." %>
           <%= f.submit "Share Tweet Suggestion" %>

--- a/app/views/notifications/_notifications_list.html.erb
+++ b/app/views/notifications/_notifications_list.html.erb
@@ -14,7 +14,7 @@
   <div class="content notification-content comment-content">
     An error occurred! This has been logged and we're tracking it.
     <br>
-    If you see too many of these, please report it to <a href="mailto:<%= ApplicationConfig["DEFAULT_SITE_EMAIL"] %>"><%= ApplicationConfig["DEFAULT_SITE_EMAIL"] %></a>!
+    If you see too many of these, please report it to <a href="mailto:<%= SiteConfig.default_site_email %>"><%= SiteConfig.default_site_email %></a>!
   </div>
 <% end %>
 

--- a/app/views/notifications/_tagadjustment.html.erb
+++ b/app/views/notifications/_tagadjustment.html.erb
@@ -23,6 +23,6 @@
   <% end %>
   <br><br />
   Thanks for being part of DEV! If you feel like this mod action was a mistake, feel free to contact
-  <a href="mailto:<%= ApplicationConfig["DEFAULT_SITE_EMAIL"] %>"><%= ApplicationConfig["DEFAULT_SITE_EMAIL"] %></a>. 🤗
+  <a href="mailto:<%= SiteConfig.default_site_email %>"><%= SiteConfig.default_site_email %></a>. 🤗
   <br /><br />
 </div>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -12,7 +12,7 @@
   <meta property="og:site_name" content="The Practical Dev" />
 
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:site" content="@<%= ApplicationConfig["SITE_TWITTER_HANDLE"] %>">
+  <meta name="twitter:site" content="@<%= SiteConfig.social_networks_handle %>">
   <meta name="twitter:title" content="Notifications - dev.to">
   <meta name="twitter:description" content="Notifications inbox for dev.to">
 <% end %>

--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -13,7 +13,7 @@
   <meta property="og:site_name" content="<%= ApplicationConfig["COMMUNITY_NAME"] %>" />
 
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:site" content="@<%= ApplicationConfig["SITE_TWITTER_HANDLE"] %>">
+  <meta name="twitter:site" content="@<%= SiteConfig.social_networks_handle %>">
   <meta name="twitter:title" content="About <%= ApplicationConfig["COMMUNITY_NAME"] %>">
   <meta name="twitter:description" content="<%= ApplicationConfig["COMMUNITY_NAME"] %> is great!">
   <meta name="twitter:image:src" content="http://i.imgur.com/B4JNl1w.png">

--- a/app/views/pages/badges.html.erb
+++ b/app/views/pages/badges.html.erb
@@ -13,7 +13,7 @@
   <meta property="og:site_name" content="The Practical Dev" />
 
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:site" content="@<%= ApplicationConfig["SITE_TWITTER_HANDLE"] %>">
+  <meta name="twitter:site" content="@<%= SiteConfig.social_networks_handle %>">
   <meta name="twitter:title" content="Add the DEV Badge to your personal site">
   <meta name="twitter:description" content="Show visitors that you are an active member of our wonderful community. Put the badge on your personal website or use it as you see fit.">
   <meta name="twitter:image:src" content="https://thepracticaldev.s3.amazonaws.com/i/kjn1gduswyrrisc1basc.png">

--- a/app/views/pages/bounty.html.erb
+++ b/app/views/pages/bounty.html.erb
@@ -10,7 +10,7 @@
   <meta property="og:title" content="About The Practical Dev Bounty System" />
 
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:site" content="@<%= ApplicationConfig["SITE_TWITTER_HANDLE"] %>">
+  <meta name="twitter:site" content="@<%= SiteConfig.social_networks_handle %>">
   <meta name="twitter:title" content="The Practical Dev Bounty System">
 <% end %>
 

--- a/app/views/pages/code_of_conduct.html.erb
+++ b/app/views/pages/code_of_conduct.html.erb
@@ -11,7 +11,7 @@
   <%#  <meta property="og:description" content="The Practical Dev is great!" /> %>
   <meta property="og:site_name" content="The Practical Dev" />
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:site" content="@<%= ApplicationConfig["SITE_TWITTER_HANDLE"] %>">
+  <meta name="twitter:site" content="@<%= SiteConfig.social_networks_handle %>">
   <meta name="twitter:title" content="The Practical Dev Code of Conduct">
   <%#  <meta name="twitter:description" content="The Practical Dev is great!"> %>
   <%#  <meta name="twitter:image:src" content="http://i.imgur.com/B4JNl1w.png"> %>

--- a/app/views/pages/contact.html.erb
+++ b/app/views/pages/contact.html.erb
@@ -13,7 +13,7 @@
   <meta property="og:site_name" content="The Practical Dev" />
 
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:site" content="@<%= ApplicationConfig["SITE_TWITTER_HANDLE"] %>">
+  <meta name="twitter:site" content="@<%= SiteConfig.social_networks_handle %>">
   <meta name="twitter:title" content="Contact The Practical Dev">
   <meta name="twitter:description" content="The Practical Dev is great!">
   <meta name="twitter:image:src" content="http://i.imgur.com/B4JNl1w.png">
@@ -30,10 +30,10 @@
       The Practical Dev would love to hear from you!
     </p>
     <p>
-      Email: <a href="mailto:<%= ApplicationConfig["DEFAULT_SITE_EMAIL"] %>"><%= ApplicationConfig["DEFAULT_SITE_EMAIL"] %></a> 😁
+      Email: <a href="mailto:<%= SiteConfig.default_site_email %>"><%= SiteConfig.default_site_email %></a> 😁
     </p>
     <p>
-      Twitter: <a href="http://twitter.com/<%= ApplicationConfig["SITE_TWITTER_HANDLE"] %>">@<%= ApplicationConfig["SITE_TWITTER_HANDLE"] %></a> 👻
+      Twitter: <a href="http://twitter.com/<%= SiteConfig.social_networks_handle %>">@<%= SiteConfig.social_networks_handle %></a> 👻
     </p>
     <p>
       Report a vulnerability: <a href="https://dev.to/security">dev.to/security</a> 🐛

--- a/app/views/pages/information.html.erb
+++ b/app/views/pages/information.html.erb
@@ -8,7 +8,7 @@
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://dev.to/p/information" />
   <meta property="og:title" content="All information about The Practical Dev" />
-  <meta property="og:image" content="<%= ApplicationConfig["MAIN_SOCIAL_IMAGE"] %>" />
+  <meta property="og:image" content="<%= SiteConfig.main_social_image %>" />
   <meta property="og:description" content="The DEV Community is great!" />
   <meta property="og:site_name" content="The DEV Community" />
 
@@ -16,7 +16,7 @@
   <meta name="twitter:site" content="@ThePracticalDev">
   <meta name="twitter:title" content="All information about The Practical Dev">
   <meta name="twitter:description" content="The DEV Community is great!">
-  <meta name="twitter:image:src" content="<%= ApplicationConfig["MAIN_SOCIAL_IMAGE"] %>">
+  <meta name="twitter:image:src" content="<%= SiteConfig.main_social_image %>">
 <% end %>
 
 <style>

--- a/app/views/pages/shecoded.html.erb
+++ b/app/views/pages/shecoded.html.erb
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
     <title>#SheCoded 👩🏿‍💻👩‍💻👩🏾‍💻 - DEV Community</title>
-    <%= favicon_link_tag ApplicationConfig["FAVICON_URL"] %>
+    <%= favicon_link_tag SiteConfig.favicon_url %>
     <style>
       * {
           padding: 0;

--- a/app/views/pages/swagnets.html.erb
+++ b/app/views/pages/swagnets.html.erb
@@ -25,7 +25,7 @@
 
     <p>We understand that some of you won't have a device that supports your new Swagnet, but we hope that you have a friend who can enjoy it :)<br>By the way, you can also buy Swagnets that benefit open-source projects: you can check those out
       <b><a href="https://www.swagnets.com/pages/activism">here</a></b>.<br>Comments? Suggestions? Ping us on Twitter or at
-      <a href="mailto:<%= ApplicationConfig["DEFAULT_SITE_EMAIL"] %>"><%= ApplicationConfig["DEFAULT_SITE_EMAIL"] %></a>.</p>
+      <a href="mailto:<%= SiteConfig.default_site_email %>"><%= SiteConfig.default_site_email %></a>.</p>
 
   </div>
 </div>

--- a/app/views/podcast_episodes/_sidebar.html.erb
+++ b/app/views/podcast_episodes/_sidebar.html.erb
@@ -28,7 +28,7 @@
               </div>
             </a>
           <% end %>
-          <p>If you know of a great dev podcast that should be added to this list, contact <a href="mailto:<%= ApplicationConfig["DEFAULT_SITE_EMAIL"] %>"><%= ApplicationConfig["DEFAULT_SITE_EMAIL"] %></a></p>
+          <p>If you know of a great dev podcast that should be added to this list, contact <a href="mailto:<%= SiteConfig.default_site_email %>"><%= SiteConfig.default_site_email %></a></p>
         </div>
       </div>
     <% elsif @podcast %>

--- a/app/views/shell/_top.html.erb
+++ b/app/views/shell/_top.html.erb
@@ -37,7 +37,7 @@
       <% end %>
       <%= yield(:page_meta) %>
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
-      <%= favicon_link_tag ApplicationConfig["FAVICON_URL"] %>
+      <%= favicon_link_tag SiteConfig.favicon_url %>
       <link rel="apple-touch-icon" href="<%= asset_path "apple-icon.png" %>">
       <link rel="apple-touch-icon" sizes="152x152" href="<%= asset_path "apple-icon-152x152.png" %>">
       <link rel="apple-touch-icon" sizes="180x180" href="<%= asset_path "apple-icon-180x180.png" %>">

--- a/app/views/users/_account.html.erb
+++ b/app/views/users/_account.html.erb
@@ -111,7 +111,7 @@ If you would like to keep your content under the <%= link_to "@ghost", "/ghost" 
 <h3>Request Account Deletion</h3>
 <h4 style="font-weight: 400;">
   <br>
-  <a href="mailto:<%= ApplicationConfig["DEFAULT_SITE_EMAIL"] %>?subject=Request Account Deletion&body=<%= @email_body %>">
+  <a href="mailto:<%= SiteConfig.default_site_email %>?subject=Request Account Deletion&body=<%= @email_body %>">
     Click this link to request account deletion via email.
   </a>
   <br>

--- a/app/views/users/_publishing_from_rss.html.erb
+++ b/app/views/users/_publishing_from_rss.html.erb
@@ -26,7 +26,7 @@
 </p>
 <p>
   Your feed will be fetched every time you submit this form and updates will be automatically fetched periodically thereafter. Contact
-  <a href="mailto:<%= ApplicationConfig["DEFAULT_SITE_EMAIL"] %>"><%= ApplicationConfig["DEFAULT_SITE_EMAIL"] %></a> if you encounter issues.
+  <a href="mailto:<%= SiteConfig.default_site_email %>"><%= SiteConfig.default_site_email %></a> if you encounter issues.
 </p>
 <p>
   FYI: Medium RSS feed URLs are <em>https://medium.com/feed/@your_username</em>

--- a/app/views/users/confirm_destroy.html.erb
+++ b/app/views/users/confirm_destroy.html.erb
@@ -47,7 +47,7 @@
     <h3>Request Account Deletion</h3>
     <h4 style="font-weight: 400;">
       <br>
-      <a href="mailto:<%= ApplicationConfig["DEFAULT_SITE_EMAIL"] %>?subject=Request Account Deletion&body=<%= @email_body %>">
+      <a href="mailto:<%= SiteConfig.default_site_email %>?subject=Request Account Deletion&body=<%= @email_body %>">
         Click this link to request account deletion via email.
       </a>
       <br>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -15,7 +15,7 @@
 <% if params[:state] == "previous-registration" %>
   <div class="notice error-notice" id="notice">
     There is an existing account authorized with that social account. Contact
-    <a href="mailto:<%= ApplicationConfig["DEFAULT_SITE_EMAIL"] %>"><%= ApplicationConfig["DEFAULT_SITE_EMAIL"] %></a> if this is a mistake.
+    <a href="mailto:<%= SiteConfig.default_site_email %>"><%= SiteConfig.default_site_email %></a> if this is a mistake.
   </div>
 <% end %>
 

--- a/app/views/videos/index.html.erb
+++ b/app/views/videos/index.html.erb
@@ -8,14 +8,14 @@
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://dev.to<%= request.path %>" />
   <meta property="og:title" content="<% title "Videos" %>" />
-  <meta property="og:image" content="<%= ApplicationConfig["MAIN_SOCIAL_IMAGE"] %>">
+  <meta property="og:image" content="<%= SiteConfig.main_social_image %>">
   <meta property="og:description" content="All videos on DEV" />
   <meta property="og:site_name" content="<%= community_qualified_name %>" />
 
   <meta name="twitter:site" content="@ThePracticalDev">
   <meta name="twitter:title" content="<% title "Videos" %>">
   <meta name="twitter:description" content="All videos on DEV">
-  <meta name="twitter:image:src" content="<%= ApplicationConfig["MAIN_SOCIAL_IMAGE"] %>">
+  <meta name="twitter:image:src" content="<%= SiteConfig.main_social_image %>">
   <meta name="twitter:card" content="summary_large_image">
 <% end %>
 

--- a/app/views/videos/new.html.erb
+++ b/app/views/videos/new.html.erb
@@ -33,7 +33,7 @@
   <% end %>
   <div style="margin:50px auto;max-width:80%;font-size:0.86em;">
     <p>
-      <strong>Video is beta:</strong> Email <a href="mailto:<%= ApplicationConfig["DEFAULT_SITE_EMAIL"] %>"><%= ApplicationConfig["DEFAULT_SITE_EMAIL"] %></a> if you have any problems.
+      <strong>Video is beta:</strong> Email <a href="mailto:<%= SiteConfig.default_site_email %>"><%= SiteConfig.default_site_email %></a> if you have any problems.
     </p>
   </div>
 </center>

--- a/spec/labor/rate_limit_checker_spec.rb
+++ b/spec/labor/rate_limit_checker_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe RateLimitChecker, type: :labor do
   let(:article) { create(:article, user_id: user.id) }
 
   describe "self.daily_account_follow_limit " do
-    it 'returns the value set in ApplicationConfig["RATE_LIMIT_FOLLOW_COUNT_DAILY"' do
-      expect(described_class.daily_account_follow_limit).to eq(ApplicationConfig["RATE_LIMIT_FOLLOW_COUNT_DAILY"])
+    it "returns the value set in SiteConfig.rate_limit_follow_count_daily" do
+      expect(described_class.daily_account_follow_limit).to eq(SiteConfig.rate_limit_follow_count_daily)
     end
   end
 

--- a/spec/mailers/digest_mailer_spec.rb
+++ b/spec/mailers/digest_mailer_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe DigestMailer, type: :mailer do
 
       expect(email.subject).not_to be_nil
       expect(email.to).to eq([user.email])
-      expect(email.from).to eq([ApplicationConfig["DEFAULT_SITE_EMAIL"]])
+      expect(email.from).to eq([SiteConfig.default_site_email])
     end
 
     it "includes the tracking pixel" do

--- a/spec/mailers/pro_membership_mailer_spec.rb
+++ b/spec/mailers/pro_membership_mailer_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ProMembershipMailer, type: :mailer do
 
         expect(email.subject).to eq("Your Pro Membership will expire in 7 days!")
         expect(email.to).to eq([user.email])
-        expect(email.from).to eq([ApplicationConfig["DEFAULT_SITE_EMAIL"]])
+        expect(email.from).to eq([SiteConfig.default_site_email])
       end
     end
 

--- a/spec/requests/user/user_settings_spec.rb
+++ b/spec/requests/user/user_settings_spec.rb
@@ -237,7 +237,7 @@ RSpec.describe "UserSettings", type: :request do
       it "sets the proper error message" do
         delete "/users/remove_association", params: { provider: "github" }
         expect(flash[:error]).
-          to eq "An error occurred. Please try again or send an email to: #{ApplicationConfig['DEFAULT_SITE_EMAIL']}"
+          to eq "An error occurred. Please try again or send an email to: #{SiteConfig.default_site_email}"
       end
 
       it "does not delete any identities" do


### PR DESCRIPTION
What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR only deals with the first remaining part outlined in #5384, starting to use existing SiteConfig keys instead of the env variables

## Related Tickets & Documents

[Migrate from ENV vars to SiteConfig](https://github.com/thepracticaldev/dev.to/issues/5384)

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

n/a

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed

@rhymes Requested you as reviewer, since you did most of the original work from what I saw.