### PR TITLE
Use page location as indicator for page load

### DIFF
--- a/app/views/layouts/_top_bar.html.erb
+++ b/app/views/layouts/_top_bar.html.erb
@@ -50,8 +50,9 @@
       }
 
       // Load notifications count as quickly as it's available.
+      // Not if we're on the notifications page itself
       if (
-        document.getElementById('notifications-container') == null
+        window.location.pathname !== '/notifications'
       ) {
         var xmlhttp;
         if (window.XMLHttpRequest) {


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
We check for notifications count in the app shell before the rest of the page loads or is available, so we actually don't know whether `document.getElementById('notifications-container') == null` is a thing either way.

This code used to be called after the rest of the page loads.

This ensures we don't show the number if anyone lands directly on the notifications page.