### PR TITLE
Allow for proper deselect of email_newsletter during onboarding

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -126,7 +126,7 @@ class UsersController < ApplicationController
   def onboarding_checkbox_update
     if params[:user]
       permitted_params = %i[
-        checked_code_of_conduct checked_terms_and_conditions email_membership_newsletter email_digest_periodic
+        checked_code_of_conduct checked_terms_and_conditions email_newsletter email_digest_periodic
       ]
       current_user.assign_attributes(params[:user].permit(permitted_params))
     end

--- a/app/javascript/onboarding/__tests__/__snapshots__/Onboarding.test.jsx.snap
+++ b/app/javascript/onboarding/__tests__/__snapshots__/Onboarding.test.jsx.snap
@@ -154,11 +154,11 @@ preact-render-spy (1 nodes)
           </a>
         </label>
         <h3>Email Preferences</h3>
-        <label htmlFor="email_membership_newsletter">
+        <label htmlFor="email_newsletter">
           <input
             type="checkbox"
-            id="email_membership_newsletter"
-            name="email_membership_newsletter"
+            id="email_newsletter"
+            name="email_newsletter"
             checked={true}
             onChange={[Function bound handleChange]}
            />

--- a/app/javascript/onboarding/components/EmailListTermsConditionsForm.jsx
+++ b/app/javascript/onboarding/components/EmailListTermsConditionsForm.jsx
@@ -19,7 +19,7 @@ class EmailTermsConditionsForm extends Component {
     this.state = {
       checked_code_of_conduct: false,
       checked_terms_and_conditions: false,
-      email_membership_newsletter: true,
+      email_newsletter: true,
       email_digest_periodic: true,
       message: '',
       textShowing: null,
@@ -104,7 +104,7 @@ class EmailTermsConditionsForm extends Component {
       message,
       checked_code_of_conduct,
       checked_terms_and_conditions,
-      email_membership_newsletter,
+      email_newsletter,
       email_digest_periodic,
       textShowing,
     } = this.state;
@@ -169,12 +169,12 @@ class EmailTermsConditionsForm extends Component {
               </a>
             </label>
             <h3>Email Preferences</h3>
-            <label htmlFor="email_membership_newsletter">
+            <label htmlFor="email_newsletter">
               <input
                 type="checkbox"
-                id="email_membership_newsletter"
-                name="email_membership_newsletter"
-                checked={email_membership_newsletter}
+                id="email_newsletter"
+                name="email_newsletter"
+                checked={email_newsletter}
                 onChange={this.handleChange}
               />
               Do you want to receive our weekly newsletter emails?


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
The email newsletter field on one of the onboarding steps is using/updating an incorrect property of User. Onboard-er were not able to opt-out of the newsletter because of this. 

for clarity:
- `email_newsletter` is for the weekly email from Jess/Mailchimp
- `email_membership_newsletter` is for sustaining membership campaign
## Related Tickets & Documents
n/a
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
1) Deselect both choices during onboarding.
![Screen Shot 2020-01-23 at 1 41 22 PM](https://user-images.githubusercontent.com/15793250/73015122-76524980-3de9-11ea-883a-b0c3798380c9.png)
2) Setting page does not reflect the choice made during onboarding
![Screen Shot 2020-01-23 at 2 10 00 PM](https://user-images.githubusercontent.com/15793250/73015516-2c1d9800-3dea-11ea-9185-4fefc53f2647.png)

This PR fixes that



## Added to documentation?

- [x] no documentation needed

