### PR TITLE
Migrate delayed job that updates media url for podcast episodes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,6 +28,10 @@ AllCops:
   ExtraDetails: true
   TargetRubyVersion: 2.6
 
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    - "spec/**/*"
+
 Naming/AccessorMethodName:
   Description: Check the naming of accessor methods for get_/set_.
   Enabled: false

--- a/app/services/podcasts/feed.rb
+++ b/app/services/podcasts/feed.rb
@@ -45,7 +45,7 @@ module Podcasts
     # If they are not, the podcast will be hidden.
     def refetch_items
       podcast.podcast_episodes.find_each do |episode|
-        PodcastEpisodes::UpdateMediaUrlJob.perform_later(episode.id, episode.media_url)
+        PodcastEpisodes::UpdateMediaUrlWorker.perform_async(episode.id, episode.media_url)
       end
     end
   end

--- a/app/services/podcasts/get_episode.rb
+++ b/app/services/podcasts/get_episode.rb
@@ -27,7 +27,7 @@ module Podcasts
 
       unreachable = !(episode.https? && episode.reachable?)
       need_url_update = (unreachable && episode.created_at > 12.hours.ago) || force_update
-      PodcastEpisodes::UpdateMediaUrlJob.perform_later(episode.id, item_data.enclosure_url) if need_url_update
+      PodcastEpisodes::UpdateMediaUrlWorker.perform_async(episode.id, item_data.enclosure_url) if need_url_update
     end
 
     def update_published_at(episode, item_data)

--- a/app/workers/podcast_episodes/update_media_url_worker.rb
+++ b/app/workers/podcast_episodes/update_media_url_worker.rb
@@ -1,0 +1,12 @@
+module PodcastEpisodes
+  class UpdateMediaUrlWorker
+    include Sidekiq::Worker
+
+    sidekiq_options queue: :medium_priority
+
+    def perform(episode_id, enclosure_url)
+      episode = PodcastEpisode.find_by!(id: episode_id)
+      Podcasts::UpdateEpisodeMediaUrl.call(episode, enclosure_url)
+    end
+  end
+end

--- a/spec/services/podcasts/feed_spec.rb
+++ b/spec/services/podcasts/feed_spec.rb
@@ -37,9 +37,10 @@ RSpec.describe Podcasts::Feed, type: :service, vcr: vcr_option do
     it "schedules the update url jobs when setting as unreachable" do
       allow(HTTParty).to receive(:get).with("http://podcast.example.com/podcast", httparty_options).and_raise(Errno::ECONNREFUSED)
       create_list(:podcast_episode, 2, podcast: unpodcast)
+
       expect do
         described_class.new(unpodcast).get_episodes(limit: 2)
-      end.to have_enqueued_job(PodcastEpisodes::UpdateMediaUrlJob).exactly(2)
+      end.to change { PodcastEpisodes::UpdateMediaUrlWorker.jobs.size }.by(2)
     end
 
     it "re-checks episodes urls when setting as unreachable" do
@@ -48,7 +49,7 @@ RSpec.describe Podcasts::Feed, type: :service, vcr: vcr_option do
       allow(HTTParty).to receive(:head).with("http://podcast.example.com/ep1.mp3").and_raise(Errno::ECONNREFUSED)
       allow(HTTParty).to receive(:head).with("https://podcast.example.com/ep1.mp3").and_raise(Errno::ECONNREFUSED)
 
-      perform_enqueued_jobs do
+      sidekiq_perform_enqueued_jobs do
         described_class.new(unpodcast).get_episodes
       end
 
@@ -62,7 +63,7 @@ RSpec.describe Podcasts::Feed, type: :service, vcr: vcr_option do
       create_list(:podcast_episode, 2, podcast: unpodcast)
       expect do
         described_class.new(unpodcast).get_episodes(limit: 2)
-      end.not_to have_enqueued_job(PodcastEpisodes::UpdateMediaUrlJob)
+      end.not_to change { PodcastEpisodes::UpdateMediaUrlWorker.jobs.size }
     end
   end
 

--- a/spec/services/podcasts/get_episode_spec.rb
+++ b/spec/services/podcasts/get_episode_spec.rb
@@ -19,28 +19,31 @@ RSpec.describe Podcasts::GetEpisode, type: :service do
   let(:get_episode) { described_class.new(podcast) }
 
   context "when episode exists" do
