### PR TITLE
Update Travis Artifacts Path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ after_script:
   addons:
     artifacts:
       paths:
-      - /tmp/screenshots/*.png
+      - ~/build/thepracticaldev/dev.to/tmp/screenshots/*.png
       debug: true
 deploy:
   provider: heroku


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
We had a [failed travis build](https://travis-ci.com/thepracticaldev/dev.to/builds/144760546) that should have sent artifacts to S3 but did not. I updated our ENV variables bc there is a good chance I had those wrong. I also decided to be more explicit about this path rather than assume we are in the dev.to repo.

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media3.giphy.com/media/ywStNZ2sbBXjRS6eM2/giphy.gif)
