### PR TITLE
Don't raise StandardError for invalid liquid tags when updating comment

### DIFF
--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -532,7 +532,6 @@ a.header-link {
     border-radius: 5px;
     margin: 20px auto;
     padding: 20px;
-    text-align: center;
   }
 }
 

--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -523,6 +523,17 @@ a.header-link {
       text-overflow: ellipsis;
     }
   }
+
+  .alert-error {
+    background: $red;
+    max-width: 730px;
+    font-family: $helvetica;
+    color: white;
+    border-radius: 5px;
+    margin: 20px auto;
+    padding: 20px;
+    text-align: center;
+  }
 }
 
 .single-comment-node {

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -106,7 +106,7 @@ class CommentsController < ApplicationController
     raise
   rescue StandardError => e
     Rails.logger.error(e)
-    message = "There was a error in your markdown: #{e}"
+    message = "There was an error in your markdown: #{e}"
     render json: { error: message }, status: :unprocessable_entity
   end
 
@@ -121,6 +121,10 @@ class CommentsController < ApplicationController
       @commentable = @comment.commentable
       render :edit
     end
+  rescue StandardError => e
+    @commentable = @comment.commentable
+    flash.now[:error] = "There was an error in your markdown: #{e}"
+    render :edit
   end
 
   # DELETE /comments/1
@@ -150,7 +154,7 @@ class CommentsController < ApplicationController
       parsed_markdown = MarkdownParser.new(fixed_body_markdown)
       processed_html = parsed_markdown.finalize
     rescue StandardError => e
-      processed_html = "<p>😔 There was a error in your markdown</p><hr><p>#{e}</p>"
+      processed_html = "<p>😔 There was an error in your markdown</p><hr><p>#{e}</p>"
     end
     respond_to do |format|
       format.json { render json: { processed_html: processed_html }, status: :ok }

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,3 +1,7 @@
+<% flash.each do |type, message| %>
+  <div class="alert alert-<%= type %>"><%= message %></div>
+<% end %>
+
 <% if @comment.errors.any? %>
   <div id="error_explanation">
     <h2><%= pluralize(@comment.errors.count, "error") %> prohibited this comment from being saved:</h2>

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -199,6 +199,20 @@ RSpec.describe "Comments", type: :request do
     end
   end
 
+  describe "PUT /comments/:id" do
+    before do
+      sign_in user
+    end
+
+    it "does not raise a StandardError for invalid liquid tags" do
+      put "/comments/#{comment.id}",
+          params: { comment: { body_markdown: "{% gist flsnjfklsd %}" } }
+
+      expect(response).to have_http_status(:ok)
+      expect(flash[:error]).not_to be_nil
+    end
+  end
+
   describe "POST /comments/preview" do
     it "returns 401 if user is not logged in" do
       post "/comments/preview",


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR fixes generic Standard Error that is raised on comments#update if comment contains an invalid liquid tag. With the new changes user can see the error instead of breaking the page.

Honeybadger: https://app.honeybadger.io/fault/66984/6b348042b61c88825e56b6362a3ae2f7

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/issues/5608

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
<img width="815" alt="Screenshot 2020-01-24 at 09 30 32" src="https://user-images.githubusercontent.com/3431279/73058010-fc769a80-3e92-11ea-974c-c7f6b269866e.png">

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![error](https://media.giphy.com/media/EFXGvbDPhLoWs/giphy.gif)
