### PR TITLE
Remove extra dev.to from travis upload artifact path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
   chrome: 'stable'
   artifacts:
     paths:
-      - $TRAVIS_BUILD_DIR/dev.to/tmp/screenshots/*.png
+      - $TRAVIS_BUILD_DIR/tmp/screenshots/*.png
     debug: true
 services:
   - redis-server


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
One minor path fix to get this working. Found out the path was dup'ed in [this build](https://travis-ci.com/thepracticaldev/dev.to/builds/145558324)
```
ERROR: failed to upload: /home/travis/build/thepracticaldev/dev.to/dev.to/tmp/screenshots/*.png
  err: open /home/travis/build/thepracticaldev/dev.to/dev.to/tmp/screenshots/*.png: no such file or directory
```

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media.tenor.com/images/8635f6ded51d5f5e20f56d5a75013335/tenor.gif)
