### PR TITLE
Return 429 Too Many Requests instead of raising

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -47,7 +47,10 @@ class CommentsController < ApplicationController
   # POST /comments
   # POST /comments.json
   def create
-    raise if RateLimitChecker.new(current_user).limit_by_action("comment_creation")
+    if RateLimitChecker.new(current_user).limit_by_action("comment_creation")
+      skip_authorization
+      return head(:too_many_requests)
+    end
 
     @comment = Comment.new(permitted_attributes(Comment))
     @comment.user_id = current_user.id

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -49,7 +49,8 @@ class CommentsController < ApplicationController
   def create
     if RateLimitChecker.new(current_user).limit_by_action("comment_creation")
       skip_authorization
-      return head(:too_many_requests)
+      render json: {}, status: :too_many_requests
+      return
     end
 
     @comment = Comment.new(permitted_attributes(Comment))

--- a/spec/requests/comments_create_spec.rb
+++ b/spec/requests/comments_create_spec.rb
@@ -25,6 +25,17 @@ RSpec.describe "CommentsCreate", type: :request do
     expect(NotificationSubscription.last.notifiable).to eq(Comment.last)
   end
 
+  it "returns 429 Too Many Requests when a user reachers their rate limit" do
+    create_list(:comment, 10, user: user, commentable: article)
+    new_body = "NEW BODY #{rand(100)}"
+
+    post "/comments", params: {
+      comment: { body_markdown: new_body, commentable_id: article.id, commentable_type: "Article" }
+    }
+
+    expect(response).to have_http_status(429)
+  end
+
   context "when user is posting on an author that blocks user" do
     it "returns unauthorized" do
       create(:user_block, blocker: blocker, blocked: user, config: "default")

--- a/spec/requests/comments_create_spec.rb
+++ b/spec/requests/comments_create_spec.rb
@@ -4,33 +4,31 @@ RSpec.describe "CommentsCreate", type: :request do
   let(:user) { create(:user) }
   let(:blocker) { create(:user) }
   let(:article) { create(:article, user_id: user.id) }
+  let(:new_body) { -> { "NEW BODY #{rand(100)}" } }
 
   before do
     sign_in user
   end
 
   it "creates ordinary article with proper params" do
-    new_body = "NEW BODY #{rand(100)}"
     post "/comments", params: {
-      comment: { body_markdown: new_body, commentable_id: article.id, commentable_type: "Article" }
+      comment: { body_markdown: new_body.call, commentable_id: article.id, commentable_type: "Article" }
     }
     expect(Comment.last.user_id).to eq(user.id)
   end
 
   it "creates NotificationSubscription for comment" do
-    new_body = "NEW BODY #{rand(100)}"
     post "/comments", params: {
-      comment: { body_markdown: new_body, commentable_id: article.id, commentable_type: "Article" }
+      comment: { body_markdown: new_body.call, commentable_id: article.id, commentable_type: "Article" }
     }
     expect(NotificationSubscription.last.notifiable).to eq(Comment.last)
   end
 
   it "returns 429 Too Many Requests when a user reachers their rate limit" do
     create_list(:comment, 10, user: user, commentable: article)
-    new_body = "NEW BODY #{rand(100)}"
 
     post "/comments", params: {
-      comment: { body_markdown: new_body, commentable_id: article.id, commentable_type: "Article" }
+      comment: { body_markdown: new_body.call, commentable_id: article.id, commentable_type: "Article" }
     }
 
     expect(response).to have_http_status(429)

--- a/spec/requests/comments_create_spec.rb
+++ b/spec/requests/comments_create_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "CommentsCreate", type: :request do
       comment: { body_markdown: new_body.call, commentable_id: article.id, commentable_type: "Article" }
     }
 
-    expect(response).to have_http_status(429)
+    expect(response).to have_http_status(:too_many_requests)
   end
 
   context "when user is posting on an author that blocks user" do


### PR DESCRIPTION
#5246  What type of PR is this? (check all applicable)

- [X] Refactor

## Description

Instead of raising an exception when the user's comment rate limit has been reached we now return an empty response with a status code of 429.

## Related Tickets & Documents

#5503 

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed
