### PR TITLE
Increase cache TTL for social preview images

### DIFF
--- a/app/lib/html_css_to_image.rb
+++ b/app/lib/html_css_to_image.rb
@@ -4,6 +4,8 @@ module HtmlCssToImage
 
   FALLBACK_IMAGE = "https://thepracticaldev.s3.amazonaws.com/i/g355ol6qsrg0j2mhngz9.png".freeze
 
+  CACHE_EXPIRATION = 2.years
+
   def self.url(html:, css: nil, google_fonts: nil)
     image = HTTParty.post("https://hcti.io/v1/image",
                           body: { html: html, css: css, google_fonts: google_fonts },
@@ -19,8 +21,9 @@ module HtmlCssToImage
     return cached_url if cached_url.present?
 
     image_url = url(html: html, css: css, google_fonts: google_fonts)
-
-    Rails.cache.write(cache_key, image_url) unless image_url == FALLBACK_IMAGE
+    unless image_url == FALLBACK_IMAGE
+      Rails.cache.write(cache_key, image_url, expires_in: CACHE_EXPIRATION)
+    end
 
     image_url
   end

--- a/app/lib/html_css_to_image.rb
+++ b/app/lib/html_css_to_image.rb
@@ -4,7 +4,7 @@ module HtmlCssToImage
 
   FALLBACK_IMAGE = "https://thepracticaldev.s3.amazonaws.com/i/g355ol6qsrg0j2mhngz9.png".freeze
 
-  CACHE_EXPIRATION = 2.years
+  CACHE_EXPIRATION = 6.weeks
 
   def self.url(html:, css: nil, google_fonts: nil)
     image = HTTParty.post("https://hcti.io/v1/image",

--- a/spec/lib/html_css_to_image_spec.rb
+++ b/spec/lib/html_css_to_image_spec.rb
@@ -37,6 +37,17 @@ RSpec.describe HtmlCssToImage, type: :lib do
       expect(Rails.cache).to have_received(:write).once
     end
 
+    it "cache has a long expiration" do
+      # Images are expensive to generate, make sure we don't expire them too quickly.
+      stub_request(:post, /hcti.io/).
+        to_return(status: 200,
+                  body: '{ "url": "https://hcti.io/v1/image/6c52de9d-4d37-4008-80f8-67155589e1a1" }',
+                  headers: { "Content-Type" => "application/json" })
+
+      expect(described_class.fetch_url(html: "test")).to eq("https://hcti.io/v1/image/6c52de9d-4d37-4008-80f8-67155589e1a1")
+      expect(Rails.cache).to have_received(:write).with(anything, anything, expires_in: HtmlCssToImage::CACHE_EXPIRATION).once
+    end
+
     it "does not cache errors" do
       stub_request(:post, /hcti.io/).
         to_return(status: 429,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [X] Optimization
- [ ] Documentation Update

## Description
The currently default is 24 hours. These images are expensive to generate + don't change often. So we can make it much much longer.

Ideally, these keys would never expire, and get auto evicted by redis when space fills up. But I don't think a `nil` ttl is possible when a default is set in the Rails config (see [production.rb](https://github.com/thepracticaldev/dev.to/blob/e8c623807cdeb2b43d84893eaad10fcd29baf0ab/config/environments/production.rb#L105)).

So I set it to a real long value. + test to guard against it accidentally being changed.