### PR TITLE
Internal articles: resize textarea to fill parent

### DIFF
--- a/app/views/internal/articles/index.html.erb
+++ b/app/views/internal/articles/index.html.erb
@@ -66,7 +66,7 @@
                 <input type="hidden" name="authenticity_token" value="<%= form_authenticity_token %>" />
                 <input type="hidden" name="_method" value="patch" />
                 <input type="hidden" name="status" value="confirmed" />
-                <textarea name="body_text" style="height: 100px"><%= buffer_update.body_text %></textarea>
+                <textarea name="body_text" class="form-control"><%= buffer_update.body_text %></textarea>
               </div>
               <button value="confirmed" name="status" class="btn btn-success">Confirm</button>
             </form>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Michael just DM'd me a request to make this textarea a more useful size.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Before:
![image](https://user-images.githubusercontent.com/11466782/72090175-1df05780-32d3-11ea-8de7-6e123c845ef0.png)

After:
![image](https://user-images.githubusercontent.com/11466782/72090128-01541f80-32d3-11ea-8a14-d7fbf311aece.png)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![What is this? A center for ants!?](https://user-images.githubusercontent.com/11466782/72090515-d7e7c380-32d3-11ea-9e67-e0cdef2e0e7e.gif)

