### PR TITLE
Add "functional.cafe" to Mastodon list

### DIFF
--- a/app/lib/constants.rb
+++ b/app/lib/constants.rb
@@ -11,6 +11,7 @@ module Constants
     "fosstodon.org",
     "framapiaf.org",
     "friends.nico",
+    "functional.cafe",
     "hackers.town",
     "hearthtodon.com",
     "hex.bz",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Documentation Update

## Description

This adds [functional.cafe](https://functional.cafe) to the list of allowed Mastodon instances.

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed