### PR TITLE
Fix article description issues

### DIFF
--- a/app/decorators/article_decorator.rb
+++ b/app/decorators/article_decorator.rb
@@ -55,7 +55,7 @@ class ArticleDecorator < ApplicationDecorator
   def description_and_tags
     modified_description = description.strip
     modified_description += "." unless description.end_with?(".")
-    return modified_description unless  cached_tag_list.present?
+    return modified_description if cached_tag_list.blank?
 
     modified_description + " Tagged with #{cached_tag_list}."
   end

--- a/app/decorators/article_decorator.rb
+++ b/app/decorators/article_decorator.rb
@@ -51,4 +51,12 @@ class ArticleDecorator < ApplicationDecorator
   def published_at_int
     published_at.to_i
   end
+
+  def description_and_tags
+    modified_description = description.strip
+    modified_description += "." unless description.end_with?(".")
+    return modified_description unless  cached_tag_list.present?
+
+    modified_description + " Tagged with #{cached_tag_list}."
+  end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -275,11 +275,10 @@ class Article < ApplicationRecord
 
   def contrived_description
     text_portion = body_text.present? ? "#{body_text[0..100].tr("\n", ' ').strip}" : ""
-    text_portion += + "..." if body_text.size > 100 || tag_list.present?
-    tags_portion = (" Tagged with #{tag_list}" if tag_list.present?).to_s
-    return "A post by #{user.name}" if text_portion.blank? && tags_portion.blank?
+    text_portion = + text_portion.strip + "..." if body_text.size > 100
+    return "A post by #{user.name}" if text_portion.blank?
 
-    (text_portion + tags_portion).strip
+    text_portion.strip
   end
 
   def body_text

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -275,7 +275,7 @@ class Article < ApplicationRecord
 
   def processed_description
     text_portion = body_text.present? ? body_text[0..100].tr("\n", " ").strip.to_s : ""
-    text_portion = + text_portion.strip + "..." if body_text.size > 100
+    text_portion = text_portion.strip + "..." if body_text.size > 100
     return "A post by #{user.name}" if text_portion.blank?
 
     text_portion.strip

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -501,7 +501,7 @@ class Article < ApplicationRecord
     self.published_at = parse_date(front_matter["date"]) if published
     self.main_image = front_matter["cover_image"] if front_matter["cover_image"].present?
     self.canonical_url = front_matter["canonical_url"] if front_matter["canonical_url"].present?
-    self.description = front_matter["description"].presence || contrived_description
+    self.description = front_matter["description"].presence || description.presence || contrived_description
     self.collection_id = nil if front_matter["title"].present?
     self.collection_id = Collection.find_series(front_matter["series"], user).id if front_matter["series"].present?
     self.automatically_renew = front_matter["automatically_renew"] if front_matter["automatically_renew"].present? && tag_list.include?("hiring")

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -273,7 +273,7 @@ class Article < ApplicationRecord
     end
   end
 
-  def contrived_description
+  def processed_description
     text_portion = body_text.present? ? body_text[0..100].tr("\n", " ").strip.to_s : ""
     text_portion = + text_portion.strip + "..." if body_text.size > 100
     return "A post by #{user.name}" if text_portion.blank?
@@ -430,7 +430,7 @@ class Article < ApplicationRecord
     self.reading_time = parsed_markdown.calculate_reading_time
     self.processed_html = parsed_markdown.finalize
     evaluate_front_matter(parsed.front_matter)
-    self.description = contrived_description if description.blank?
+    self.description = processed_description if description.blank?
   rescue StandardError => e
     errors[:base] << ErrorMessageCleaner.new(e.message).clean
   end

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -38,6 +38,7 @@
 
 <% if internal_navigation? %>
     <link rel="canonical" href="<%= @article.canonical_url.presence || "https://#{ApplicationConfig['APP_DOMAIN']}#{@article.path}" %>" />
+    <meta name="description" content="<%= @article.description || "An article from the community" %>">
 <% else %>
   <%= content_for :page_meta do %>
     <link rel="canonical" href="<%= @article.canonical_url.presence || "https://#{ApplicationConfig['APP_DOMAIN']}#{@article.path}" %>" />

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -38,12 +38,13 @@
 
 <% if internal_navigation? %>
     <link rel="canonical" href="<%= @article.canonical_url.presence || "https://#{ApplicationConfig['APP_DOMAIN']}#{@article.path}" %>" />
