### PR TITLE
[WIP] fix bug preventing tags of mismatched case from being removed

### DIFF
--- a/app/models/tag_adjustment.rb
+++ b/app/models/tag_adjustment.rb
@@ -29,7 +29,7 @@ class TagAdjustment < ApplicationRecord
   end
 
   def article_tag_list
-    errors.add(:tag_id, "selected for removal is not a current live tag.") if adjustment_type == "removal" && article.tag_list.exclude?(tag_name)
+    errors.add(:tag_id, "selected for removal is not a current live tag.") if adjustment_type == "removal" && article.tag_list.map(&:downcase).exclude?(tag_name.downcase)
     errors.add(:base, "4 tags max per article.") if adjustment_type == "addition" && article.tag_list.count > 3
   end
 end

--- a/app/services/tag_adjustment_creation_service.rb
+++ b/app/services/tag_adjustment_creation_service.rb
@@ -20,7 +20,7 @@ class TagAdjustmentCreationService
   private
 
   def update_article
-    article.update!(tag_list: article.tag_list.remove(@tag_adjustment.tag_name)) if @tag_adjustment.adjustment_type == "removal"
+    article.update!(tag_list: article.tag_list.delete_if { |t| t.casecmp(@tag_adjustment.tag_name).zero? }) if @tag_adjustment.adjustment_type == "removal"
     article.update!(tag_list: article.tag_list.add(@tag_adjustment.tag_name)) if @tag_adjustment.adjustment_type == "addition"
   end
 

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
       published { true }
       date { "01/01/2015" }
       tags { Faker::Hipster.words(number: 4).join(", ") }
+      tags_list { [] }
       canonical_url { Faker::Internet.url }
       with_canonical_url { false }
       with_date { false }

--- a/spec/models/tag_adjustment_spec.rb
+++ b/spec/models/tag_adjustment_spec.rb
@@ -84,5 +84,12 @@ RSpec.describe TagAdjustment, type: :model do
       tag_adjustment = build(:tag_adjustment, user_id: admin_user.id, article_id: article.id, adjustment_type: "removal")
       expect(tag_adjustment).to be_invalid
     end
+
+    it "allows removal of tag regardless of case" do
+      article = create(:article, tags: nil, tag_list: ["Career"])
+      tag = create(:tag, name: "career")
+      tag_adjustment = build(:tag_adjustment, user_id: admin_user.id, article_id: article.id, tag_id: tag.id, tag_name: tag.name, adjustment_type: "removal")
+      expect(tag_adjustment).to be_valid
+    end
   end
 end

--- a/spec/requests/tag_adjustments_spec.rb
+++ b/spec/requests/tag_adjustments_spec.rb
@@ -47,6 +47,18 @@ RSpec.describe "TagAdjustments", type: :request do
         expect(article.reload.tag_list.include?("heyheyhey")).to be true
       end
     end
+
+    context "when tag being removed has a different case" do
+      let(:article) { create(:article, tags: nil, tag_list: [tag.name.titleize, "yoyo"]) }
+
+      it "removes the tag regardless of case" do
+        expect(article.reload.tag_list.include?(tag.name.titleize)).to be false
+      end
+
+      it "keeps the other tags" do
+        expect(article.reload.tag_list.include?("yoyo")).to be true
+      end
+    end
   end
 
   describe "POST /tag_adjustments with adjustment_type addition" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix


## Description
Tag mods are currently not able to remove tags from articles is the tags have mismatched cases, even if they are the same tag (ex. `git` vs. `Git`)

This PR makes it so mods are able remove tags regardless of case sensitivity by downcasing tag names when a Tag adjustment is created. However, I put this PR in WIP at the moment because my fix is mainly addressing the symptom while there is another possible solution that would address the root of the issue.

If tag names were transformed to lowercase when an article is created, it would prevent any edge cases like this arising. It would be a simple matter of calling `.map(&:downcase)` at these two lines.

https://github.com/sunny-b/dev.to/blob/9bd875670e0d7b15bacf67f55eb6cb915d866e9e/app/services/articles/creator.rb#L44

https://github.com/sunny-b/dev.to/blob/9bd875670e0d7b15bacf67f55eb6cb915d866e9e/app/services/articles/updater.rb#L28

However, that would have the side-effect of making all tags appear in lowercase. I'm not sure if that's a no-go or not so figured I'd bring it up to the other contributors.

## Related Tickets & Documents

#5325 

## Recordings

[screen recording](https://recordit.co/q3cQRikMa8)

![screen recording of fix](http://g.recordit.co/q3cQRikMa8.gif)

## Added to documentation?

- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/G2MPcSmq0DZcs/giphy.gif)


cc: @rhymes @mstruve @citizen428 