### PR TITLE
Remove unnecessary heroku slug commit values in cache keys

### DIFF
--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -25,7 +25,7 @@
 <% end %>
 <%= javascript_pack_tag "homePage", defer: true %>
 
-<% cache("main-stories-index-#{params}-#{user_signed_in?}-#{ApplicationConfig['HEROKU_SLUG_COMMIT']}", expires_in: 90.seconds) do %>
+<% cache("main-stories-index-#{params}-#{user_signed_in?}", expires_in: 90.seconds) do %>
   <div class="home" id="index-container"
       data-params="<%= params.to_json(only: %i[tag username q]) %>" data-which="<%= @list_of %>"
       data-algolia-tag=""

--- a/app/views/stories/_main_stories_feed.html.erb
+++ b/app/views/stories/_main_stories_feed.html.erb
@@ -1,5 +1,5 @@
 <% if @default_home_feed && user_signed_in? %>
-  <% cache("fetched-home-articles-object-#{ApplicationConfig['HEROKU_SLUG_COMMIT']}", expires_in: 3.minutes) do %>
+  <% cache("fetched-home-articles-object", expires_in: 3.minutes) do %>
     <% @new_stories = Article.published.
          where("published_at > ? AND score > ?", rand(2..6).hours.ago, -15).
          limited_column_select.


### PR DESCRIPTION

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

PR #5472 introduced two changes in cache keys, which are likely and probably unnecessary after the deployment.

Though I understand the motivation (to quickly refresh something right after deploy), the fact that
the expiration values have been decreased to 90 seconds and 180 seconds respectively, probably invalidates
the need to have them refresh instantly on deploy (we can just wait 3 minutes).

Let me know if I'm wrong about this and I'll modify or close this PR
