### PR TITLE
Add documentation around our use of pg-bouncer [ci-skip]

### DIFF
--- a/docs/installation/postgresql.md
+++ b/docs/installation/postgresql.md
@@ -13,13 +13,12 @@ operating system:
    - [Homebrew](https://brew.sh/): if you use Homebrew you can easily install
      PostgreSQL with `brew install postgresql`
 1. Linux (Ubuntu)
-   - [Ubuntu
-     `14.04`](https://www.digitalocean.com/community/tutorials/how-to-install-and-use-postgresql-on-ubuntu-14-04)
+   - [Ubuntu `14.04`](https://www.digitalocean.com/community/tutorials/how-to-install-and-use-postgresql-on-ubuntu-14-04)
    - [Ubuntu `16.04 and higher`](https://www.digitalocean.com/community/tutorials/how-to-install-and-use-postgresql-on-ubuntu-16-04)
 1. [Windows](https://www.postgresql.org/download/windows/)
 
-_You can find all installation options for a variety of operating systems [on
-the official PostgreSQL download page](https://www.postgresql.org/download/)_.
+_You can find all installation options for a variety of operating systems
+[on the official PostgreSQL download page](https://www.postgresql.org/download/)_.
 
 ## Configuration
 
@@ -28,8 +27,8 @@ By default, the application is configured to connect to a local database named
 password, you can go about it by using the environment variable `DATABASE_URL`
 with a connection string.
 
-The [official Rails
-guides](https://guides.rubyonrails.org/configuring.html#connection-preference)
+The
+[official Rails guides](https://guides.rubyonrails.org/configuring.html#connection-preference)
 go into depth on how Rails merges the existing `database.yml` with the
 connection string.
 
@@ -46,18 +45,33 @@ DATABASE_URL: postgresql://USERNAME:PASSWORD@localhost
 1. Replace `USERNAME` with your database username, `PASSWORD` with your database
    password.
 
-You can find more details on connection strings in [PostgreSQL's own
-documentation](https://www.postgresql.org/docs/10/static/libpq-connect.html#LIBPQ-CONNSTRING).
+You can find more details on connection strings in
+[PostgreSQL's own documentation](https://www.postgresql.org/docs/10/static/libpq-connect.html#LIBPQ-CONNSTRING).
 
 NOTE: due to how Rails merges `database.yml` and `DATABASE_URL` it's recommended
 not to add the database name in the connection string. This will default to your
 development database name also during tests, which will effectively empty the
 development DB each time tests are run.
 
+## Connection Pooling
+
+We use [PgBouncer](http://www.pgbouncer.org) to manage connection pooling.
+
+Database pooling creates a shared pool of connections to our database, rather
+than creating new connection each time. PgBouncer is a wrapper around our
+database connection and ensures that we only have a finite set of "cached"
+connections to the database. This means that our app doesn't need to actually
+connect to the database, it only needs to connect to the pool of connections.
+The number of connections to the database (the connection limit) is dependent on
+our
+[Heroku Postgres plan](https://devcenter.heroku.com/articles/heroku-postgres-plans).
+PgBouncer ensures that we do not exceed our plan's connection limit.
+
 ## Troubleshooting tests
 
-- While running test cases, if you get an error message `postgresql connection timeout`, please re-run the tests by increasing the statement timeout, for
-  example:
+- While running test cases, if you get an error message
+  `postgresql connection timeout`, please re-run the tests by increasing the
+  statement timeout, for example:
 
 ```shell
 STATEMENT_TIMEOUT=10000 bundle exec rspec


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

I learned about `pgbouncer` (apparently that's a thing!) in my technical walk-through with @benhalpern, and thought it would be nice to add it to our docs. Not entirely sure that _this_ is the right place for it, so if you disagree, just let me know :)

While learning about PgBouncer, I read that PostgreSQL's default connection limit is set to 100 concurrent connections; does anyone know if we use the default connection limit or if we use PgBouncer to change that? If it's relevant, I can add it to the docs here.

Also cleaned up some formatting in the docs for the page that I modified (well, VSCode cleaned it up if we wanna be specific about it 👀)

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [x] docs.dev.to
- [ ] readme
- [ ] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![](https://media2.giphy.com/media/23ccjDw8MELMJDtNZS/giphy.gif?cid=5a38a5a2f3ed3be69fb31cd659fe0f8e81edf775efb6e0cc&rid=giphy.gif)

