### PR TITLE
Remove SiteConfig From Org Validation

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -33,7 +33,7 @@ class Organization < ApplicationRecord
             format: { with: /\A[a-zA-Z0-9\-_]+\Z/ },
             length: { in: 2..18 },
             exclusion: { in: ReservedWords.all,
-                         message: "%<value>s is a reserved word. Contact #{SiteConfig.default_site_email} for help registering your organization." }
+                         message: "%<value>s is a reserved word. Contact site admins for help registering your organization." }
   validates :url, url: { allow_blank: true, no_local: true, schemes: %w[https http] }
   validates :secret, uniqueness: { allow_blank: true }
   validates :location, :email, :company_size, length: { maximum: 64 }

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -10,7 +10,7 @@ class SiteConfig < RailsSettings::Base
 
   # staff account
   field :staff_user_id, type: :integer, default: 1
-  field :default_site_email, type: :string, default: "yo@dev.to"
+  field :default_site_email, type: :string, default: "yo@dev.to", readonly: true
   field :social_networks_handle, type: :string, default: "thepracticaldev"
 
   # images

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -10,7 +10,7 @@ class SiteConfig < RailsSettings::Base
 
   # staff account
   field :staff_user_id, type: :integer, default: 1
-  field :default_site_email, type: :string, default: "yo@dev.to", readonly: true
+  field :default_site_email, type: :string, default: "yo@dev.to"
   field :social_networks_handle, type: :string, default: "thepracticaldev"
 
   # images


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
~When Rails loads validations it does so BEFORE it initializes the rest of the application  and this causes our gem to raise the error [`"You cannot use settings before Rails initialize." `](https://github.com/huacnlee/rails-settings-cached/blob/master/lib/rails-settings/base.rb#L118). In order to fix this we have to make default_site_email [readonly according to the gem docs](default_site_email).~

~To reproduce and validate this was the fix I turned on eager loading locally, tried to load rails, it failed with the above error. I added `readonly: true` to the SiteConfig variable and Rails loaded without a problem.~

Taking the easy way out! Because otherwise SiteConfigs can't be updated

## Related Tickets & Documents
#5384 

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media.tenor.com/images/f0c3b09d51c834fd539c728e74c72fdb/tenor.gif)
