### PR TITLE
Fix typo in Skipping CI docs [ci skip]

### DIFF
--- a/docs/tests/skip-ci.md
+++ b/docs/tests/skip-ci.md
@@ -5,7 +5,7 @@ title: Skipping CI for minor changes
 # Skipping Continuous Integration
 
 It's almost always a good idea to let our [Continuous Integration][ci] tools do
-their work, but sometimes it can makes sense to skip CI.
+their work, but sometimes it can make sense to skip CI.
 
 In the case of extremely minor changes, like updating the project README or
 fixing a typo in the docs, you might want to skip CI by including `[ci skip]` in


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [X] Documentation Update

## Description
Fixed a small typo in the Docs under Testing/QA Guide/Skipping Continuous Integration.

## Related Tickets & Documents
I'm thinking that the Docs site might just need an update or some sort of "re-build", but I noticed that the files included in `/docs` aren't all on the production site.

For example, you can see in the [code](https://github.com/thepracticaldev/dev.to/blob/master/docs/tests/readme.md) that there should be a link to the [Regression Testing](https://github.com/thepracticaldev/dev.to/blob/master/docs/tests/regression-tests.md) page.

When I run `gitdocs serve` locally, it shows up fine. Regression Testing is included in the left menu, the text containing the typo shows up, and the title matches the [code](https://github.com/thepracticaldev/dev.to/blob/master/docs/tests/skip-ci.md#skipping-continuous-integration):
![local](https://user-images.githubusercontent.com/15987080/72480278-c870ea80-37ab-11ea-8b31-d3f5d1d058dd.png)

I also ran `gitdocs build` locally and took a look at the files that were generated. Regression Testing seems to be included as we'd expect.


However, when I visit the [Docs](https://docs.dev.to/tests/skip-ci/) in production, Regression Testing doesn't show up in the left side menu, the section of the Skipping CI containing the typo is missing, and the title doesn't match the [code](https://github.com/thepracticaldev/dev.to/blob/master/docs/tests/skip-ci.md#skipping-continuous-integration):
![production](https://user-images.githubusercontent.com/15987080/72480287-ce66cb80-37ab-11ea-912f-fb530c0925d0.png)

All this makes me wonder if the Docs site just needs a little nudge/refresh? If this is, in fact, a bug I'm happy to create an issue for it. My thinking was that maybe pushing the fix for this typo might fix all that.

## Added to documentation?
- [X] docs.dev.to
- [ ] readme
- [ ] no documentation needed

![confused](https://media.giphy.com/media/iHe7mA9M9SsyQ/giphy.gif)
