### PR TITLE
Set default email in application mailer using ENV variable

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,5 +1,5 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "DEV Community <#{SiteConfig.default_site_email}>"
+  default from: "DEV Community <#{ApplicationConfig['DEFAULT_SITE_EMAIL']}>"
   layout "mailer"
   default template_path: ->(mailer) { "mailers/#{mailer.class.name.underscore}" }
 

--- a/app/mailers/digest_mailer.rb
+++ b/app/mailers/digest_mailer.rb
@@ -1,5 +1,5 @@
 class DigestMailer < ApplicationMailer
-  default from: "DEV Digest <#{SiteConfig.default_site_email}>"
+  default from: "DEV Digest <#{ApplicationConfig['DEFAULT_SITE_EMAIL']}>"
 
   def digest_email(user, articles)
     @user = user

--- a/app/mailers/pro_membership_mailer.rb
+++ b/app/mailers/pro_membership_mailer.rb
@@ -1,5 +1,5 @@
 class ProMembershipMailer < ApplicationMailer
-  default from: "DEV Pro Memberships <#{SiteConfig.default_site_email}>"
+  default from: "DEV Pro Memberships <#{ApplicationConfig['DEFAULT_SITE_EMAIL']}>"
 
   def expiring_membership(pro_membership, expiration_date)
     @pro_membership = pro_membership

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -10,7 +10,7 @@ class SiteConfig < RailsSettings::Base
 
   # staff account
   field :staff_user_id, type: :integer, default: 1
-  field :default_site_email, type: :string, default: "yo@dev.to", readonly: true
+  field :default_site_email, type: :string, default: "yo@dev.to"
   field :social_networks_handle, type: :string, default: "thepracticaldev"
 
   # images


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Fixes:
```
RuntimeError: You cannot use settings before Rails initialize.
application_mailer.rb  2 <class:ApplicationMailer>(...)
[PROJECT_ROOT]/app/mailers/application_mailer.rb:2:in `<class:ApplicationMailer>'
1 class ApplicationMailer < ActionMailer::Base
2   default from: "DEV Community <#{SiteConfig.default_site_email}>"
3   layout "mailer"
4   default template_path: ->(mailer) { "mailers/#{mailer.class.name.underscore}" }
```
## Related Tickets & Documents
#5384 

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media3.giphy.com/media/fCUnd2enoRNfs37vAp/giphy.gif)
