### PR TITLE
Raise not_found for spam-banished users

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -35,14 +35,6 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def user_banished?(user_or_org)
-    # User suspended and has no content
-    user_or_org.class.name == "User" &&
-      user_or_org.articles_count.zero? &&
-      user_or_org.comments_count.zero? &&
-      user_or_org.banned
-  end
-
   def customize_params
     params[:signed_in] = user_signed_in?.to_s
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -35,6 +35,14 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def user_banished?(user_or_org)
+    # User suspended and has no content
+    user_or_org.class.name == "User" &&
+      user_or_org.articles_count.zero? &&
+      user_or_org.comments_count.zero? &&
+      user_or_org.banned
+  end
+
   def customize_params
     params[:signed_in] = user_signed_in?.to_s
   end

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -42,7 +42,7 @@ class StoriesController < ApplicationController
     potential_username = params[:username].tr("@", "").downcase
     user_or_org = User.find_by("old_username = ? OR old_old_username = ?", potential_username, potential_username) ||
       Organization.find_by("old_slug = ? OR old_old_slug = ?", potential_username, potential_username)
-    if user_or_org.present?
+    if user_or_org.present? && !user_banished?(user_or_org)
       redirect_to user_or_org.path
     else
       not_found
@@ -163,14 +163,9 @@ class StoriesController < ApplicationController
       redirect_to_changed_username_profile
       return
     end
+    not_found if @user.username.include?("spam_") && user_banished?(@user)
     assign_user_comments
-    @pinned_stories = Article.published.where(id: @user.profile_pins.select(:pinnable_id)).
-      limited_column_select.
-      order("published_at DESC").decorate
-    @stories = ArticleDecorator.decorate_collection(@user.articles.published.
-      limited_column_select.
-      where.not(id: @pinned_stories.pluck(:id)).
-      order("published_at DESC").page(@page).per(user_signed_in? ? 2 : 5))
+    assign_user_stories
     @article_index = true
     @list_of = "articles"
     redirect_if_view_param
@@ -242,6 +237,16 @@ class StoriesController < ApplicationController
                 else
                   []
                 end
+  end
+
+  def assign_user_stories
+    @pinned_stories = Article.published.where(id: @user.profile_pins.select(:pinnable_id)).
+      limited_column_select.
+      order("published_at DESC").decorate
+    @stories = ArticleDecorator.decorate_collection(@user.articles.published.
+      limited_column_select.
+      where.not(id: @pinned_stories.pluck(:id)).
+      order("published_at DESC").page(@page).per(user_signed_in? ? 2 : 5))
   end
 
   def stories_by_timeframe

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -42,7 +42,7 @@ class StoriesController < ApplicationController
     potential_username = params[:username].tr("@", "").downcase
     user_or_org = User.find_by("old_username = ? OR old_old_username = ?", potential_username, potential_username) ||
       Organization.find_by("old_slug = ? OR old_old_slug = ?", potential_username, potential_username)
-    if user_or_org.present? && !user_banished?(user_or_org)
+    if user_or_org.present? && !user_or_org.decorate.fully_banished?
       redirect_to user_or_org.path
     else
       not_found
@@ -163,7 +163,7 @@ class StoriesController < ApplicationController
       redirect_to_changed_username_profile
       return
     end
-    not_found if @user.username.include?("spam_") && user_banished?(@user)
+    not_found if @user.username.include?("spam_") && @user.decorate.fully_banished?
     assign_user_comments
     assign_user_stories
     @article_index = true

--- a/app/decorators/organization_decorator.rb
+++ b/app/decorators/organization_decorator.rb
@@ -25,4 +25,10 @@ class OrganizationDecorator < ApplicationDecorator
       text: "#ffffff"
     }
   end
+
+  def fully_banished?
+    # We do not *currently* have the functionality to "ban" organizations.
+    # We deal with them in other ways, but we still need to respond to this question.
+    false
+  end
 end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -95,6 +95,13 @@ class UserDecorator < ApplicationDecorator
     colors[id % 10]
   end
 
+  def fully_banished?
+    # User suspended and has no content
+    articles_count.zero? &&
+      comments_count.zero? &&
+      banned
+  end
+
   def stackbit_integration?
     access_tokens.any?
   end

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -35,6 +35,16 @@ RSpec.describe UserDecorator, type: :decorator do
       follow.update(points: 0.1)
       expect(user.decorate.cached_followed_tags.first.points).to eq(0.1)
     end
+
+    it "returns not fully banished if in good standing" do
+      expect(user.decorate.fully_banished?).to eq(false)
+    end
+
+    it "returns fully banished if user has been banished" do
+      Moderator::BanishUser.call_banish(admin: user, user: user)
+      expect(user.decorate.fully_banished?).to eq(true)
+    end
+
   end
 
   describe "#config_body_class" do

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -202,4 +202,10 @@ RSpec.describe Organization, type: :model do
       expect(build(:organization).pro?).to be(false)
     end
   end
+
+  describe "#decoarated" do
+    it "returns not fully banished" do
+      expect(organization.decorate.fully_banished?).to eq(false)
+    end
+  end
 end

--- a/spec/requests/user/user_profile_spec.rb
+++ b/spec/requests/user/user_profile_spec.rb
@@ -39,6 +39,13 @@ RSpec.describe "UserProfiles", type: :request do
       expect(response).to redirect_to("/#{user.username}")
     end
 
+    it "raises not found for banished users" do
+      banishable_user = create(:user)
+      Moderator::BanishUser.call_banish(admin: user, user: banishable_user)
+      expect { get "/#{banishable_user.reload.old_username}" }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { get "/#{banishable_user.reload.username}" }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
     it "renders noindex meta if banned" do
       user.add_role(:banned)
       get "/#{user.username}"


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
We ban spam accounts and mark them as spam but don't currently raise not found, which we can essentially do. It's likely not correct to keep those empty profiles visible and discoverable.