### PR TITLE
Raise an error if the ENV variable DEPLOY_STATUS is set to blocked 

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -37,17 +37,20 @@ Upon deploy, the app installs dependencies, bundles assets, and gets the app
 ready for launch. However, before it launches and releases the app Heroku runs a
 release script on a one-off dyno. If that release script/step succeeds the new
 app is released on all of the dynos. If that release script/step fails then the
-deploy is halted and we are notified. During this release step, we first run any
-outstanding migrations. This ensures that a migration finishes successfully
-before the code that uses it goes live. After running migrations, we use the
-Rails runner to output a simple string indicating that it ran and the app was
-able to load successfully. The Rails runner will also check the DEPLOY_STATUS
-environment variable. In the event that we want to prevent deploys, for example
-after a rollback, we will set DEPLOY_STATUS to "blocked". This will cause the
-Rails runner to raise an error and prevent the release phase from finishing
-successfully which will halt the deploy. This ensures that we don't accidentally
-push out code while we are waiting for a fix or running other tasks. We deploy
+deploy is halted and we are notified. During this release step, we first check
+the DEPLOY_STATUS environment variable. In the event that we want to prevent
+deploys, for example after a rollback, we will set DEPLOY_STATUS to "blocked".
+This will cause the release script to exit with a code of 1 which will halt the
+deploy. This ensures that we don't accidentally push out code while we are
+waiting for a fix or running other tasks. Next, we run any outstanding
+migrations. This ensures that a migration finishes successfully before the code
+that uses it goes live. After running migrations, we use the Rails runner to
+output a simple string. Executing a Rails runner command ensures that we can
+boot up the entire app successfully before it is deployed. We deploy
 asynchronously, so the website is running the new code a few minutes after
 deploy. A new instance of Heroku Rails console will immediately run a new code.
+We deploy asynchronously, so the website is running the new code a few minutes
+after deploy. A new instance of Heroku Rails console will immediately run a new
+code.
 
 ![](https://devcenter0.assets.heroku.com/article-images/1494371187-release-phase-diagram-3.png)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -40,10 +40,14 @@ app is released on all of the dynos. If that release script/step fails then the
 deploy is halted and we are notified. During this release step, we first run any
 outstanding migrations. This ensures that a migration finishes successfully
 before the code that uses it goes live. After running migrations, we use the
-rails runner to output a simple string. Executing a Rails runner command allows
-us to ensure that we can boot up the entire app successfully before it is
-deployed. We deploy asynchronously, so the website is running the new code a few
-minutes after deploy. A new instance of Heroku Rails console will immediately
-run a new code.
+Rails runner to output a simple string indicating that it ran and the app was
+able to load successfully. The Rails runner will also check the DEPLOY_STATUS
+environment variable. In the event that we want to prevent deploys, for example
+after a rollback, we will set DEPLOY_STATUS to "blocked". This will cause the
+Rails runner to raise an error and prevent the release phase from finishing
+successfully which will halt the deploy. This ensures that we don't accidentally
+push out code while we are waiting for a fix or running other tasks. We deploy
+asynchronously, so the website is running the new code a few minutes after
+deploy. A new instance of Heroku Rails console will immediately run a new code.
 
 ![](https://devcenter0.assets.heroku.com/article-images/1494371187-release-phase-diagram-3.png)

--- a/release-tasks.sh
+++ b/release-tasks.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-STATEMENT_TIMEOUT=180000 bundle exec rails db:migrate && rails runner "puts 'app load success'"
+STATEMENT_TIMEOUT=180000 bundle exec rails db:migrate && rails runner "puts 'app load success'; raise 'Deploy blocked' if ENV['DEPLOY_STATUS']=='blocked'"

--- a/release-tasks.sh
+++ b/release-tasks.sh
@@ -1,3 +1,11 @@
 #!/bin/bash
 
-STATEMENT_TIMEOUT=180000 bundle exec rails db:migrate && rails runner "puts 'app load success'; raise 'Deploy blocked' if ENV['DEPLOY_STATUS']=='blocked'"
+# enable echo mode
+set -x
+
+# abort release if deploy status equals "blocked"
+[[ $DEPLOY_STATUS = "blocked" ]] && echo "Deploy blocked" && exit 1
+
+# runs migration and boots the app to check there are no errors
+STATEMENT_TIMEOUT=180000 bundle exec rails db:migrate && \
+  bundle exec rails runner "puts 'app load success'"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
In the event that we want to prevent deploys, for example after a rollback, we will set DEPLOY_STATUS to "blocked". This will cause the Rails runner to raise an error and prevent the release phase from finishing successfully which will halt the deploy. This ensures that we don't accidentally push out code while we are waiting for a fix or running other tasks.

## Added to documentation?
- [x] readme

![alt_text](https://media1.tenor.com/images/c3d942614471e2978d065b29120d0621/tenor.gif?itemid=13476334)
