### PR TITLE
Handle liquid tag errors in comments form

### DIFF
--- a/app/assets/javascripts/initializers/initializeCommentsPage.js.erb
+++ b/app/assets/javascripts/initializers/initializeCommentsPage.js.erb
@@ -144,7 +144,7 @@ function initializeCommentsPage() {
       };
     }
     if (document.getElementById('new_comment')) {
-      document.getElementById('new_comment').onsubmit = handleCommentSubmit;
+      document.getElementById('new_comment').addEventListener('submit', handleCommentSubmit);
     }
   }
   listenForDetailsToggle();
@@ -255,6 +255,12 @@ function handleCommentSubmit(event) {
           initializeCommentDate();
           initializeCommentDropdown();
         })
+      } else {
+        response.json().then(function parseError(errorReponse) {
+          form.classList.remove('submitting');
+          window.alert(errorReponse.error); // eslint-disable-line no-alert
+          return false;
+        });
       }
       return false;
     });

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -98,6 +98,8 @@ class CommentsController < ApplicationController
     else
       render json: { status: "errors" }
     end
+  rescue Pundit::NotAuthorizedError
+    raise
   rescue StandardError => e
     Rails.logger.error(e)
     message = "There was a error in your markdown: #{e}"

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -55,10 +55,13 @@ class CommentsController < ApplicationController
     authorize @comment
 
     if @comment.save
-      current_user.update(checked_code_of_conduct: true) if params[:checked_code_of_conduct].present? && !current_user.checked_code_of_conduct
+      checked_code_of_conduct = params[:checked_code_of_conduct].present? && !current_user.checked_code_of_conduct
+      current_user.update(checked_code_of_conduct: true) if checked_code_of_conduct
 
       Mention.create_all(@comment)
-      NotificationSubscription.create(user: current_user, notifiable_id: @comment.id, notifiable_type: "Comment", config: "all_comments")
+      NotificationSubscription.create(
+        user: current_user, notifiable_id: @comment.id, notifiable_type: "Comment", config: "all_comments",
+      )
       Notification.send_new_comment_notifications_without_delay(@comment)
 
       if @comment.invalid?
@@ -95,6 +98,10 @@ class CommentsController < ApplicationController
     else
       render json: { status: "errors" }
     end
+  rescue StandardError => e
+    Rails.logger.error(e)
+    message = "There was a error in your markdown: #{e}"
+    render json: { error: message }, status: :unprocessable_entity
   end
 
   # PATCH/PUT /comments/1


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When a liquid tag breaks in the comments form, the form hangs forever.

This PR is the result of some investigation prompted by  https://github.com/thepracticaldev/dev.to/pull/5439

The comments form handles nicely errors with the preview:

![Screenshot_2020-01-13 awesome — DEV - DEV(local) Community 👩‍💻👨‍💻](https://user-images.githubusercontent.com/146201/72251116-77bb8f00-35fd-11ea-8ea1-cef9639f4af7.png)

but doesn't handle the same errors when the `SUBMIT` button is pressed. 

ps. I'm using `window.alert` because it's already used in the JS file in other places, hopefully we can come up with a better error handling UX in the future.

I added a video recording below

## Related Tickets & Documents

https://github.com/thepracticaldev/dev.to/pull/5439

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![invalid liquid tags](https://user-images.githubusercontent.com/146201/72251171-9b7ed500-35fd-11ea-9268-528fa22331ce.gif)
