### PR TITLE
Internal users edit: fix typo

### DIFF
--- a/app/views/internal/users/edit.html.erb
+++ b/app/views/internal/users/edit.html.erb
@@ -17,7 +17,7 @@
       <% if @user.banned %>
         <span class="badge badge-danger">🚨 Member is Suspended 🚨</span>
       <% elsif @user.warned %>
-        <span class="badge badge-warning">Member is @arned</span>
+        <span class="badge badge-warning">Member is Warned</span>
       <% elsif @user.comment_banned %>
         <span class="badge badge-warning">Member is Comment Banned</span>
       <% elsif @user.trusted %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Typo

## Description

Since the "2" is right above "W", I guess this was supposed be "Warned", not "@arned".

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed
