### PR TITLE
Remove ENV["USE_NEW_AWS"] and use Orig ENV variables for New Creds

### DIFF
--- a/Envfile
+++ b/Envfile
@@ -67,7 +67,7 @@ variable :ALGOLIASEARCH_SEARCH_ONLY_KEY, :String, default: only_in_test
 variable :AWS_ID, :String, default: "Optional"
 variable :AWS_SECRET, :String, default: "Optional"
 variable :AWS_BUCKET_NAME, :String, default: "Optional"
-variable :AWS_UPLOAD_REGION, :String, default: "Optional"
+variable :AWS_UPLOAD_REGION, :String, default: ""
 
 # AWS SDK
 # (https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/setup-config.html)

--- a/Envfile
+++ b/Envfile
@@ -30,12 +30,6 @@ variable :SESSION_EXPIRY_SECONDS, :Integer, default: 1209600 # two weeks in seco
 # Redis Sidekiq storage
 variable :REDIS_SIDEKIQ_URL, :String, default: "redis://localhost:6379"
 
-# Temp
-variable :AWS_UPLOAD_ID, :String, default: "Optional"
-variable :AWS_UPLOAD_SECRET, :String, default: "Optional"
-variable :AWS_UPLOAD_REGION, :String, default: "Optional"
-variable :AWS_UPLOAD_BUCKET_NAME, :String, default: "Optional"
-
 ################################################
 ############## 3rd Party Services ##############
 ################################################
@@ -73,6 +67,7 @@ variable :ALGOLIASEARCH_SEARCH_ONLY_KEY, :String, default: only_in_test
 variable :AWS_ID, :String, default: "Optional"
 variable :AWS_SECRET, :String, default: "Optional"
 variable :AWS_BUCKET_NAME, :String, default: "Optional"
+variable :AWS_UPLOAD_REGION, :String, default: "Optional"
 
 # AWS SDK
 # (https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/setup-config.html)

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -6,23 +6,14 @@ CarrierWave.configure do |config|
     config.storage = :file
   else
     config.fog_provider = "fog/aws"
-    if ENV["USE_NEW_AWS"]
-      config.fog_credentials = {
-        provider: "AWS",
-        aws_access_key_id: ApplicationConfig["AWS_UPLOAD_ID"],
-        aws_secret_access_key: ApplicationConfig["AWS_UPLOAD_SECRET"],
-        region: ApplicationConfig["AWS_UPLOAD_REGION"]
-      }
-      config.fog_directory = ApplicationConfig["AWS_UPLOAD_BUCKET_NAME"]
-    else
-      config.fog_credentials = {
-        provider: "AWS",
-        aws_access_key_id: ApplicationConfig["AWS_ID"],
-        aws_secret_access_key: ApplicationConfig["AWS_SECRET"],
-        region: ApplicationConfig["AWS_DEFAULT_REGION"]
-      }
-      config.fog_directory = ApplicationConfig["AWS_BUCKET_NAME"]
-    end
+    region = ApplicationConfig["AWS_UPLOAD_REGION"] || ApplicationConfig["AWS_DEFAULT_REGION"]
+    config.fog_credentials = {
+      provider: "AWS",
+      aws_access_key_id: ApplicationConfig["AWS_ID"],
+      aws_secret_access_key: ApplicationConfig["AWS_SECRET"],
+      region: region
+    }
+    config.fog_directory = ApplicationConfig["AWS_BUCKET_NAME"]
     config.storage = :fog
   end
 end

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -6,7 +6,7 @@ CarrierWave.configure do |config|
     config.storage = :file
   else
     config.fog_provider = "fog/aws"
-    region = ApplicationConfig["AWS_UPLOAD_REGION"] || ApplicationConfig["AWS_DEFAULT_REGION"]
+    region = ApplicationConfig["AWS_UPLOAD_REGION"].presence || ApplicationConfig["AWS_DEFAULT_REGION"]
     config.fog_credentials = {
       provider: "AWS",
       aws_access_key_id: ApplicationConfig["AWS_ID"],

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -1,5 +1,5 @@
 if Rails.env.production?
-  region = ApplicationConfig["AWS_UPLOAD_REGION"] || ApplicationConfig["AWS_DEFAULT_REGION"]
+  region = ApplicationConfig["AWS_UPLOAD_REGION"].presence || ApplicationConfig["AWS_DEFAULT_REGION"]
   SitemapGenerator::Sitemap.adapter = SitemapGenerator::S3Adapter.new(
     fog_provider: "AWS",
     aws_access_key_id: ApplicationConfig["AWS_ID"],

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -1,24 +1,13 @@
 if Rails.env.production?
-  if ENV["USE_NEW_AWS"]
-    SitemapGenerator::Sitemap.adapter = SitemapGenerator::S3Adapter.new(
-      fog_provider: "AWS",
-      aws_access_key_id: ApplicationConfig["AWS_UPLOAD_ID"],
-      aws_secret_access_key: ApplicationConfig["AWS_UPLOAD_SECRET"],
-      fog_directory: ApplicationConfig["AWS_UPLOAD_BUCKET_NAME"],
-      fog_region: ApplicationConfig["AWS_UPLOAD_REGION"],
-    )
-    SitemapGenerator::Sitemap.sitemaps_host = "https://#{ApplicationConfig['AWS_UPLOAD_BUCKET_NAME']}.s3.amazonaws.com/"
-  else
-    SitemapGenerator::Sitemap.adapter = SitemapGenerator::S3Adapter.new(
-      fog_provider: "AWS",
-      aws_access_key_id: ApplicationConfig["AWS_ID"],
-      aws_secret_access_key: ApplicationConfig["AWS_SECRET"],
-      fog_directory: ApplicationConfig["AWS_BUCKET_NAME"],
-      fog_region: ApplicationConfig["AWS_DEFAULT_REGION"],
-    )
-    SitemapGenerator::Sitemap.sitemaps_host = "https://thepracticaldev.s3.amazonaws.com/"
-  end
-
+  region = ApplicationConfig["AWS_UPLOAD_REGION"] || ApplicationConfig["AWS_DEFAULT_REGION"]
+  SitemapGenerator::Sitemap.adapter = SitemapGenerator::S3Adapter.new(
+    fog_provider: "AWS",
+    aws_access_key_id: ApplicationConfig["AWS_ID"],
+    aws_secret_access_key: ApplicationConfig["AWS_SECRET"],
+    fog_directory: ApplicationConfig["AWS_BUCKET_NAME"],
+    fog_region: region,
+  )
+  SitemapGenerator::Sitemap.sitemaps_host = "https://#{ApplicationConfig['AWS_BUCKET_NAME']}.s3.amazonaws.com/"
   SitemapGenerator::Sitemap.public_path = "tmp/"
   SitemapGenerator::Sitemap.sitemaps_path = "sitemaps/"
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
Now that we are pointed at our new AWS bucket swap over the original ENV variables to the new bucket ones and use those. The only variable we have to keep is the region since that is different than our default region and that default region is being used by the SDK which is used by the `AWS_LAMBDA` client.

The ENV variables have all been set properly in Heroku. 
AWS_SECRET = AWS_UPLOAD_SECRET 
AWS_ID = AWS_UPLOAD_ID
AWS_BUCKET_NAME = AWS_UPLOAD_BUCKET_NAME

## Related Tickets & Documents
#5570 

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media2.giphy.com/media/Jn3fqI2I0m5cB2L8g6/giphy.gif)
