### PR TITLE
Removed redundant yarn install command

### DIFF
--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -70,7 +70,7 @@ and start the container again_
 
 1. run `docker-compose build`
 1. run `docker-compose run web rails db:setup`
-1. run `docker-compose run web yarn install`
+1. run `docker-compose run web yarn`
 1. run `docker-compose up`
 1. That's it! Navigate to <http://localhost:3000>
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

A very minor update to the Docker documentation. Yarn by default installs packages by simply running `yarn`. See the [Yarn Install](https://legacy.yarnpkg.com/lang/en/docs/cli/install/).

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [x] docs.dev.to
- [ ] readme
- [] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![Bruce Banner changes into Hulk](https://media.giphy.com/media/e99fnyAcR7LI4/giphy.gif)