-    <meta name="description" content="<%= @article.description || "An article from the community" %>">
+    <meta name="description" content="<%= @article.description_and_tags %>">
+    <meta name="keywords" content="<%= @article.cached_tag_list %>, software, coding, development, engineering, inclusive, community">
 <% else %>
   <%= content_for :page_meta do %>
     <link rel="canonical" href="<%= @article.canonical_url.presence || "https://#{ApplicationConfig['APP_DOMAIN']}#{@article.path}" %>" />
-    <meta name="description" content="<%= @article.description || "An article from the community" %>">
-    <meta name="keywords" content="software development, inclusive, community, engineering, <%= @article.cached_tag_list %>">
+    <meta name="description" content="<%= @article.description_and_tags %>">
+    <meta name="keywords" content="<%= @article.cached_tag_list %>, software, coding, development, engineering, inclusive, community">
 
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://dev.to<%= @article.path %>" />

--- a/spec/decorators/article_decorator_spec.rb
+++ b/spec/decorators/article_decorator_spec.rb
@@ -1,6 +1,11 @@
 require "rails_helper"
 
 RSpec.describe ArticleDecorator, type: :decorator do
+  def create_article(*args)
+    article = create(:article, *args)
+    article.decorate
+  end
+
   let(:article) { build_stubbed(:article) }
 
   describe "#processed_canonical_url" do
@@ -27,6 +32,33 @@ RSpec.describe ArticleDecorator, type: :decorator do
       expect(article.decorate.title_length_classification).to eq("medium")
       article.title = "0" * 20
       expect(article.decorate.title_length_classification).to eq("short")
+    end
+  end
+
+  describe "#description_and_tags" do
+    it "creates proper description when description is not present and body is present and short, and tags are present" do
+      paragraphs = Faker::Hipster.paragraph(sentence_count: 40)
+      body_markdown = "---\ntitle: Title\npublished: false\ndescription:\ntags: heytag\n---\n\nHey this is the article"
+      expect(create_article(body_markdown: body_markdown).description_and_tags).to eq("Hey this is the article. Tagged with heytag.")
+    end
+
+    it "creates proper description when description is not present and body is present and short, and tags are not present" do
+      paragraphs = Faker::Hipster.paragraph(sentence_count: 40)
+      body_markdown = "---\ntitle: Title\npublished: false\ndescription:\ntags:\n---\n\nHey this is the article"
+      expect(create_article(body_markdown: body_markdown).description_and_tags).to eq("Hey this is the article.")
+    end
+
+
+    it "creates proper description when description is not present and body is present and long, and tags are present" do
+      paragraphs = Faker::Hipster.paragraph(sentence_count: 40)
+      body_markdown = "---\ntitle: Title\npublished: false\ndescription:\ntags: heytag\n---\n\n#{paragraphs}"
+      expect(create_article(body_markdown: body_markdown).description_and_tags).to end_with("... Tagged with heytag.")
+    end
+
+    it "creates proper description when description is not present and body is not present and long, and tags are present" do
+      body_markdown = "---\ntitle: Title\npublished: false\ndescription:\ntags: heytag\n---\n\n"
+      created_article = create_article(body_markdown: body_markdown)
+      expect(created_article.description_and_tags).to eq("A post by #{created_article.user.name}. Tagged with heytag.")
     end
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -153,26 +153,15 @@ RSpec.describe Article, type: :model do
         expect(build_and_validate_article(body_markdown: body_markdown).description).to eq("This is the body yo")
       end
 
-      it "creates proper description when description is not present and body is present and short, and tags are present" do
+      it "creates proper description when description is not present and body is present and short" do
         body_markdown = "---\ntitle: Title\npublished: false\ndescription:\ntags: heytag\n---\n\nThis is the body yo"
-        expect(build_and_validate_article(body_markdown: body_markdown).description).to eq("This is the body yo... Tagged with heytag")
+        expect(build_and_validate_article(body_markdown: body_markdown).description).to eq("This is the body yo")
       end
 
-      it "creates proper description when description is not present and body is present and long, with no tags" do
+      it "creates proper description when description is not present and body is present and long" do
         paragraphs = Faker::Hipster.paragraph(sentence_count: 40)
         body_markdown = "---\ntitle: Title\npublished: false\ndescription:\ntags:\n---\n\n#{paragraphs}"
         expect(build_and_validate_article(body_markdown: body_markdown).description).to end_with("...")
