### PR TITLE
Allow `cover_image` of an article to be removed

### DIFF
--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
       tags { Faker::Hipster.words(number: 4).join(", ") }
       canonical_url { Faker::Internet.url }
       with_canonical_url { false }
+      with_main_image { true }
       with_date { false }
       with_tags { true }
       with_hr_issue { false }
@@ -18,7 +19,7 @@ FactoryBot.define do
     end
     association :user, factory: :user, strategy: :create
     description { Faker::Hipster.paragraph(sentence_count: 1)[0..100] }
-    main_image    { Faker::Avatar.image }
+    main_image    { with_main_image ? Faker::Avatar.image : nil }
     language { "en" }
     experience_level_rating { rand(4..6) }
     body_markdown do

--- a/spec/fixtures/files/article_published_empty_cover_image.txt
+++ b/spec/fixtures/files/article_published_empty_cover_image.txt
@@ -1,0 +1,9 @@
+---
+title: Sample Article
+published: true
+description: this is a sample article
+tags: test
+cover_image:
+---
+
+Suspendisse ac lobortis velit, a feugiat sapien. Aenean condimentum, nulla at fermentum sagittis, tellus nisi suscipit velit, vel sollicitudin odio ligula a odio. Integer eget efficitur massa, in sodales velit. Nunc fermentum consequat scelerisque. Morbi elementum tristique faucibus. Nulla vel lectus non justo euismod varius. Vivamus id nisl sit amet odio tincidunt fringilla. Pellentesque odio odio, vulputate in risus eu, lacinia porttitor lorem. Nunc posuere tempus est, imperdiet suscipit odio maximus id. Nam eget feugiat magna.

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -263,6 +263,52 @@ RSpec.describe Article, type: :model do
         expect(test_article.body_text).to eq(sanitized_html)
       end
     end
+
+    context "when a main_image does not already exist" do
+      let!(:article_without_main_image) { build(:article, with_main_image: false) }
+      let(:image) { Faker::Avatar.image }
+
+      before { article_without_main_image.validate }
+
+      it "can parse the main_image" do
+        expect(article_without_main_image.main_image).to eq(nil)
+      end
+
+      it "can parse the main_image when added" do
+        article_without_main_image.main_image = image
+        article_without_main_image.validate
+
+        expect(article_without_main_image.main_image).to eq(image)
+      end
+    end
+
+    context "when a main_image exists" do
+      # The `with_main_image` flag is the factory default, but we're being explicit here.
+      let!(:article_with_main_image) { build(:article, with_main_image: true) }
+      let(:image) { article_with_main_image.main_image }
+
+      before { article_with_main_image.validate }
+
+      it "can parse the main_image" do
+        expect(article_with_main_image.main_image).to eq(image)
+      end
+
+      it "can parse the main_image when removed" do
+        article_with_main_image.main_image = nil
+        article_with_main_image.validate
+
+        expect(article_with_main_image.main_image).to eq(nil)
+      end
+
+      it "can parse the main_image when changed" do
+        expect(article_with_main_image.main_image).to eq(image)
+
+        other_image = Faker::Avatar.image
+        article_with_main_image.main_image = other_image
+        article_with_main_image.validate
+        expect(article_with_main_image.main_image).to eq(other_image)
+      end
+    end
   end
 
   describe "#class_name" do

--- a/spec/requests/api/v0/articles_spec.rb
+++ b/spec/requests/api/v0/articles_spec.rb
@@ -806,6 +806,34 @@ RSpec.describe "Api::V0::Articles", type: :request do
         expect(article.body_markdown).to eq(body_markdown)
       end
 
+      it "updates the main_image to be empty if given an empty cover_image" do
+        image = Faker::Avatar.image
+        article.update(main_image: image)
+        expect(article.main_image).to eq(image)
+
+        body_markdown = file_fixture("article_published_empty_cover_image.txt").read
+        put_article(
+          title: Faker::Book.title,
+          body_markdown: body_markdown,
+        )
+        expect(response).to have_http_status(:ok)
+        expect(article.reload.main_image).to eq(nil)
+      end
+
+      it "updates the main_image to be empty if given a different cover_image" do
+        image = Faker::Avatar.image
+        article.update(main_image: image)
+        expect(article.main_image).to eq(image)
+
+        body_markdown = file_fixture("article_published_cover_image.txt").read
+        put_article(
+          title: Faker::Book.title,
+          body_markdown: body_markdown,
+        )
+        expect(response).to have_http_status(:ok)
+        expect(article.reload.main_image).to eq("https://dummyimage.com/100x100")
+      end
+
       it "updates the tags" do
         expect do
           put_article(


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

As @rhymes [pointed out to me](https://github.com/thepracticaldev/dev.to/pull/5660#pullrequestreview-347173956) in the context of another PR I made, we have a bug where we do not actually save a user's changes to their cover image on an article.

To see this in action, head over to production and:
1) Create a post with the cover image and save it.
2) Edit the post and remove the cover image and save.
3) Check out the post again; you'll see that the cover image is still there, even though you removed it.

This isn't a great experience, and we should allow users to actually persist this change.

However, I had some trouble getting the logic correct here because we can't just rely on the presence of `cover_image` in the `front_matter`; we need to be able to distinguish the scenario of when the user is trying to clear out a previous image (the `main_image` on the article), and when they just haven't set a `cover_image` at all. Because we allow users to add `cover_image` to the markdown as well as remove it, it's hard to know exactly which action they're trying to take.

My solution for this was to depend on the `cover_image` key being sent through the markdown/front_matter. If there is no `cover_image` being sent through, we rely on the `main_image` of the article, but if there is `cover_image`, then we should take that into account. If the `cover_image` being sent through is `nil`, then we know that the user is trying to clear out the image, and if the value is a url, then we know that they're trying to change the image.

Let me know what you think about my approach. I've added the appropriate tests for both the API side and the model side, so you can get a sense of what I've described here in the context of the code. I'm definitely open to ideas/thoughts 😸 

## Related Tickets & Documents

Fixes https://github.com/thepracticaldev/dev.to/issues/5630

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed (though I added inline comments for clarity!)

## [optional] What gif best describes this PR or how it makes you feel?


![](https://media2.giphy.com/media/QmKAToUMrbcikgQmiz/giphy.gif?cid=5a38a5a22d3e199d3553a7b8e7b3d749fbeb7c8da40965c4&rid=giphy.gif)

