### PR TITLE
Fix Travis S3 Artifact AddOn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ rvm:
 addons:
   postgresql: '9.6'
   chrome: 'stable'
+  artifacts:
+    paths:
+      - $TRAVIS_BUILD_DIR/dev.to/tmp/screenshots/*.png
+    debug: true
 services:
   - redis-server
 env:
@@ -44,12 +48,6 @@ script:
   - './cc-test-reporter upload-coverage'
   - 'bundle exec bundle-audit check --update --ignore CVE-2015-9284'
   - yarn build-storybook
-after_script:
-  addons:
-    artifacts:
-      paths:
-      - ~/build/thepracticaldev/dev.to/tmp/screenshots/*.png
-      debug: true
 deploy:
   provider: heroku
   api_key: '$HEROKU_AUTH_TOKEN'


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Uploading artifacts to S3 has not been working so I emailed support and got a few insights into why. For starters we just need to declare the addon, we dont actually have to run the script. That happens automatically. I also inquired about the directory and was told to use the TRAVIS_BUILD_DIR.

> TRAVIS_BUILD_DIR: The absolute path to the directory where the repository being built has been copied on the worker.

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media1.giphy.com/media/kKLmEOQy45G4QzFPOO/giphy.gif)
