### PR TITLE
Send Sidekiq data to Honeycomb

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -8,4 +8,8 @@ Sidekiq.configure_server do |config|
   # On Heroku this configuration is overridden and Sidekiq will point at the redis
   # instance given by the ENV variable REDIS_PROVIDER
   config.redis = { url: sidekiq_url }
+
+  config.server_middleware do |chain|
+    chain.add Sidekiq::HoneycombMiddleware
+  end
 end

--- a/lib/sidekiq/honeycomb_middleware.rb
+++ b/lib/sidekiq/honeycomb_middleware.rb
@@ -5,7 +5,7 @@ module Sidekiq
     #   * @see https://github.com/mperham/sidekiq/wiki/Job-Format
     # @param [String] queue the name of the queue the job was pulled from
     def call(worker, job, queue)
-      Honeycomb.start_span(name: "sidekiq.job") do |span|
+      Honeycomb.start_span(name: "sidekiq") do |span|
         span.add_field("sidekiq.class", worker.class.name)
         span.add_field("sidekiq.queue", queue)
         span.add_field("sidekiq.jid", job["jid"])

--- a/lib/sidekiq/honeycomb_middleware.rb
+++ b/lib/sidekiq/honeycomb_middleware.rb
@@ -1,0 +1,24 @@
+module Sidekiq
+  class HoneycombMiddleware
+    # @param [Object] worker the worker instance
+    # @param [Hash] job the full job payload
+    #   * @see https://github.com/mperham/sidekiq/wiki/Job-Format
+    # @param [String] queue the name of the queue the job was pulled from
+    def call(worker, job, queue)
+      Honeycomb.start_span(name: "sidekiq.job") do |span|
+        span.add_field("sidekiq.class", worker.class.name)
+        span.add_field("sidekiq.queue", queue)
+        span.add_field("sidekiq.jid", job["jid"])
+        span.add_field("sidekiq.args", job["args"])
+        begin
+          yield
+          span.add_field("sidekiq.result", "success")
+        rescue StandardError => e
+          span.add_field("sidekiq.result", "error")
+          span.add_field("sidekiq.error", e.message)
+          raise e
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/sidekiq/honeycomb_middleware_spec.rb
+++ b/spec/lib/sidekiq/honeycomb_middleware_spec.rb
@@ -21,18 +21,39 @@ RSpec.describe Sidekiq::HoneycombMiddleware do
   end
 
   before do
-    Sidekiq::Testing.inline!
-
     Sidekiq::Testing.server_middleware do |chain|
       chain.add described_class
     end
   end
 
   it "sends an event with expected keys" do
-    TestSidekiqWorker.perform_async(*args)
+    Sidekiq::Testing.inline! do
+      TestSidekiqWorker.perform_async("dont fail")
+    end
 
-    collected_data = Honeycomb.client.send("client").events.map(&:data).first
+    collected_data = Honeycomb.client.send("client").events.map(&:data).detect { |h| h["sidekiq.args"] == expected_hash["sidekiq.args"] }
     expect(collected_data).to include(expected_hash)
+  end
+
+  context "without args" do
+    let(:expected_hash) do
+      {
+        "sidekiq.class" => TestSidekiqWorker.to_s,
+        "sidekiq.queue" => "low_priority",
+        "sidekiq.jid" => instance_of(String),
+        "sidekiq.args" => [],
+        "sidekiq.result" => "success"
+      }
+    end
+
+    it "sends an event with expected keys" do
+      Sidekiq::Testing.inline! do
+        TestSidekiqWorker.perform_async
+      end
+
+      collected_data = Honeycomb.client.send("client").events.map(&:data).detect { |h| h["sidekiq.args"] == expected_hash["sidekiq.args"] }
+      expect(collected_data).to include(expected_hash)
+    end
   end
 
   context "with an error" do
@@ -48,9 +69,11 @@ RSpec.describe Sidekiq::HoneycombMiddleware do
     end
 
     it "sends an event with expected keys" do
-      expect { TestSidekiqWorker.perform_async("fail") }.to raise_error(StandardError)
+      Sidekiq::Testing.inline! do
+        expect { TestSidekiqWorker.perform_async("fail") }.to raise_error(StandardError)
+      end
 
-      collected_data = Honeycomb.client.send("client").events.map(&:data).detect { |h| h.key?("sidekiq.error") }
+      collected_data = Honeycomb.client.send("client").events.map(&:data).detect { |h| h["sidekiq.args"] == error_hash["sidekiq.args"] }
       expect(collected_data).to include(error_hash)
     end
   end

--- a/spec/lib/sidekiq/honeycomb_middleware_spec.rb
+++ b/spec/lib/sidekiq/honeycomb_middleware_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+class TestSidekiqWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: :low_priority
+
+  def perform(arg = nil)
+    raise StandardError, "BOOM" if arg == "fail"
+  end
+end
+
+RSpec.describe Sidekiq::HoneycombMiddleware do
+  let(:expected_hash) do
+    {
+      "sidekiq.class" => TestSidekiqWorker.to_s,
+      "sidekiq.queue" => "low_priority",
+      "sidekiq.jid" => instance_of(String),
+      "sidekiq.args" => ["dont fail"],
+      "sidekiq.result" => "success"
+    }
+  end
+
+  before do
+    Sidekiq::Testing.inline!
+
+    Sidekiq::Testing.server_middleware do |chain|
+      chain.add described_class
+    end
+  end
+
+  it "sends an event with expected keys" do
+    TestSidekiqWorker.perform_async(*args)
+
+    collected_data = Honeycomb.client.send("client").events.map(&:data).first
+    expect(collected_data).to include(expected_hash)
+  end
+
+  context "with an error" do
+    let(:error_hash) do
+      {
+        "sidekiq.class" => TestSidekiqWorker.to_s,
+        "sidekiq.queue" => "low_priority",
+        "sidekiq.jid" => instance_of(String),
+        "sidekiq.args" => ["fail"],
+        "sidekiq.error" => "BOOM",
+        "sidekiq.result" => "error"
+      }
+    end
+
+    it "sends an event with expected keys" do
+      expect { TestSidekiqWorker.perform_async("fail") }.to raise_error(StandardError)
+
+      collected_data = Honeycomb.client.send("client").events.map(&:data).detect { |h| h.key?("sidekiq.error") }
+      expect(collected_data).to include(error_hash)
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
To give us a more complete picture of what the app is doing at any given time I thought sending Sidekiq information to Honeycomb would be important. I found [this code in an issue on the beeline ruby gem](https://github.com/honeycombio/beeline-ruby/issues/29) and liked the way it was implemented. Specs included this time :)  

I was going to add a duration field but then realized all Honeycomb spans come with a duration so it would be redundant. 

## Related Tickets & Documents
#4925 

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media0.giphy.com/media/3o6nUOzXO0dw8vzN7O/giphy.gif)
