### PR TITLE
Add verify stage to TravisCI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,6 @@ script:
   - './cc-test-reporter upload-coverage'
   - 'bundle exec bundle-audit check --update --ignore CVE-2015-9284'
   - yarn build-storybook
-after_script:
   - RAILS_ENV=production bundle exec rails runner 'puts "App booted successfully"'
 deploy:
   provider: heroku

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ script:
   - './cc-test-reporter upload-coverage'
   - 'bundle exec bundle-audit check --update --ignore CVE-2015-9284'
   - yarn build-storybook
-verify:
+after_script:
   env:
     - RAILS_ENV=production
   script: bundle exec rails runner 'puts "App booted successfully"'

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,9 +49,7 @@ script:
   - 'bundle exec bundle-audit check --update --ignore CVE-2015-9284'
   - yarn build-storybook
 after_script:
-  env:
-    - RAILS_ENV=production
-  script: bundle exec rails runner 'puts "App booted successfully"'
+  - RAILS_ENV=production bundle exec rails runner 'puts "App booted successfully"'
 deploy:
   provider: heroku
   api_key: '$HEROKU_AUTH_TOKEN'

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,10 @@ script:
   - './cc-test-reporter upload-coverage'
   - 'bundle exec bundle-audit check --update --ignore CVE-2015-9284'
   - yarn build-storybook
+verify:
+  env:
+    - RAILS_ENV=production
+  script: bundle exec rails runner 'puts "App booted successfully"'
 deploy:
   provider: heroku
   api_key: '$HEROKU_AUTH_TOKEN'

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
     - RAILS_ENV=test
     - CC_TEST_REPORTER_ID=f39e060a8b1a558ebd8aff75d5b9760bf1ae98f3f85d628ae28814f3c66438cd
     - DATABASE_URL=postgres://postgres@localhost/
+    - TIMBER=dummy
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,14 @@ env:
     - RAILS_ENV=test
     - CC_TEST_REPORTER_ID=f39e060a8b1a558ebd8aff75d5b9760bf1ae98f3f85d628ae28814f3c66438cd
     - DATABASE_URL=postgres://postgres@localhost/
+    - APP_PROTOCOL=http://
+    - APP_DOMAIN=localhost:3000
     - TIMBER=dummy
+    - SEND_LOGS_TO_TIMBER=false
+    - SENDGRID_USERNAME_ACCEL=dummy
+    - SENDGRID_PASSWORD_ACCEL=dummy
+    - HEROKU_APP_URL=practicaldev.herokuapp.com
+    - SECRET_KEY_BASE=dummydummydummy
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ script:
   - './cc-test-reporter upload-coverage'
   - 'bundle exec bundle-audit check --update --ignore CVE-2015-9284'
   - yarn build-storybook
-  - RAILS_ENV=production bundle exec rails runner 'puts "App booted successfully"'
+  - bundle exec rails runner -e production 'puts "App booted successfully"'
 deploy:
   provider: heroku
   api_key: '$HEROKU_AUTH_TOKEN'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -101,7 +101,7 @@ Rails.application.configure do
 
   # DEV uses the RedisCloud Heroku Add-On which comes with the predefined env variable REDISCLOUD_URL
   redis_url = ENV["REDISCLOUD_URL"]
-  redis_url ||= ApplicationConfig["REDIS_URL"]
+  redis_url ||= ENV["REDIS_URL"]
   DEFAULT_EXPIRATION = 24.hours.to_i.freeze
   config.cache_store = :redis_cache_store, { url: redis_url, expires_in: DEFAULT_EXPIRATION }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

As discussed on Slack, this PR adds a verify stage to the Travis pipeline which will try to start a production Rails runner to verify that the app can boot up, so we don't solely rely on `deploy-tasks.sh` for that purpose.

## Related Tickets & Documents

n/a

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

n/a

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed
