### PR TITLE
Use edge caching for API Article show endpoint

### DIFF
--- a/app/controllers/api/v0/comments_controller.rb
+++ b/app/controllers/api/v0/comments_controller.rb
@@ -10,7 +10,7 @@ module Api
 
         @comments = article.comments.includes(:user).select(%i[id processed_html user_id ancestry]).arrange
 
-        set_surrogate_key_header article.record_key, "comments", edge_cache_keys(@comments)
+        set_surrogate_key_header article.record_key, Comment.table_key, edge_cache_keys(@comments)
       end
 
       def show
@@ -23,7 +23,7 @@ module Api
         @comment = tree_with_root_comment.keys.first
         @comments = tree_with_root_comment[@comment]
 
-        set_surrogate_key_header "comments", edge_cache_keys(tree_with_root_comment)
+        set_surrogate_key_header Comment.table_key, edge_cache_keys(tree_with_root_comment)
       end
 
       private

--- a/spec/requests/api/v0/articles_spec.rb
+++ b/spec/requests/api/v0/articles_spec.rb
@@ -302,6 +302,13 @@ RSpec.describe "Api::V0::Articles", type: :request do
       get api_article_path("9999")
       expect(response).to have_http_status(:not_found)
     end
+
+    it "sets the correct edge caching surrogate key" do
+      get api_article_path(article)
+
+      expected_key = [article.record_key].to_set
+      expect(response.headers["surrogate-key"].split.to_set).to eq(expected_key)
+    end
   end
 
   describe "GET /api/articles/me(/:status)" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Right now we're caching the `/api/articles/{id}` endpoint for 5 minutes on the server side.

Internally it stores the JSON payload in Redis for 300 seconds:

```shell
127.0.0.1:6379> keys "views/*"
1) "views/localhost:3000/api/articles/4.json"
127.0.0.1:6379> ttl "views/localhost:3000/api/articles/4.json"
(integer) 266
127.0.0.1:6379> get "views/localhost:3000/api/articles/4.json"
"\x04\bo: ActiveSupport::Cache::Entry\n:\x0b..."
```

This is not really efficient for multiple reasons:

- the 5 minute duration is quite short for 99% of articles (those that are not updated continuosly, which usually happens in the few minutes / hours right after an article is published, for last minute changes or updates)
- being an API endpoint there's a very HIGH likelyhood that this results in a lot of HTTP calls to Redis (if I request an old article I'm 100% sure it's not going to be in the cache)

The solution I propose is to use the default edge caching as we do for the index, now that with #5606 we have purging in place (tested by me and @mstruve) we can confidently let go of action caching for this.

The cache will also last for 24hrs, gets purge near istantenously if the article is changed, and use Fastly resources instead of ours :D 

## Related Tickets & Documents

#5606 

