### PR TITLE
[WIP] Allow viewing your hearts (❤️) and unicorns (🦄) history

### DIFF
--- a/app/assets/javascripts/initializers/initScrolling.js.erb
+++ b/app/assets/javascripts/initializers/initScrolling.js.erb
@@ -184,6 +184,11 @@ function fetchNextPodcastPage(el){
   fetchNext(el, "/api/podcast_episodes", insertArticles)
 }
 
+function fetchNextReactionsPage(el){
+  fetchNext(el, "/api/reactions/articles", insertArticles)
+}
+
+
 function algoliaPaginate(tag){
   var filters = [];
   if (tag && tag.length > 0) {
@@ -251,6 +256,11 @@ function fetchNextPageIfNearBottom() {
     scrollableElemId = "user-dashboard";
     fetchCallback = function fetch() {
       fetchNextFollowingPage(indexContainer);
+    }
+  } else if (indexWhich === "reactions"){
+    scrollableElemId = "articles-list";
+    fetchCallback = function fetch() {
+      fetchNextReactionsPage(indexContainer);
     }
   } else {
     scrollableElemId = "articles-list";

--- a/app/assets/stylesheets/articles.scss
+++ b/app/assets/stylesheets/articles.scss
@@ -879,6 +879,74 @@
         height: 339px;
       }
     }
+
+    .actions-container {
+      width: 600px;
+      max-width: 100%;
+      margin: auto;
+
+      .actions {
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        align-items: center;
+        padding: 2% 0;
+
+        @media screen and (min-width: 600px) {
+          flex-direction: row;
+        }
+
+        .action {
+          flex-basis: 0;
+          flex-grow: 1;
+          flex-shrink: 0;
+          width: 100%;
+          @include themeable(color, theme-color, $black);
+          padding: 10px 0px;
+          border-radius: 3px;
+          min-width: 115px;
+          transition: background-color 250ms ease, opacity 250ms ease;
+          font-family: $helvetica-condensed;
+          font-stretch: condensed;
+          font-size: 0.95em;
+          text-align: center;
+
+          &.active {
+            @include themeable(
+              background,
+              theme-container-accent-background,
+              $purple
+            );
+            @include themeable(color, theme-container-color, $black);
+          }
+
+          &:not(.active):hover {
+            background: $light-medium-purple;
+            @include themeable(
+              background,
+              theme-container-background-hover,
+              $light-medium-purple
+            );
+            @include themeable(color, theme-container-color, $black);
+          }
+
+          &:not(:last-child) {
+            /* gap between actions */
+            margin-bottom: 8px;
+
+            @media screen and (min-width: 600px) {
+              margin-bottom: 0;
+              margin-right: 8px;
+            }
+          }
+        }
+      }
+
+    }
+
+    .fluid-height {
+      height: 100% !important;
+    }
   }
   @media screen and (max-width: 949px) {
     .sidebar-wrapper {

--- a/app/controllers/api/v0/reactions_controller.rb
+++ b/app/controllers/api/v0/reactions_controller.rb
@@ -31,14 +31,7 @@ module Api
 
         return unless user
 
-        @stories = Article.
-          joins(:reactions).
-          where(reactions: { user_id: user.id, reactable_type: "Article", category: %w[like unicorn] }).
-          order("published_at DESC").
-          page(params[:page]).
-          per(@reactions_limit).
-          decorate.
-          uniq
+        @stories = Reactions::FetchArticlesService.call(user, params[:page], @reactions_limit)
       end
 
       def onboarding

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -182,13 +182,7 @@ class StoriesController < ApplicationController
   def handle_user_reactions_index
     @comments = Comment.none # add comments
     @pinned_stories = Article.none
-    @stories = Article.
-      joins(:reactions).
-      where(reactions: { user_id: @user.id, reactable_type: "Article", category: %w[like unicorn] }).
-      order("published_at DESC").
-      page(@page).per(user_signed_in? ? 2 : 5).
-      decorate.
-      uniq
+    @stories = Reactions::FetchArticlesService.call(@user, @page, user_signed_in? ? 2 : 5)
     @article_index = true
     @list_of = "reactions"
     render template: "users/reactions"

--- a/app/services/reactions/fetch_articles_service.rb
+++ b/app/services/reactions/fetch_articles_service.rb
@@ -1,0 +1,32 @@
+module Reactions
+  class FetchArticlesService
+    def initialize(user, page, per)
+      @user = user
+      @page = page
+      @per = per
+    end
+
+    def self.call(*args)
+      new(*args).call
+    end
+
+    def call
+      fetch_articles
+    end
+
+    private
+
+    attr_reader :user, :page, :per
+
+    def fetch_articles
+      Article.
+        joins(:reactions).
+        where(reactions: { user_id: user.id, reactable_type: "Article", category: %w[like unicorn] }).
+        order("published_at DESC").
+        page(page).
+        per(per).
+        decorate.
+        uniq
+    end
+  end
+end

--- a/app/views/api/v0/reactions/articles.json.jbuilder
+++ b/app/views/api/v0/reactions/articles.json.jbuilder
@@ -1,0 +1,3 @@
+json.array! @stories do |article|
+  json.partial! "api/v0/shared/article", article: article
+end

--- a/app/views/api/v0/shared/_article.json.jbuilder
+++ b/app/views/api/v0/shared/_article.json.jbuilder
@@ -1,0 +1,24 @@
+json.type_of                  "article"
+json.id                       article.id
+json.title                    article.title
+json.description              article.description
+json.cover_image              cloud_cover_url(article.main_image)
+json.readable_publish_date    article.readable_publish_date
+json.social_image             article_social_image_url(article)
+json.tag_list                 article.cached_tag_list_array
+json.tags                     article.cached_tag_list
+json.slug                     article.slug
+json.path                     article.path
+json.url                      article.url
+json.canonical_url            article.processed_canonical_url
+json.comments_count           article.comments_count
+json.positive_reactions_count article.positive_reactions_count
+json.collection_id            article.collection_id
+json.created_at               article.created_at.utc.iso8601
+json.edited_at                article.edited_at&.utc&.iso8601
+json.crossposted_at           article.crossposted_at&.utc&.iso8601
+json.published_at             article.published_at&.utc&.iso8601
+json.last_comment_at          article.last_comment_at&.utc&.iso8601
+json.published_timestamp      article.published_timestamp
+
+json.partial! "api/v0/shared/user", user: article.user

--- a/app/views/users/_actions.html.erb
+++ b/app/views/users/_actions.html.erb
@@ -1,0 +1,18 @@
+<div class="on-page-nav-controls fluid-height" id="on-page-nav-controls">
+  <div class="actions-container">
+    <div class="actions">
+      <a class="action <%= "active" if params[:view].blank? %>" href="/<%= @user.username %>">
+        <span>ARTICLES</span>
+      </a>
+      <a class="action <%= "active" if params[:view] == "reactions" %>" href="/<%= @user.username %>/reactions">
+        <span>REACTIONS</span>
+      </a>
+    </div>
+  </div>
+  <button class="on-page-nav-butt on-page-nav-butt-left" id="on-page-nav-butt-left" aria-label="nav-button-left">
+    <img src="<%= asset_path "stack.svg" %>" alt="left-sidebar-nav">
+  </button>
+  <button class="on-page-nav-butt on-page-nav-butt-right" style="margin-top:-1px;" id="on-page-nav-butt-right" aria-label="nav-button-right">
+    <img style="height:28px;width:28px;" src="<%= asset_path "ribbon.svg" %>" alt="right-sidebar-nav">
+  </button>
+</div>

--- a/app/views/users/_user_profile.html.erb
+++ b/app/views/users/_user_profile.html.erb
@@ -1,0 +1,168 @@
+<% title @user.name %>
+
+<%= content_for :page_meta do %>
+  <%= render "users/meta" %>
+<% end %>
+
+<% cache "main-user-profile-header-area-#{@user.id}-#{@user.profile_updated_at}", expires_in: 10.days do %>
+  <style>
+    .widget header {
+      color: <%= HexComparer.new([user_colors(@user)[:bg], user_colors(@user)[:text]]).brightness(0.88) %>;
+    }
+    .night-theme .widget header {
+      color: #cedae2;
+    }
+    .user-profile-header .user-profile-header-container .profile-details h1{
+      color: <%= HexComparer.new([user_colors(@user)[:bg], user_colors(@user)[:text]]).brightness(0.78) %> !important;
+    }
+    .night-theme .user-profile-header .user-profile-header-container .profile-details h1{
+      color: white !important;
+    }
+    <% if user_colors(@user)[:bg].downcase.start_with?("#fff") %>
+    .user-profile-follow-button {
+      border: 1px solid <%= user_colors(@user)[:text] %> !important;
+    }
+    <% end %>
+  </style>
+  <div class="user-profile-header" style="<%= user_colors_style(@user) %>" itemscope itemtype="http://schema.org/Person" itemprop="mainEntity">
+    <meta itemprop="url" content="https://dev.to/<%= @user.username %>">
+    <div class="user-profile-header-container">
+      <div class="profile-pic-wrapper">
+        <img class="profile-pic" src="<%= ProfileImage.new(@user).get(320) %>" itemprop="image" alt="<%= @user.username %> profile" style="border-color:<%= user_colors(@user)[:bg] %>;background:<%= user_colors(@user)[:bg] %>" />
+      </div>
+      <div class="profile-details">
+        <h1>
+          <span itemprop="name"><%= @user.name %><%= render "shared/pro_checkmark", style: nil, width: nil %></span>
+          <span class="user-profile-follow-button-wrapper">
+            <button id="user-follow-butt" class="cta follow-action-button user-profile-follow-button" style="color:<%= user_colors(@user)[:text] %>;background-color:<%= user_colors(@user)[:bg] %>" data-info='{"id":<%= @user.id %>,"className":"<%= @user.class.name %>"}'>&nbsp;</button>
+          </span>
+          <span class="user-profile-chat-button-wrapper">
+            <a href="/connect/@<%= @user.username %>" id="user-connect-redirect" style="display:none">
+              <button class="chat-action-button user-profile-chat-button" id="modal-opener" style="color:<%= user_colors(@user)[:text] %>;background-color:<%= user_colors(@user)[:bg] %>; display:none; ">CHAT</button>
+            </a>
+          </span>
+
+        </h1>
+        <p class="profile-description" itemprop="description">
+          <%= @user.summary.presence || ["404 bio not found"].sample %>
+        </p>
+        <style>
+          .profile-details .social .icon-img path {
+            fill: <%= HexComparer.new([user_colors(@user)[:bg], user_colors(@user)[:text]]).brightness(0.78) %> !important;
+          }
+          .night-theme .profile-details .social .icon-img path {
+            fill: white;
+          }
+        </style>
+        <p class="social">
+          <% if @user.twitter_username? %>
+            <a href="https://twitter.com/<%= @user.twitter_username %>" target="_blank" rel="noopener me">
+              <%= inline_svg_tag("twitter-logo.svg", class: "icon-img", aria: true, title: "Twitter logo") %>
+            </a>
+          <% end %>
+          <% if @user.github_username? %>
+            <a href="https://github.com/<%= @user.github_username %>" target="_blank" rel="noopener me">
+              <%= inline_svg_tag("github-logo.svg", class: "icon-img", aria: true, title: "GitHub logo") %>
+            </a>
+          <% end %>
+          <% if @user.mastodon_url? %>
+            <a href="<%= @user.mastodon_url %>" target="_blank" rel="noopener me">
+              <%= inline_svg_tag("mastodon-logo.svg", class: "icon-img", aria: true, title: "Mastodon logo") %>
+            </a>
+          <% end %>
+          <% if @user.facebook_url? %>
+            <a href="<%= @user.facebook_url %>" target="_blank" rel="noopener me">
+              <%= inline_svg_tag("facebook-logo.svg", class: "icon-img", aria: true, title: "Facebook logo") %>
+            </a>
+          <% end %>
+          <% if @user.linkedin_url? %>
+            <a href="<%= @user.linkedin_url %>" target="_blank" rel="noopener me">
+              <%= inline_svg_tag("linkedin_icon.svg", class: "icon-img", aria: true, title: "LinkedIn logo") %>
+            </a>
+          <% end %>
+          <% if @user.behance_url? %>
+            <a href="<%= @user.behance_url %>" target="_blank" rel="noopener me">
+              <%= inline_svg_tag("behance_icon.svg", class: "icon-img", aria: true, title: "Behance logo") %>
+            </a>
+          <% end %>
+          <% if @user.stackoverflow_url? %>
+            <a href="<%= @user.stackoverflow_url %>" target="_blank" rel="noopener me">
+              <%= inline_svg_tag("stackoverflow-logo.svg", class: "icon-img", aria: true, title: "StackOverflow logo") %>
+            </a>
+          <% end %>
+          <% if @user.dribbble_url? %>
+            <a href="<%= @user.dribbble_url %>" target="_blank" rel="noopener me">
+              <%= inline_svg_tag("dribbble_icon.svg", class: "icon-img", aria: true, title: "Dribbble logo") %>
+            </a>
+          <% end %>
+          <% if @user.medium_url? %>
+            <a href="<%= @user.medium_url %>" target="_blank" rel="noopener nofollow me">
+              <%= inline_svg_tag("medium_icon.svg", class: "icon-img", aria: true, title: "Medium logo") %>
+            </a>
+          <% end %>
+          <% if @user.gitlab_url? %>
+            <a href="<%= @user.gitlab_url %>" target="_blank" rel="noopener nofollow me">
+              <%= inline_svg_tag("gitlab.svg", class: "icon-img", aria: true, title: "GitLab logo") %>
+            </a>
+          <% end %>
+          <% if @user.instagram_url? %>
+            <a href="<%= @user.instagram_url %>" target="_blank" rel="noopener nofollow me">
+              <%= inline_svg_tag("instagram-logo.svg", class: "icon-img", aria: true, title: "Instagram logo") %>
+            </a>
+          <% end %>
+          <% if @user.twitch_username? %>
+            <%= link_to twitch_live_stream_path(username: @user.username) do %>
+              <%= inline_svg_tag("twitch-logo.svg", class: "icon-img", id: "icon-twitch", aria: true, title: "Twitch logo") %>
+            <% end %>
+          <% elsif @user.twitch_url? %>
+            <a href="<%= @user.twitch_url %>" target="_blank" rel="noopener nofollow me">
+              <%= inline_svg_tag("twitch-logo.svg", class: "icon-img", aria: true, title: "Twitch logo") %>
+            </a>
+          <% end %>
+          <% if @user.website_url? %>
+            <a href="<%= @user.website_url %>" target="_blank" rel="noopener nofollow me">
+              <%= inline_svg_tag("external-link-logo.svg", class: "icon-img", aria: true, title: "external link icon") %>
+            </a>
+          <% end %>
+        </p>
+      </div>
+    </div>
+    <div class="modal" style="display: none">
+      <div class="overlay"></div>
+      <div class="modal-content " id="new-message-modal">
+        <button title="Close" class="close-modal">X</button>
+        <% if @user.inbox_guidelines.present? %>
+          <p><b>@<%= @user.username %>'s guidelines:</b></p>
+          <p><%= @user.inbox_guidelines %></p>
+        <% end %>
+        <form id="new-message-form" class="message-form" data-info='{"id":<%= @user.id %>,"className":"<%= @user.class.name %>","username":"<%= @user.username %>", "showChat":"<%= @user.inbox_type %>"}'>
+          <textarea id="new-message" rows="4" cols="70" placeholder="Enter your message here..."></textarea>
+          <button type="submit" value="Submit" class="submit-message cta">SEND</button>
+        </form>
+        <p>
+          <em>All private interactions <b>must</b> abide by the <a href="/code-of-conduct">code of conduct</a></em>
+        </p>
+      </div>
+    </div>
+    <%= render "articles/user_metadata", context: "profile" %>
+    <div class="profile-dropdown" data-username="<%= @user.username %>">
+      <button id="user-profile-dropdown">
+        <%= image_tag("three-dots.svg", class: "dropdown-icon", alt: "Toggle dropdown menu") %>
+      </button>
+      <div id="user-profile-dropdownmenu" class="profile-dropdownmenu">
+        <button id="user-profile-dropdownmenu-block-button" data-profile-user-id="<%= @user.id %>" class="block-button" type="button">Block @<%= @user.username %></button>
+        <%= javascript_pack_tag "profileDropdown", defer: true %>
+        <a href="/report-abuse?url=https://dev.to/<%= @user.username %>">Report Abuse</a>
+      </div>
+    </div>
+  </div>
+<% end %>
+
+<% if @user.currently_streaming_on_twitch? %>
+  <style>
+    #icon-twitch path {
+      fill: green !important;
+      stroke: green !important;
+    }
+  </style>
+<% end %>

--- a/app/views/users/reactions.html.erb
+++ b/app/views/users/reactions.html.erb
@@ -9,11 +9,7 @@
   <div class="articles-list" id="articles-list">
     <%= render "users/actions" %>
     <div class="substories" id="substories">
-      <% if params[:view] == "comments" %>
-        <%= render "users/comments_section" %>
-      <% elsif @stories.any? || @comments.any? || @pinned_stories.any? %>
-        <%= render "users/main_feed" %>
-      <% end %>
+      <%= render "users/main_feed" %>
     </div>
     <div class="loading-articles" id="loading-articles">
       loading...

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -133,6 +133,11 @@ Rails.application.routes.draw do
           get :podcasts
         end
       end
+      resources :reactions do
+        collection do
+          get :articles
+        end
+      end
       resources :github_repos, only: [:index] do
         collection do
           post "/update_or_create", to: "github_repos#update_or_create"
@@ -405,7 +410,7 @@ Rails.application.routes.draw do
   get "/:username/:slug/delete_confirm" => "articles#delete_confirm"
   get "/:username/:slug/stats" => "articles#stats"
   get "/:username/:view" => "stories#index",
-      :constraints => { view: /comments|moderate|admin/ }
+      :constraints => { view: /comments|moderate|admin|reactions/ }
   get "/:username/:slug" => "stories#show"
   get "/:username" => "stories#index"
 

--- a/spec/requests/reactions_api_spec.rb
+++ b/spec/requests/reactions_api_spec.rb
@@ -26,4 +26,17 @@ RSpec.describe "ArticlesApi", type: :request do
       expect(response).to have_http_status(:unprocessable_entity)
     end
   end
+
+  describe "GET /api/reactions/articles" do
+    let(:reaction) { create(:reaction, reactable: article, user: user) }
+
+    before do
+      reaction.reload
+    end
+
+    it "returns a list of reacted articles" do
+      get "/api/reactions/articles", params: { username: user.username }
+      expect(response.body).to include article.title
+    end
+  end
 end

--- a/spec/requests/user/user_profile_spec.rb
+++ b/spec/requests/user/user_profile_spec.rb
@@ -121,6 +121,22 @@ RSpec.describe "UserProfiles", type: :request do
         expect(response.body).to include "A book bot 🤖"
       end
     end
+
+    context "when /reactions" do
+      let(:articles) { create_list(:article, 3) }
+      let(:reaction) { create(:reaction, reactable: articles[0], user: user) }
+
+      before do
+        reaction.reload
+      end
+
+      it "renders reaction page" do
+        get "/#{user.username}/reactions"
+        expect(response.body).to include articles[0].title
+        expect(response.body).not_to include articles[1].title
+        expect(response.body).not_to include articles[2].title
+      end
+    end
   end
 
   describe "GET /user" do

--- a/spec/services/reactions/fetch_articles_service_spec.rb
+++ b/spec/services/reactions/fetch_articles_service_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe Reactions::FetchArticlesService, type: :service do
+  let(:size) { 3 }
+  let(:page) { 0 }
+  let(:user) { create(:user) }
+  let(:articles) { create_list(:article, size) }
+
+  describe "#call" do
+    context "when reactions occur to multiple articles" do
+      before do
+        articles.each do |article|
+          create(:reaction, reactable: article, user: user)
+        end
+      end
+
+      it "returns the number of reactions" do
+        stories = described_class.call(user, page, size)
+        expect(stories.size).to eq size
+      end
+    end
+
+    context "when multiple reactions occur to same article" do
+      before do
+        article = articles[0]
+        create(:reaction, reactable: article, user: user, category: "like")
+        create(:reaction, reactable: article, user: user, category: "unicorn")
+      end
+
+      it "returns only one copy of the reaction" do
+        stories = described_class.call(user, page, size)
+        expect(stories.size).to eq 1
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [x] Feature

## Description

Adds reaction history to user profile. 

- The reactions are public (similar to twitter) and can be seen in the user's profile.
- There's no visual distinction between ❤️ and 🦄
- Articles reacted with both ❤️ and 🦄 are rendered only once.

## Related Tickets & Documents

Closes #1806

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![wip_reactions](https://user-images.githubusercontent.com/9089551/73113902-311b3e00-3ef5-11ea-939b-e9bfe144edeb.png)

## Added to documentation?

- [x] no documentation needed
