### PR TITLE
Update Heroku Release to Migrate and Load App

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
-release: STATEMENT_TIMEOUT=180000 bundle exec rails db:migrate
+release: ./release-tasks.sh
 web: bin/start-pgbouncer bundle exec puma -C config/puma.rb
 worker: bundle exec rails jobs:work
 sidekiq_worker: bundle exec sidekiq -t 25

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -37,10 +37,13 @@ Upon deploy, the app installs dependencies, bundles assets, and gets the app
 ready for launch. However, before it launches and releases the app Heroku runs a
 release script on a one-off dyno. If that release script/step succeeds the new
 app is released on all of the dynos. If that release script/step fails then the
-deploy is halted and we are notified. During this release step, we have chosen
-to run migrations. This ensures that a migration finishes successfully before
-the code that uses it goes live. We deploy asynchronously, so the website is
-running the new code a few minutes after deploy. A new instance of Heroku Rails
-console will immediately run a new code.
+deploy is halted and we are notified. During this release step, we first run any
+outstanding migrations. This ensures that a migration finishes successfully
+before the code that uses it goes live. After running migrations, we use the
+rails runner to output a simple string. Executing a Rails runner command allows
+us to ensure that we can boot up the entire app successfully before it is
+deployed. We deploy asynchronously, so the website is running the new code a few
+minutes after deploy. A new instance of Heroku Rails console will immediately
+run a new code.
 
 ![](https://devcenter0.assets.heroku.com/article-images/1494371187-release-phase-diagram-3.png)

--- a/release-tasks.sh
+++ b/release-tasks.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+STATEMENT_TIMEOUT=180000 bundle exec rails db:migrate
+rails runner "puts 'app load success'"

--- a/release-tasks.sh
+++ b/release-tasks.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-STATEMENT_TIMEOUT=180000 bundle exec rails db:migrate
-rails runner "puts 'app load success'"
+STATEMENT_TIMEOUT=180000 bundle exec rails db:migrate && rails runner "puts 'app load success'"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
Last night was a bit of a doozy having a configuration change take down the app twice. The reason for this was that the problem with the config changes was not noticeable until the app was booted up with eager loading enabled and the only place we do that is in production. By adding a `rails runner` command to our release phase we will force the app to boot up prior to the deploy going out. If the app boots successfully and the command is run the deploy will finish. If the app is unable to boot up, like last night, then the release phase will fail, we will be alerted, and the deploy will stop. 

This will likely add 5-10 seconds of time to the deploy process which I think is completely worth it to test these kinds of changes which are SO easy to miss since our development and test configurations are different. 

## Related Tickets & Documents
#5384 

## Added to documentation?
- [x] readme

![alt_text](https://media1.tenor.com/images/dde585dcd448284b5da75c045dcbd9b7/tenor.gif?itemid=13252377)
