### PR TITLE
Show User a LiquidTag error for an invalid YouTube ID 

### DIFF
--- a/app/liquid_tags/youtube_tag.rb
+++ b/app/liquid_tags/youtube_tag.rb
@@ -23,7 +23,7 @@ class YoutubeTag < LiquidTagBase
 
   def parse_id(input)
     input_no_space = input.delete(" ")
-    raise StandardError, "Invalid YouTube ID" unless valid_id?(input_no_space)
+    raise Liquid::SyntaxError, "Invalid YouTube ID" unless valid_id?(input_no_space)
     return translate_start_time(input_no_space) if input_no_space.include?("?t=")
 
     input_no_space

--- a/spec/liquid_tags/youtube_tag_spec.rb
+++ b/spec/liquid_tags/youtube_tag_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe YoutubeTag, type: :liquid_tag do
     end
 
     it "raises an error for invalid IDs" do
-      expect { generate_new_liquid(invalid_id).render }.to raise_error("Invalid YouTube ID")
+      expect { generate_new_liquid(invalid_id).render }.to raise_error(Liquid::SyntaxError)
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
I noticed that [this error](https://app.honeybadger.io/projects/66984/faults/59411310) was getting raised for an invalid youtube tag but when that happens the user gets no valuable feedback
```
StandardError: Invalid YouTube ID
youtube_tag.rb  26 parse_id(...)
[PROJECT_ROOT]/app/liquid_tags/youtube_tag.rb:26:in `parse_id'
24   def parse_id(input)
25     input_no_space = input.delete(" ")
26     raise StandardError, "Invalid YouTube ID" unless valid_id?(input_no_space)
27     return translate_start_time(input_no_space) if input_no_space.include?("?t=")
```
By raising a`Liquid::SyntaxError` we will catch the error and display the message helpfully to the individual. 

![Screen Shot 2020-01-10 at 10 49 50 AM](https://user-images.githubusercontent.com/1813380/72170898-53f70f80-3397-11ea-9730-eb6c95ce22b8.png)
![Screen Shot 2020-01-10 at 10 49 57 AM](https://user-images.githubusercontent.com/1813380/72170899-548fa600-3397-11ea-8e2b-3acd066db673.png)

## Added to documentation?
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media1.giphy.com/media/l2QE2xoLnnRGgxTnq/giphy.gif)