-    it "schedules an Update job when media_url wasn't available by https" do
+    it "enqueues a worker to update url when media url wasn't available by https" do
       ep = create(:podcast_episode, published_at: Time.current, reachable: true, https: false, podcast: podcast)
       allow(podcast).to receive(:existing_episode).and_return(ep)
+
       expect do
         get_episode.call(item: item)
-      end.to have_enqueued_job.on_queue("podcast_episode_update")
+      end.to change { PodcastEpisodes::UpdateMediaUrlWorker.jobs.size }.by(1)
     end
 
-    it "doesn't schedule a job when episode wasn't reachable" do
+    it "enqueues a worker when episode isn't reachable" do
       ep = create(:podcast_episode, published_at: Time.current, reachable: false, https: true, podcast: podcast)
       allow(podcast).to receive(:existing_episode).and_return(ep)
+
       expect do
         get_episode.call(item: item)
-      end.to have_enqueued_job.on_queue("podcast_episode_update")
+      end.to change { PodcastEpisodes::UpdateMediaUrlWorker.jobs.size }
     end
 
-    it "doesn't schedule a job when media_url is ok" do
+    it "doesn't schedule a worker when the media url is ok" do
       ep = create(:podcast_episode, published_at: nil, reachable: true, https: true, podcast: podcast)
       allow(podcast).to receive(:existing_episode).and_return(ep)
+
       expect do
         get_episode.call(item: item)
-      end.not_to have_enqueued_job.on_queue("podcast_episode_update")
+      end.not_to change { PodcastEpisodes::UpdateMediaUrlWorker.jobs.size }
     end
 
     it "doesn't schedule a job when an episode was created long ago" do
@@ -69,16 +72,16 @@ RSpec.describe Podcasts::GetEpisode, type: :service do
       expect(ep.published_at).to eq(nil)
     end
 
-    it "schedules a job when force_update is passed" do
+    it "enqueues a worker when force_update is passed" do
       ep = create(:podcast_episode, published_at: Time.current, reachable: true, https: true, podcast: podcast)
       allow(podcast).to receive(:existing_episode).and_return(ep)
       expect do
         get_episode.call(item: item, force_update: true)
-      end.to have_enqueued_job.on_queue("podcast_episode_update")
+      end.to change { PodcastEpisodes::UpdateMediaUrlWorker.jobs.size }.by(1)
     end
   end
 
-  it "schedules a Create job when an episode doesn't exist" do
+  it "enqueues a worker to create an episode when it doesn't exist" do
     allow(podcast).to receive(:existing_episode).and_return(nil)
 
     sidekiq_assert_enqueued_with(job: PodcastEpisodes::CreateWorker, args: [podcast.id, item.to_h]) do

--- a/spec/workers/podcast_episodes/update_media_url_worker_spec.rb
+++ b/spec/workers/podcast_episodes/update_media_url_worker_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe PodcastEpisodes::UpdateMediaUrlWorker, type: :worker do
+  include_examples "#enqueues_on_correct_queue", "medium_priority", [212, "https://devto.australianopen.com"]
+
+  describe "#perform" do
+    let(:worker) { subject }
+    let(:feed) { double }
+    let(:episode) { create(:podcast_episode) }
+    let(:url) { Faker::Internet.url }
+
+    before do
+      allow(Podcasts::UpdateEpisodeMediaUrl).to receive(:call)
+    end
+
+    it "calls the service" do
+      worker.perform(episode.id, url)
+      expect(Podcasts::UpdateEpisodeMediaUrl).to have_received(:call).with(episode, url).once
+    end
+
+    it "raises an error if episode is not found" do
+      expect do
+        worker.perform(PodcastEpisode.maximum(:id).to_i + 1, url)
+      end.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

* Sidekiq version of delayed job and updating services that used the
delayed job
* Intentionally removed the defensive check in the sidekiq version. If
the episode is missing and there's worker scheduled to update it's media
url then that reveals a bug elsewhere and should fail fast instead of
skipping ahead.
* Also excluded the ambiguous block rule for rspecs since that
conflicts with the rspec `expect` block, found that recommentation
thanks to https://github.com/rubocop-hq/rubocop/issues/4222 (and rubocop
was complaining about this in the pre-commit hook for these changes)

## Related Tickets & Documents

#5305 

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed