### PR TITLE
Fix podcast NaN time issue

### DIFF
--- a/app/assets/javascripts/initializers/initializePodcastPlayback.js
+++ b/app/assets/javascripts/initializers/initializePodcastPlayback.js
@@ -240,7 +240,7 @@ function initializePodcastPlayback() {
         setMediaState(audio)
       }
     }
-    if (progress) {
+    if (progress && time && currentTime > 0) {
       progress.style.width = value + '%';
       buffer.style.width = bufferValue + '%';
       time.innerHTML =
@@ -325,7 +325,8 @@ function initializePodcastPlayback() {
   findAndApplyOnclickToRecords();
   getMediaState();
   var audio = getById('audio');
-  if (audio) {
+  var audioContent = getById('audiocontent')
+  if (audio && audioContent && audioContent.innerHTML.length < 25) { // audio not already loaded
     audio.load();
   }
 }

--- a/app/views/podcast_episodes/_liquid.html.erb
+++ b/app/views/podcast_episodes/_liquid.html.erb
@@ -69,7 +69,7 @@
       <span class="buffer-wrapper" id="bufferwrapper">
         <span id="buffer"></span>
         <span id="progress"></span>
-        <span id="time"></span>
+        <span id="time">initializing...</span>
         <span id="closebutt">×</span>
       </span>
     </div>

--- a/app/views/podcast_episodes/_podcast_bar.html.erb
+++ b/app/views/podcast_episodes/_podcast_bar.html.erb
@@ -35,7 +35,7 @@
     <span class="buffer-wrapper" id="bufferwrapper">
       <span id="buffer"></span>
       <span id="progress"></span>
-      <span id="time"></span>
+      <span id="time">initializing...</span>
       <span id="closebutt">×</span>
     </span>
   </div>


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR fixes a small bug where `NaN` flashes for a moment during initialization of a podcast. Also fixes an issue where audio tries to load even if already loaded.