### PR TITLE
Remove non-indexable logged-out links

### DIFF
--- a/app/views/articles/_actions.html.erb
+++ b/app/views/articles/_actions.html.erb
@@ -58,27 +58,27 @@
         <web-share-wrapper shareurl="https://dev.to<%= @article.path %>" sharetext="<%= @article.title %>" template="web-share-button">
           <div class="dropdown-link-row">
             <a target="_blank"
-               href='https://twitter.com/intent/tweet?text="<%= u @article.title.strip %>" by <%= @article.user.twitter_username ? "@" + @article.user.twitter_username : @article.user.name %> %23DEVcommunity https://dev.to<%= @article.path %>' rel='nofollow'>
+               href='https://twitter.com/intent/tweet?text="<%= u @article.title.strip %>" by <%= @article.user.twitter_username ? "@" + @article.user.twitter_username : @article.user.name %> %23DEVcommunity https://dev.to<%= @article.path %>'>
               Share to Twitter
             </a>
           </div>
           <div class="dropdown-link-row">
-            <a target='_blank' href='https://www.linkedin.com/shareArticle?mini=true&url=https://dev.to<%= @article.path %>&title=<%= @article.title %>&summary=<%= @article.description %>&source=dev.to'  rel='nofollow'>
+            <a target='_blank' href='https://www.linkedin.com/shareArticle?mini=true&url=https://dev.to<%= @article.path %>&title=<%= @article.title %>&summary=<%= @article.description %>&source=dev.to'>
               Share to LinkedIn
             </a>
           </div>
           <div class="dropdown-link-row">
-            <a target='_blank' href='https://www.reddit.com/submit?url=https://dev.to<%= @article.path %>&title=<%= @article.title %>' rel='nofollow'>
+            <a target='_blank' href='https://www.reddit.com/submit?url=https://dev.to<%= @article.path %>&title=<%= @article.title %>'>
               Share to Reddit
             </a>
           </div>
           <div class="dropdown-link-row">
-            <a target='_blank' href='https://news.ycombinator.com/submitlink?u=https://dev.to<%= @article.path %>&t=<%= @article.title %>' rel='nofollow'>
+            <a target='_blank' href='https://news.ycombinator.com/submitlink?u=https://dev.to<%= @article.path %>&t=<%= @article.title %>'>
               Share to Hacker News
             </a>
           </div>
           <div class="dropdown-link-row">
-            <a target='_blank' href='https://www.facebook.com/sharer.php?u=https://dev.to<%= @article.path %>' rel='nofollow'>
+            <a target='_blank' href='https://www.facebook.com/sharer.php?u=https://dev.to<%= @article.path %>'>
               Share to Facebook
             </a>
           </div>

--- a/app/views/articles/_actions.html.erb
+++ b/app/views/articles/_actions.html.erb
@@ -58,27 +58,27 @@
         <web-share-wrapper shareurl="https://dev.to<%= @article.path %>" sharetext="<%= @article.title %>" template="web-share-button">
           <div class="dropdown-link-row">
             <a target="_blank"
-               href='https://twitter.com/intent/tweet?text="<%= u @article.title.strip %>" by <%= @article.user.twitter_username ? "@" + @article.user.twitter_username : @article.user.name %> %23DEVcommunity https://dev.to<%= @article.path %>'>
+               href='https://twitter.com/intent/tweet?text="<%= u @article.title.strip %>" by <%= @article.user.twitter_username ? "@" + @article.user.twitter_username : @article.user.name %> %23DEVcommunity https://dev.to<%= @article.path %>' rel='nofollow'>
               Share to Twitter
             </a>
           </div>
           <div class="dropdown-link-row">
-            <a target='_blank' href='https://www.linkedin.com/shareArticle?mini=true&url=https://dev.to<%= @article.path %>&title=<%= @article.title %>&summary=<%= @article.description %>&source=dev.to'>
+            <a target='_blank' href='https://www.linkedin.com/shareArticle?mini=true&url=https://dev.to<%= @article.path %>&title=<%= @article.title %>&summary=<%= @article.description %>&source=dev.to'  rel='nofollow'>
               Share to LinkedIn
             </a>
           </div>
           <div class="dropdown-link-row">
