### PR TITLE
Destroy messages if chat channels are destroyed

### DIFF
--- a/app/models/chat_channel.rb
+++ b/app/models/chat_channel.rb
@@ -2,7 +2,7 @@ class ChatChannel < ApplicationRecord
   include AlgoliaSearch
   attr_accessor :current_user, :usernames_string
 
-  has_many :messages
+  has_many :messages, dependent: :destroy
   has_many :chat_channel_memberships, dependent: :destroy
   has_many :users, through: :chat_channel_memberships
 

--- a/spec/models/chat_channel_spec.rb
+++ b/spec/models/chat_channel_spec.rb
@@ -5,7 +5,9 @@ RSpec.describe ChatChannel, type: :model do
 
   let_it_be(:users) { create_list(:user, 2) }
 
-  it { is_expected.to have_many(:messages) }
+  it { is_expected.to have_many(:messages).dependent(:destroy) }
+  it { is_expected.to have_many(:chat_channel_memberships).dependent(:destroy) }
+  it { is_expected.to have_many(:users) }
   it { is_expected.to validate_presence_of(:channel_type) }
 
   describe "#clear_channel" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

While reviewing #5460 I tried to destroy a channel and encountered a violation error from the DB. Messages can't not belong to a chat channel so they should be destroyed as a dependency.

See:

https://github.com/thepracticaldev/dev.to/blob/851508f62825c056bb39df122e11ada35fcadbc6/db/schema.rb#L528-L529

and

https://github.com/thepracticaldev/dev.to/blob/851508f62825c056bb39df122e11ada35fcadbc6/db/schema.rb#L1198