### PR TITLE
Fix tags 'View Rules' disappearing bug (Firefox)

### DIFF
--- a/app/javascript/shared/components/tags.jsx
+++ b/app/javascript/shared/components/tags.jsx
@@ -377,6 +377,7 @@ class Tags extends Component {
     let searchResultsHTML = '';
     const { searchResults, selectedIndex, showingRulesForTag } = this.state;
     const { classPrefix, defaultValue, maxTags, listing } = this.props;
+    const { activeElement } = document;
     const searchResultsRows = searchResults.map((tag, index) => (
       <div
         tabIndex="-1"
@@ -411,9 +412,11 @@ class Tags extends Component {
     ));
     if (
       searchResults.length > 0 &&
-      (document.activeElement.id === 'tag-input' ||
-        document.activeElement.className ===
-          'articleform__tagsoptionrulesbutton')
+      (activeElement.id === 'tag-input' ||
+        activeElement.classList.contains(
+          'articleform__tagsoptionrulesbutton',
+        ) ||
+        activeElement.classList.contains('articleform__tagoptionrow'))
     ) {
       searchResultsHTML = (
         <div className={`${classPrefix}__tagsoptions`}>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

I noticed that, in Firefox, when I'm writing an article and attempt to search for a tag, the tags list will disappear if I click "View Rules" for a certain tag. Only after I bring the tags search back up am I able to view the tag rules.

Screencast:

![Firefox tags list bug](http://g.recordit.co/3hZieIHl7B.gif)*[Link](https://recordit.co/3hZieIHl7B)*

It looks like when the "View Rules" button is clicked, Chrome considers the button to be the `activeElement` while Firefox considers the entire tag row to be the `activeElement`, causing the eventHandler not to work as expected.

This PR fixes it so Firefox works as expected.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![Firefox tags list bug fixed](http://g.recordit.co/kGuMZ1MZvx.gif)*[Link](https://recordit.co/kGuMZ1MZvx)*

## Added to documentation?

- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![peekaboo](https://media.giphy.com/media/4a9Tlz3Mj2LS5LMw33/giphy.gif)