-            <a target='_blank' href='https://www.reddit.com/submit?url=https://dev.to<%= @article.path %>&title=<%= @article.title %>'>
+            <a target='_blank' href='https://www.reddit.com/submit?url=https://dev.to<%= @article.path %>&title=<%= @article.title %>' rel='nofollow'>
               Share to Reddit
             </a>
           </div>
           <div class="dropdown-link-row">
-            <a target='_blank' href='https://news.ycombinator.com/submitlink?u=https://dev.to<%= @article.path %>&t=<%= @article.title %>'>
+            <a target='_blank' href='https://news.ycombinator.com/submitlink?u=https://dev.to<%= @article.path %>&t=<%= @article.title %>' rel='nofollow'>
               Share to Hacker News
             </a>
           </div>
           <div class="dropdown-link-row">
-            <a target='_blank' href='https://www.facebook.com/sharer.php?u=https://dev.to<%= @article.path %>'>
+            <a target='_blank' href='https://www.facebook.com/sharer.php?u=https://dev.to<%= @article.path %>' rel='nofollow'>
               Share to Facebook
             </a>
           </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -155,7 +155,7 @@
         <% if user_signed_in? %>
           <%= javascript_pack_tag "profileDropdown", defer: true %>
         <% end %>
-        <a href="/report-abuse?url=https://dev.to/<%= @user.username %>" rel="nofollow">Report Abuse</a>
+        <a href="/report-abuse?url=https://dev.to/<%= @user.username %>">Report Abuse</a>
       </div>
     </div>
   </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -36,12 +36,13 @@
           <span class="user-profile-follow-button-wrapper">
             <button id="user-follow-butt" class="cta follow-action-button user-profile-follow-button" style="color:<%= user_colors(@user)[:text] %>;background-color:<%= user_colors(@user)[:bg] %>" data-info='{"id":<%= @user.id %>,"className":"<%= @user.class.name %>"}'>&nbsp;</button>
           </span>
-          <span class="user-profile-chat-button-wrapper">
-            <a href="/connect/@<%= @user.username %>" id="user-connect-redirect" style="display:none">
-              <button class="chat-action-button user-profile-chat-button" id="modal-opener" style="color:<%= user_colors(@user)[:text] %>;background-color:<%= user_colors(@user)[:bg] %>; display:none; ">CHAT</button>
-            </a>
-          </span>
-
+          <% if user_signed_in? %>
+            <span class="user-profile-chat-button-wrapper">
+              <a href="/connect/@<%= @user.username %>" id="user-connect-redirect" style="display:none">
+                <button class="chat-action-button user-profile-chat-button" id="modal-opener" style="color:<%= user_colors(@user)[:text] %>;background-color:<%= user_colors(@user)[:bg] %>; display:none; ">CHAT</button>
+              </a>
+            </span>
+          <% end %>
         </h1>
         <p class="profile-description" itemprop="description">
           <%= @user.summary.presence || ["404 bio not found"].sample %>
@@ -151,8 +152,10 @@
       </button>
       <div id="user-profile-dropdownmenu" class="profile-dropdownmenu">
         <button id="user-profile-dropdownmenu-block-button" data-profile-user-id="<%= @user.id %>" class="block-button" type="button">Block @<%= @user.username %></button>
-        <%= javascript_pack_tag "profileDropdown", defer: true %>
-        <a href="/report-abuse?url=https://dev.to/<%= @user.username %>">Report Abuse</a>
+        <% if user_signed_in? %>
+          <%= javascript_pack_tag "profileDropdown", defer: true %>
+        <% end %>
+        <a href="/report-abuse?url=https://dev.to/<%= @user.username %>" rel="nofollow">Report Abuse</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
I saw in our [search console dashboard](https://search.google.com/search-console/about) that Google is crawling some user-only pages because we link to them in non-logged-in views. There is still a layer of authentication, so it's not a problem other than likely waisting the crawler's time (which could hurt our SEO).

This feature adds a check for `user_signed_in?` where functionality is only needed for signed-in users and the link does not need to be crawled by search engines. ~Also added `nofollow` on some links that should still exist for non-logged-in users but are not links to indexable content per se.~

I removed the "nofollow links" part of this PR because I had hesitations about the exact right choice. Everything else should be a no-brainer.