### PR TITLE
Use honeybadger.js from npm

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,10 +103,6 @@ gem "ulid", "~> 1.1" # Universally Unique Lexicographically Sortable Identifier 
 gem "validate_url", "~> 1.0" # Library for validating urls in Rails
 gem "webpacker", "~> 3.5" # Use webpack to manage app-like JavaScript modules in Rails
 
-source "https://rails-assets.org" do
-  gem "rails-assets-honeybadger"
-end
-
 group :development do
   gem "better_errors", "~> 2.5" # Provides a better error page for Rails and other Rack apps
   gem "binding_of_caller", "~> 0.8" # Retrieve the binding of a method's caller

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,6 @@ GIT
 
 GEM
   remote: https://rubygems.org/
-  remote: https://rails-assets.org/
   specs:
     actioncable (5.2.4.1)
       actionpack (= 5.2.4.1)
@@ -587,7 +586,6 @@ GEM
       bundler (>= 1.3.0)
       railties (= 5.2.4.1)
       sprockets-rails (>= 2.0.0)
-    rails-assets-honeybadger (5.0.0)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -961,7 +959,6 @@ DEPENDENCIES
   rack-host-redirect (~> 1.3)
   rack-timeout (~> 0.6)
   rails (~> 5.2)
-  rails-assets-honeybadger!
   rails-observers (~> 0.1)
   rails-settings-cached (>= 2.1.1)
   ransack (~> 2.3)

--- a/app/assets/javascripts/base.js.erb
+++ b/app/assets/javascripts/base.js.erb
@@ -3,7 +3,7 @@
 //= require lib/xss
 //= require initializePage
 //= require utilities/getImageForLink
-//= require honeybadger
+//= require honeybadger-js/dist/honeybadger.js
 //= require serviceworker-companion
 //= require algolia/v3/algoliasearch.min
 

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -6,7 +6,7 @@ Rails.application.config.assets.version = "1.1"
 # Add additional assets to the asset load path
 # Rails.application.config.assets.paths << Emoji.images_path
 
-# Yarn node_moduless
+# Yarn node_modules
 Rails.application.config.assets.paths << Rails.root.join("node_modules")
 
 # Precompile additional assets.
@@ -33,3 +33,4 @@ Rails.application.config.assets.precompile += %w[lib/pulltorefresh.js]
 Rails.application.config.assets.precompile += %w[internal.js]
 Rails.application.config.assets.precompile += %w[internal/layout]
 Rails.application.config.assets.precompile << /\.(?:svg|eot|woff|ttf)\z/
+Rails.application.config.assets.precompile += %w[honeybadger-js/dist/honeybadger.js]

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "clipboard-polyfill": "^2.8.6",
     "codemirror": "^5.50.2",
     "focus-visible": "^5.0.2",
+    "honeybadger-js": "2.0.2",
     "intersection-observer": "^0.7.0",
     "linkstate": "^1.1.1",
     "lodash.debounce": "4.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5837,6 +5837,11 @@ homedir-polyfill@^1.0.1:
   dependencies:
     parse-passwd "^1.0.0"
 
+honeybadger-js@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/honeybadger-js/-/honeybadger-js-2.0.2.tgz#191f4c0fc2b280b9591bd033e165707e9c7264f6"
+  integrity sha512-XBzVxiA0Kw91Lh6lM9IXp++IaBt26BwEgmItUhn8Cb8kOWrYeR9h0tAHgvSsB+PS02G7e6IszgpIrMeU69X8ww==
+
 hosted-git-info@^2.1.4:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

rails-assets.org is often down, and apparently has been down intermittently since yesterday.

In addition to this the only thing the gem does is literally to add `honeybadger.js` to the assets path:

```ruby
gem_path.join('app/assets').each_child.to_a
```

Hence we can ditch the gem and use the library directly thus removing our dependence from `rails-assets.org`


## Screenshots

![Screenshot 2020-01-22 at 11 42 02 AM](https://user-images.githubusercontent.com/146201/72887985-02db0a00-3d0d-11ea-99d4-43d5ff9ce817.png)
