### PR TITLE
Remove Unused(I think) Algolia Module from Tweet

### DIFF
--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -1,6 +1,4 @@
 class Tweet < ApplicationRecord
-  include AlgoliaSearch
-
   mount_uploader :profile_image, ProfileImageUploader
 
   belongs_to :user, optional: true


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
I was poking around Algolia and noticed that the Tweet index has not been updated in the last 4 months. After further digging, I found that no documents had been indexed or search(see graph below) for what looks like the last year. I then did a text search of our repo to see if I could find the index name referenced anywhere `Tweet_` and I could not. Based on this information I don't believe we are using search for Tweets in which case I think we should remove it. 

![Screen Shot 2020-01-20 at 4 40 45 PM](https://user-images.githubusercontent.com/1813380/72759548-00a96c00-3ba4-11ea-9c60-cf210d584519.png)

## Related Tickets & Documents
GH Issue: https://github.com/thepracticaldev/dev.to/issues/5616
Piv Epic: https://www.pivotaltracker.com/n/projects/2430255

## Added to documentation?
- [x] no documentation needed

![alt_text](http://24.media.tumblr.com/tumblr_m9ye2p1UbS1ryl3dho1_500.gif)
