### PR TITLE
Send Travis screenshots to s3 After A Failed Master Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,12 @@ script:
   - './cc-test-reporter upload-coverage'
   - 'bundle exec bundle-audit check --update --ignore CVE-2015-9284'
   - yarn build-storybook
+after_script:
+  addons:
+    artifacts:
+      paths:
+      - /tmp/screenshots/*.png
+      debug: true
 deploy:
   provider: heroku
   api_key: '$HEROKU_AUTH_TOKEN'


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
> Note that the artifacts addon is not available for pull request builds.

I was originally not going to bother with this bc it wasnt going to help me with my debugging branch since it's not available for PRs but then I reconsidered and figured it would probably be useful to have given how often flaky specs are popping up. I put together the yml file based on [Travis's documentation](https://docs.travis-ci.com/user/uploading-artifacts/) and added the necessary ENV variables to our Travis configuration so this should be good to go. 

## Related Tickets & Documents
#4884 

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media1.giphy.com/media/SSF73Sa5WH1E0vRo1s/giphy.gif)
