### PR TITLE
Set type for user_selects_looking_for_work_spec to system

### DIFF
--- a/spec/system/user_selects_looking_for_work_spec.rb
+++ b/spec/system/user_selects_looking_for_work_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Looking For Work" do
+RSpec.describe "Looking For Work", type: :system do
   let(:user) { create(:user) }
   let(:tag) { create(:tag, name: "hiring") }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This doesn't really solve much but this spec is a system spec which relies on some Devise integration helpers. Without this tag, those helpers won't get included properly, not even sure how it runs without them tbh. 

## Related Tickets & Documents
#4884 

## Added to documentation?
- [x] no documentation needed

I'm in flaky spec hell right now
![hell_peach](https://user-images.githubusercontent.com/1813380/71924753-a0efa180-315d-11ea-8c57-2dd4c417f74b.gif)
