### PR TITLE
Restore default email from SiteConfig for mailers

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,7 +1,10 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "DEV Community <#{ApplicationConfig['DEFAULT_SITE_EMAIL']}>"
   layout "mailer"
-  default template_path: ->(mailer) { "mailers/#{mailer.class.name.underscore}" }
+
+  default(
+    from: -> { "DEV Community <#{SiteConfig.default_site_email}>" },
+    template_path: ->(mailer) { "mailers/#{mailer.class.name.underscore}" },
+  )
 
   def generate_unsubscribe_token(id, email_type)
     Rails.application.message_verifier(:unsubscribe).generate(

--- a/app/mailers/digest_mailer.rb
+++ b/app/mailers/digest_mailer.rb
@@ -1,5 +1,5 @@
 class DigestMailer < ApplicationMailer
-  default from: "DEV Digest <#{ApplicationConfig['DEFAULT_SITE_EMAIL']}>"
+  default from: -> { "DEV Digest <#{SiteConfig.default_site_email}>" }
 
   def digest_email(user, articles)
     @user = user

--- a/app/mailers/pro_membership_mailer.rb
+++ b/app/mailers/pro_membership_mailer.rb
@@ -1,5 +1,5 @@
 class ProMembershipMailer < ApplicationMailer
-  default from: "DEV Pro Memberships <#{ApplicationConfig['DEFAULT_SITE_EMAIL']}>"
+  default from: -> { "DEV Pro Memberships <#{SiteConfig.default_site_email}>" }
 
   def expiring_membership(pro_membership, expiration_date)
     @pro_membership = pro_membership

--- a/app/views/service_worker/index.js.erb
+++ b/app/views/service_worker/index.js.erb
@@ -103,6 +103,7 @@
         !url.href.includes('?preview=') && // Skip for /future.
         !url.href.includes('/delayed_job') && // Skip for Delayed Job dashboard
         !url.href.includes('/sidekiq') && // Skip for Sidekiq dashboard
+        !url.href.includes('/rails/mailers') && // Skip for mailers previews in development mode
         caches.match('/shell_top') && // Ensure shell_top is in the cache.
         caches.match('/shell_bottom')) { // Ensure shell_bottom is in the cache.
         event.respondWith(createPageStream(event.request)); // Respond with the stream

--- a/spec/mailers/digest_mailer_spec.rb
+++ b/spec/mailers/digest_mailer_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe DigestMailer, type: :mailer do
       expect(email.subject).not_to be_nil
       expect(email.to).to eq([user.email])
       expect(email.from).to eq([SiteConfig.default_site_email])
+      expect(email["from"].value).to eq("DEV Digest <#{SiteConfig.default_site_email}>")
     end
 
     it "includes the tracking pixel" do

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -7,24 +7,27 @@ RSpec.describe NotifyMailer, type: :mailer do
   let(:comment)   { create(:comment, user_id: user.id, commentable_id: article.id) }
 
   describe "#new_reply_email" do
+    let(:email) { described_class.new_reply_email(comment) }
+
     it "renders proper subject" do
-      email = described_class.new_reply_email(comment)
       expected_subject = "#{comment.user.name} replied to your #{comment.parent_type}"
       expect(email.subject).to eq(expected_subject)
     end
 
+    it "renders proper sender" do
+      expect(email.from).to eq([SiteConfig.default_site_email])
+      expect(email["from"].value).to eq("DEV Community <#{SiteConfig.default_site_email}>")
+    end
+
     it "renders proper receiver" do
-      email = described_class.new_reply_email(comment)
       expect(email.to).to eq([comment.user.email])
     end
 
     it "includes the tracking pixel" do
-      email = described_class.new_reply_email(comment)
       expect(email.html_part.body).to include("open.gif")
     end
 
     it "includes UTM params" do
-      email = described_class.new_reply_email(comment)
       expect(email.html_part.body).to include(CGI.escape("utm_medium=email"))
       expect(email.html_part.body).to include(CGI.escape("utm_source=notify_mailer"))
       expect(email.html_part.body).to include(CGI.escape("utm_campaign=new_reply_email"))
@@ -32,25 +35,28 @@ RSpec.describe NotifyMailer, type: :mailer do
   end
 
   describe "#new_follower_email" do
+    let(:email) { described_class.new_follower_email(user2.follows.last) }
+
     before { user2.follow(user) }
 
     it "renders proper subject" do
-      email = described_class.new_follower_email(user2.follows.last)
       expect(email.subject).to eq("#{user2.name} just followed you on dev.to")
     end
 
+    it "renders proper sender" do
+      expect(email.from).to eq([SiteConfig.default_site_email])
+      expect(email["from"].value).to eq("DEV Community <#{SiteConfig.default_site_email}>")
+    end
+
     it "renders proper receiver" do
-      email = described_class.new_follower_email(user2.follows.last)
       expect(email.to).to eq([user.email])
     end
 
     it "includes the tracking pixel" do
-      email = described_class.new_follower_email(user2.follows.last)
       expect(email.html_part.body).to include("open.gif")
     end
 
     it "includes UTM params" do
-      email = described_class.new_follower_email(user2.follows.last)
       expect(email.html_part.body).to include(CGI.escape("utm_medium=email"))
       expect(email.html_part.body).to include(CGI.escape("utm_source=notify_mailer"))
       expect(email.html_part.body).to include(CGI.escape("utm_campaign=new_follower_email"))
@@ -58,25 +64,27 @@ RSpec.describe NotifyMailer, type: :mailer do
   end
 
   describe "#new_mention_email" do
-    let(:mention) { create(:mention, user_id: user2.id, mentionable: comment) }
+    let(:mention) { create(:mention, user: user2, mentionable: comment) }
+    let(:email) { described_class.new_mention_email(mention) }
 
     it "renders proper subject" do
-      email = described_class.new_mention_email(mention)
       expect(email.subject).to eq("#{comment.user.name} just mentioned you!")
     end
 
+    it "renders proper sender" do
+      expect(email.from).to eq([SiteConfig.default_site_email])
+      expect(email["from"].value).to eq("DEV Community <#{SiteConfig.default_site_email}>")
+    end
+
     it "renders proper receiver" do
-      email = described_class.new_mention_email(mention)
       expect(email.to).to eq([user2.email])
     end
 
     it "includes the tracking pixel" do
-      email = described_class.new_mention_email(mention)
       expect(email.html_part.body).to include("open.gif")
     end
 
     it "includes UTM params" do
-      email = described_class.new_mention_email(mention)
       expect(email.html_part.body).to include(CGI.escape("utm_medium=email"))
       expect(email.html_part.body).to include(CGI.escape("utm_source=notify_mailer"))
       expect(email.html_part.body).to include(CGI.escape("utm_campaign=new_mention_email"))
@@ -84,23 +92,26 @@ RSpec.describe NotifyMailer, type: :mailer do
   end
 
   describe "#unread_notifications_email" do
+    let(:email) { described_class.unread_notifications_email(user) }
+
     it "renders proper subject" do
-      email = described_class.unread_notifications_email(user)
       expect(email.subject).to eq("🔥 You have 0 unread notifications on dev.to")
     end
 
+    it "renders proper sender" do
+      expect(email.from).to eq([SiteConfig.default_site_email])
+      expect(email["from"].value).to eq("DEV Community <#{SiteConfig.default_site_email}>")
+    end
+
     it "renders proper receiver" do
-      email = described_class.unread_notifications_email(user)
       expect(email.to).to eq([user.email])
     end
 
     it "includes the tracking pixel" do
-      email = described_class.unread_notifications_email(user)
       expect(email.html_part.body).to include("open.gif")
     end
 
     it "includes UTM params" do
-      email = described_class.unread_notifications_email(user)
       expect(email.html_part.body).to include(CGI.escape("utm_medium=email"))
       expect(email.html_part.body).to include(CGI.escape("utm_source=notify_mailer"))
       expect(email.html_part.body).to include(CGI.escape("utm_campaign=unread_notifications_email"))
@@ -108,23 +119,26 @@ RSpec.describe NotifyMailer, type: :mailer do
   end
 
   describe "#video_upload_complete_email" do
+    let(:email) { described_class.video_upload_complete_email(article) }
+
     it "renders proper subject" do
-      email = described_class.video_upload_complete_email(article)
       expect(email.subject).to eq("Your video upload is complete")
     end
 
+    it "renders proper sender" do
+      expect(email.from).to eq([SiteConfig.default_site_email])
+      expect(email["from"].value).to eq("DEV Community <#{SiteConfig.default_site_email}>")
+    end
+
     it "renders proper receiver" do
-      email = described_class.video_upload_complete_email(article)
       expect(email.to).to eq([article.user.email])
     end
 
     it "includes the tracking pixel" do
-      email = described_class.video_upload_complete_email(article)
       expect(email.html_part.body).to include("open.gif")
     end
 
     it "includes UTM params" do
-      email = described_class.video_upload_complete_email(article)
       expect(email.html_part.body).to include(CGI.escape("utm_medium=email"))
       expect(email.html_part.body).to include(CGI.escape("utm_source=notify_mailer"))
       expect(email.html_part.body).to include(CGI.escape("utm_campaign=video_upload_complete_email"))
@@ -134,6 +148,7 @@ RSpec.describe NotifyMailer, type: :mailer do
   describe "#new_badge_email" do
     let(:badge) { create(:badge) }
     let(:badge_achievement) { create_badge_achievement(user, badge, user2) }
+    let(:email) { described_class.new_badge_email(badge_achievement) }
 
     def create_badge_achievement(user, badge, rewarder)
       BadgeAchievement.create(
@@ -145,22 +160,23 @@ RSpec.describe NotifyMailer, type: :mailer do
     end
 
     it "renders proper subject" do
-      email = described_class.new_badge_email(badge_achievement)
       expect(email.subject).to eq("You just got a badge")
     end
 
+    it "renders proper sender" do
+      expect(email.from).to eq([SiteConfig.default_site_email])
+      expect(email["from"].value).to eq("DEV Community <#{SiteConfig.default_site_email}>")
+    end
+
     it "renders proper receiver" do
-      email = described_class.new_badge_email(badge_achievement)
       expect(email.to).to eq([user.email])
     end
 
     it "includes the tracking pixel" do
-      email = described_class.new_badge_email(badge_achievement)
       expect(email.html_part.body).to include("open.gif")
     end
 
     it "includes UTM params" do
-      email = described_class.new_badge_email(badge_achievement)
       expect(email.html_part.body).to include(CGI.escape("utm_medium=email"))
       expect(email.html_part.body).to include(CGI.escape("utm_source=notify_mailer"))
       expect(email.html_part.body).to include(CGI.escape("utm_campaign=new_badge_email"))
@@ -169,49 +185,41 @@ RSpec.describe NotifyMailer, type: :mailer do
 
   describe "#feedback_message_resolution_email" do
     let(:feedback_message) { create(:feedback_message, :abuse_report, reporter_id: user.id) }
-
-    def params(user_email, feedback_message_id)
+    let(:email_params) do
       {
-        email_to: user_email,
+        email_to: user.email,
         email_subject: "DEV Report Status Update",
         email_body: "You've violated our code of conduct",
         email_type: "Reporter",
-        feedback_message_id: feedback_message_id
+        feedback_message_id: feedback_message.id
       }
     end
+    let(:email) { described_class.feedback_message_resolution_email(email_params) }
 
     it "renders proper subject" do
-      email_params = params(user.email, feedback_message.id)
-      email = described_class.feedback_message_resolution_email(email_params)
       expect(email.subject).to eq("DEV Report Status Update")
     end
 
+    it "renders proper sender" do
+      expect(email.from).to eq([SiteConfig.default_site_email])
+      expect(email["from"].value).to eq("DEV Community <#{SiteConfig.default_site_email}>")
+    end
+
     it "renders proper receiver" do
-      email_params = params(user.email, feedback_message.id)
-      email = described_class.feedback_message_resolution_email(email_params)
       expect(email.to).to eq([user.email])
     end
 
     it "includes the tracking pixel" do
-      email_params = params(user.email, feedback_message.id)
-      email = described_class.feedback_message_resolution_email(email_params)
       expect(email.html_part.body).to include("open.gif")
     end
 
     it "includes UTM params" do
-      email_params = params(user.email, feedback_message.id)
-      email = described_class.feedback_message_resolution_email(email_params)
       expect(email.html_part.body).to include(CGI.escape("utm_medium=email"))
       expect(email.html_part.body).to include(CGI.escape("utm_source=notify_mailer"))
-      expect(email.html_part.body).to include(
-        CGI.escape("utm_campaign=#{email_params[:email_type]}"),
-      )
+      expect(email.html_part.body).to include(CGI.escape("utm_campaign=#{email_params[:email_type]}"))
     end
 
     it "tracks the feedback message ID after delivery" do
-      email_params = params(user.email, feedback_message.id)
-      email = described_class.feedback_message_resolution_email(email_params)
-
       assert_emails 1 do
         email.deliver_now
       end
@@ -223,24 +231,26 @@ RSpec.describe NotifyMailer, type: :mailer do
   describe "#new_message_email" do
     let(:direct_channel) { ChatChannel.create_with_users([user, user2], "direct") }
     let(:direct_message) { create(:message, user: user, chat_channel: direct_channel) }
+    let(:email) { described_class.new_message_email(direct_message) }
 
     it "renders proper subject" do
-      email = described_class.new_message_email(direct_message)
       expect(email.subject).to eq("#{user.name} just messaged you")
     end
 
+    it "renders proper sender" do
+      expect(email.from).to eq([SiteConfig.default_site_email])
+      expect(email["from"].value).to eq("DEV Community <#{SiteConfig.default_site_email}>")
+    end
+
     it "renders proper receiver" do
-      email = described_class.new_message_email(direct_message)
       expect(email.to).to eq([direct_message.direct_receiver.email])
     end
 
     it "includes the tracking pixel" do
-      email = described_class.new_message_email(direct_message)
       expect(email.html_part.body).to include("open.gif")
     end
 
     it "includes UTM params" do
-      email = described_class.new_message_email(direct_message)
       expect(email.html_part.body).to include(CGI.escape("utm_medium=email"))
       expect(email.html_part.body).to include(CGI.escape("utm_source=notify_mailer"))
       expect(email.html_part.body).to include(CGI.escape("utm_campaign=new_message_email"))
@@ -248,23 +258,26 @@ RSpec.describe NotifyMailer, type: :mailer do
   end
 
   describe "#account_deleted_email" do
+    let(:email) { described_class.account_deleted_email(user) }
+
     it "renders proper subject" do
-      email = described_class.account_deleted_email(user)
       expect(email.subject).to eq("dev.to - Account Deletion Confirmation")
     end
 
+    it "renders proper sender" do
+      expect(email.from).to eq([SiteConfig.default_site_email])
+      expect(email["from"].value).to eq("DEV Community <#{SiteConfig.default_site_email}>")
+    end
+
     it "renders proper receiver" do
-      email = described_class.account_deleted_email(user)
       expect(email.to).to eq([user.email])
     end
 
     it "includes the tracking pixel" do
-      email = described_class.account_deleted_email(user)
       expect(email.html_part.body).to include("open.gif")
     end
 
     it "does not include UTM params" do
-      email = described_class.account_deleted_email(user)
       expect(email.html_part.body).not_to include(CGI.escape("utm_medium=email"))
       expect(email.html_part.body).not_to include(CGI.escape("utm_source=notify_mailer"))
       expect(email.html_part.body).not_to include(CGI.escape("utm_campaign=account_deleted_email"))
@@ -272,34 +285,35 @@ RSpec.describe NotifyMailer, type: :mailer do
   end
 
   describe "#export_email" do
+    let(:email) { described_class.export_email(user, "attachment") }
+
     it "renders proper subject" do
-      email = described_class.export_email(user, "attachment")
       expect(email.subject).to include("export of your content is ready")
     end
 
+    it "renders proper sender" do
+      expect(email.from).to eq([SiteConfig.default_site_email])
+      expect(email["from"].value).to eq("DEV Community <#{SiteConfig.default_site_email}>")
+    end
+
     it "renders proper receiver" do
-      email = described_class.export_email(user, "attachment")
       expect(email.to).to eq([user.email])
     end
 
     it "attaches a zip file" do
-      email = described_class.export_email(user, "attachment")
       expect(email.attachments[0].content_type).to include("application/zip")
     end
 
     it "adds the correct filename" do
-      email = described_class.export_email(user, "attachment")
       expected_filename = "devto-export-#{Date.current.iso8601}.zip"
       expect(email.attachments[0].filename).to eq(expected_filename)
     end
 
     it "includes the tracking pixel" do
-      email = described_class.export_email(user, "attachment")
       expect(email.html_part.body).to include("open.gif")
     end
 
     it "includes UTM params" do
-      email = described_class.export_email(user, "attachment")
       expect(email.html_part.body).to include(CGI.escape("utm_medium=email"))
       expect(email.html_part.body).to include(CGI.escape("utm_source=notify_mailer"))
       expect(email.html_part.body).to include(CGI.escape("utm_campaign=export_email"))
@@ -308,24 +322,26 @@ RSpec.describe NotifyMailer, type: :mailer do
 
   describe "#tag_moderator_confirmation_email" do
     let(:tag) { create(:tag) }
+    let(:email) { described_class.tag_moderator_confirmation_email(user, tag.name) }
 
     it "renders proper subject" do
-      email = described_class.tag_moderator_confirmation_email(user, tag.name)
       expect(email.subject).to eq("Congrats! You're the moderator for ##{tag.name}")
     end
 
+    it "renders proper sender" do
+      expect(email.from).to eq([SiteConfig.default_site_email])
+      expect(email["from"].value).to eq("DEV Community <#{SiteConfig.default_site_email}>")
+    end
+
     it "renders proper receiver" do
-      email = described_class.tag_moderator_confirmation_email(user, tag.name)
       expect(email.to).to eq([user.email])
     end
 
     it "includes the tracking pixel" do
-      email = described_class.tag_moderator_confirmation_email(user, tag.name)
       expect(email.html_part.body).to include("open.gif")
     end
 
     it "includes UTM params" do
-      email = described_class.tag_moderator_confirmation_email(user, tag.name)
       expect(email.html_part.body).to include(CGI.escape("utm_medium=email"))
       expect(email.html_part.body).to include(CGI.escape("utm_source=notify_mailer"))
       expect(email.html_part.body).to include(CGI.escape("utm_campaign=tag_moderator_confirmation_email"))
@@ -334,24 +350,26 @@ RSpec.describe NotifyMailer, type: :mailer do
 
   describe "#trusted_role_email" do
     let(:tag) { create(:tag) }
+    let(:email) { described_class.trusted_role_email(user) }
 
     it "renders proper subject" do
-      email = described_class.trusted_role_email(user)
       expect(email.subject).to eq("You've been upgraded to #{ApplicationConfig['COMMUNITY_NAME']} Community mod status!")
     end
 
+    it "renders proper sender" do
+      expect(email.from).to eq([SiteConfig.default_site_email])
+      expect(email["from"].value).to eq("DEV Community <#{SiteConfig.default_site_email}>")
+    end
+
     it "renders proper receiver" do
-      email = described_class.trusted_role_email(user)
       expect(email.to).to eq([user.email])
     end
 
     it "includes the tracking pixel" do
-      email = described_class.trusted_role_email(user)
       expect(email.html_part.body).to include("open.gif")
     end
 
     it "includes UTM params" do
-      email = described_class.trusted_role_email(user)
       expect(email.html_part.body).to include(CGI.escape("utm_medium=email"))
       expect(email.html_part.body).to include(CGI.escape("utm_source=notify_mailer"))
       expect(email.html_part.body).to include(CGI.escape("utm_campaign=trusted_role_email"))

--- a/spec/mailers/previews/notify_mailer_preview.rb
+++ b/spec/mailers/previews/notify_mailer_preview.rb
@@ -5,7 +5,8 @@ class NotifyMailerPreview < ActionMailer::Preview
   end
 
   def new_follower_email
-    NotifyMailer.new_follower_email(Follow.last)
+    follow = User.first.follow(User.last)
+    NotifyMailer.new_follower_email(follow)
   end
 
   def unread_notifications_email

--- a/spec/mailers/pro_membership_mailer_spec.rb
+++ b/spec/mailers/pro_membership_mailer_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe ProMembershipMailer, type: :mailer do
         expect(email.subject).to eq("Your Pro Membership will expire in 7 days!")
         expect(email.to).to eq([user.email])
         expect(email.from).to eq([SiteConfig.default_site_email])
+        expect(email["from"].value).to eq("DEV Pro Memberships <#{SiteConfig.default_site_email}>")
       end
     end
 

--- a/spec/mailers/scholarship_mailer_spec.rb
+++ b/spec/mailers/scholarship_mailer_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe ScholarshipMailer, type: :mailer do
     it "renders proper from" do
       email = described_class.scholarship_awarded_email(user)
       expect(email.from).to eq(["members@dev.to"])
+      expect(email["from"].value).to eq("members@dev.to")
     end
 
     it "renders proper receiver" do


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

With https://github.com/thepracticaldev/dev.to/pull/5394 we learned that `SiteConfig`'s values can't be used in initializers.

`from` (and `to`) in mailer's  `default` method can take procs though, which means that we can restore the usage of `SiteConfig`. These procs will be called when the `mail` method is invoked at runtime to send the email, which is late enough to `SiteConfig` to be available.

I've also improved mailer tests a little bit.

I've also tested a before scenario and after to confirm.

**Before** (with `config.eager_load = true` in development mode):

By setting `default from: "DEV Community <#{SiteConfig.default_site_email}>"`

```shell
/Users/rhymes/.rvm/gems/ruby-2.6.5/gems/rails-settings-cached-2.1.1/lib/rails-settings/base.rb:118:in `_all_settings': You cannot use settings before Rails initialize. (RuntimeError)
```

the app doesn't even boot :)

**After** (with `config.eager_load = true` in development mode):

By setting `default from: -> { "DEV Community <#{SiteConfig.default_site_email}>" }`

![Screenshot_2020-01-08 Screenshot](https://user-images.githubusercontent.com/146201/71960323-fd51d000-31f4-11ea-9042-b8281352e595.png)


