### PR TITLE
Update settings links + descriptions in editor guide

### DIFF
--- a/app/views/pages/_editor_guide_text.html.erb
+++ b/app/views/pages/_editor_guide_text.html.erb
@@ -6,7 +6,7 @@
     <% if version == "1" %>
       <%= render "pages/v1_editor_guide_preamble" %>
     <% else %>
-      <p><em><b>We have two editor versions</b>. If you prefer Jekyll-style "frontmatter", switch to "v1" in <a href="/settings/misc">/settings/misc</a>.</em></p>
+      <p><em><b>We have two editor versions</b>. If you prefer Jekyll-style "frontmatter", switch to "basic markdown" in <a href="/settings/ux">/settings/ux</a>.</em></p>
       <h2 style="font-size:2.8em"><strong>Things to Know</strong></h2>
       <ul>
         <li>Use <a href="#markdown"><strong>markdown</strong></a> to write and format <a href="/">dev.to</a> posts.</li>

--- a/app/views/pages/_v1_editor_guide_preamble.html.erb
+++ b/app/views/pages/_v1_editor_guide_preamble.html.erb
@@ -8,7 +8,7 @@
   <li>When you're ready to publish, set the published variable to <strong>true.</strong></li>
 </ul>
 
-<p><em><b>We have two editor versions</b>. If you'd prefer to edit title and tags etc. as separate fields, switch to the V2 editor in <a href="/settings/misc">/settings/misc</a>. Otherwise, continue:</em></p>
+<p><em><b>We have two editor versions</b>. If you'd prefer to edit title and tags etc. as separate fields, switch to the "rich + markdown" option in <a href="/settings/ux">/settings/ux</a>. Otherwise, continue:</em></p>
 
 <h2><u><strong>Front Matter</strong></u></h2>
 <p>Custom variables set for each post, located between the triple-dashed lines in your editor. Here is a list of possibilities:</p>


### PR DESCRIPTION
Closes #5461 

## What type of PR is this? 

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [X] Documentation Update

## Description

Editor settings moved from `/settings/misc` to `/settings/ux`. This PR updates both the links and the descriptions to reflect the new wording and URL.

## Related Tickets & Documents

#5461

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

<img width="600" alt="Screen Shot 2020-01-13 at 13 39 22" src="https://user-images.githubusercontent.com/47985/72236696-8197bf00-360a-11ea-8858-4d6f879af5db.png">

<img width="515" alt="Screen Shot 2020-01-13 at 13 40 01" src="https://user-images.githubusercontent.com/47985/72236697-8197bf00-360a-11ea-831c-09ba773c3de5.png">

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed
