### PR TITLE
Add visual indication for listing buffer actions

### DIFF
--- a/app/views/internal/articles/_article_script.html.erb
+++ b/app/views/internal/articles/_article_script.html.erb
@@ -20,8 +20,11 @@
      }).success(function (json) {
        form.parents(".card").addClass("highlighted-bg")
        form.parents(".card").addClass("highlighted-border")
+       form.parents(".single-internal-listing").addClass("highlighted-bg")
+       form.parents(".single-internal-listing").addClass("highlighted-border")
        setTimeout(function () {
          form.parents(".card").removeClass("highlighted-bg")
+         form.parents(".single-internal-listing").removeClass("highlighted-bg")
        }, 350)
      });
      return false; // prevents normal behaviour


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Michael asked that this behavior be extended to the buffer actions on
internal/listings as well.

We should probably look for an opportunity to refactor the JS currently
living in article_script.erb.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
