### PR TITLE
move 'remove-all' from active job to worker

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -115,13 +115,13 @@ class Notification < ApplicationRecord
     def remove_all(notifiable_ids:, notifiable_type:)
       return unless %w[Article Comment Mention].include?(notifiable_type) && notifiable_ids.present?
 
-      Notifications::RemoveAllJob.perform_later(notifiable_ids, notifiable_type)
+      Notifications::RemoveAllWorker.perform_async(notifiable_ids, notifiable_type)
     end
 
     def remove_all_without_delay(notifiable_ids:, notifiable_type:)
       return unless %w[Article Comment Mention].include?(notifiable_type) && notifiable_ids.present?
 
-      Notifications::RemoveAllJob.perform_now(notifiable_ids, notifiable_type)
+      Notifications::RemoveAllWorker.new.perform(notifiable_ids, notifiable_type)
     end
 
     def update_notifications(notifiable, action = nil)

--- a/app/workers/notifications/remove_all_worker.rb
+++ b/app/workers/notifications/remove_all_worker.rb
@@ -1,0 +1,12 @@
+module Notifications
+  class RemoveAllWorker
+    include Sidekiq::Worker
+    sidekiq_options queue: :low_priority, retry: 10
+
+    def perform(notifiable_ids, notifiable_type)
+      return unless %w[Article Comment Mention].include?(notifiable_type) && notifiable_ids.present?
+
+      Notifications::RemoveAll.call(Array.wrap(notifiable_ids), notifiable_type)
+    end
+  end
+end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -504,11 +504,11 @@ RSpec.describe Notification, type: :model do
       mention = create(:mention, user: user, mentionable: comment)
       create(:notification, user: mention.user, notifiable: mention)
 
-      perform_enqueued_jobs do
-        expect do
+      expect do
+        sidekiq_perform_enqueued_jobs do
           described_class.remove_all(notifiable_ids: mention.id, notifiable_type: "Mention")
-        end.to change(user.notifications, :count).by(-1)
-      end
+        end
+      end.to change(user.notifications, :count).by(-1)
     end
   end
 

--- a/spec/requests/articles/articles_destroy_spec.rb
+++ b/spec/requests/articles/articles_destroy_spec.rb
@@ -14,11 +14,11 @@ RSpec.describe "ArticlesDestroy", type: :request do
     expect(destroyed_article).to be_nil
   end
 
-  it "schedules a RemoveAllJob if there are comments" do
+  it "schedules a RemoveAllWorker if there are comments" do
     create(:comment, commentable: article, user: user)
-    expect do
+    sidekiq_assert_enqueued_with(job: Notifications::RemoveAllWorker) do
       delete "/articles/#{article.id}"
-    end.to have_enqueued_job(Notifications::RemoveAllJob).once
+    end
   end
 
   it "removes all previous published notifications" do

--- a/spec/services/articles/destroyer_spec.rb
+++ b/spec/services/articles/destroyer_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe Articles::Destroyer, type: :service do
 
   it "schedules removing notifications if there are comments" do
     create(:comment, commentable: article)
-    expect do
+    sidekiq_assert_enqueued_with(job: Notifications::RemoveAllWorker) do
       described_class.call(article)
-    end.to have_enqueued_job(Notifications::RemoveAllJob).once
+    end
   end
 
   it "calls events dispatcher" do

--- a/spec/workers/notifications/remove_all_worker_spec.rb
+++ b/spec/workers/notifications/remove_all_worker_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+RSpec.describe Notifications::RemoveAllWorker, type: :worker do
+  describe "#perform" do
+    let(:service) { Notifications::RemoveAll }
+    let(:worker) { subject }
+    let(:notifiable_type) { "Article" }
+    let(:notifiable_id) { 1 }
+
+    before do
+      allow(service).to receive(:call)
+    end
+
+    it "calls a service" do
+      worker.perform(notifiable_id, notifiable_type)
+      expect(service).to have_received(:call).with([notifiable_id], notifiable_type).once
+    end
+
+    it "does nothing for non-existent notifiable_id" do
+      worker.perform(nil, notifiable_type)
+      expect(service).not_to have_received(:call)
+    end
+
+    it "does nothing for when called for non-notifiable type" do
+      worker.perform(notifiable_id, "Other")
+      expect(service).not_to have_received(:call)
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor
## Description

In this PR we added a new RemoveAll Worker and call it directly instead of the RemoveAllJob. Notable things in this PR:

- The job was called via perform_later and perform now in two different methods. I did the same thing for the worker code. 


## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/issues/5305
- [x] no documentation needed
