### PR TITLE
Retry more for Articles::UpdateAnalyticsWorker

### DIFF
--- a/app/workers/articles/update_analytics_worker.rb
+++ b/app/workers/articles/update_analytics_worker.rb
@@ -2,7 +2,7 @@ module Articles
   class UpdateAnalyticsWorker
     include Sidekiq::Worker
 
-    sidekiq_options queue: :low_priority, retry: 5
+    sidekiq_options queue: :low_priority, retry: 15
 
     def perform(user_id)
       user = User.find_by(id: user_id)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
[Just saw a bunch of these jobs fail](https://app.honeybadger.io/fault/66984/cbf1f2d80ce7b8d61cde97b8c5ba3063) due to `Google::Apis::RateLimitError` so I decided it would be a good idea to increase the retry limit for this job so that in the event of a rate limit it has more time to retry. This gives it up to 10 hours. 

## Related Tickets & Documents
#5305 

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media.giphy.com/media/l0COHqFzwacAwQcNi/giphy.gif)
