### PR TITLE
Add article's record key to Fastly Surrogate-Key to separate caches

### DIFF
--- a/app/controllers/api/v0/comments_controller.rb
+++ b/app/controllers/api/v0/comments_controller.rb
@@ -10,7 +10,7 @@ module Api
 
         @comments = article.comments.includes(:user).select(%i[id processed_html user_id ancestry]).arrange
 
-        set_surrogate_key_header "comments", edge_cache_keys(@comments)
+        set_surrogate_key_header article.record_key, "comments", edge_cache_keys(@comments)
       end
 
       def show

--- a/app/jobs/comments/bust_cache_job.rb
+++ b/app/jobs/comments/bust_cache_job.rb
@@ -7,6 +7,8 @@ module Comments
       return unless comment&.commentable
 
       comment.purge
+      comment.commentable.purge
+
       service.call(comment.commentable)
     end
   end

--- a/app/workers/comments/bust_cache_worker.rb
+++ b/app/workers/comments/bust_cache_worker.rb
@@ -9,6 +9,8 @@ module Comments
       return unless comment&.commentable
 
       comment.purge
+      comment.commentable.purge
+
       EdgeCache::Commentable::Bust.call(comment.commentable)
     end
   end

--- a/spec/jobs/comments/bust_cache_job_spec.rb
+++ b/spec/jobs/comments/bust_cache_job_spec.rb
@@ -28,7 +28,24 @@ RSpec.describe Comments::BustCacheJob, type: :job do
         expect(edge_cache_commentable_bust_service).to have_received(:call).with(comment.commentable).once
       end
 
-      it "does not call the service with a comment without a commentable" do
+      it "does not call purge on comment when commentable is not available" do
+        allow(comment).to receive(:commentable).and_return(nil)
+
+        described_class.perform_now(comment_id, edge_cache_commentable_bust_service)
+
+        expect(comment).not_to have_received(:purge)
+        expect(commentable).not_to have_received(:purge)
+      end
+
+      it "does not call purge on commentable when commentable is not available" do
+        allow(comment).to receive(:commentable).and_return(nil)
+
+        described_class.perform_now(comment_id, edge_cache_commentable_bust_service)
+
+        expect(commentable).not_to have_received(:purge)
+      end
+
+      it "does not call the service when commentable is not available" do
         allow(comment).to receive(:commentable).and_return(nil)
 
         described_class.perform_now(comment_id, edge_cache_commentable_bust_service)

--- a/spec/jobs/comments/bust_cache_job_spec.rb
+++ b/spec/jobs/comments/bust_cache_job_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Comments::BustCacheJob, type: :job do
       before do
         allow(comment).to receive(:commentable).and_return(commentable)
         allow(comment).to receive(:purge)
+        allow(commentable).to receive(:purge)
         allow(Comment).to receive(:find_by).with(id: comment_id).and_return(comment)
       end
 

--- a/spec/requests/api/v0/comments_spec.rb
+++ b/spec/requests/api/v0/comments_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "Api::V0::Comments", type: :request do
       get "/api/comments?a_id=#{article.id}"
 
       expected_key = [
-        "comments", sibling_root_comment.record_key,
+        article.record_key, "comments", sibling_root_comment.record_key,
         root_comment.record_key, child_comment.record_key,
         grandchild_comment.record_key, great_grandchild_comment.record_key
       ].to_set

--- a/spec/workers/comments/bust_cache_worker_spec.rb
+++ b/spec/workers/comments/bust_cache_worker_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Comments::BustCacheWorker, type: :worker do
   describe "#perform" do
     let(:worker) { subject }
 
-    before(:each) do
+    before do
       allow(EdgeCache::Commentable::Bust).to receive(:call)
     end
 
@@ -19,6 +19,7 @@ RSpec.describe Comments::BustCacheWorker, type: :worker do
         allow(comment).to receive(:commentable).and_return(commentable)
         allow(Comment).to receive(:find_by).with(id: comment_id).and_return(comment)
         allow(comment).to receive(:purge)
+        allow(commentable).to receive(:purge)
       end
 
       it "calls the service" do

--- a/spec/workers/comments/bust_cache_worker_spec.rb
+++ b/spec/workers/comments/bust_cache_worker_spec.rb
@@ -28,7 +28,24 @@ RSpec.describe Comments::BustCacheWorker, type: :worker do
         expect(EdgeCache::Commentable::Bust).to have_received(:call).with(comment.commentable).once
       end
 
-      it "does not call the service with a comment without a commentable" do
+      it "does not call purge on comment when commentable is not available" do
+        allow(comment).to receive(:commentable).and_return(nil)
+
+        worker.perform(comment_id)
+
+        expect(comment).not_to have_received(:purge)
+        expect(commentable).not_to have_received(:purge)
+      end
+
+      it "does not call purge on commentable when commentable is not available" do
+        allow(comment).to receive(:commentable).and_return(nil)
+
+        worker.perform(comment_id)
+
+        expect(commentable).not_to have_received(:purge)
+      end
+
+      it "does not call the service when commentable is not available" do
         allow(comment).to receive(:commentable).and_return(nil)
 
         worker.perform(comment_id)


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

After #4744 we successfully setup an auto purging system based on Fastly's surrogate key based cache and purging API.
Unfortunately this worked only in the `:show` action as comments are their own tree-based resource.
The `:index` though, is related to a single article, so without the article's record key in the `Surrogate-Key` header the first time we hit the API the result would become the value stored in Fastly's API, for all articles.

