### PR TITLE
Add let_it_be_readonly to avoid updating variables

### DIFF
--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -1,16 +1,16 @@
 require "rails_helper"
 
 RSpec.describe Notification, type: :model do
-  let_it_be(:user)            { create(:user) }
-  let_it_be(:user2)           { create(:user) }
-  let_it_be(:user3)           { create(:user) }
-  let_it_be(:organization)    { create(:organization) }
-  let_it_be(:article) do
+  let_it_be_readonly(:user)            { create(:user) }
+  let_it_be_readonly(:user2)           { create(:user) }
+  let_it_be_readonly(:user3)           { create(:user) }
+  let_it_be_readonly(:organization)    { create(:organization) }
+  let_it_be_changeable(:article) do
     create(:article, :with_notification_subscription, user: user, page_views_count: 4000, positive_reactions_count: 70)
   end
-  let_it_be(:user_follows_user2) { user.follow(user2) }
-  let_it_be(:comment) { create(:comment, user: user2, commentable: article) }
-  let_it_be(:badge_achievement) { create(:badge_achievement) }
+  let_it_be_readonly(:user_follows_user2) { user.follow(user2) }
+  let_it_be_changeable(:comment) { create(:comment, user: user2, commentable: article) }
+  let_it_be_readonly(:badge_achievement) { create(:badge_achievement) }
 
   it do
     scopes = %i[organization_id notifiable_id notifiable_type action]
@@ -136,7 +136,7 @@ RSpec.describe Notification, type: :model do
     end
 
     context "when a user follows an organization" do
-      let_it_be(:user_follows_organization) { user.follow(organization) }
+      let_it_be_readonly(:user_follows_organization) { user.follow(organization) }
 
       it "creates a notification belonging to the organization" do
         perform_enqueued_jobs do
@@ -187,8 +187,8 @@ RSpec.describe Notification, type: :model do
   end
 
   describe "#send_new_comment_notifications" do
-    let_it_be(:comment) { create(:comment, user: user2, commentable: article) }
-    let_it_be(:child_comment) { create(:comment, user: user3, commentable: article, parent: comment) }
+    let_it_be_changeable(:comment) { create(:comment, user: user2, commentable: article) }
+    let_it_be_readonly(:child_comment) { create(:comment, user: user3, commentable: article, parent: comment) }
 
     context "when all commenters are subscribed" do
       it "sends a notification to the author of the article" do
@@ -267,8 +267,8 @@ RSpec.describe Notification, type: :model do
 
   describe "#send_reaction_notification" do
     before do
-      article.update_columns(receive_notifications: true)
-      comment.update_columns(receive_notifications: true)
+      article.update(receive_notifications: true)
+      comment.update(receive_notifications: true)
     end
 
     context "when reactable is receiving notifications" do
@@ -415,7 +415,7 @@ RSpec.describe Notification, type: :model do
     end
 
     context "when the notifiable is an article from an organization" do
-      let_it_be(:org_article) { create(:article, organization: organization, user: user) }
+      let_it_be_readonly(:org_article) { create(:article, organization: organization, user: user) }
 
       it "sends a notification to author's followers" do
         user2.follow(user)
@@ -448,8 +448,7 @@ RSpec.describe Notification, type: :model do
 
       it "updates the notification with the new article title" do
         new_title = "hehehe hohoho!"
-        article.update_column(:title, new_title)
-        article.reload
+        article.update_attribute(:title, new_title)
 
         perform_enqueued_jobs do
           described_class.update_notifications(article, "Published")
@@ -459,8 +458,7 @@ RSpec.describe Notification, type: :model do
       end
 
       it "adds organization data when the article now belongs to an org" do
-        article.update_column(:organization_id, organization.id)
-        article.reload
+        article.update(organization_id: organization.id)
 
         perform_enqueued_jobs do
           described_class.update_notifications(article, "Published")
@@ -472,7 +470,7 @@ RSpec.describe Notification, type: :model do
   end
 
   describe "#aggregated?" do
