### PR TITLE
Handle Missing Root Comment in Deleted Comment View

### DIFF
--- a/app/views/comments/deleted_commentable_comment.html.erb
+++ b/app/views/comments/deleted_commentable_comment.html.erb
@@ -3,7 +3,7 @@
   <h3>Comment from a deleted article or podcast</h3>
   <div class="single-comment-node root">
     <% @user ||= @root_comment.user %>
-    <% if @root_comment.deleted %>
+    <% if @root_comment.blank? || @root_comment.deleted %>
       <div class="inner-comment">
         <div class="body">
           [deleted]


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Saw [this error come through Honeybadger](https://app.honeybadger.io/fault/66984/e30f73ae223c77d00689206f3c231888) where the root comment was missing for a view so I added a blank check to the view to handle this situation. 
```
ActionView::Template::Error: undefined method `deleted' for nil:NilClass
deleted_commentable_comment.html.erb  6 _app_views_comments_deleted_commentable_comment_html_erb___245802387296255488_73890320(...)
[PROJECT_ROOT]/app/views/comments/deleted_commentable_comment.html.erb:6:in `_app_views_comments_deleted_commentable_comment_html_erb___245802387296255488_73890320'
4   <div class="single-comment-node root">
5     <% @user ||= @root_comment.user %>
6     <% if @root_comment.deleted %>
7       <div class="inner-comment">
8         <div class="body">
```

## Added to documentation?
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media1.giphy.com/media/3o6Zt6STS5leMvs6R2/giphy.gif)
