### PR TITLE
Move welcome notification job to worker

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -82,7 +82,7 @@ class Notification < ApplicationRecord
     end
 
     def send_welcome_notification(receiver_id)
-      Notifications::WelcomeNotificationJob.perform_later(receiver_id)
+      Notifications::WelcomeNotificationWorker.perform_async(receiver_id)
     end
 
     def send_moderation_notification(notifiable)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -149,7 +149,7 @@ class User < ApplicationRecord
 
   scope :dev_account, -> { find_by(id: SiteConfig.staff_user_id) }
 
-  after_create :send_welcome_notification
+  after_create_commit :send_welcome_notification
   after_save  :bust_cache
   after_save  :subscribe_to_mailchimp_newsletter
   after_save  :conditionally_resave_articles

--- a/app/workers/notifications/welcome_notification_worker.rb
+++ b/app/workers/notifications/welcome_notification_worker.rb
@@ -1,0 +1,12 @@
+module Notifications
+  class WelcomeNotificationWorker
+    include Sidekiq::Worker
+    sidekiq_options queue: :low_priority, retry: 10
+
+    def perform(receiver_id)
+      welcome_broadcast = Broadcast.find_by(title: "Welcome Notification")
+
+      Notifications::WelcomeNotification::Send.call(receiver_id, welcome_broadcast) if welcome_broadcast
+    end
+  end
+end

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -296,7 +296,7 @@ RSpec.describe "NotificationsIndex", type: :request do
 
       it "renders the welcome notification" do
         broadcast = create(:broadcast, :onboarding)
-        perform_enqueued_jobs do
+        sidekiq_perform_enqueued_jobs do
           Notification.send_welcome_notification(user.id)
         end
         get "/notifications"

--- a/spec/workers/notifications/welcome_notification_worker_spec.rb
+++ b/spec/workers/notifications/welcome_notification_worker_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+RSpec.describe Notifications::WelcomeNotificationWorker, type: :worker do
+  describe "#perform" do
+    let!(:broadcast) { create(:broadcast, :onboarding) }
+    let(:user) { create(:user) }
+    let(:service) { Notifications::WelcomeNotification::Send }
+    let(:worker) { subject }
+
+    before do
+      allow(service).to receive(:call)
+    end
+
+    it "calls a service" do
+      worker.perform(user.id)
+      expect(service).to have_received(:call).with(user.id, broadcast).once
+    end
+
+    context "when there is a non-existent broadcast" do
+      before do
+        broadcast.destroy
+      end
+
+      it "does nothing" do
+        worker.perform(user.id)
+        expect(service).not_to have_received(:call)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor

## Description

Very similar Pr to https://github.com/thepracticaldev/dev.to/pull/5358. In this PR we are moving the WelcomeNotification sending from ActiveJob to a Sidekiq worker. 

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/issues/5305

## Added to documentation?

- [x] no documentation needed
