### PR TITLE
Install less

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM ruby:2.6.5-alpine3.10
 #
 #------------------------------------------------------------------------------
 RUN apk update -qq && apk add git nodejs postgresql-client ruby-dev build-base \
-  libxml2-dev libxslt-dev pcre-dev libffi-dev postgresql-dev tzdata imagemagick
+  less libxml2-dev libxslt-dev pcre-dev libffi-dev postgresql-dev tzdata imagemagick
 
 #------------------------------------------------------------------------------
 #


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

I was unable to fully use pry using the docker version of dev.to.
For instance while trying to examine certain variables or trying to use
`caller` to checkout the backtrace, I would run into the a `multi-call binary error` with
`BusyBox`.

On looking up this error, discovered https://github.com/pry/pry/issues/1248 which also
had the fix which was simply to install less for the docker image.

Verified locally that pry's full functionality works.

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

![giphy](https://user-images.githubusercontent.com/2251508/73023690-1021f280-3dfa-11ea-9c70-b4123f7d885a.gif)
