### PR TITLE
Change font size for search and message input

### DIFF
--- a/app/assets/stylesheets/chat.scss
+++ b/app/assets/stylesheets/chat.scss
@@ -1045,7 +1045,7 @@
 
 .messagecomposer__input {
   border-radius: 3px;
-  font-size: 14px;
+  font-size: 16px;
   margin: 6px 2px 6px 6px;
   padding: 5px;
   resize: none;

--- a/app/assets/stylesheets/top-bar.scss
+++ b/app/assets/stylesheets/top-bar.scss
@@ -418,8 +418,8 @@
     margin: 0;
     width: calc(100% - 12px);
     border-radius: 3px;
-    padding: 6px 9px;
-    font-size: 0.9em;
+    padding: 6px 9px 5px;
+    font-size: 16px;
     @include themeable(
       background, 
       theme-top-bar-search-background, 

--- a/app/views/service_worker/index.js.erb
+++ b/app/views/service_worker/index.js.erb
@@ -104,6 +104,7 @@
         !url.href.includes('/delayed_job') && // Skip for Delayed Job dashboard
         !url.href.includes('/sidekiq') && // Skip for Sidekiq dashboard
         !url.href.includes('/oauth/') && // Skip oauth apps
+        !url.href.includes('/robots.txt') && // Skip oauth apps
         !url.href.includes('/rails/mailers') && // Skip for mailers previews in development mode
         caches.match('/shell_top') && // Ensure shell_top is in the cache.
         caches.match('/shell_bottom')) { // Ensure shell_bottom is in the cache.


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This changes the font size of the nav search and /connect input to `16px` which is the minimum needed to not awkardly zoom in when focusing on these in iOS Safari.

Prior computed value of the nav bar input was `15.3px`, so very minor change.