### PR TITLE
Remove git add from lint staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,28 +23,22 @@
   "lint-staged": {
     "*.{js,jsx}": [
       "prettier --write",
-      "eslint --fix",
-      "git add"
+      "eslint --fix"
     ],
     "{app,spec,config,lib}/**/*.rb": [
-      "bundle exec rubocop --require rubocop-rspec --safe-auto-correct",
-      "git add"
+      "bundle exec rubocop --require rubocop-rspec --safe-auto-correct"
     ],
     "Gemfile": [
-      "bundle exec rubocop --require rubocop-rspec --safe-auto-correct",
-      "git add"
+      "bundle exec rubocop --require rubocop-rspec --safe-auto-correct"
     ],
     "app/**/*.html.erb": [
-      "bundle exec erblint",
-      "git add"
+      "bundle exec erblint"
     ],
     "*.json": [
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ],
     "*.md": [
-      "prettier --write --prose-wrap always",
-      "git add"
+      "prettier --write --prose-wrap always"
     ]
   },
   "prettier": {


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

In https://github.com/thepracticaldev/dev.to/pull/5592 we upgrade `lint-staged` to 1.0 which removed the requirement for `git add` as the last step. Until this is merged we'll get this warning:

```shell
⚠ Some of your tasks use `git add` command. Please remove it from the config since all modifications made by tasks will be automatically added to the git commit index.
```

## Related Tickets & Documents

https://github.com/thepracticaldev/dev.to/pull/5592
