### PR TITLE
Disable Beeline on Schedulers and in Console

### DIFF
--- a/datadog/prerun.sh
+++ b/datadog/prerun.sh
@@ -3,4 +3,5 @@
 # Disable the Datadog Agent for scheduler workers
 if [ "$DYNOTYPE" == "scheduler" ] || [ "$DYNOTYPE" == "run" ]; then
   DISABLE_DATADOG_AGENT="true"
+  HONEYCOMB_DISABLE_AUTOCONFIGURE="true"
 fi

--- a/datadog/prerun.sh
+++ b/datadog/prerun.sh
@@ -3,5 +3,8 @@
 # Disable the Datadog Agent for scheduler workers
 if [ "$DYNOTYPE" == "scheduler" ] || [ "$DYNOTYPE" == "run" ]; then
   DISABLE_DATADOG_AGENT="true"
+  # Disable Automatic Beeline integrations to prevent unnecessary
+  # data from being tracked in Honeycomb
+  # more info here: https://docs.honeycomb.io/getting-data-in/ruby/beeline/#using-env-variables-to-control-framework-integrations
   HONEYCOMB_DISABLE_AUTOCONFIGURE="true"
 fi


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix
- [x] Optimization

## Description
In Honeycomb we have these giant 30k event long spans that are coming from when we run scheduled tasks. The reason for this is bc many of these task iterates through lots of users or articles for processing. In an effort to decrease the size of what we send to Honeycomb in order to increase our data retention I think these are stats we can live without for now so [per the docs I set HONEYCOMB_DISABLE_AUTOCONFIGURE to true](https://docs.honeycomb.io/getting-data-in/ruby/beeline/#using-env-variables-to-control-framework-integrations) which will stop Beeline from including any of the automatic integrations. This script is run by Datadog before dynos are booted up so I figured why not use it to also set this ENV variable 🤷 

Something to consider is that Datadog is also disabled in an effort to save money on unique hosts because every time we kick off a rake task it is a new host. Given this, we have no really monitoring on those rake tasks at the moment. I do not think this is a problem bc anything we do decide we want to monitor we can move to a Sidekiq worker and then we will get it for free. We have also talked a lot about moving these tasks to Sidekiq anyways and ditching the scheduler so I dont think we are losing much here. If anything we are enticing us more to get those being run in a different place where we can gain more insights into them. 

Thoughts?

## Related Tickets & Documents
#4925 

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media1.tenor.com/images/3c7bd7bcd3f0729f96c524cbb3ea2355/tenor.gif?itemid=9743385)