-      end
-
-      it "creates proper description when description is not present and body is present and long, and tags are present" do
-        paragraphs = Faker::Hipster.paragraph(sentence_count: 40)
-        body_markdown = "---\ntitle: Title\npublished: false\ndescription:\ntags: heytag\n---\n\n#{paragraphs}"
-        expect(build_and_validate_article(body_markdown: body_markdown).description).to end_with("... Tagged with heytag")
-      end
-
-      it "creates proper description when description is not present and body is not present and long, and tags are present" do
-        body_markdown = "---\ntitle: Title\npublished: false\ndescription:\ntags: heytag\n---\n\n"
-        expect(build_and_validate_article(body_markdown: body_markdown).description).to eq("... Tagged with heytag")
       end
     end
 

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -142,6 +142,40 @@ RSpec.describe Article, type: :model do
       end
     end
 
+    describe "#description" do
+      it "creates proper description when description is present" do
+        body_markdown = "---\ntitle: Title\npublished: false\ndescription: hey hey hoho\ntags: one\n---\n\n"
+        expect(build_and_validate_article(body_markdown: body_markdown).description).to eq("hey hey hoho")
+      end
+
+      it "creates proper description when description is not present and body is present and short, with no tags" do
+        body_markdown = "---\ntitle: Title\npublished: false\ndescription:\ntags:\n---\n\nThis is the body yo"
+        expect(build_and_validate_article(body_markdown: body_markdown).description).to eq("This is the body yo")
+      end
+
+      it "creates proper description when description is not present and body is present and short, and tags are present" do
+        body_markdown = "---\ntitle: Title\npublished: false\ndescription:\ntags: heytag\n---\n\nThis is the body yo"
+        expect(build_and_validate_article(body_markdown: body_markdown).description).to eq("This is the body yo... Tagged with heytag")
+      end
+
+      it "creates proper description when description is not present and body is present and long, with no tags" do
+        paragraphs = Faker::Hipster.paragraph(sentence_count: 40)
+        body_markdown = "---\ntitle: Title\npublished: false\ndescription:\ntags:\n---\n\n#{paragraphs}"
+        expect(build_and_validate_article(body_markdown: body_markdown).description).to end_with("...")
+      end
+
+      it "creates proper description when description is not present and body is present and long, and tags are present" do
+        paragraphs = Faker::Hipster.paragraph(sentence_count: 40)
+        body_markdown = "---\ntitle: Title\npublished: false\ndescription:\ntags: heytag\n---\n\n#{paragraphs}"
+        expect(build_and_validate_article(body_markdown: body_markdown).description).to end_with("... Tagged with heytag")
+      end
+
+      it "creates proper description when description is not present and body is not present and long, and tags are present" do
+        body_markdown = "---\ntitle: Title\npublished: false\ndescription:\ntags: heytag\n---\n\n"
+        expect(build_and_validate_article(body_markdown: body_markdown).description).to eq("... Tagged with heytag")
+      end
+    end
+
     describe "#canonical_url" do
       let!(:article_with_canon_url) { build(:article, with_canonical_url: true) }
 

--- a/spec/requests/api/v0/articles_spec.rb
+++ b/spec/requests/api/v0/articles_spec.rb
@@ -654,11 +654,11 @@ RSpec.describe "Api::V0::Articles", type: :request do
         expect do
           post_article(
             title: Faker::Book.title,
-            body_markdown: "yooo" * 100,
+            body_markdown: "yoooo" * 100,
           )
           expect(response).to have_http_status(:created)
         end.to change(Article, :count).by(1)
-        expect(Article.find(response.parsed_body["id"]).description).to eq("yooo" * 20 + "y...")
+        expect(Article.find(response.parsed_body["id"]).description).to eq("yoooo" * 20 + "y...")
       end
 
       it "does not raise an error if article params are missing" do

--- a/spec/requests/api/v0/articles_spec.rb
+++ b/spec/requests/api/v0/articles_spec.rb
@@ -910,7 +910,10 @@ RSpec.describe "Api::V0::Articles", type: :request do
 
       it "updates a description" do
         description = "this is a very interesting article"
-        put_article(description: description)
+        put_article(
+          body_markdown: "Yo ho ho bsddsdsobo",
+          description: description,
+        )
         expect(response).to have_http_status(:ok)
         expect(article.reload.description).to eq(description)
       end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR fixes a few logical problems currently with "article description"

- Currently the attempt at a contrived description if it were blank were not resulting in anything because blank strings were being submitted and the `||` wasn't being called.
- Description wasn't present in the "internal navigation" version of the page, which _may or may not_ matter, but just in case it has any impact on SEO, I think this is the right way to go about it.
- The contrived name now includes tags at the end to help possible search engine cases.

Part of this is strictly for hypothetical SEO issues, part is slightly more for user-reading purposes where we use the description in different places where now it's erroneously not present.