### PR TITLE
add following button to my tags

### DIFF
--- a/app/assets/javascripts/initializers/initializeBaseUserData.js
+++ b/app/assets/javascripts/initializers/initializeBaseUserData.js
@@ -56,6 +56,15 @@ function initializeUserSidebar(user) {
           tag.name +
           '</span>' +
           '</a>' +
+          '<a class="follow-action-button sidebar-nav-link-follow cta"' +
+          'href="#" id="sidebar-nav-link-follow-' +
+          tag.name +
+          '"' +
+          'data-info=\'{"id": ' +
+          tag.id +
+          ',"className":"Tag"}\'>' +
+          '+ FOLLOW' +
+          '</a>' +
           '</div>'
         : '';
     if (element) element.remove();
@@ -98,15 +107,21 @@ function addRelevantButtonsToComments(user) {
 
     for (let i = 0; i < settingsButts.length; i += 1) {
       let butt = settingsButts[i];
-      const { action, commentableUserId, userId } = butt.dataset
+      const { action, commentableUserId, userId } = butt.dataset;
 
       if (parseInt(userId, 10) === user.id) {
         butt.style.display = 'inline-block';
       }
-      if (action === 'hide-button' && parseInt(commentableUserId, 10) === user.id) {
+      if (
+        action === 'hide-button' &&
+        parseInt(commentableUserId, 10) === user.id
+      ) {
         butt.style.display = 'inline-block';
-      } else if (action === 'hide-button' && parseInt(commentableUserId, 10) !== user.id) {
-        butt.style.display = 'none'
+      } else if (
+        action === 'hide-button' &&
+        parseInt(commentableUserId, 10) !== user.id
+      ) {
+        butt.style.display = 'none';
       }
     }
 

--- a/app/assets/javascripts/initializers/initializeBaseUserData.js
+++ b/app/assets/javascripts/initializers/initializeBaseUserData.js
@@ -112,15 +112,9 @@ function addRelevantButtonsToComments(user) {
       if (parseInt(userId, 10) === user.id) {
         butt.style.display = 'inline-block';
       }
-      if (
-        action === 'hide-button' &&
-        parseInt(commentableUserId, 10) === user.id
-      ) {
+      if (action === 'hide-button' && parseInt(commentableUserId, 10) === user.id) {
         butt.style.display = 'inline-block';
-      } else if (
-        action === 'hide-button' &&
-        parseInt(commentableUserId, 10) !== user.id
-      ) {
+      } else if (action === 'hide-button' && parseInt(commentableUserId, 10) !== user.id) {
         butt.style.display = 'none';
       }
     }


### PR DESCRIPTION
I propose a solution for issue #5397 

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
@flexdinesh talked about a problem that he was facing, he wanted to delete some old tags and he couldn't do it because some of them changed their name, so my solution is: add a new button "following" to "my tags" for anyone to manage their own tags, following and unfollowing as needed.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
old behavior
![image](https://user-images.githubusercontent.com/25162312/72108098-8ceca100-3311-11ea-99a3-6875b0f21b64.png)
new behavior
![image](https://user-images.githubusercontent.com/25162312/72108344-22883080-3312-11ea-9f5b-6eff63ef8acb.png)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
