### PR TITLE
Fix missing redis server to gitpod configuration

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -2,5 +2,10 @@ FROM gitpod/workspace-postgres
 
 # Install Ruby
 ENV RUBY_VERSION=2.6.5
-RUN bash -lc "rvm install ruby-$RUBY_VERSION && rvm use ruby-$RUBY_VERSION --default" \
- && rm -f /tmp/*
+RUN bash -lc "rvm install ruby-$RUBY_VERSION && rvm use ruby-$RUBY_VERSION --default"
+
+# Install Redis.
+RUN sudo apt-get update \
+ && sudo apt-get install -y \
+  redis-server \
+ && sudo rm -rf /var/lib/apt/lists/*

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,7 +7,10 @@ ports:
     onOpen: ignore
   - port: 5432
     onOpen: ignore
+  - port: 6379
+    onOpen: ignore
 tasks:
+  - command: redis-server
   - init: >
       cp config/sample_application.yml config/application.yml &&
       bin/setup 2>/dev/null || true


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Before, the setup in gitpod wasn't working because was missing a running redis-server. Now, the installation of redis-server is been doing on gitpod dockerfile and is running after workspace build.

## Related Tickets & Documents
#5464 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![image](https://user-images.githubusercontent.com/30028621/72452260-049c4f00-379c-11ea-94d0-f0164744ee10.png)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/13xEKxMqnclCE0/giphy.gif)
