### PR TITLE
Setup SitemapGenerator and CarrierWave to use new AWS creds when ENV …

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -6,13 +6,23 @@ CarrierWave.configure do |config|
     config.storage = :file
   else
     config.fog_provider = "fog/aws"
-    config.fog_credentials = {
-      provider: "AWS",
-      aws_access_key_id: ApplicationConfig["AWS_ID"],
-      aws_secret_access_key: ApplicationConfig["AWS_SECRET"],
-      region: ApplicationConfig["AWS_DEFAULT_REGION"]
-    }
-    config.fog_directory = ApplicationConfig["AWS_BUCKET_NAME"]
+    if ENV["USE_NEW_AWS"]
+      config.fog_credentials = {
+        provider: "AWS",
+        aws_access_key_id: ApplicationConfig["AWS_UPLOAD_ID"],
+        aws_secret_access_key: ApplicationConfig["AWS_UPLOAD_SECRET"],
+        region: ApplicationConfig["AWS_UPLOAD_REGION"]
+      }
+      config.fog_directory = ApplicationConfig["AWS_UPLOAD_BUCKET_NAME"]
+    else
+      config.fog_credentials = {
+        provider: "AWS",
+        aws_access_key_id: ApplicationConfig["AWS_ID"],
+        aws_secret_access_key: ApplicationConfig["AWS_SECRET"],
+        region: ApplicationConfig["AWS_DEFAULT_REGION"]
+      }
+      config.fog_directory = ApplicationConfig["AWS_BUCKET_NAME"]
+    end
     config.storage = :fog
   end
 end

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -1,14 +1,25 @@
 if Rails.env.production?
-  SitemapGenerator::Sitemap.adapter = SitemapGenerator::S3Adapter.new(
-    fog_provider: "AWS",
-    aws_access_key_id: ApplicationConfig["AWS_ID"],
-    aws_secret_access_key: ApplicationConfig["AWS_SECRET"],
-    fog_directory: ApplicationConfig["AWS_BUCKET_NAME"],
-    fog_region: ApplicationConfig["AWS_DEFAULT_REGION"],
-  )
+  if ENV["USE_NEW_AWS"]
+    SitemapGenerator::Sitemap.adapter = SitemapGenerator::S3Adapter.new(
+      fog_provider: "AWS",
+      aws_access_key_id: ApplicationConfig["AWS_UPLOAD_ID"],
+      aws_secret_access_key: ApplicationConfig["AWS_UPLOAD_SECRET"],
+      fog_directory: ApplicationConfig["AWS_UPLOAD_BUCKET_NAME"],
+      fog_region: ApplicationConfig["AWS_UPLOAD_REGION"],
+    )
+    SitemapGenerator::Sitemap.sitemaps_host = "https://#{ApplicationConfig['AWS_UPLOAD_BUCKET_NAME']}.s3.amazonaws.com/"
+  else
+    SitemapGenerator::Sitemap.adapter = SitemapGenerator::S3Adapter.new(
+      fog_provider: "AWS",
+      aws_access_key_id: ApplicationConfig["AWS_ID"],
+      aws_secret_access_key: ApplicationConfig["AWS_SECRET"],
+      fog_directory: ApplicationConfig["AWS_BUCKET_NAME"],
+      fog_region: ApplicationConfig["AWS_DEFAULT_REGION"],
+    )
+    SitemapGenerator::Sitemap.sitemaps_host = "https://thepracticaldev.s3.amazonaws.com/"
+  end
 
   SitemapGenerator::Sitemap.public_path = "tmp/"
-  SitemapGenerator::Sitemap.sitemaps_host = "https://thepracticaldev.s3.amazonaws.com/"
   SitemapGenerator::Sitemap.sitemaps_path = "sitemaps/"
 end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
Steps to migrate to the new AWS bucket
1) Deploy this PR
2) Sync the 2 buckets (5-10min)
3) Set `USE_NEW_AWS` to true
4) Re-sync buckets to copy any new data that came in after first sync
5) Assign new credentials to original ENV variables
6) Open PR to switch back to original ENV variables that point to new creds 

~TODO: Put ENV variables in Heroku~
New ENV variables are in place and ready to go

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media1.tenor.com/images/5d17e101b8ed5dd93b20ee22b0250b12/tenor.gif?itemid=14872438)
