### PR TITLE
Fix Time flacky test

### DIFF
--- a/spec/services/pro_memberships/expiration_notifier_spec.rb
+++ b/spec/services/pro_memberships/expiration_notifier_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe ProMemberships::ExpirationNotifier, type: :service do
     end
 
     it "sets the expiration notification datetime" do
-      Timecop.travel(pro_membership.expires_at - 1.week) do
+      Timecop.freeze(pro_membership.expires_at - 1.week) do
         described_class.call(1.week.from_now)
         expect(pro_membership.reload.expiration_notification_at.to_i).to eq(Time.current.to_i)
       end


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

After traveling back in time with Timecop, it can be the case that between the call
to the service and the moment we check the current time, we moved on to
the next second.

Using Timecop.freeze takes care of that.

## Related Tickets & Documents

Fixes https://github.com/thepracticaldev/dev.to/issues/5381

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
