### PR TITLE
Fix capitalization in settings placeholders

### DIFF
--- a/app/views/users/_profile.html.erb
+++ b/app/views/users/_profile.html.erb
@@ -94,11 +94,11 @@
   </div>
   <div class="field">
     <%= f.label :mostly_work_with, "Skills/Languages" %>
-    <%= f.text_area :mostly_work_with, placeholder: "What tools and languages are you most experienced with? are you specialized or more of a generalist?", maxlength: 500 %>
+    <%= f.text_area :mostly_work_with, placeholder: "What tools and languages are you most experienced with? Are you specialized or more of a generalist?", maxlength: 500 %>
   </div>
   <div class="field">
     <%= f.label :currently_learning, "I'm getting into" %>
-    <%= f.text_area :currently_learning, placeholder: "What are you learning right now? what are the new tools and languages you're picking up in #{Time.zone.now.year}?", maxlength: 500 %>
+    <%= f.text_area :currently_learning, placeholder: "What are you learning right now? What are the new tools and languages you're picking up in #{Time.zone.now.year}?", maxlength: 500 %>
   </div>
   <div class="field">
     <%= f.label :currently_hacking_on, "My projects and hacks" %>
@@ -106,7 +106,7 @@
   </div>
   <div class="field">
     <%= f.label :available_for %>
-    <%= f.text_area :available_for, placeholder: "What kinds of collaborations or discussions are you available for? what's a good reason to say hey to you these days?", maxlength: 500 %>
+    <%= f.text_area :available_for, placeholder: "What kinds of collaborations or discussions are you available for? What's a good reason to say hey to you these days?", maxlength: 500 %>
   </div>
   <p><strong>Links</strong></p>
   <div class="field">


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixes capitalization of some placeholder sentences on the User Profile settings page. This is pretty minor but was a) annoying me, b) seemed like a good first baby step to committing code!

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Before:
<img width="704" alt="Settings_-_DEV_local__Community_👩💻👨💻" src="https://user-images.githubusercontent.com/37842/73086453-49a83b80-3e96-11ea-8bb8-6e778ea8b706.png">

After:
<img width="685" alt="Settings_-_DEV_local__Community_👩💻👨💻" src="https://user-images.githubusercontent.com/37842/73086509-617fbf80-3e96-11ea-9e36-b5d05ffa6801.png">


## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![Mother of Grammar](https://media.giphy.com/media/3TmdDWohQFcsM/giphy.gif)
