### PR TITLE
Add suggested tags to SiteConfig

### DIFF
--- a/app/controllers/api/v0/tags_controller.rb
+++ b/app/controllers/api/v0/tags_controller.rb
@@ -4,6 +4,7 @@ module Api
       caches_action :index,
                     cache_path: proc { |c| c.params.permit! },
                     expires_in: 10.minutes
+      before_action :set_cache_control_headers, only: %i[onboarding] # essentially static content
       respond_to :json
 
       def index
@@ -12,7 +13,8 @@ module Api
       end
 
       def onboarding
-        @tags = Tag.where(name: Tag::NAMES)
+        set_surrogate_key_header "siteconfig/onboarding-tags"
+        @tags = Tag.where(name: SiteConfig.suggested_tags)
       end
     end
   end

--- a/app/controllers/internal/configs_controller.rb
+++ b/app/controllers/internal/configs_controller.rb
@@ -30,7 +30,8 @@ class Internal::ConfigsController < Internal::ApplicationController
   end
 
   def clean_up_params
-    params[:site_config][:suggested_tags] = params[:site_config][:suggested_tags].delete(" ") if params[:site_config][:suggested_tags]
+    config = params[:site_config]
+    config[:suggested_tags] = config[:suggested_tags].downcase.delete(" ") if config[:suggested_tags]
   end
 
   def bust_relevant_caches

--- a/app/controllers/internal/configs_controller.rb
+++ b/app/controllers/internal/configs_controller.rb
@@ -6,9 +6,11 @@ class Internal::ConfigsController < Internal::ApplicationController
   end
 
   def create
+    clean_up_params
     config_params.keys.each do |key|
       SiteConfig.public_send("#{key}=", config_params[key].strip) unless config_params[key].nil?
     end
+    bust_relevant_caches
     redirect_to internal_config_path, notice: "Site configuration was successfully updated."
   end
 
@@ -22,8 +24,16 @@ class Internal::ConfigsController < Internal::ApplicationController
       ga_view_id ga_fetch_rate
       mailchimp_newsletter_id mailchimp_sustaining_members_id
       mailchimp_tag_moderators_id mailchimp_community_moderators_id
-      periodic_email_digest_max periodic_email_digest_min
+      periodic_email_digest_max periodic_email_digest_min suggested_tags
     ]
     params.require(:site_config).permit(allowed_params)
+  end
+
+  def clean_up_params
+    params[:site_config][:suggested_tags] = params[:site_config][:suggested_tags].delete(" ") if params[:site_config][:suggested_tags]
+  end
+
+  def bust_relevant_caches
+    CacheBuster.bust("/api/tags/onboarding") # Needs to change when suggested_tags is edited
   end
 end

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -36,4 +36,8 @@ class SiteConfig < RailsSettings::Base
   # Email digest frequency
   field :periodic_email_digest_max, type: :integer, default: 0
   field :periodic_email_digest_min, type: :integer, default: 2
+
+  # Tags
+
+  field :suggested_tags, type: :array, default: %w[beginners career computerscience git go java javascript react vue webassembly]
 end

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -38,6 +38,5 @@ class SiteConfig < RailsSettings::Base
   field :periodic_email_digest_min, type: :integer, default: 2
 
   # Tags
-
   field :suggested_tags, type: :array, default: %w[beginners career computerscience javascript security ruby rails swift kotlin]
 end

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -39,5 +39,5 @@ class SiteConfig < RailsSettings::Base
 
   # Tags
 
-  field :suggested_tags, type: :array, default: %w[beginners career computerscience git go java javascript react vue webassembly]
+  field :suggested_tags, type: :array, default: %w[beginners career computerscience javascript security ruby rails swift kotlin]
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -5,13 +5,7 @@ class Tag < ActsAsTaggableOn::Tag
   acts_as_followable
   resourcify
 
