### PR TITLE
Adding info about disappearing tokens

### DIFF
--- a/docs/backend/auth-twitter.md
+++ b/docs/backend/auth-twitter.md
@@ -13,35 +13,35 @@ application.
 
 1. [Sign in](https://developer.twitter.com/apps) to your Twitter account.
 
-
-2. In order to get the API keys, you will have to
-   [apply for a developer account](https://developer.twitter.com/en/apply-for-access). Click the **Apply** button.
+2) In order to get the API keys, you will have to
+   [apply for a developer account](https://developer.twitter.com/en/apply-for-access).
+   Click the **Apply** button.
 
    ![twitter-up-1](https://user-images.githubusercontent.com/22895284/51078779-53139b00-16bb-11e9-911c-f232e229872a.png)
 
-3. Setup your Twitter account. Be sure you have your phone number and email
+3) Setup your Twitter account. Be sure you have your phone number and email
    address filled in.
 
    ![twitter-up-2](https://user-images.githubusercontent.com/22895284/51078780-53139b00-16bb-11e9-91d5-08c9365ff08f.png)
 
-4. Fill in your account information and give a name to your **developer
+4) Fill in your account information and give a name to your **developer
    account**.
 
    ![twitter-up-3](https://user-images.githubusercontent.com/22895284/51078781-53ac3180-16bb-11e9-8cf4-005efbb92d8a.png)
 
-5. Write down the reasons that you want to use Twitter API. Mention DEV's
+5) Write down the reasons that you want to use Twitter API. Mention DEV's
    community and describe the issues and tests and things that you want to work
    on. Copy it, you might use it later ;)
 
    ![twitter-up-4](https://user-images.githubusercontent.com/22895284/51078782-53ac3180-16bb-11e9-9937-c888ae40143c.png)
 
-6. Read :) and accept the Terms and Conditions.
+6) Read :) and accept the Terms and Conditions.
 
    ![twitter-up-5](https://user-images.githubusercontent.com/22895284/51078783-53ac3180-16bb-11e9-9cf1-8e009ada6e57.png)
 
-7. Verify your email address once more, and you will be done.
+7) Verify your email address once more, and you will be done.
 
-8. You are done.
+8) You are done.
 
 ## Get API keys
 
@@ -49,6 +49,7 @@ application.
    to your Twitter developer account.
 
 2. From **Apps** dashboard, click on **Create and app**.
+
    ![twitter-1](https://user-images.githubusercontent.com/22895284/51078797-9a019080-16bb-11e9-8130-1cd13008461e.png)
 
 3. Fill in the app name, description, and URL `https://dev.to`.
@@ -70,8 +71,8 @@ application.
 
    ![twitter-5](https://user-images.githubusercontent.com/22895284/51078801-9a9a2700-16bb-11e9-9bd9-76c9ca1ba526.png)
 
-7. Review the [Twitter Developer
-   Terms](https://developer.twitter.com/en/developer-terms/agreement-and-policy.html)
+7. Review the
+   [Twitter Developer Terms](https://developer.twitter.com/en/developer-terms/agreement-and-policy.html)
    and agree to do nothing sketchy.
 
    ![twitter-6](https://user-images.githubusercontent.com/22895284/51078802-9a9a2700-16bb-11e9-8789-53720bcfc9d9.png)
@@ -84,7 +85,9 @@ application.
    ![twitter-7](https://user-images.githubusercontent.com/22895284/51078803-9a9a2700-16bb-11e9-8f27-dbfe04b52031.png)
 
 10. From the same dashboard access the **Keys and tokens** and change them
-    accordingly (name of Twitter key -> name of our `ENV` variable):
+    accordingly (name of Twitter key -> name of our `ENV` variable). Be sure to
+    copy the _access token_ and _access token secret_ right away because it is
+    the only time you will see it.
 
     ```text
     API key -> TWITTER_KEY

--- a/docs/backend/auth-twitter.md
+++ b/docs/backend/auth-twitter.md
@@ -13,35 +13,35 @@ application.
 
 1. [Sign in](https://developer.twitter.com/apps) to your Twitter account.
 
-2) In order to get the API keys, you will have to
+2. In order to get the API keys, you will have to
    [apply for a developer account](https://developer.twitter.com/en/apply-for-access).
    Click the **Apply** button.
 
    ![twitter-up-1](https://user-images.githubusercontent.com/22895284/51078779-53139b00-16bb-11e9-911c-f232e229872a.png)
 
-3) Setup your Twitter account. Be sure you have your phone number and email
+3. Setup your Twitter account. Be sure you have your phone number and email
    address filled in.
 
    ![twitter-up-2](https://user-images.githubusercontent.com/22895284/51078780-53139b00-16bb-11e9-91d5-08c9365ff08f.png)
 
-4) Fill in your account information and give a name to your **developer
+4. Fill in your account information and give a name to your **developer
    account**.
 
    ![twitter-up-3](https://user-images.githubusercontent.com/22895284/51078781-53ac3180-16bb-11e9-8cf4-005efbb92d8a.png)
 
-5) Write down the reasons that you want to use Twitter API. Mention DEV's
+5. Write down the reasons that you want to use Twitter API. Mention DEV's
    community and describe the issues and tests and things that you want to work
    on. Copy it, you might use it later ;)
 
    ![twitter-up-4](https://user-images.githubusercontent.com/22895284/51078782-53ac3180-16bb-11e9-9937-c888ae40143c.png)
 
-6) Read :) and accept the Terms and Conditions.
+6. Read :) and accept the Terms and Conditions.
 
    ![twitter-up-5](https://user-images.githubusercontent.com/22895284/51078783-53ac3180-16bb-11e9-9cf1-8e009ada6e57.png)
 
-7) Verify your email address once more, and you will be done.
+7. Verify your email address once more, and you will be done.
 
-8) You are done.
+8. You are done.
 
 ## Get API keys
 
@@ -86,8 +86,8 @@ application.
 
 10. From the same dashboard access the **Keys and tokens** and change them
     accordingly (name of Twitter key -> name of our `ENV` variable). Be sure to
-    copy the _access token_ and _access token secret_ right away because it is
-    the only time you will see it.
+    copy the _access token_ and _access token secret_ right away because it will
+    be hidden from you in the future.
 
     ```text
     API key -> TWITTER_KEY


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description
Starting January 21st 2020 Twitter will show _access token_ and _access token secret_ only once.

![image](https://user-images.githubusercontent.com/108287/72424987-322acd80-3787-11ea-8815-ed938d05c52a.png)

So I'm updating the docs to ensure devs are aware of this and they copy the tokens.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![image](https://user-images.githubusercontent.com/108287/72425102-669e8980-3787-11ea-9498-6852516a712a.png)


## Added to documentation?

- [x] docs.dev.to
- [ ] readme
- [ ] no documentation needed