### PR TITLE
Group all PG::TRDeadlockDetected and PG::QueryCanceled errors together

### DIFF
--- a/config/initializers/honeybadger.rb
+++ b/config/initializers/honeybadger.rb
@@ -1,6 +1,16 @@
 # Can be used to implement more programatic error handling
 # https://docs.honeybadger.io/lib/ruby/getting-started/ignoring-errors.html#ignore-programmatically
 
+MESSAGE_FINGERPRINTS = {
+  "BANNED" => "banned",
+  "Rack::Timeout::RequestTimeoutException" => "rack_timeout",
+  "PG::QueryCanceled" => "pg_query_canceled"
+}.freeze
+
+COMPONENT_FINGERPRINTS = {
+  "internal" => "internal"
+}.freeze
+
 Honeybadger.configure do |config|
   config.api_key = ApplicationConfig["HONEYBADGER_API_KEY"]
   config.revision = ApplicationConfig["HEROKU_SLUG_COMMIT"]
@@ -16,12 +26,10 @@ Honeybadger.configure do |config|
   config.before_notify do |notice|
     notice.fingerprint = if notice.error_message&.include?("SIGTERM") && notice.component&.include?("fetch_all_rss")
                            notice.error_message
-                         elsif notice.error_message&.include?("BANNED")
-                           "banned"
-                         elsif notice.error_message&.include?("Rack::Timeout::RequestTimeoutException")
-                           "rack_timeout"
-                         elsif notice.component&.include?("internal")
-                           "internal"
+                         elsif (msg_key = MESSAGE_FINGERPRINTS.keys.detect { |k, _v| notice.error_message&.include?(k) })
+                           MESSAGE_FINGERPRINTS[msg_key]
+                         elsif (cmp_key = COMPONENT_FINGERPRINTS.keys.detect { |k, _v| notice.component&.include?(k) })
+                           COMPONENT_FINGERPRINTS[cmp_key]
                          end
   end
 end

--- a/spec/initializers/honeybadger_spec.rb
+++ b/spec/initializers/honeybadger_spec.rb
@@ -32,12 +32,22 @@ describe Honeybadger do
   end
 
   context "when error is raised from an internal route" do
-    it "halts notification" do
+    it "sets fingerprint to internal" do
       notice = Honeybadger::Notice.new(
         described_class.config, component: "internal/feedback_messages"
       )
       described_class.config.before_notify_hooks.first.call(notice)
       expect(notice.fingerprint).to eq("internal")
+    end
+  end
+
+  context "when a PG::QueryCanceled error is raised" do
+    it "sets fingerprint to pg_query_cancel" do
+      notice = Honeybadger::Notice.new(
+        described_class.config, error_message: "ActionView::Template::Error: PG::QueryCanceled:"
+      )
+      described_class.config.before_notify_hooks.first.call(notice)
+      expect(notice.fingerprint).to eq("pg_query_canceled")
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
We get a lot of these two errors from all over the app. They are usually one-off or a lot of them are actually from our admin which is not very performant. Rather than recording a new error for every different backtrace that produces one of these, let's group them together.

Also included a little refractor, what do you all think? It makes adding a grouping as simple as adding a search key and fingerprint. 

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media0.giphy.com/media/8j2wrmWdc0Kf6/giphy.gif)
