### PR TITLE
replace notifiable action job with worker

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -40,7 +40,7 @@ class Notification < ApplicationRecord
     end
 
     def send_to_followers(notifiable, action = nil)
-      Notifications::NotifiableActionJob.perform_later(notifiable.id, notifiable.class.name, action)
+      Notifications::NotifiableActionWorker.perform_async(notifiable.id, notifiable.class.name, action)
     end
 
     def send_new_comment_notifications(comment)

--- a/app/workers/notifications/notifiable_action_worker.rb
+++ b/app/workers/notifications/notifiable_action_worker.rb
@@ -1,0 +1,14 @@
+module Notifications
+  class NotifiableActionWorker
+    include Sidekiq::Worker
+
+    sidekiq_options queue: :low_priority, retry: 10
+    def perform(notifiable_id, notifiable_type, action)
+      # checking type, but leaving space for notifyable types
+      return unless notifiable_type == "Article"
+
+      notifiable = notifiable_type.constantize.find_by(id: notifiable_id)
+      Notifications::NotifiableAction::Send.call(notifiable, action) if notifiable
+    end
+  end
+end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -1,16 +1,16 @@
 require "rails_helper"
 
 RSpec.describe Notification, type: :model do
-  let_it_be(:user)            { create(:user) }
-  let_it_be(:user2)           { create(:user) }
-  let_it_be(:user3)           { create(:user) }
-  let_it_be(:organization)    { create(:organization) }
-  let_it_be(:article) do
+  let_it_be_readonly(:user)            { create(:user) }
+  let_it_be_readonly(:user2)           { create(:user) }
+  let_it_be_readonly(:user3)           { create(:user) }
+  let_it_be_readonly(:organization)    { create(:organization) }
+  let_it_be_changeable(:article) do
     create(:article, :with_notification_subscription, user: user, page_views_count: 4000, positive_reactions_count: 70)
   end
-  let_it_be(:user_follows_user2) { user.follow(user2) }
-  let_it_be(:comment) { create(:comment, user: user2, commentable: article) }
-  let_it_be(:badge_achievement) { create(:badge_achievement) }
+  let_it_be_readonly(:user_follows_user2) { user.follow(user2) }
+  let_it_be_changeable(:comment) { create(:comment, user: user2, commentable: article) }
+  let_it_be_readonly(:badge_achievement) { create(:badge_achievement) }
 
   it do
     scopes = %i[organization_id notifiable_id notifiable_type action]
@@ -136,7 +136,7 @@ RSpec.describe Notification, type: :model do
     end
 
     context "when a user follows an organization" do
-      let_it_be(:user_follows_organization) { user.follow(organization) }
+      let_it_be_readonly(:user_follows_organization) { user.follow(organization) }
 
       it "creates a notification belonging to the organization" do
         expect do
@@ -150,7 +150,7 @@ RSpec.describe Notification, type: :model do
         sidekiq_perform_enqueued_jobs do
           described_class.send_new_follower_notification(user_follows_organization)
         end
-        expect(organization.notifications.last.user_id).to be(nil)
+        expect(organization.notifications.last&.user_id).to be(nil)
       end
 
       it "creates a notification from the follow instance" do
@@ -187,8 +187,8 @@ RSpec.describe Notification, type: :model do
   end
 
   describe "#send_new_comment_notifications" do
-    let_it_be(:comment) { create(:comment, user: user2, commentable: article) }
-    let_it_be(:child_comment) { create(:comment, user: user3, commentable: article, parent: comment) }
+    let_it_be_changeable(:comment) { create(:comment, user: user2, commentable: article) }
+    let_it_be_readonly(:child_comment) { create(:comment, user: user3, commentable: article, parent: comment) }
 
     context "when all commenters are subscribed" do
       it "sends a notification to the author of the article" do
@@ -267,8 +267,8 @@ RSpec.describe Notification, type: :model do
 
   describe "#send_reaction_notification" do
     before do
-      article.update_columns(receive_notifications: true)
-      comment.update_columns(receive_notifications: true)
+      article.update(receive_notifications: true)
+      comment.update(receive_notifications: true)
     end
 
     context "when reactable is receiving notifications" do
@@ -417,7 +417,7 @@ RSpec.describe Notification, type: :model do
     end
 
     context "when the notifiable is an article from an organization" do
-      let_it_be(:org_article) { create(:article, organization: organization, user: user) }
+      let_it_be_readonly(:org_article) { create(:article, organization: organization, user: user) }
 
       it "sends a notification to author's followers" do
         user2.follow(user)
