### PR TITLE
Migrate Users/FollowJob to Sidekiq

### DIFF
--- a/app/controllers/api/v0/follows_controller.rb
+++ b/app/controllers/api/v0/follows_controller.rb
@@ -6,7 +6,7 @@ module Api
       def create
         user_ids = params[:users].map { |h| h["id"] }
         user_ids.each do |user_id|
-          Users::FollowJob.perform_later(current_user.id, user_id, "User")
+          Users::FollowWorker.perform_async(current_user.id, user_id, "User")
         end
         render json: { outcome: "followed #{user_ids.count} users" }
       end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -186,7 +186,7 @@ class UsersController < ApplicationController
     return unless user.looking_for_work?
 
     hiring_tag = Tag.find_by(name: "hiring")
-    Users::FollowJob.perform_later(user.id, hiring_tag.id, "Tag")
+    Users::FollowWorker.perform_async(user.id, hiring_tag.id, "Tag")
   end
 
   def handle_settings_tab

--- a/app/workers/users/follow_worker.rb
+++ b/app/workers/users/follow_worker.rb
@@ -1,0 +1,17 @@
+module Users
+  class FollowWorker
+    include Sidekiq::Worker
+    sidekiq_options queue: :high_priority, retry: 10
+
+    def perform(user_id, followable_id, followable_type)
+      return unless %w[Tag Organization User].include?(followable_type)
+
+      user = User.find_by(id: user_id)
+      followable = followable_type.constantize.find_by(id: followable_id)
+
+      return unless user && followable
+
+      user.follow(followable)
+    end
+  end
+end

--- a/spec/requests/api/v0/follows_spec.rb
+++ b/spec/requests/api/v0/follows_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Api::V0::FollowsController", type: :request do
       it "creates follows" do
         sign_in user
         expect do
-          perform_enqueued_jobs do
+          sidekiq_perform_enqueued_jobs do
             post "/api/follows", params: { users: users_hash }
           end
         end.to change(Follow, :count).by(users_hash.size)

--- a/spec/system/user_selects_looking_for_work_spec.rb
+++ b/spec/system/user_selects_looking_for_work_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Looking For Work" do
   it "user selects looking for work and autofollows hiring tag" do
     visit "/settings"
     page.check "Looking for work"
-    perform_enqueued_jobs do
+    sidekiq_perform_enqueued_jobs do
       click_button("SUBMIT")
     end
     expect(page).to have_text("Your profile was successfully updated")

--- a/spec/workers/users/follow_worker_spec.rb
+++ b/spec/workers/users/follow_worker_spec.rb
@@ -13,12 +13,6 @@ RSpec.describe Users::FollowWorker, type: :worker do
           worker.perform(user.id, invalid_id, followable.class.name)
         end.not_to change(Follow, :count)
       end
-
-      it "doesn't follow user with unexpected type" do
-        expect do
-          worker.perform(user.id, followable.id, "Article")
-        end.not_to change(Follow, :count)
-      end
     end
 
     context "when user doesn't exist" do
@@ -30,6 +24,12 @@ RSpec.describe Users::FollowWorker, type: :worker do
     end
 
     context "when user + followable exist" do
+      it "doesn't follow user with unexpected type" do
+        expect do
+          worker.perform(user.id, followable.id, "Article")
+        end.not_to change(Follow, :count)
+      end
+
       it "follows user" do
         expect do
           worker.perform(user.id, followable.id, followable.class.name)

--- a/spec/workers/users/follow_worker_spec.rb
+++ b/spec/workers/users/follow_worker_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe Users::FollowWorker, type: :worker do
+  describe "#perform" do
+    let(:user) { create(:user) }
+    let(:followable) { create(:user) }
+    let(:invalid_id) { -1 }
+    let(:worker) { subject }
+
+    context "when followable doesn't exist" do
+      it "doesn't follow user" do
+        expect do
+          worker.perform(user.id, invalid_id, followable.class.name)
+        end.not_to change(Follow, :count)
+      end
+
+      it "doesn't follow user with unexpected type" do
+        expect do
+          worker.perform(user.id, followable.id, "Article")
+        end.not_to change(Follow, :count)
+      end
+    end
+
+    context "when user doesn't exist" do
+      it "doesn't follow user" do
+        expect do
+          worker.perform(invalid_id, followable.id, followable.class.name)
+        end.not_to change(Follow, :count)
+      end
+    end
+
+    context "when user + followable exist" do
+      it "follows user" do
+        expect do
+          worker.perform(user.id, followable.id, followable.class.name)
+        end.to change(Follow, :count).by(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this?

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
In order to move all jobs to Sidekiq, this commit creates a new
Users/FollowWorker using Sidekiq based on Users/FollowJob.

## Related Tickets & Documents
Related to: #5305

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
