### PR TITLE
Use .execute to avoid any possibility of prepared statements

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -4,24 +4,20 @@ class ApplicationRecord < ActiveRecord::Base
   QUERY_ESTIMATED_COUNT = <<~SQL.squish.freeze
     SELECT (
       (reltuples / GREATEST(relpages, 1)) *
-      (pg_relation_size($1) / (GREATEST(current_setting('block_size')::integer, 1)))
+      (pg_relation_size(?) / (GREATEST(current_setting('block_size')::integer, 1)))
     )::bigint AS count
-    FROM pg_class WHERE relname = $2;
+    FROM pg_class WHERE relname = ?;
   SQL
 
   # Computes an estimated count of the number of rows using stats collected by VACUUM
   # inspired by <https://www.citusdata.com/blog/2016/10/12/count-performance/#dup_counts_estimated_full>
   # and <https://stackoverflow.com/a/48391562/4186181>
   def self.estimated_count
-    query_name = "SQL COUNT ESTIMATE: #{table_name}"
-    table_name_attr = ActiveRecord::Relation::QueryAttribute.new(
-      "relname", table_name, ActiveRecord::Type::String.new
-    )
+    query = sanitize_sql_array([QUERY_ESTIMATED_COUNT, table_name, table_name])
+    result = connection.execute(query)
 
-    result = connection.exec_query(
-      QUERY_ESTIMATED_COUNT, query_name, [table_name_attr, table_name_attr]
-    )
-
-    result.first["count"]
+    count = result.first["count"]
+    result.clear # PG::Result is manually managed in memory, we need to release its resources
+    count
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We can't use prepared statements in production because of PGBouncer, this uses the `connection.execute` directly to avoid triggering that issue
