### PR TITLE
comment_controller: add skip_auth to rescue error block

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -107,6 +107,8 @@ class CommentsController < ApplicationController
   rescue Pundit::NotAuthorizedError
     raise
   rescue StandardError => e
+    skip_authorization
+
     Rails.logger.error(e)
     message = "There was an error in your markdown: #{e}"
     render json: { error: message }, status: :unprocessable_entity


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

A `Pundit::AuthorizationNotPerformedError` in the CommentsController `#create` path (https://app.honeybadger.io/fault/66984/9508988843fe9435805fbb822bbe8242). It appears this is happening in the rescue error block since that is the only data path that doesn't use `skip_authorize` or `authorize`.

It's not immediately clear from HoneyBadger how this occurring and I wasn't able to reproduce the error naturally (I was able to repro it with `binding.pry`). But it appears an error is occurring before the authorization putting `skip_authorization` in the rescue block will ensure all data paths are covered.

## Related Tickets & Documents

Closes #5717 

## Added to documentation?

- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/f0BaErqmljUd2/giphy.gif)

cc: @mstruve @citizen428 @rhymes 
