### PR TITLE
Migrate creation of podcast episode

### DIFF
--- a/app/services/podcasts/get_episode.rb
+++ b/app/services/podcasts/get_episode.rb
@@ -10,20 +10,25 @@ module Podcasts
 
       episode = podcast.existing_episode(item_data)
       if episode
-        if !episode.published_at? && item_data.pubDate
-          update_published_at(episode, item_data)
-        end
-        unreachable = !(episode.https? && episode.reachable?)
-        need_url_update = (unreachable && episode.created_at > 12.hours.ago) || force_update
-        PodcastEpisodes::UpdateMediaUrlJob.perform_later(episode.id, item_data.enclosure_url) if need_url_update
+        try_update_media_url(episode: episode, item_data: item_data, force_update: force_update)
       else
-        PodcastEpisodes::CreateJob.perform_later(podcast.id, item_data.to_h)
+        PodcastEpisodes::CreateWorker.perform_async(podcast.id, item_data.to_h)
       end
     end
 
     private
 
     attr_reader :podcast
+
+    def try_update_media_url(episode:, item_data:, force_update:)
+      if !episode.published_at? && item_data.pubDate
+        update_published_at(episode, item_data)
+      end
+
+      unreachable = !(episode.https? && episode.reachable?)
+      need_url_update = (unreachable && episode.created_at > 12.hours.ago) || force_update
+      PodcastEpisodes::UpdateMediaUrlJob.perform_later(episode.id, item_data.enclosure_url) if need_url_update
+    end
 
     def update_published_at(episode, item_data)
       episode.published_at = item_data.pubDate.to_date

--- a/app/workers/podcast_episodes/create_worker.rb
+++ b/app/workers/podcast_episodes/create_worker.rb
@@ -5,7 +5,7 @@ module PodcastEpisodes
     sidekiq_options queue: :high_priority
 
     def perform(podcast_id, item)
-      Podcasts::CreateEpisode.call(podcast_id, item)
+      Podcasts::CreateEpisode.call(podcast_id, item.with_indifferent_access)
     end
   end
 end

--- a/app/workers/podcast_episodes/create_worker.rb
+++ b/app/workers/podcast_episodes/create_worker.rb
@@ -1,0 +1,11 @@
+module PodcastEpisodes
+  class CreateWorker
+    include Sidekiq::Worker
+
+    sidekiq_options queue: :high_priority
+
+    def perform(podcast_id, item)
+      Podcasts::CreateEpisode.call(podcast_id, item)
+    end
+  end
+end

--- a/spec/services/podcasts/feed_spec.rb
+++ b/spec/services/podcasts/feed_spec.rb
@@ -87,14 +87,14 @@ RSpec.describe Podcasts::Feed, type: :service, vcr: vcr_option do
 
     it "fetches podcast episodes" do
       expect do
-        perform_enqueued_jobs do
+        sidekiq_perform_enqueued_jobs do
           described_class.new(podcast).get_episodes(limit: 2)
         end
       end.to change(PodcastEpisode, :count).by(2)
     end
 
     it "fetches correct podcasts" do
-      perform_enqueued_jobs do
+      sidekiq_perform_enqueued_jobs do
         described_class.new(podcast).get_episodes(limit: 2)
       end
       episodes = podcast.podcast_episodes

--- a/spec/services/podcasts/get_episode_spec.rb
+++ b/spec/services/podcasts/get_episode_spec.rb
@@ -80,9 +80,10 @@ RSpec.describe Podcasts::GetEpisode, type: :service do
 
   it "schedules a Create job when an episode doesn't exist" do
     allow(podcast).to receive(:existing_episode).and_return(nil)
+
     expect do
       described_class.new(podcast).call(item: item)
-    end.to have_enqueued_job.on_queue("podcast_episode_create") # .with(podcast.id)
+    end.to change { PodcastEpisodes::CreateWorker.jobs.size }.by(1)
   end
 
   context "when feed doesn't contain enclosure urls" do

--- a/spec/services/podcasts/get_episode_spec.rb
+++ b/spec/services/podcasts/get_episode_spec.rb
@@ -81,9 +81,9 @@ RSpec.describe Podcasts::GetEpisode, type: :service do
   it "schedules a Create job when an episode doesn't exist" do
     allow(podcast).to receive(:existing_episode).and_return(nil)
 
-    expect do
+    sidekiq_assert_enqueued_with(job: PodcastEpisodes::CreateWorker, args: [podcast.id, item.to_h]) do
       described_class.new(podcast).call(item: item)
-    end.to change { PodcastEpisodes::CreateWorker.jobs.size }.by(1)
+    end
   end
 
   context "when feed doesn't contain enclosure urls" do

--- a/spec/workers/podcast_episodes/create_worker_spec.rb
+++ b/spec/workers/podcast_episodes/create_worker_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe PodcastEpisodes::CreateWorker, type: :worker do
     let(:worker) { subject }
 
     let(:podcast_id) { 781 }
-    let(:item) { double(:item) }
+    let(:item) { { foo: "bar" } }
 
     before do
       allow(Podcasts::CreateEpisode).to receive(:call)
@@ -17,6 +17,14 @@ RSpec.describe PodcastEpisodes::CreateWorker, type: :worker do
       worker.perform(podcast_id, item)
 
       expect(Podcasts::CreateEpisode).to have_received(:call).with(podcast_id, item).once
+    end
+
+    context "when item has string keys" do
+      it "creates a podcast episode regardless of whether item has string or symbol keys" do
+        worker.perform(podcast_id, item.stringify_keys)
+
+        expect(Podcasts::CreateEpisode).to have_received(:call).with(podcast_id, item).once
+      end
     end
   end
 end

--- a/spec/workers/podcast_episodes/create_worker_spec.rb
+++ b/spec/workers/podcast_episodes/create_worker_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe PodcastEpisodes::CreateWorker, type: :worker do
-  include_examples "#enqueues_on_correct_queue", "high_priority", 1
+  include_examples "#enqueues_on_correct_queue", "high_priority", [123, {}]
 
   describe "#perform" do
     let(:worker) { subject }

--- a/spec/workers/podcast_episodes/create_worker_spec.rb
+++ b/spec/workers/podcast_episodes/create_worker_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe PodcastEpisodes::CreateWorker, type: :worker do
+  include_examples "#enqueues_on_correct_queue", "high_priority", 1
+
+  describe "#perform" do
+    let(:worker) { subject }
+
+    let(:podcast_id) { 781 }
+    let(:item) { double(:item) }
+
+    before do
+      allow(Podcasts::CreateEpisode).to receive(:call)
+    end
+
+    it "creates a podcast episode" do
+      worker.perform(podcast_id, item)
+
+      expect(Podcasts::CreateEpisode).to have_received(:call).with(podcast_id, item).once
+    end
+  end
+end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

* Create sidekiq version and update get episode to use this sidekiq
* Did a mini refactor in `Podcasts::GetEpisode` to make the code a bit more readable
* The tests around `Podcasts::Feed` helped catch a bug around the migration of the podcast episode creation delayed job where the sidekiq version was passing a string version of item hash to
`Podcasts::CreateEpisode` which was in fact expecting the hash to contain symbols.

## Related Tickets & Documents

#5305 

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed