### PR TITLE
Enable Bullet in development mode

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -101,10 +101,17 @@ Rails.application.configure do
   logger.level = config.log_level
   config.logger = ActiveSupport::TaggedLogging.new(logger)
 
+  # See <https://github.com/flyerhzm/bullet#configuration> for other config options
   config.after_initialize do
-    Bullet.enable = false
-    Bullet.console = false
+    Bullet.enable = true
+
+    Bullet.add_footer = true
+    Bullet.console = true
     Bullet.rails_logger = true
+
+    Bullet.add_whitelist(type: :unused_eager_loading, class_name: "ApiSecret", association: :user)
+    # acts-as-taggable-on has super weird eager loading problems: <https://github.com/mbleigh/acts-as-taggable-on/issues/91>
+    Bullet.add_whitelist(type: :n_plus_one_query, class_name: "ActsAsTaggableOn::Tagging", association: :tag)
   end
 end
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Bullet, the gem that helps us stay on top of N + 1 queries, was accidentally disabled in #5020

I've also enabled the floating window (because by only logging in the JS console and terminal there's a high probability people won't notice). See screenshots.

I've also updated its configuration to whitelist two known limitations.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![Screenshot 2020-01-15 at 5 29 09 PM](https://user-images.githubusercontent.com/146201/72452233-805ac380-37bd-11ea-88fc-ad001e3c0bad.png)

![Screenshot 2020-01-15 at 5 29 38 PM](https://user-images.githubusercontent.com/146201/72452305-9ff1ec00-37bd-11ea-8928-c20445abbd15.png)
