### PR TITLE
Internal feedback: skip negative reactions for unpublished content

### DIFF
--- a/app/views/internal/feedback_messages/index.html.erb
+++ b/app/views/internal/feedback_messages/index.html.erb
@@ -80,6 +80,7 @@
     <div id="vomitReactionsBodyContainer" class="collapse hide" aria-labelledby="vomitReactionsHeader" data-parent="#vomitReactions">
       <div class="card-body" style="overflow: scroll; max-height: 500px;">
         <% @vomits.each do |reaction| %>
+          <% next unless reaction.reactable.published %>
           <div class="d-flex justify-content-between">
             <span>
               🤢 <a href="<%= reaction.user.path %>">@<%= reaction.user.username %></a>


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

If content is unpublished it shouldn't be immediately necessary for
negative reactions to be acted on.

There is a higher touch solution here, but I'm not sure it's warranted.

I am curious to see if there is any push back here, one could make a pretty solid argument that we should still act on negative feedback on unpublished content. Still, I'd argue that it  would be futile; someone determined enough to flout the system by abusing publishing status is also savvy enough to know how copy + paste works.

## Related Tickets & Documents

Solves #5191 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
