### PR TITLE
Add rate limits to admin interface

### DIFF
--- a/app/controllers/internal/configs_controller.rb
+++ b/app/controllers/internal/configs_controller.rb
@@ -25,6 +25,8 @@ class Internal::ConfigsController < Internal::ApplicationController
       mailchimp_newsletter_id mailchimp_sustaining_members_id
       mailchimp_tag_moderators_id mailchimp_community_moderators_id
       periodic_email_digest_max periodic_email_digest_min suggested_tags
+      rate_limit_comment_creation rate_limit_published_article_creation
+      rate_limit_image_upload rate_limit_email_recipient
     ]
     params.require(:site_config).permit(allowed_params)
   end

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -89,6 +89,50 @@
         <div class="alert alert-info">Used to limit the amount of users a person can follow daily</div>
       </div>
     </div>
+    <div class="card-body">
+      <div class="form-group">
+        <%= f.label :rate_limit_comment_creation %>
+        <%= f.number_field :rate_limit_comment_creation,
+                           class: "form-control",
+                           value: SiteConfig.rate_limit_comment_creation,
+                           min: 0,
+                           placeholder: 9 %>
+        <div class="alert alert-info">Used to limit the amount of comments a user can create within 30 seconds</div>
+      </div>
+    </div>
+        <div class="card-body">
+      <div class="form-group">
+        <%= f.label :rate_limit_published_article_creation %>
+        <%= f.number_field :rate_limit_published_article_creation,
+                           class: "form-control",
+                           value: SiteConfig.rate_limit_published_article_creation,
+                           min: 0,
+                           placeholder: 9 %>
+        <div class="alert alert-info">Used to limit the amount of articles a user can create within 30 seconds</div>
+      </div>
+    </div>
+        <div class="card-body">
+      <div class="form-group">
+        <%= f.label :rate_limit_image_upload %>
+        <%= f.number_field :rate_limit_image_upload,
+                           class: "form-control",
+                           value: SiteConfig.rate_limit_image_upload,
+                           min: 0,
+                           placeholder: 9 %>
+        <div class="alert alert-info">Used to limit the amount of images a user can upload within 30 seconds</div>
+      </div>
+    </div>
+    <div class="card-body">
+      <div class="form-group">
+        <%= f.label :rate_limit_email_recipient %>
+        <%= f.number_field :rate_limit_email_recipient,
+                           class: "form-control",
+                           value: SiteConfig.rate_limit_email_recipient,
+                           min: 0,
+                           placeholder: 5 %>
+        <div class="alert alert-info">Used to limit the amount of emails we send to a user within 2 minutes</div>
+      </div>
+    </div>
   </div>
 
   <div class="card mt-3">

--- a/spec/requests/internal/configs_spec.rb
+++ b/spec/requests/internal/configs_spec.rb
@@ -60,8 +60,33 @@ RSpec.describe "/internal/config", type: :request do
 
     describe "rate limits" do
       it "updates rate_limit_follow_count_daily" do
-        post "/internal/config", params: { site_config: { rate_limit_follow_count_daily: 3 } }
-        expect(SiteConfig.rate_limit_follow_count_daily).to eq(3)
+        expect do
+          post "/internal/config", params: { site_config: { rate_limit_follow_count_daily: 3 } }
+        end.to change(SiteConfig, :rate_limit_follow_count_daily).from(500).to(3)
+      end
+
+      it "updates rate_limit_comment_creation" do
+        expect do
+          post "/internal/config", params: { site_config: { rate_limit_comment_creation: 3 } }
+        end.to change(SiteConfig, :rate_limit_comment_creation).from(9).to(3)
+      end
+
+      it "updates rate_limit_published_article_creation" do
+        expect do
+          post "/internal/config", params: { site_config: { rate_limit_published_article_creation: 3 } }
+        end.to change(SiteConfig, :rate_limit_published_article_creation).from(9).to(3)
+      end
+
+      it "updates rate_limit_image_upload" do
+        expect do
+          post "/internal/config", params: { site_config: { rate_limit_image_upload: 3 } }
+        end.to change(SiteConfig, :rate_limit_image_upload).from(9).to(3)
+      end
+
+      it "updates rate_limit_email_recipient" do
+        expect do
+          post "/internal/config", params: { site_config: { rate_limit_email_recipient: 3 } }
+        end.to change(SiteConfig, :rate_limit_email_recipient).from(5).to(3)
       end
     end
 


### PR DESCRIPTION
## What type of PR is this?

- [X] Feature

## Description

#5521 refactored `RateLimitChecker` to use `SiteConfig` instead of hardcoding values. This PR adds the values to the admin interface at `/internal/config`.

## Related Tickets & Documents

#5520 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

<img width="1095" alt="Screen Shot 2020-01-22 at 17 32 13" src="https://user-images.githubusercontent.com/47985/72886852-25851700-3d3d-11ea-9f4d-5c9391403d10.png">

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed
