### PR TITLE
Update FAQ about changing Twitter/GitHub username with info about self-removing an association

### DIFF
--- a/app/views/pages/faq.html.erb
+++ b/app/views/pages/faq.html.erb
@@ -49,6 +49,7 @@
       <b>How do I change my Twitter/GitHub username?</b>
       <br>
       Email yo@dev.to and we'll take care of it.
+      If you are authenticating with the other one of the two, you can also head to <a href="https://dev.to/settings/account">Settings &gt; Account</a> and remove and then reässociate the one that you want to change yourself.
     <p>
       <b>What about my post's Google ranking?</b>
       <br>


### PR DESCRIPTION
##  What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

In FAQ, under <q>How do I change my Twitter/GitHub username?</q>, below <q>Email yo@dev.to and we'll take care of it.</q>, adds `If you are authenticating with the other one of the two, you can also head to <a href="https://dev.to/settings/account">Settings &gt; Account</a> and remove and then reässociate the one that you want to change yourself.`.

## Related Tickets & Documents

Idk, #820 ig

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

didn't run, my change seems fine :wink: 

EDIT: I did a thing with devtools, although it is not processed by erb and stuff but just added to output:
![2020-01-27-032759_876x261_scrot](https://user-images.githubusercontent.com/7753506/73146912-2effdd80-40b5-11ea-9c78-031ea23f2666.png)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed