### PR TITLE
Scrub Unused data sent to Honeycomb to save space

### DIFF
--- a/config/initializers/honeycomb.rb
+++ b/config/initializers/honeycomb.rb
@@ -21,6 +21,16 @@ else
       send_data.action_controller
       deliver.action_mailer
     ].freeze
+
+    # Scrub unused data to save space in Honeycomb
+    config.presend_hook do |fields|
+      if fields.key?("redis.command")
+        fields["redis.command"].slice!(0, 300)
+      elsif fields.key?("sql.active_record.binds")
+        fields.delete("sql.active_record.binds")
+        fields.delete("sql.active_record.datadog_span")
+      end
+    end
   end
 
   # here we create an additional Honeycomb client that can be used to send custom events


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
After doing a walkthrough of our data with the fine folks at Honeycomb(@lizthegrey) we found that our data is pretty bloated with unnecessary fields that we don't need. By removing these fields we will shrink the size of the data we are sending which will allow us to retain data for a longer period bc we won't be hitting our data cap as quickly as before. 

[Here are the docs on using this method to scrub data](https://docs.honeycomb.io/getting-data-in/ruby/beeline/#augmenting-or-scrubbing-spans) I tested this in a production console and saw the data removed in Honeycomb so I think that means its good to go.

1. "sql.active_record.binds" are the AR models that are bound to the SQL which is useless. We still have the values from the field "sql.active_record.type_casted_binds"
2. "sql.active_record.datadog_span" I dont think we need Datadog info in Honeycomb
3. "redis.command" These commands include the entire payload and when that is a view it is a lot of data. The only useful part of this field is the method and key itself. From there if we need data on the payload we can always ask Redis. I figured 300 characters was enough to ensure we get the key and method. 

## Related Tickets & Documents
#4925 

## Added to documentation?
- [x] no documentation needed

![honey I shrunk the kids gif](https://media.giphy.com/media/JUh0yTz4h931K/giphy.gif)
