### PR TITLE
Migrate popular history job 5305

### DIFF
--- a/app/services/pro_memberships/creator.rb
+++ b/app/services/pro_memberships/creator.rb
@@ -10,7 +10,7 @@ module ProMemberships
 
     def call
       if purchase_pro_membership
-        ProMemberships::PopulateHistoryJob.perform_later(user.id)
+        ProMemberships::PopulateHistoryWorker.perform_async(user.id)
 
         channel = ChatChannel.find_by(slug: "pro-members")
         channel&.add_users(user)

--- a/app/workers/pro_memberships/populate_history_worker.rb
+++ b/app/workers/pro_memberships/populate_history_worker.rb
@@ -1,0 +1,14 @@
+module ProMemberships
+  class PopulateHistoryWorker
+    include Sidekiq::Worker
+
+    sidekiq_options queue: :medium_priority, retry: 10
+
+    def perform(user_id)
+      user = User.find_by(id: user_id)
+      return unless user&.pro?
+
+      user.page_views.reindex!
+    end
+  end
+end

--- a/spec/requests/pro_memberships_spec.rb
+++ b/spec/requests/pro_memberships_spec.rb
@@ -69,10 +69,10 @@ RSpec.describe "Pro Memberships", type: :request do
       end
 
       it "enqueues a job to populate the history" do
-        assert_enqueued_with(
-          job: ProMemberships::PopulateHistoryJob,
+        sidekiq_assert_enqueued_with(
+          job: ProMemberships::PopulateHistoryWorker,
           args: [user.id],
-          queue: "pro_memberships_populate_history",
+          queue: "medium_priority",
         ) do
           post pro_membership_path
         end

--- a/spec/workers/pro_memberships/populate_history_worker_spec.rb
+++ b/spec/workers/pro_memberships/populate_history_worker_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe ProMemberships::PopulateHistoryWorker, type: :worker do
+  include_examples "#enqueues_on_correct_queue", "medium_priority", 1
+
+  describe "#perform" do
+    let(:user) { create(:user, :pro) }
+
+    before do
+      allow(User).to receive(:find_by).and_return(user)
+      allow(user.page_views).to receive(:reindex!)
+    end
+
+    it "indexes user page views" do
+      described_class.new.perform(user.id)
+      expect(user.page_views).to have_received(:reindex!).once
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This change creates a Sidekiq Worker equivalent of ProMemberships::PopulateHistoryJob


## Related Tickets & Documents
#5305 

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

