### PR TITLE
Add proper surrogate key headers for API users#show, articles#feed, stories#index (for users), twitch#show

### DIFF
--- a/app/controllers/api/v0/users_controller.rb
+++ b/app/controllers/api/v0/users_controller.rb
@@ -2,6 +2,7 @@ module Api
   module V0
     class UsersController < ApiController
       before_action :authenticate!, only: %i[me]
+      before_action :set_cache_control_headers, only: [:show]
       before_action -> { doorkeeper_authorize! :public }, only: :me, if: -> { doorkeeper_token }
 
       def index
@@ -27,6 +28,7 @@ module Api
                 else
                   User.find(params[:id])
                 end
+        set_surrogate_key_header @user.record_key
       end
 
       def me; end

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -176,7 +176,7 @@ class StoriesController < ApplicationController
     redirect_if_view_param
     return if performed?
 
-    set_surrogate_key_header "articles-user-#{@user.id}"
+    set_surrogate_key_header @user.record_key
     render template: "users/show"
   end
 

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -176,7 +176,7 @@ class StoriesController < ApplicationController
     redirect_if_view_param
     return if performed?
 
-    set_surrogate_key_header @user.record_key
+    set_surrogate_key_header @user.record_key, Article.table_key, User.table_key, @stories.map(&:record_key)
     render template: "users/show"
   end
 

--- a/app/controllers/twitch_live_streams_controller.rb
+++ b/app/controllers/twitch_live_streams_controller.rb
@@ -3,6 +3,7 @@ class TwitchLiveStreamsController < ApplicationController
 
   def show
     @user = User.find_by!(username: params[:username].tr("@", "").downcase)
+    set_surrogate_key_header @user.record_key
     if @user.twitch_username.present?
       render :show
     else

--- a/app/labor/cache_buster.rb
+++ b/app/labor/cache_buster.rb
@@ -172,6 +172,11 @@ module CacheBuster
       "/feed/#{username}"
     ]
     paths.each { |path| bust(path) }
+
+    # ^ TODO We can remove the above most or all of the manual paths purge
+    # once past relevant caches expire and get new surrogate keys (> 1 day after merge).
+
+    user.purge
   end
 
   # bust commentable if it's an article

--- a/spec/requests/user/user_profile_spec.rb
+++ b/spec/requests/user/user_profile_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "UserProfiles", type: :request do
 
     it "sets the correct edge caching surrogate key" do
       get "/#{user.username}"
-      expect(response.headers["surrogate-key"].split.to_set).to eq([user.record_key].to_set)
+      expect(response.headers["surrogate-key"].split.to_set).to eq([user.record_key, "articles", "users"].to_set)
     end
 
     context "when organization" do

--- a/spec/requests/user/user_profile_spec.rb
+++ b/spec/requests/user/user_profile_spec.rb
@@ -50,6 +50,11 @@ RSpec.describe "UserProfiles", type: :request do
       expect(response.body).not_to include("<meta name=\"googlebot\" content=\"noindex\">")
     end
 
+    it "sets the correct edge caching surrogate key" do
+      get "/#{user.username}"
+      expect(response.headers["surrogate-key"].split.to_set).to eq([user.record_key].to_set)
+    end
+
     context "when organization" do
       it "renders organization page if org" do
         get organization.path

--- a/spec/requests/users_api_spec.rb
+++ b/spec/requests/users_api_spec.rb
@@ -22,5 +22,10 @@ RSpec.describe "Api::V0::Users", type: :request do
       get "/api/users/#{user.id}"
       expect(response.body).to include(user.name)
     end
+
+    it "sets the correct edge caching surrogate key" do
+      get "/api/users/#{user.id}"
+      expect(response.headers["surrogate-key"].split.to_set).to eq([user.record_key].to_set)
+    end
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
This adds edge caching to the `/api/users/:id` endpoint which will make it more scalable. But adding that means we need to keep track of its caching lifecycle effectively. So this also adds _proper_ surrogate control headers building on #4744.