### PR TITLE
Record Background Queue stats in a Sidekiq Worker

### DIFF
--- a/app/workers/metrics/record_background_queue_stats_worker.rb
+++ b/app/workers/metrics/record_background_queue_stats_worker.rb
@@ -1,0 +1,10 @@
+module Metrics
+  class RecordBackgroundQueueStatsWorker
+    include Sidekiq::Worker
+    sidekiq_options queue: :low_priority, retry: 10
+
+    def perform
+      Loggers::LogWorkerQueueStats.run
+    end
+  end
+end

--- a/lib/tasks/fetch.rake
+++ b/lib/tasks/fetch.rake
@@ -113,9 +113,9 @@ task fix_credits_count_cache: :environment do
 end
 
 task record_db_table_counts: :environment do
-  RecordDbTableCountsWorker.perform_async
+  Metrics::RecordDbTableCountsWorker.perform_async
 end
 
 task log_worker_queue_stats: :environment do
-  Loggers::LogWorkerQueueStats.run
+  Metrics::RecordBackgroundQueueStatsWorker.perform_async
 end

--- a/spec/workers/metrics/record_background_queue_stats_worker_spec.rb
+++ b/spec/workers/metrics/record_background_queue_stats_worker_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe Metrics::RecordBackgroundQueueStatsWorker, type: :worker do
+  include_examples "#enqueues_on_correct_queue", "low_priority", 1
+
+  describe "#perform" do
+    it "logs estimated counts in Datadog" do
+      allow(Loggers::LogWorkerQueueStats).to receive(:run)
+      described_class.new.perform
+
+      expect(Loggers::LogWorkerQueueStats).to have_received(:run)
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
We are STILL not logging queue stats because currently, we run this task via our scheduler and in an effort to save money and decrease our host counts I disabled the Datadog APM on schedulers bc each task was run on a new host. This PR moves the logic into a worker and will ensure the counts get sent to Datadog bc the actual work will be done in a Sidekiq worker and those do have the APM enabled.

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media0.giphy.com/media/l4FGlDSngYRfnN1Ic/giphy.gif)