@@ -461,8 +461,7 @@ RSpec.describe Notification, type: :model do
       end
 
       it "adds organization data when the article now belongs to an org" do
-        article.update_column(:organization_id, organization.id)
-        article.reload
+        article.update(organization_id: organization.id)
 
         perform_enqueued_jobs do
           described_class.update_notifications(article, "Published")
@@ -474,7 +473,7 @@ RSpec.describe Notification, type: :model do
   end
 
   describe "#aggregated?" do
-    let_it_be(:notification) { build(:notification) }
+    let_it_be_readonly(:notification) { build(:notification) }
     it "returns true if a notification's action is 'Reaction'" do
       notification.action = "Reaction"
       expect(notification.aggregated?).to be(true)

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -450,8 +450,7 @@ RSpec.describe Notification, type: :model do
 
       it "updates the notification with the new article title" do
         new_title = "hehehe hohoho!"
-        article.update_column(:title, new_title)
-        article.reload
+        article.update_attribute(:title, new_title)
 
         perform_enqueued_jobs do
           described_class.update_notifications(article, "Published")

--- a/spec/requests/articles/articles_update_spec.rb
+++ b/spec/requests/articles/articles_update_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe "ArticlesUpdate", type: :request do
 
   it "creates a notification job if published" do
     article.update_column(:published, false)
-    assert_enqueued_with(job: Notifications::NotifiableActionJob) do
+    sidekiq_assert_enqueued_with(job: Notifications::NotifiableActionWorker) do
       put "/articles/#{article.id}", params: {
         article: { published: true }
       }
@@ -94,7 +94,7 @@ RSpec.describe "ArticlesUpdate", type: :request do
 
   it "removes all published notifications if unpublished" do
     user2.follow(user)
-    perform_enqueued_jobs do
+    sidekiq_perform_enqueued_jobs do
       Notification.send_to_followers(article, "Published")
     end
     expect(article.notifications.size).to eq 1

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -369,7 +369,7 @@ RSpec.describe "NotificationsIndex", type: :request do
 
       before do
         user2.follow(user)
-        perform_enqueued_jobs do
+        sidekiq_perform_enqueued_jobs do
           Notification.send_to_followers(article, "Published")
         end
         sign_in user2

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -410,7 +410,7 @@ RSpec.describe "NotificationsIndex", type: :request do
 
       before do
         user2.follow(user)
-        perform_enqueued_jobs do
+        sidekiq_perform_enqueued_jobs do
           Notification.send_to_followers(article, "Published")
         end
         sign_in admin

--- a/spec/services/articles/creator_spec.rb
+++ b/spec/services/articles/creator_spec.rb
@@ -20,9 +20,9 @@ RSpec.describe Articles::Creator, type: :service do
 
     it "schedules a job" do
       valid_attributes[:published] = true
-      expect do
+      sidekiq_assert_enqueued_with(job: Notifications::NotifiableActionWorker) do
         described_class.call(user, valid_attributes)
-      end.to have_enqueued_job(Notifications::NotifiableActionJob).once
+      end
     end
 
     it "creates a notification subscription" do

--- a/spec/workers/notifications/notifiable_action_worker_spec.rb
+++ b/spec/workers/notifications/notifiable_action_worker_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+RSpec.describe Notifications::NotifiableActionWorker, type: :worker do
+  describe "#perform" do
+    let(:service) { Notifications::NotifiableAction::Send }
+    let(:worker) { subject }
+    let(:action) { "Published" }
+
+    before do
+      allow(service).to receive(:call)
+    end
+
+    it "calls the service when existing notifiable passed" do
+      notifiable = create(:article)
+      worker.perform(notifiable.id, "Article", action)
+      expect(service).to have_received(:call).with(notifiable, action).once
+    end
+
+    it "doesn't call a service when notifiable doesn't exist" do
+      worker.perform(Article.maximum(:id).to_i + 1, "Article", action)
+      expect(service).not_to have_received(:call)
+    end
+
+    it "doesn't call a service when unexpected notifiable type passed" do
+      user = create(:user)
+      worker.perform(user.id, "User", "Upgraded")
+      expect(service).not_to have_received(:call)
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
In this PR we are replacing NotifiableActionJob with a new NotifiableActionWorker. Will remove the now uncalled job in a subsequent PR 
## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/issues/5305
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
