### PR TITLE
Send additional Sidekiq data to Honeycomb

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -8,4 +8,8 @@ Sidekiq.configure_server do |config|
   # On Heroku this configuration is overridden and Sidekiq will point at the redis
   # instance given by the ENV variable REDIS_PROVIDER
   config.redis = { url: sidekiq_url }
+
+  config.server_middleware do |chain|
+    chain.add Sidekiq::HoneycombMiddleware
+  end
 end

--- a/lib/sidekiq/honeycomb_middleware.rb
+++ b/lib/sidekiq/honeycomb_middleware.rb
@@ -1,0 +1,24 @@
+module Sidekiq
+  class HoneycombMiddleware
+    # @param [Object] worker the worker instance
+    # @param [Hash] job the full job payload
+    #   * @see https://github.com/mperham/sidekiq/wiki/Job-Format
+    # @param [String] queue the name of the queue the job was pulled from
+    def call(worker, job, queue)
+      Honeycomb.start_span(name: "sidekiq.job") do |span|
+        span.add_field("sidekiq.class", worker.class.name)
+        span.add_field("sidekiq.queue", queue)
+        span.add_field("sidekiq.jid", job["jid"])
+        span.add_field("sidekiq.args", job["args"])
+        begin
+          yield
+          span.add_field("sidekiq.result", "success")
+        rescue StandardError => e
+          span.add_field("sidekiq.result", "error")
+          span.add_field("sidekiq.error", e.message)
+          raise e
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
To give us a more complete picture of what the app is doing at any given time I thought sending Sidekiq information to Honeycomb would be important. I found [this code in an issue on the beeline ruby gem](https://github.com/honeycombio/beeline-ruby/issues/29) 

## Related Tickets & Documents
#4925 

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media0.giphy.com/media/3o6nUOzXO0dw8vzN7O/giphy.gif)