-    let_it_be(:notification) { build(:notification) }
+    let_it_be_readonly(:notification) { build(:notification) }
     it "returns true if a notification's action is 'Reaction'" do
       notification.action = "Reaction"
       expect(notification.aggregated?).to be(true)

--- a/spec/support/initializers/test_prof.rb
+++ b/spec/support/initializers/test_prof.rb
@@ -1,0 +1,12 @@
+TestProf::LetItBe.configure do |config|
+  config.register_modifier :readonly do |record, val|
+    next record unless record.is_a?(::ActiveRecord::Base)
+
+    next record unless val
+
+    record.tap(&:readonly!)
+  end
+
+  config.alias_to :let_it_be_readonly, readonly: true
+  config.alias_to :let_it_be_changeable, reload: true
+end


### PR DESCRIPTION


<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This is a **suggestion** for using `let_it_be` more safely, it seems pretty dangerous to me.
TL;DR Use readonly records mainly, and make it clear when records are not readonly.

With let_it_be, we define variables that are created for the whole
context. In case we update them in an example, there might be a
discrepancy between the object and its value in the database, since the
database is cleaned between examples, but not the object itself.

This is what happened here with the `article` object. In one of the
tests, we update its organization, and in another, we reupdate it. The
problem is that the `article` object still thinks it has an
organization, but it has been cleaned in the database. So setting the
same organization id to the object doesn't trigger the SQL query, and
the article in the database still doesn't have an organization attached.

One solution is to use `reload: true` as a parameter of `let_it_be`: it
will reload the object from the database at the beginning of each test. To
make sure we don't have other dormant traps like this one, what I
propose is to either have `reload: true`, or to have the object
readonly to avoid getting to a difference between the object and its
database value.

To make it more obvious, we can define `let_it_be_readonly` and `let_it_be_changeable` instead of having to set the records either readonly or reloaded.

To see the tests failing on master:
```
$> rspec --seed 39429 -f d spec/models/notification_spec.rb[1:5:1:5,1:6:4:1]

Randomized with seed 39429
[Zonebie] Setting timezone: ZONEBIE_TZ="Alaska"

Notification
  #send_reaction_notification
    when the reactable is an organization's article
      creates a notification with the organization's ID
  #send_new_comment_notifications
    when all commenters are subscribed
      sends a notification to the organization (FAILED - 1)

Failures:

  1) Notification#send_new_comment_notifications when all commenters are subscribed sends a notification to the organization
     Failure/Error:
       expect do
         described_class.send_new_comment_notifications_without_delay(comment)
       end.to change(organization.notifications, :count).by(1)

       expected `Notification::ActiveRecord_Associations_CollectionProxy#count` to have changed by 1, but was changed by 0
     # ./spec/models/notification_spec.rb:224:in `block (4 levels) in <main>'
     # ./spec/rails_helper.rb:95:in `block (3 levels) in <main>'
     # /usr/local/bundle/gems/vcr-5.0.0/lib/vcr.rb:264:in `turned_off'
     # ./spec/rails_helper.rb:95:in `block (2 levels) in <main>'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:124:in `block in run'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `loop'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `run'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec_ext/rspec_ext.rb:12:in `run_with_retry'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:37:in `block (2 levels) in setup'
     # /usr/local/bundle/gems/bootsnap-1.4.5/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:54:in `load'
     # /usr/local/bundle/gems/bootsnap-1.4.5/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:54:in `load'
     # /usr/local/bundle/gems/spring-commands-rspec-1.0.4/lib/spring/commands/rspec.rb:18:in `call'
     # -e:1:in `<main>'

Finished in 2.64 seconds (files took 1.79 seconds to load)
2 examples, 1 failure

Failed examples:

rspec ./spec/models/notification_spec.rb:219 # Notification#send_new_comment_notifications when all commenters are subscribed sends a notification to the organization
```

I understand it is a bit a big change, if you choose to go to these custom `let_it_be` methods. To solve this specific spec problem, juste add `reload: true` to `let_it_be(:article)`.

## Related Tickets & Documents

This is related to https://github.com/thepracticaldev/dev.to/issues/4884 (flaky tests) because having objects defined over several tests can make the tests order dependent.

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
