### PR TITLE
Apply Monkey Patch To Attempt To Fix Sidekiq Admin UI

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
     mount DelayedJobWeb, at: "/delayed_job"
 
     Sidekiq::Web.set :session_secret, Rails.application.secrets[:secret_key_base]
+    Sidekiq::Web.set :sessions, Rails.application.config.session_options
     mount Sidekiq::Web => "/sidekiq"
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,8 @@ Rails.application.routes.draw do
   require "sidekiq/web"
   authenticated :user, ->(user) { user.tech_admin? } do
     mount DelayedJobWeb, at: "/delayed_job"
+
+    Sidekiq::Web.set :session_secret, Rails.application.secrets[:secret_key_base]
     mount Sidekiq::Web => "/sidekiq"
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Currently, when we try to do anything in the Sidekiq Admin UI besides a GET request we get a Forbidden error. I think the reason for this is because we are not tracking sessions. The reason we are not tracking sessions is because of a [rack bug that was recently fixed](https://github.com/rack/rack/pull/1428). Since the new gem has not been released I applied the patch in the Sidekiq initializer and set the session [the way it is suggested here](https://github.com/mperham/sidekiq/issues/1289#issuecomment-415714146). This works locally but the real test will be production. 

The reason we need this fixed is bc if workers break in Sidekiq I have to go into a console to clean them up. Moving forward as we start an on-call rotation we need to empower everyone to be able to handle and work with Sidekiq and the best way to do that is through the UI. 

Pivotal: https://www.pivotaltracker.com/story/show/170820884

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media3.giphy.com/media/21I909B1Us5hsGiupn/giphy.gif)
