### PR TITLE
Introduce BanishedUser table

### DIFF
--- a/app/controllers/internal/users_controller.rb
+++ b/app/controllers/internal/users_controller.rb
@@ -47,7 +47,7 @@ class Internal::UsersController < Internal::ApplicationController
   def banish
     @user = User.find(params[:id])
     begin
-      Moderator::BanishUser.call_banish(admin: current_user, user: @user)
+      Moderator::BanishUser.call(admin: current_user, user: @user)
     rescue StandardError => e
       flash[:danger] = e.message
     end

--- a/app/models/banished_user.rb
+++ b/app/models/banished_user.rb
@@ -1,5 +1,7 @@
 class BanishedUser < ApplicationRecord
-  before_validation ->(user) { user.username = user.username.downcase }
+  belongs_to :banished_by, class_name: "User", optional: true
+
+  before_validation ->(user) { user.username = user.username&.downcase }
 
   validates :username, uniqueness: true, on: :create
 end

--- a/app/models/banished_user.rb
+++ b/app/models/banished_user.rb
@@ -1,0 +1,5 @@
+class BanishedUser < ApplicationRecord
+  before_validation ->(user) { user.username = user.username.downcase }
+
+  validates :username, uniqueness: true, on: :create
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -145,6 +145,7 @@ class User < ApplicationRecord
   validate  :conditionally_validate_summary
   validate  :validate_mastodon_url
   validate  :validate_feed_url, if: :feed_url_changed?
+  validate  :non_banished_username, :username_changed?
   validate  :unique_including_orgs_and_podcasts, if: :username_changed?
 
   scope :dev_account, -> { find_by(id: SiteConfig.staff_user_id) }
@@ -386,6 +387,10 @@ class User < ApplicationRecord
 
   def unique_including_orgs_and_podcasts
     errors.add(:username, "is taken.") if Organization.find_by(slug: username) || Podcast.find_by(slug: username) || Page.find_by(slug: username)
+  end
+
+  def non_banished_username
+    errors.add(:username, "has been banished.") if BanishedUser.exists?(username: username)
   end
 
   def subscribe_to_mailchimp_newsletter

--- a/app/services/moderator/banish_user.rb
+++ b/app/services/moderator/banish_user.rb
@@ -1,5 +1,9 @@
 module Moderator
   class BanishUser < ManageActivityAndRoles
+    def self.call(admin:, user:)
+      new(user: user, admin: admin).banish
+    end
+
     attr_reader :user, :admin
 
     def initialize(admin:, user:)
@@ -7,11 +11,8 @@ module Moderator
       @admin = admin
     end
 
-    def self.call_banish(admin:, user:)
-      new(user: user, admin: admin).banish
-    end
-
     def banish
+      BanishedUser.create(username: user.username)
       user.unsubscribe_from_newsletters if user.email?
       remove_profile_info
       handle_user_status("Ban", "spam account")

--- a/app/services/moderator/banish_user.rb
+++ b/app/services/moderator/banish_user.rb
@@ -12,7 +12,7 @@ module Moderator
     end
 
     def banish
-      BanishedUser.create(username: user.username)
+      BanishedUser.create(username: user.username, banished_by: admin)
       user.unsubscribe_from_newsletters if user.email?
       remove_profile_info
       handle_user_status("Ban", "spam account")

--- a/db/migrate/20200120053525_add_banished_users_table.rb
+++ b/db/migrate/20200120053525_add_banished_users_table.rb
@@ -1,0 +1,10 @@
+class AddBanishedUsersTable < ActiveRecord::Migration[5.2]
+  def change
+    create_table :banished_users do |t|
+      t.string :username
+      t.index :username, unique: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200120053525_add_banished_users_table.rb
+++ b/db/migrate/20200120053525_add_banished_users_table.rb
@@ -3,6 +3,7 @@ class AddBanishedUsersTable < ActiveRecord::Migration[5.2]
     create_table :banished_users do |t|
       t.string :username
       t.index :username, unique: true
+      t.references :banished_by, references: :user
 
       t.timestamps
     end

--- a/db/migrate/20200120053525_add_banished_users_table.rb
+++ b/db/migrate/20200120053525_add_banished_users_table.rb
@@ -3,7 +3,7 @@ class AddBanishedUsersTable < ActiveRecord::Migration[5.2]
     create_table :banished_users do |t|
       t.string :username
       t.index :username, unique: true
-      t.references :banished_by, references: :user
+      t.references :banished_by
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -194,9 +194,11 @@ ActiveRecord::Schema.define(version: 2020_01_20_053525) do
   end
 
   create_table "banished_users", force: :cascade do |t|
+    t.string "username"
+    t.bigint "banished_by_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "username"
+    t.index ["banished_by_id"], name: "index_banished_users_on_banished_by_id"
     t.index ["username"], name: "index_banished_users_on_username", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -194,10 +194,10 @@ ActiveRecord::Schema.define(version: 2020_01_20_053525) do
   end
 
   create_table "banished_users", force: :cascade do |t|
-    t.string "username"
     t.bigint "banished_by_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "username"
     t.index ["banished_by_id"], name: "index_banished_users_on_banished_by_id"
     t.index ["username"], name: "index_banished_users_on_username", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_17_135902) do
