### PR TITLE
Use the correct cover image in article form preview

### DIFF
--- a/app/javascript/article-form/elements/__tests__/__snapshots__/bodyPreview.test.jsx.snap
+++ b/app/javascript/article-form/elements/__tests__/__snapshots__/bodyPreview.test.jsx.snap
@@ -1,0 +1,133 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<bodyPreview /> v1: renders properly 1`] = `
+<div
+  class="container"
+  style={
+    Object {
+      "border": "0px",
+      "boxShadow": "0px 0px 0px #fff",
+      "marginTop": "10px",
+      "minHeight": "508px",
+      "overflow": "hidden",
+    }
+  }
+>
+  <div>
+    <div
+      class="articleform__mainimage articleform__mainimagepreview"
+    >
+      <img
+        alt="cover"
+        src="http://lorempixel.com/400/200/"
+      />
+    </div>
+    <div
+      class="title"
+      style={
+        Object {
+          "maxWidth": "1000px",
+          "width": "90%",
+        }
+      }
+    >
+      <h1>
+        My Awesome Post
+      </h1>
+      <h3>
+        <img
+          alt="profile"
+          class="profile-pic"
+          src="/uploads/user/profile_image/41/0841dbe2-208c-4daa-b498-b2f01f3d37b2.png"
+        />
+         
+        <span>
+          Guy Fieri
+        </span>
+      </h3>
+      <div
+        class="tags"
+      />
+    </div>
+  </div>
+  <div
+    class="body"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "<p>My Awesome Post! Not very long, but still very awesome.</p>↵↵",
+      }
+    }
+    style={
+      Object {
+        "width": "90%",
+      }
+    }
+  />
+</div>
+`;
+
+exports[`<bodyPreview /> v2: renders properly 1`] = `
+<div
+  class="container"
+  style={
+    Object {
+      "border": "0px",
+      "boxShadow": "0px 0px 0px #fff",
+      "marginTop": "10px",
+      "minHeight": "508px",
+      "overflow": "hidden",
+    }
+  }
+>
+  <div>
+    <div
+      class="articleform__mainimage articleform__mainimagepreview"
+    >
+      <img
+        alt="cover"
+        src="http://lorempixel.com/400/200/"
+      />
+    </div>
+    <div
+      class="title"
+      style={
+        Object {
+          "maxWidth": "1000px",
+          "width": "90%",
+        }
+      }
+    >
+      <h1>
+        My Awesome Post
+      </h1>
+      <h3>
+        <img
+          alt="profile"
+          class="profile-pic"
+          src="/uploads/user/profile_image/41/0841dbe2-208c-4daa-b498-b2f01f3d37b2.png"
+        />
+         
+        <span>
+          Guy Fieri
+        </span>
+      </h3>
+      <div
+        class="tags"
+      />
+    </div>
+  </div>
+  <div
+    class="body"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "<p>My Awesome Post! Not very long, but still very awesome.</p>↵↵",
+      }
+    }
+    style={
+      Object {
+        "width": "90%",
+      }
+    }
+  />
+</div>
+`;

--- a/app/javascript/article-form/elements/__tests__/bodyPreview.test.jsx
+++ b/app/javascript/article-form/elements/__tests__/bodyPreview.test.jsx
@@ -1,0 +1,118 @@
+import { h } from 'preact';
+import render from 'preact-render-to-json';
+import { JSDOM } from 'jsdom';
+import { shallow } from 'preact-render-spy';
+import BodyPreview from '../bodyPreview';
+
+const doc = new JSDOM('<!doctype html><html><body></body></html>');
+global.document = doc;
+global.window = doc.defaultView;
+global.window.currentUser = {
+  id: 1,
+  name: 'Guy Fieri',
+  username: 'guyfieri',
+  profile_image_90:
+    '/uploads/user/profile_image/41/0841dbe2-208c-4daa-b498-b2f01f3d37b2.png',
+};
+
+describe('<bodyPreview />', () => {
+  let previewResponse;
+  let articleState;
+
+  beforeEach(() => {
+    previewResponse = {
+      processed_html:
+        '<p>My Awesome Post! Not very long, but still very awesome.</p>↵↵',
+      title: 'My Awesome Post',
+      tags: null,
+      cover_image: 'http://lorempixel.com/400/200/',
+    };
+
+    articleState = {
+      id: 1,
+      title: 'My Awesome Post',
+      tagList: '',
+      bodyMarkdown:
+        '---↵title: My Awesome Post↵published: false↵description: ↵tags: ↵---↵↵My Awesome Post Not very long, but still very awesome! ↵',
+      published: false,
+      previewShowing: true,
+      previewResponse,
+    };
+  });
+
+  it('v1: renders properly', () => {
+    const tree = render(
+      <BodyPreview
+        previewResponse={previewResponse}
+        version="v1"
+        articleState={articleState}
+      />,
+    );
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('v2: renders properly', () => {
+    const tree = render(
+      <BodyPreview
+        previewResponse={previewResponse}
+        version="v2"
+        articleState={articleState}
+      />,
+    );
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('v1: shows a cover image in preview if one exists', () => {
+    const container = shallow(
+      <BodyPreview
+        previewResponse={previewResponse}
+        version="v1"
+        articleState={articleState}
+      />,
+    );
+    expect(container.find('.articleform__mainimagepreview').exists()).toEqual(
+      true,
+    );
+  });
+
+  it('v1: does not show a cover image in preview if one does not exist', () => {
+    previewResponse.cover_image = null;
+    const container = shallow(
+      <BodyPreview
+        previewResponse={previewResponse}
+        version="v1"
+        articleState={articleState}
+      />,
+    );
+    expect(container.find('.articleform__mainimagepreview').exists()).toEqual(
+      false,
+    );
+  });
+
+  it('v2: shows a cover image in preview if one exists', () => {
+    const container = shallow(
+      <BodyPreview
+        previewResponse={previewResponse}
+        version="v2"
+        articleState={articleState}
+      />,
+    );
+    expect(container.find('.articleform__mainimagepreview').exists()).toEqual(
+      true,
+    );
+  });
+
+  it('v2: does not show a cover image in preview if one does not exist', () => {
+    previewResponse.cover_image = null;
+    const container = shallow(
+      <BodyPreview
+        previewResponse={previewResponse}
+        version="v2"
+        articleState={articleState}
+      />,
+    );
+    expect(container.find('.articleform__mainimagepreview').exists()).toEqual(
+      false,
+    );
+  });
+});

--- a/app/javascript/article-form/elements/bodyPreview.jsx
+++ b/app/javascript/article-form/elements/bodyPreview.jsx
@@ -30,9 +30,13 @@ function titleArea(previewResponse, version, articleState) {
   }
 
   let coverImage = '';
-  if (previewResponse.cover_image && previewResponse.cover_image.length > 0) {
-    coverImage = previewResponse.cover_image;
+  if (articleState.previewShowing) {
+    // In preview state, use the cover_image from previewResponse.
+    if (previewResponse.cover_image && previewResponse.cover_image.length > 0) {
+      coverImage = previewResponse.cover_image;
+    }
   } else if (articleState.mainImage) {
+    // Otherwise, use the mainImage from the article if it exists.
     coverImage = articleState.mainImage;
   }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixes an issue where the cover image appeared to be stale and would continue to appear in preview mode even if it had been removed from the front matter data! I also added a new test file for the `bodyPreview` component since there wasn't one yet, and added some tests for both v1 and v2 of the editor.

Note: this is my first time working with Jest, and my first time in _years_ working with (P)React. Happy to hear thoughts and suggestions on those tests if you have them! 🙈 

## Related Tickets & Documents

Related to https://github.com/thepracticaldev/dev.to/issues/5630.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed (though I added a relevant code comment)

## What gif best describes this PR or how it makes you feel

![](https://media3.giphy.com/media/wIXg7i1X8OW5i/giphy.gif?cid=5a38a5a2886e2e0ad0cdcb37ccd4c1031e649c6f1991515d&rid=giphy.gif)
