### PR TITLE
Setup Carrierwave and Sitemap to use New AWS Creds

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -8,11 +8,11 @@ CarrierWave.configure do |config|
     config.fog_provider = "fog/aws"
     config.fog_credentials = {
       provider: "AWS",
-      aws_access_key_id: ApplicationConfig["AWS_ID"],
-      aws_secret_access_key: ApplicationConfig["AWS_SECRET"],
-      region: ApplicationConfig["AWS_DEFAULT_REGION"]
+      aws_access_key_id: ApplicationConfig["AWS_UPLOAD_ID"],
+      aws_secret_access_key: ApplicationConfig["AWS_UPLOAD_SECRET"],
+      region: ApplicationConfig["AWS_UPLOAD_REGION"]
     }
-    config.fog_directory = ApplicationConfig["AWS_BUCKET_NAME"]
+    config.fog_directory = ApplicationConfig["AWS_UPLOAD_BUCKET_NAME"]
     config.storage = :fog
   end
 end

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -1,14 +1,14 @@
 if Rails.env.production?
   SitemapGenerator::Sitemap.adapter = SitemapGenerator::S3Adapter.new(
     fog_provider: "AWS",
-    aws_access_key_id: ApplicationConfig["AWS_ID"],
-    aws_secret_access_key: ApplicationConfig["AWS_SECRET"],
-    fog_directory: ApplicationConfig["AWS_BUCKET_NAME"],
-    fog_region: ApplicationConfig["AWS_DEFAULT_REGION"],
+    aws_access_key_id: ApplicationConfig["AWS_UPLOAD_ID"],
+    aws_secret_access_key: ApplicationConfig["AWS_UPLOAD_SECRET"],
+    fog_directory: ApplicationConfig["AWS_UPLOAD_BUCKET_NAME"],
+    fog_region: ApplicationConfig["AWS_UPLOAD_REGION"],
   )
 
   SitemapGenerator::Sitemap.public_path = "tmp/"
-  SitemapGenerator::Sitemap.sitemaps_host = "https://thepracticaldev.s3.amazonaws.com/"
+  SitemapGenerator::Sitemap.sitemaps_host = "https://#{ApplicationConfig['AWS_UPLOAD_BUCKET_NAME']}.s3.amazonaws.com/"
   SitemapGenerator::Sitemap.sitemaps_path = "sitemaps/"
 end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
I was doing a lot of thinking about this and I know we talked about copying over from the old bucket to the new one but I don't think there is any need to do that. The images already uploaded are going to have their same urls and will still be served from the old bucket. After this goes out everything going forward will be uploaded to the new bucket and the urls will point at the new bucket. With that logic there should be no need for any additional "switch over" tasks. Am I thinking about that correctly @benhalpern?

~TODO: Put ENV variables in Heroku if everyone is on board with these variable names.~
New ENV variables are in place and ready to go

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media.giphy.com/media/H6bLvR0rwui3k3de0y/giphy.gif)
