### PR TITLE
Modify podcast design details and functionality

### DIFF
--- a/app/assets/javascripts/initializePage.js.erb
+++ b/app/assets/javascripts/initializePage.js.erb
@@ -44,6 +44,7 @@ function callInitalizers(){
   initializeArchivedPostFilter();
   initializeCreditsPage();
   initializeUserProfilePage();
+  initializePodcastPlayback();
 
   initializeDrawerSliders();
 

--- a/app/assets/javascripts/initializers/initializeFetchFollowedArticles.js.erb
+++ b/app/assets/javascripts/initializers/initializeFetchFollowedArticles.js.erb
@@ -191,7 +191,8 @@ function insertPodcasts() {
       data.forEach(function(ep) {
         if (user.followed_podcast_ids.indexOf(ep.podcast.id) > -1) {
           episodeCount += 1;
-          podcastHTML = podcastHTML + '<a class="individual-podcast-link" href="/' + ep.podcast.slug + '/' + ep.slug + '"><strong>' + ep.podcast.title + '</strong> ' + ep.title + '</a>'
+          podcastHTML = podcastHTML + '<a class="individual-podcast-link" href="/' + ep.podcast.slug + '/' + ep.slug + '">\
+            <img src="' + ep.podcast.image_90 + '"/><div class="individual-podcast-link-details"><strong>' + ep.title + '</strong> ' + ep.podcast.title + '</div></a>'
         }
       });
       if (episodeCount > 0) {

--- a/app/assets/javascripts/initializers/initializePodcastPlayback.js
+++ b/app/assets/javascripts/initializers/initializePodcastPlayback.js
@@ -1,3 +1,5 @@
+'use strict'
+
 /**
  * This script hunts for podcast's "Record" for both the podcast_episde's
  * show page and an article page containing podcast liquid tag. It handles
@@ -28,7 +30,7 @@ function initializePodcastPlayback() {
   function spinPodcastRecord(customMessage) {
     if (audioExistAndIsPlaying() && recordExist()) {
       getById(`record-${window.activeEpisode}`).classList.add('playing');
-      changeStatusMessage(customMessage || 'playing');
+      changeStatusMessage(customMessage);
     }
   }
 
@@ -128,35 +130,20 @@ function initializePodcastPlayback() {
   }
 
   function changeStatusMessage(message) {
-    if (getById(`status-message-${window.activeEpisode}`)) {
-      getById(`status-message-${window.activeEpisode}`).innerHTML = message;
+    var statusBox = getById(`status-message-${window.activeEpisode}`);
+    if (statusBox) {
+      if (message) {
+        statusBox.classList.add('showing');
+        statusBox.innerHTML = message;
+      } else {
+        statusBox.classList.remove('showing');
+      }
     } else if (
-      message === 'loading' &&
+      message === 'initializing...' &&
       document.querySelector('.status-message')
     ) {
       document.querySelector('.status-message').innerHTML = message;
     }
-  }
-
-  function applyOnbeforeUnloadWarning() {
-    var message =
-      'You are currently playing a podcast. Are you sure you want to leave?';
-    window.onclick = function(event) {
-      if (
-        event.target.tagName === 'A' &&
-        !event.target.href.includes('https://dev.to') &&
-        !event.ctrlKey &&
-        !event.metaKey
-      ) {
-        event.preventDefault();
-        if (window.confirm(message)) {
-          window.location = event.target.href;
-        }
-      }
-    };
-    window.onbeforeunload = function() {
-      return message;
-    };
   }
 
   function startPodcastBar() {
@@ -172,7 +159,6 @@ function initializePodcastPlayback() {
         function() {
           spinPodcastRecord();
           startPodcastBar();
-          applyOnbeforeUnloadWarning();
         },
         function() {
           // Handle any pause() failures.
@@ -181,17 +167,10 @@ function initializePodcastPlayback() {
       .catch(function(error) {
         audio.play();
         setTimeout(function() {
-          spinPodcastRecord('loading');
+          spinPodcastRecord('initializing...');
           startPodcastBar();
-          applyOnbeforeUnloadWarning();
-        }, 300);
+        }, 5);
       });
-  }
-
-  function removeOnbeforeUnloadWarning() {
-    window.onbeforeunload = function() {
-      return null;
-    };
   }
 
   function pausePodcastBar() {
@@ -203,13 +182,13 @@ function initializePodcastPlayback() {
     audio.pause();
     stopRotatingActivePodcastIfExist();
     pausePodcastBar();
-    removeOnbeforeUnloadWarning();
   }
 
   function playPause(audio) {
-    changeStatusMessage('loading');
     window.activeEpisode = audio.getAttribute('data-episode');
     window.activePodcast = audio.getAttribute('data-podcast');
+
+
     if (audio.paused) {
       ga(
         'send',
@@ -219,6 +198,7 @@ function initializePodcastPlayback() {
         `${window.activePodcast} ${window.activeEpisode}`,
         null,
       );
+      changeStatusMessage('initializing...');
       startAudioPlayback(audio);
     } else {
       ga(
@@ -230,7 +210,9 @@ function initializePodcastPlayback() {
         null,
       );
       pauseAudioPlayback(audio);
+      changeStatusMessage(null);
     }
+    setMediaState(audio)
   }
 
   function muteUnmute(audio) {
@@ -247,17 +229,25 @@ function initializePodcastPlayback() {
     var time = getById('time');
     var value = 0;
     var bufferValue = 0;
-    if (audio.currentTime > 0) {
+    var currentTime = audio.currentTime;
+    var firstDecimal = currentTime - Math.floor(currentTime);
+    if (currentTime > 0) {
       value = Math.floor((100.0 / audio.duration) * audio.currentTime);
       bufferValue =
         (audio.buffered.end(audio.buffered.length - 1) / audio.duration) * 100;
+      if(firstDecimal < 0.4) {
+        // Rewrite to mediaState storage every few beats.
+        setMediaState(audio)
+      }
     }
-    progress.style.width = value + '%';
-    buffer.style.width = bufferValue + '%';
-    time.innerHTML =
-      readableDuration(audio.currentTime) +
-      ' / ' +
-      readableDuration(audio.duration);
+    if (progress) {
+      progress.style.width = value + '%';
+      buffer.style.width = bufferValue + '%';
+      time.innerHTML =
+        readableDuration(audio.currentTime) +
+        ' / ' +
+        readableDuration(audio.duration);
+    }
   }
 
   function goToTime(e, audio) {
@@ -282,15 +272,62 @@ function initializePodcastPlayback() {
     sec = sec >= 10 ? sec : '0' + sec;
     return min + ':' + sec;
   }
+  
 
   function terminatePodcastBar(audio) {
-    event.stopPropagation();
     audio.removeEventListener('timeupdate', updateProgressListener, false);
     getById('audiocontent').innerHTML = '';
     stopRotatingActivePodcastIfExist();
-    removeOnbeforeUnloadWarning();
+    setMediaState(audio);
+  }
+
+  function setMediaState(audio) {
+    var date = new Date();
+    var timeNumber = date.getTime();
+    if (!window.name) {
+      window.name = Math.random();
+    }
+    var newState = {
+      html: document.getElementById('audiocontent').innerHTML,
+      time: audio.currentTime,
+      playing: !audio.paused,
+      updated: timeNumber,
+      windowName: window.name
+    }
+    localStorage.setItem('media_playback_state', JSON.stringify(newState));
+  }
+
+  function getMediaState() {
+    try {
+      var currentState = JSON.parse(localStorage.getItem('media_playback_state'));
+      if (!currentState || getById('audiocontent').innerHTML.length > 50 || window.name !== currentState.windowName) {
+        return;
+      }
+      document.getElementById('audiocontent').innerHTML = currentState.html;
+      var audio = getById('audio');
+      audio.currentTime = currentState.time;
+      audio.load();
+      if (currentState.playing) {
+        audio.play().catch(function(error) {
+          pausePodcastBar();
+        });
+      }
+      setTimeout(function(){
+        audio.addEventListener('timeupdate', updateProgressListener(audio), false);
+      },500)
+      applyOnclickToPodcastBar(audio);
+    } catch(e) {
+      console.log(e)
+    }
   }
 
   spinPodcastRecord();
   findAndApplyOnclickToRecords();
+  getMediaState();
+  var audio = getById('audio');
+  if (audio) {
+    audio.load();
+  }
 }
+
+

--- a/app/assets/stylesheets/articles.scss
+++ b/app/assets/stylesheets/articles.scss
@@ -311,16 +311,43 @@
       &.single-article-podcast-div {
         margin-top: 8px;
         padding: 8px 0px 15px;
-        font-size: 0.8em;
+        font-size: 0.95em;
         h3 {
           font-size: 1.5em;
           margin-left: 13px;
           font-weight: 800;
         }
         a.individual-podcast-link {
+          img {
+            height: 50px;
+            width: 50px;
+            border-radius: 120px;
+            vertical-align: top;
+          }
+          .individual-podcast-link-details {
+            width: calc(100% - 85px);
+            display: inline-block;
+            margin-left: 10px;
+          }
+          font-weight: 500;
+          @include themeable(
+            color,
+            theme-secondary-color,
+            $medium-gray
+          );
           strong {
             display: block;
             margin-bottom: 4px;
+            @media screen and (min-width: 500px) {
+              font-size: 1.2em;
+            }
+            padding-top: 0.2em;
+            font-weight: 500;
+            @include themeable(
+              color,
+              theme-color,
+              $black
+            );
           }
           display: block;
           padding: 4px 14px 7px;

--- a/app/assets/stylesheets/ltags/PodcastTag.scss
+++ b/app/assets/stylesheets/ltags/PodcastTag.scss
@@ -19,8 +19,8 @@
 
   .podcastliquidtag__info {
     color: white;
-    font-weight: 300;
-    margin: -5px 15px;
+    font-weight: 500;
+    margin: -5px 15px 10px;
 
     @media screen and (min-width: 830px) {
       margin: 20px 15px;
@@ -45,7 +45,7 @@
     }
 
     h1 {
-      margin: 0px 0px 15px 0px;
+      margin: 0px 0px 0.5em 0px;
       font-weight: inherit;
       padding: 0;
     }
@@ -55,7 +55,29 @@
     }
     .podcastliquidtag__info__podcasttitle {
       font-size:calc(1vw + 14px);
+      padding: 0px 0px;
+      button {
+        font-size:calc(1vw + 12px);
+        border-radius: 3px;
+        border: 0px;
+        margin-left: 5px;
+        width: calc(105px + 4.5vw);
+      }
     }
+
+    @media screen and (min-width: 950px) {
+      .podcastliquidtag__info__episodetitle {
+        font-size: 38px;
+      }
+      .podcastliquidtag__info__podcasttitle {
+        font-size: 24px;
+        button {
+          font-size: 22px;
+          width: 165px;
+        }  
+      }  
+    }
+
 
     .podcastliquidtag__links {
       display: flex;
@@ -132,6 +154,7 @@
       right: 0;
       box-shadow: 0px 0px 40px rgba(0, 0, 0, 0.5);
       height: 130px;
+      background: $black;
 
       @media screen and (min-width: 830px) {
         height: inherit;

--- a/app/assets/stylesheets/podcast-episodes-show.scss
+++ b/app/assets/stylesheets/podcast-episodes-show.scss
@@ -160,12 +160,12 @@
       }
       .butt{
         position:absolute;
-        width: 160px;
-        height: 160px;
+        width: 120px;
+        height: 120px;
         position: absolute;
         top: 50%;
         left: 50%;
-        margin: -80px 0 0 -80px;
+        margin: -60px 0 0 -60px;
         z-index:18;
       }
       .pause-butt{

--- a/app/assets/stylesheets/podcast-episodes-show.scss
+++ b/app/assets/stylesheets/podcast-episodes-show.scss
@@ -102,13 +102,17 @@
       left:0;
       right:0;
       color:$black;
-      padding:1px 0px 2px;
+      padding:2px 0px 3px;
       border-radius:2px;
       transition: opacity 400ms ease;
       background:white;
-      width:66px;
-      font-size:13px;
+      width:130px;
+      font-size:16px;
       font-weight:bold;
+      display: none;
+      &.showing {
+        display: block;
+      }
     }
 
     .playing{

--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -12,6 +12,10 @@ body {
   overflow-y: scroll;
 }
 
+#audiocontent {
+  display: none;
+}
+
 *:focus {
   &:active {
     outline: 0;

--- a/app/assets/stylesheets/shared.scss
+++ b/app/assets/stylesheets/shared.scss
@@ -6,10 +6,11 @@
   right: 0px;
   z-index: 15;
   font-family: $helvetica;
+  display: block;
   #progressBar {
     color: #fff;
     width: 100%;
-    height: 48px;
+    height: calc(48px + 1vh);
     margin-top: 100px;
     position: fixed;
     left: 0;
@@ -23,8 +24,8 @@
       display: block;
     }
     #episode-profile-image {
-      height: 48px;
-      width: 48px;
+      height: calc(48px + 1vh);
+      width: calc(48px + 1vh);
     }
     #animated-bars {
       position: absolute;
@@ -38,16 +39,16 @@
       }
     }
     #barPlayPause {
-      height: 48px;
-      width: 48px;
+      height: calc(48px + 1vh);
+      width: calc(48px + 1vh);
       background: rgb(32, 32, 32);
       position: absolute;
-      left: 48px;
+      left: calc(48px + 1vh);
       bottom: 0px;
       cursor: pointer;
       .butt {
-        width: 30px;
-        margin: 10px 9px;
+        width: calc(35px + 0.5vh);
+        margin: calc(8px + 0.17vh) 7px;
       }
       .pause-butt {
         display: none;
@@ -68,11 +69,11 @@
       display: none;
     }
     #volume {
-      height: 48px;
-      width: 32px;
+      height: calc(48px + 1vh);
+      width: 36px;
       background: rgb(32, 32, 32);
       position: absolute;
-      left: 96px;
+      left: calc(100px + 1vh);
       bottom: 0px;
       cursor: pointer;
       img {
@@ -83,12 +84,12 @@
       }
       #speed {
         font-weight: 300;
-        font-size: 12px;
+        font-size: calc(12px + 0.2vh);
         padding: 3px 0px;
         width: 28px;
         margin-left: -0.5px;
         text-align: center;
-        margin-top: 2px;
+        margin-top: calc(2px + 0.5vh);
         display: block;
         user-select: none;
         background: transparent;
@@ -101,7 +102,7 @@
         .range-wrapper {
           position: absolute;
           top: 0px;
-          left: 22px;
+          left: 26px;
           background: rgb(32, 32, 32);
           z-index: 30;
           width: 0;
@@ -124,15 +125,15 @@
       }
     }
     .buffer-wrapper {
-      height: 48px;
+      height: calc(48px + 1vh);
       position: absolute;
-      left: 128px;
+      left: calc(136px + 1vh);
       right: 0;
       bottom: 0;
       cursor: pointer;
       #progress {
         background-color: #00ffa3;
-        height: 48px;
+        height: calc(48px + 1vh);
         display: inline-block;
         position: relative;
         z-index: 23;
@@ -140,7 +141,7 @@
       }
       #buffer {
         background-color: #96ffd9;
-        height: 48px;
+        height: calc(48px + 1vh);
         display: inline-block;
         position: absolute;
         bottom: 0;
@@ -149,27 +150,33 @@
       }
       #time {
         position: absolute;
-        right: 30px;
-        top: 16px;
+        right: calc(50px + 0.1vh + 1.5vw);
+        top: calc(16px + 0.1vh);
         z-index: 23;
         color: rgb(161, 161, 161);
-        font-size: 13px;
+        font-size: calc(14px + 0.2vh);
         background: rgba(236, 236, 236, 0.74);
         padding: 2px;
       }
       #closebutt {
         position: absolute;
         user-select: none;
-        right: 3px;
+        right: 0;
+        top: 0;
+        bottom: 0;
+        background: white;
+        border-left: rgba(236, 236, 236, 1);
         margin: 0px;
         padding: 0px;
+        padding-top: calc(8px + 0.2vh);
         color: #535353;
         font-size: 13.5px;
         z-index: 25;
-        height: 22px;
-        width: 22px;
+        width: calc(42px + 0.1vh + 1.5vw);
+        text-align: center;
         transition: all 0.3s ease 0s;
         white-space: nowrap;
+        font-size: calc(25px + 0.2vh);
         &:hover {
           color: #ff4343;
         }

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -263,7 +263,7 @@ class StoriesController < ApplicationController
       includes(:podcast).
       order("published_at desc").
       where("published_at > ?", num_hours.hours.ago).
-      select(:slug, :title, :podcast_id)
+      select(:slug, :title, :podcast_id, :image)
   end
 
   def assign_classified_listings

--- a/app/models/podcast.rb
+++ b/app/models/podcast.rb
@@ -39,6 +39,10 @@ class Podcast < ApplicationRecord
     User.with_role(:podcast_admin, self)
   end
 
+  def image_90
+    ProfileImage.new(self).get(90)
+  end
+
   private
 
   def unique_slug_including_users_and_orgs

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -25,7 +25,7 @@
 <% end %>
 <%= javascript_pack_tag "homePage", defer: true %>
 
-<% cache("main-stories-index-#{params}-#{user_signed_in?}", expires_in: 3.minutes) do %>
+<% cache("main-stories-index-#{params}-#{user_signed_in?}-#{ApplicationConfig['HEROKU_SLUG_COMMIT']}", expires_in: 90.seconds) do %>
   <div class="home" id="index-container"
       data-params="<%= params.to_json(only: %i[tag username q]) %>" data-which="<%= @list_of %>"
       data-algolia-tag=""

--- a/app/views/podcast_episodes/_liquid.html.erb
+++ b/app/views/podcast_episodes/_liquid.html.erb
@@ -8,27 +8,11 @@
       <h1 class="podcastliquidtag__info__episodetitle"><%= episode.title %></h1>
     </a>
     <a href="/<%= podcast.slug %>">
-        <%= cl_image_tag(podcast.image_url,
-                         type: "fetch",
-                         crop: "fill",
-                         quality: "auto",
-                         sign_url: true,
-                         flags: "progressive",
-                         fetch_format: "auto",
-                         class: "tinyimage",
-                         alt: podcast.title) %>
-      <h1 class="podcastliquidtag__info__podcasttitle"><%= podcast.title %></h1>
+      <h2 class="podcastliquidtag__info__podcasttitle">
+        <%= podcast.title %> <button class="cta follow-action-button" data-info='{"id":<%= podcast.id %>,"className":"<%= podcast.class.name %>"}'>&nbsp;</button>
+
+      </h2>
     </a>
-    <div class="podcastliquidtag__links">
-      <% podcast_links.each do |name, source, img_src| %>
-        <% if source %>
-          <a href="<%= source %>" target="_blank" rel="noopener noreferrer">
-            <img src="<%= img_src %>" alt="<%= name %>">
-            <span class="service-name"><%= name %></span>
-          </a>
-        <% end %>
-      <% end %>
-    </div>
   </div>
   <div id="record-<%= episode.slug %>" data-podcast="<%= podcast.slug %>" data-episode="<%= episode.slug %>" class="podcastliquidtag__record">
     <img class="button play-butt" id="play-butt-<%= episode.slug %>" src="/assets/playbutt.png" alt="play">
@@ -86,7 +70,7 @@
         <span id="buffer"></span>
         <span id="progress"></span>
         <span id="time"></span>
-        <span id="closebutt">[ x ]</span>
+        <span id="closebutt">×</span>
       </span>
     </div>
   </div>

--- a/app/views/podcast_episodes/_podcast_bar.html.erb
+++ b/app/views/podcast_episodes/_podcast_bar.html.erb
@@ -19,8 +19,8 @@
       <img id="animated-bars" src="<%= asset_path("animated-bars.gif") %>" alt="animated volume bars">
     </a>
     <span id="barPlayPause">
-      <img class="butt play-butt" alt="play" src="<%= cloudinary("https://res.cloudinary.com/practicaldev/image/upload/f_auto/v1467584797/playbutt_o4jk1d.png", 60, 90, format = "png") %>">
-      <img class="butt pause-butt" alt="pause" src="<%= cloudinary("https://res.cloudinary.com/practicaldev/image/upload/f_auto/v1467584911/pausebutt_wrwpnr.png", 60, 90, format = "png") %>">
+      <img class="butt play-butt" alt="play" src="<%= asset_path("playbutt.png") %>">
+      <img class="butt pause-butt" alt="pause" src="<%= asset_path("pausebutt.png") %>">
     </span>
     <span id="volume">
       <span id="volumeindicator" class="volume-icon-wrapper showing">
@@ -36,25 +36,7 @@
       <span id="buffer"></span>
       <span id="progress"></span>
       <span id="time"></span>
-      <span id="closebutt">[ x ]</span>
+      <span id="closebutt">×</span>
     </span>
   </div>
-  <script>
-    setTimeout(function () {
-      initializePodcastPlayback();
-      if (InstantClick) {
-        InstantClick.on('change', function () {
-          initializePodcastPlayback();
-        });
-      }
-    }, 350)
-    setTimeout(function () {
-      initializePodcastPlayback();
-      if (InstantClick) {
-        InstantClick.on('change', function () {
-          initializePodcastPlayback();
-        });
-      }
-    }, 1000)
-  </script>
 </div>

--- a/app/views/podcast_episodes/show.html.erb
+++ b/app/views/podcast_episodes/show.html.erb
@@ -28,8 +28,6 @@
 
 <% end %>
 
-<%= render "podcast_episodes/podcast_bar" %>
-
 <div class="podcast-episode-container">
   <div class="hero">
     <% image_url = cl_image_path(@podcast.pattern_image_url || "https://i.imgur.com/fKYKgo4.png",
@@ -122,3 +120,5 @@
     </div>
   </div>
 </div>
+
+<%= render "podcast_episodes/podcast_bar" %>

--- a/app/views/stories/_main_stories_feed.html.erb
+++ b/app/views/stories/_main_stories_feed.html.erb
@@ -1,5 +1,5 @@
 <% if @default_home_feed && user_signed_in? %>
-  <% cache("fetched-home-articles-object", expires_in: 7.minutes) do %>
+  <% cache("fetched-home-articles-object-#{ApplicationConfig['HEROKU_SLUG_COMMIT']}", expires_in: 3.minutes) do %>
     <% @new_stories = Article.published.
          where("published_at > ? AND score > ?", rand(2..6).hours.ago, -15).
          limited_column_select.

--- a/app/views/stories/_main_stories_feed.html.erb
+++ b/app/views/stories/_main_stories_feed.html.erb
@@ -6,7 +6,7 @@
          order("published_at DESC").
          limit(rand(15..80)).
          decorate %>
-    <div id="followed-podcasts" data-episodes="<%= @podcast_episodes.to_json(include: { podcast: { only: %i[slug title id] } }) %>">
+    <div id="followed-podcasts" data-episodes="<%= @podcast_episodes.to_json(include: { podcast: { only: %i[slug title id], methods: %i[image_90] } }) %>">
     </div>
     <div id="new-articles-object" data-articles="
       <%= @new_stories.to_json(


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This feature adds persistence to the podcast player, so that if a user refreshes the page or hits a non-`InstantClick` link, the podcast player will stick around.

The persistence is limited to the window itself, which I think is a neat solution. If a user has one DEV tab open and opens another, it will not show the persisted player. This is done by naming the `window` and storing the name in the `localstorage`.

The old code wasn't exactly perfect, and there is still some iffy JavaScript here, but I think I ripped out a bit of necessary stuff in the process.

Also added the podcast image to the home page and adjusted the design a bit here:

<img width="723" alt="Screen Shot 2020-01-12 at 10 38 24 PM" src="https://user-images.githubusercontent.com/3102842/72231961-43f45100-358c-11ea-8b08-23fd53cf8ca5.png">

Also made some slight mods to the liquid tag, including adding a `follow` button.