+ActiveRecord::Schema.define(version: 2020_01_20_053525) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -191,6 +191,13 @@ ActiveRecord::Schema.define(version: 2020_01_17_135902) do
     t.string "title", null: false
     t.datetime "updated_at", null: false
     t.index ["title"], name: "index_badges_on_title", unique: true
+  end
+
+  create_table "banished_users", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "username"
+    t.index ["username"], name: "index_banished_users_on_username", unique: true
   end
 
   create_table "blocks", id: :serial, force: :cascade do |t|

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe UserDecorator, type: :decorator do
     end
 
     it "returns fully banished if user has been banished" do
-      Moderator::BanishUser.call_banish(admin: user, user: user)
+      Moderator::BanishUser.call(admin: user, user: user)
       expect(user.decorate.fully_banished?).to eq(true)
     end
 

--- a/spec/factories/banished_users.rb
+++ b/spec/factories/banished_users.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :banished_user do
+    username
+  end
+end

--- a/spec/models/banished_user_spec.rb
+++ b/spec/models/banished_user_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe BanishedUser, type: :model do
   describe "validations" do
     describe "builtin validations" do
+      it { is_expected.to belong_to(:banished_by).class_name("User").optional }
       it { is_expected.to validate_uniqueness_of(:username).case_insensitive }
     end
   end

--- a/spec/models/banished_user_spec.rb
+++ b/spec/models/banished_user_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe BanishedUser, type: :model do
+  describe "validations" do
+    describe "builtin validations" do
+      it { is_expected.to validate_uniqueness_of(:username).case_insensitive }
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -710,6 +710,25 @@ RSpec.describe User, type: :model do
       new_user = user_from_authorization_service(:github, nil, "navbar_basic")
       expect(new_user.github_created_at).to be_kind_of(ActiveSupport::TimeWithZone)
     end
+
+    it "does not allow previously banished users to sign up again" do
+      banished_name = "SpammyMcSpamface"
+      create(:banished_user, username: banished_name)
+      OmniAuth.config.mock_auth[:twitter].info.nickname = banished_name
+
+      expect do
+        user_from_authorization_service(:twitter, nil, "navbar_basic")
+      end.to raise_error(ActiveRecord::RecordInvalid, /Username has been banished./)
+    end
+
+    it "does not allow an existing user to change their name to a banished one" do
+      banished_name = "SpammyMcSpamface"
+      create(:banished_user, username: banished_name)
+      user = create(:user)
+
+      user.update(username: banished_name)
+      expect(user.errors.full_messages).to include("Username has been banished.")
+    end
   end
 
   describe "#follow and #all_follows" do

--- a/spec/requests/internal/users_banish_spec.rb
+++ b/spec/requests/internal/users_banish_spec.rb
@@ -234,6 +234,12 @@ RSpec.describe "Internal::Users", type: :request do
       banish_user
       expect(user.follows.count).to eq(0)
     end
+
+    it "creates an entry in the BanishedUsers table" do
+      expect do
+        banish_user
+      end.to change(BanishedUser, :count).by(1)
+    end
   end
 
   context "when handling credits" do

--- a/spec/requests/internal/users_banish_spec.rb
+++ b/spec/requests/internal/users_banish_spec.rb
@@ -240,6 +240,12 @@ RSpec.describe "Internal::Users", type: :request do
         banish_user
       end.to change(BanishedUser, :count).by(1)
     end
+
+    it "records who banished a user" do
+      banish_user
+      admin = BanishedUser.last
+      expect(admin.banished_by).to eq super_admin
+    end
   end
 
   context "when handling credits" do

--- a/spec/requests/internal/users_spec.rb
+++ b/spec/requests/internal/users_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "internal/users", type: :request do
     end
   end
 
-  describe "PUT internal/users/:id/edit" do
+  describe "POST internal/users/:id/banish" do
     it "bans user for spam" do
       post "/internal/users/#{user.id}/banish"
       expect(user.reload.username).to include("spam")

--- a/spec/requests/user/user_profile_spec.rb
+++ b/spec/requests/user/user_profile_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "UserProfiles", type: :request do
 
     it "raises not found for banished users" do
       banishable_user = create(:user)
-      Moderator::BanishUser.call_banish(admin: user, user: banishable_user)
+      Moderator::BanishUser.call(admin: user, user: banishable_user)
       expect { get "/#{banishable_user.reload.old_username}" }.to raise_error(ActiveRecord::RecordNotFound)
       expect { get "/#{banishable_user.reload.username}" }.to raise_error(ActiveRecord::RecordNotFound)
     end


### PR DESCRIPTION
Closes https://github.com/thepracticaldev/tech-private/issues/353

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Banished accounts could sign up with a different social media account and reclaim their usernames. There was a workaround for admins, but it was abusing an unrelated feature. This PR introduces a `BanishedUser` table to address this more properly. 

## Related Tickets & Documents

https://github.com/thepracticaldev/tech-private/issues/353

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed

## Context / discussion

* @benhalpern After our discussion on the issue, I decided to stick with `BanishedUser` after all. I'd rather have something narrow in scope that we refactor/broaden once we have identified more/different use cases, than trying to anticipate what we need and ending up with the wrong abstraction. Once something has been introduced, people will start using it and breaking it apart may be harder than changing something small and self contained. WDYT?
* I'll post some more comments inline.