### PR TITLE
Don't use the service worker for the feed

### DIFF
--- a/app/views/service_worker/index.js.erb
+++ b/app/views/service_worker/index.js.erb
@@ -100,12 +100,13 @@
         !url.href.includes('/admin') && // Don't fetch for administrate dashboard.
         !url.href.includes('/internal') && // Don't fetch for internal dashboard.
         !url.href.includes('/future') && // Skip for /future.
-        !url.href.includes('?preview=') && // Skip for /future.
+        !url.href.includes('?preview=') && // Skip for preview pages.
         !url.href.includes('/delayed_job') && // Skip for Delayed Job dashboard
         !url.href.includes('/sidekiq') && // Skip for Sidekiq dashboard
         !url.href.includes('/oauth/') && // Skip oauth apps
-        !url.href.includes('/robots.txt') && // Skip oauth apps
+        !url.href.includes('/robots.txt') && // Skip robots for web crawlers
         !url.href.includes('/rails/mailers') && // Skip for mailers previews in development mode
+        !url.href.includes('/feed') && // Skip the RSS feed
         caches.match('/shell_top') && // Ensure shell_top is in the cache.
         caches.match('/shell_bottom')) { // Ensure shell_bottom is in the cache.
         event.respondWith(createPageStream(event.request)); // Respond with the stream


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

While reviewing https://github.com/thepracticaldev/dev.to/pull/5612 I've noticed how if the feed is opened in a browser it's going to be intercepted by the service worker and thus the shell around it will appear:

![Screenshot 2020-01-26 at 8 31 35 PM](https://user-images.githubusercontent.com/146201/73140645-7cf7ef80-407b-11ea-9bd4-a1d5ecf881cc.png)
