### PR TITLE
Migrate delayed job to send notification email on comment creation

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -26,7 +26,7 @@ class Comment < ApplicationRecord
   after_save     :synchronous_bust
   after_destroy  :after_destroy_actions
   before_destroy :before_destroy_actions
-  after_create   :send_email_notification, if: :should_send_email_notification?
+  after_create_commit :send_email_notification, if: :should_send_email_notification?
   after_create_commit :create_first_reaction
   after_create   :send_to_moderator
   before_save    :set_markdown_character_count, if: :body_markdown
@@ -290,7 +290,7 @@ class Comment < ApplicationRecord
   end
 
   def send_email_notification
-    Comments::SendEmailNotificationJob.perform_later(id)
+    Comments::SendEmailNotificationWorker.perform_async(id)
   end
 
   def should_send_email_notification?

--- a/app/workers/comments/send_email_notification_worker.rb
+++ b/app/workers/comments/send_email_notification_worker.rb
@@ -1,0 +1,12 @@
+module Comments
+  class SendEmailNotificationWorker
+    include Sidekiq::Worker
+
+    sidekiq_options queue: :mailers
+
+    def perform(comment_id)
+      comment = Comment.find_by(id: comment_id)
+      NotifyMailer.new_reply_email(comment).deliver_now if comment
+    end
+  end
+end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -248,34 +248,39 @@ RSpec.describe Comment, type: :model do
   end
 
   context "when callbacks are triggered after create" do
-    it "creates an id code" do
-      comment = build(:comment, user: user, commentable: article)
+    let(:comment) { build(:comment, user: user, commentable: article) }
 
+    it "creates an id code" do
       comment.save
 
       expect(comment.reload.id_code).to eq(comment.id.to_s(26))
     end
 
     it "enqueue a worker to create the first reaction" do
-      comment = build(:comment, user: user, commentable: article)
-
       expect do
         comment.save
       end.to change(Comments::CreateFirstReactionWorker.jobs, :size).by(1)
     end
 
     it "enqueues a worker to calculate comment score" do
-      comment = build(:comment, user: user, commentable: article)
-
       expect do
         comment.save
       end.to change(Comments::CalculateScoreWorker.jobs, :size).by(1)
     end
 
+    it "enqueues a worker to send email" do
+      comment.save!
+      child_comment_user = create(:user)
+      child_comment = build(:comment, parent: comment, user: child_comment_user, commentable: article)
+
+      expect do
+        child_comment.save!
+      end.to change(Comments::SendEmailNotificationWorker.jobs, :size).by(1)
+    end
+
     it "touches user updated_at" do
       user.updated_at = 1.month.ago
       user.save
-      comment = build(:comment, user: user, commentable: article)
 
       expect { comment.save }.to change(user, :updated_at)
     end
@@ -283,7 +288,6 @@ RSpec.describe Comment, type: :model do
     it "touches user last_comment_at" do
       user.last_comment_at = 1.month.ago
       user.save
-      comment = build(:comment, user: user, commentable: article)
 
       expect { comment.save }.to change(user, :last_comment_at)
     end

--- a/spec/workers/comments/send_email_notification_worker_spec.rb
+++ b/spec/workers/comments/send_email_notification_worker_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe Comments::SendEmailNotificationWorker, type: :worker do
+  include_examples "#enqueues_on_correct_queue", "mailers", 1
+
+  describe "#perform" do
+    let(:worker) { subject }
+
+    context "with comment" do
+      let_it_be(:comment) { double }
+
+      before do
+        allow(Comment).to receive(:find_by).with(id: 1).and_return(comment)
+      end
+
+      it "sends reply email" do
+        mailer = double
+        allow(mailer).to receive(:deliver_now)
+        allow(NotifyMailer).to receive(:new_reply_email).and_return(mailer)
+
+        subject.perform(1)
+
+        expect(NotifyMailer).to have_received(:new_reply_email).with(comment)
+        expect(mailer).to have_received(:deliver_now)
+      end
+    end
+
+    context "without comment" do
+      it "does not error" do
+        expect { worker.perform(nil) }.not_to raise_error
+      end
+
+      it "does not call NotifyMailer" do
+        allow(NotifyMailer).to receive(:new_reply_email)
+
+        worker.perform(nil)
+
+        expect(NotifyMailer).not_to have_received(:new_reply_email)
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

* Add sidekiq version of the corresponding delayed job
* Switch the invocation of the delayed job from `after_create` to
`after_create_commit` to avoid the race condition where the worker can
be executed before the comment is persisted. Added covering spec
for this change.

## Related Tickets & Documents

https://github.com/thepracticaldev/dev.to/issues/5305

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed