### PR TITLE
Check for follow before trying to send a notification

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -24,7 +24,7 @@ class Notification < ApplicationRecord
 
   class << self
     def send_new_follower_notification(follow, is_read = false)
-      return unless Follow.need_new_follower_notification_for?(follow.followable_type)
+      return unless follow && Follow.need_new_follower_notification_for?(follow.followable_type)
       return if follow.followable_type == "User" && UserBlock.blocking?(follow.followable_id, follow.follower_id)
 
       follow_data = follow.attributes.slice("follower_id", "followable_id", "followable_type").symbolize_keys
@@ -32,7 +32,7 @@ class Notification < ApplicationRecord
     end
 
     def send_new_follower_notification_without_delay(follow, is_read = false)
-      return unless Follow.need_new_follower_notification_for?(follow.followable_type)
+      return unless follow && Follow.need_new_follower_notification_for?(follow.followable_type)
       return if follow.followable_type == "User" && UserBlock.blocking?(follow.followable_id, follow.follower_id)
 
       follow_data = follow.attributes.slice("follower_id", "followable_id", "followable_type").symbolize_keys


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Saw [this error](https://app.honeybadger.io/projects/66984/faults/59418712) come in where we were missing the follow record and then trying to send a notification. 
```
NoMethodError: undefined method `followable_type' for nil:NilClass
notification.rb  35 send_new_follower_notification_without_delay(...)
[PROJECT_ROOT]/app/models/notification.rb:35:in `send_new_follower_notification_without_delay'
33 
34     def send_new_follower_notification_without_delay(follow, is_read = false)
35       return unless Follow.need_new_follower_notification_for?(follow.followable_type)
36       return if follow.followable_type == "User" && UserBlock.blocking?(follow.followable_id, follow.follower_id)
```
Fixed by doing a presence check before we attempt to send the notification

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media1.tenor.com/images/2ab2f712f9241729dd766a67ae5be953/tenor.gif?itemid=4961346)
