### PR TITLE
Remove flaky edit button spec

### DIFF
--- a/spec/system/articles/user_edits_an_article_spec.rb
+++ b/spec/system/articles/user_edits_an_article_spec.rb
@@ -9,16 +9,6 @@ RSpec.describe "Editing with an editor", type: :system, js: true do
     sign_in user
   end
 
-  it "user clicks the edit button" do
-    link = "/#{user.username}/#{article.slug}"
-    visit link
-
-    wait_for_javascript
-
-    click_on("EDIT")
-    expect(page).to have_current_path(link + "/edit")
-  end
-
   it "user previews their changes" do
     visit "/#{user.username}/#{article.slug}/edit"
     fill_in "article_body_markdown", with: template.gsub("Suspendisse", "Yooo")


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

I don't think we should go around removing flaky tests, but this one seems to have way way way more random failures vs the value it's delivering of ensuring this edit button shows up.

We should study this to figure out the underlying problem, but I think we'll all be happier with this test stricken to the underworld.