-  NAMES = %w[
-    beginners career computerscience git go java javascript react vue webassembly
-    linux productivity python security webdev css php laravel opensource npm a11y
-    ruby cpp dotnet swift testing devops vim kotlin rust elixir graphql blockchain sre
-    scala vscode docker kubernetes aws android ios angular csharp typescript django rails
-    clojure ubuntu elm gamedev flutter dart bash machinelearning sql
-  ].freeze
+  NAMES = SiteConfig.suggested_tags.freeze
 
   ALLOWED_CATEGORIES = %w[uncategorized language library tool site_mechanic location subcommunity].freeze
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -5,8 +5,6 @@ class Tag < ActsAsTaggableOn::Tag
   acts_as_followable
   resourcify
 
-  NAMES = SiteConfig.suggested_tags.freeze
-
   ALLOWED_CATEGORIES = %w[uncategorized language library tool site_mechanic location subcommunity].freeze
 
   attr_accessor :tag_moderator_id, :remove_moderator_id

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -174,6 +174,20 @@
     </div>
   </div>
 
+  <div class="card mt-3">
+    <div class="card-header">Tags</div>
+    <div class="card-body">
+      <div class="form-group">
+        <%= f.label :suggested_tags %>
+        <%= f.text_field :suggested_tags,
+                         class: "form-control",
+                         value: SiteConfig.suggested_tags.join(","),
+                         placeholder: "List of valid tags: comma separated, letters only e.g. beginners,javascript,ruby,swift,kotlin" %>
+        <div class="alert alert-info">Determines which tags are suggested to new users during onboarding (comma separated, letters only)</div>
+      </div>
+    </div>
+  </div>
+
   <div class="form-group mt-3">
     <%= f.submit "Update Site Configuration", class: "btn btn-primary" %>
   </div>

--- a/spec/requests/internal/configs_spec.rb
+++ b/spec/requests/internal/configs_spec.rb
@@ -110,5 +110,12 @@ RSpec.describe "/internal/config", type: :request do
         expect(SiteConfig.periodic_email_digest_min).to eq(3)
       end
     end
+
+    describe "Tags" do
+      it "updates suggested_tags" do
+        post "/internal/config", params: { site_config: { suggested_tags: "hey, haha,hoho, bobo fofo" } }
+        expect(SiteConfig.suggested_tags).to eq(%w[hey haha hoho bobofofo])
+      end
+    end
   end
 end

--- a/spec/requests/internal/configs_spec.rb
+++ b/spec/requests/internal/configs_spec.rb
@@ -112,8 +112,13 @@ RSpec.describe "/internal/config", type: :request do
     end
 
     describe "Tags" do
-      it "updates suggested_tags" do
+      it "removes space suggested_tags" do
         post "/internal/config", params: { site_config: { suggested_tags: "hey, haha,hoho, bobo fofo" } }
+        expect(SiteConfig.suggested_tags).to eq(%w[hey haha hoho bobofofo])
+      end
+
+      it "downcases suggested_tags" do
+        post "/internal/config", params: { site_config: { suggested_tags: "hey, haha,hoHo, Bobo Fofo" } }
         expect(SiteConfig.suggested_tags).to eq(%w[hey haha hoho bobofofo])
       end
     end

--- a/spec/requests/tags_api_spec.rb
+++ b/spec/requests/tags_api_spec.rb
@@ -19,5 +19,11 @@ RSpec.describe "ArticlesApi", type: :request do
       expect(response.body).to include("[")
       expect(response.body).to include(tag.name)
     end
+
+    it "does not return incorrect onboarding tag objects" do
+      tag = create(:tag, name: "dsdsdsdsdsdssddsdsds")
+      get "/api/tags/onboarding"
+      expect(response.body).not_to include(tag.name)
+    end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR adds a new array type of config for `SiteConfig` called `suggested_tags` which is used for onboarding (and anywhere else default "suggested tags" might exist).

The only UI change is adding the config to the `/internal/config`.

This PR also adds edge caching to `/api/tags/onboarding` because it's basically a static endpoint that only changes when this value changes. Added area to bust certain endpoints on change of config values.

## Deployment instructions

This PR will be deployed with the default suggested tags defined here in `site_config.rb`. These should immediately be switched to our production values. We _could_ split this into different PRs, but I think doing them in this order is fine given what's going on here.

Closes #5177 