### PR TITLE
Remove direct chat channels when banishing user

### DIFF
--- a/app/services/moderator/banish_user.rb
+++ b/app/services/moderator/banish_user.rb
@@ -19,6 +19,7 @@ module Moderator
       delete_user_activity
       delete_comments
       delete_articles
+      cleanup_chat_channels
       user.remove_from_algolia_index
       reassign_and_bust_username
     end

--- a/app/services/moderator/banish_user.rb
+++ b/app/services/moderator/banish_user.rb
@@ -19,7 +19,7 @@ module Moderator
       delete_user_activity
       delete_comments
       delete_articles
-      cleanup_chat_channels
+      Users::CleanupChatChannels.call(user)
       user.remove_from_algolia_index
       reassign_and_bust_username
     end

--- a/app/services/moderator/manage_activity_and_roles.rb
+++ b/app/services/moderator/manage_activity_and_roles.rb
@@ -20,6 +20,10 @@ module Moderator
       Users::DeleteArticles.call(user)
     end
 
+    def cleanup_chat_channels
+      Users::CleanupChatChannels.call(user)
+    end
+
     def delete_user_activity
       Users::DeleteActivity.call(user)
     end

--- a/app/services/moderator/manage_activity_and_roles.rb
+++ b/app/services/moderator/manage_activity_and_roles.rb
@@ -20,10 +20,6 @@ module Moderator
       Users::DeleteArticles.call(user)
     end
 
-    def cleanup_chat_channels
-      Users::CleanupChatChannels.call(user)
-    end
-
     def delete_user_activity
       Users::DeleteActivity.call(user)
     end

--- a/app/services/users/cleanup_chat_channels.rb
+++ b/app/services/users/cleanup_chat_channels.rb
@@ -1,18 +1,24 @@
 module Users
   module CleanupChatChannels
     def self.call(user)
-      user.chat_channels.each do |chat_channel|
-        chat_channel.remove_from_index!
-        chat_channel.chat_channel_memberships.each do |ccm|
-          ccm.remove_from_index!
-          ccm.destroy!
-        end
+      # We only destroy direct message channels, not open and invite-only ones
+      direct_channels = user.chat_channels.where(channel_type: "direct")
+      direct_channels.each do |direct_channel|
+        direct_channel.remove_from_index!
+        cleanup_memberships(direct_channel.chat_channel_memberships)
+        direct_channel.destroy!
+      end
 
-        # We only destroy direct message channels, not open and invite-only ones
-        next unless chat_channel.direct?
+      # Clean up the banished user's remaining channel memberships
+      cleanup_memberships(user.chat_channel_memberships)
+    end
 
-        chat_channel.destroy!
+    def self.cleanup_memberships(chat_channel_memberships)
+      chat_channel_memberships.each do |ccm|
+        ccm.remove_from_index!
+        ccm.destroy!
       end
     end
+    private_class_method :cleanup_memberships
   end
 end

--- a/app/services/users/cleanup_chat_channels.rb
+++ b/app/services/users/cleanup_chat_channels.rb
@@ -1,0 +1,18 @@
+module Users
+  module CleanupChatChannels
+    def self.call(user)
+      user.chat_channels.each do |chat_channel|
+        chat_channel.remove_from_index!
+        chat_channel.chat_channel_memberships.each do |ccm|
+          ccm.remove_from_index!
+          ccm.destroy!
+        end
+
+        # We only destroy direct message channels, not open and invite-only ones
+        next unless chat_channel.direct?
+
+        chat_channel.destroy!
+      end
+    end
+  end
+end

--- a/app/services/users/delete_articles.rb
+++ b/app/services/users/delete_articles.rb
@@ -8,6 +8,7 @@ module Users
       virtual_articles = user.articles.map { |article| Article.new(article.attributes) }
       user.articles.find_each do |article|
         article.reactions.delete_all
+        article.buffer_updates.delete_all
         article.comments.includes(:user).find_each do |comment|
           comment.reactions.delete_all
           cache_buster.bust_comment(comment.commentable)

--- a/spec/requests/internal/users_banish_spec.rb
+++ b/spec/requests/internal/users_banish_spec.rb
@@ -229,6 +229,12 @@ RSpec.describe "Internal::Users", type: :request do
       expect(user.articles.count).to eq(0)
     end
 
+    it "removes a user's direct chat channels" do
+      ChatChannel.create_with_users([user, user2])
+
+      expect { banish_user }.to change(user.chat_channels, :count).from(1).to(0)
+    end
+
     it "removes all follow relationships" do
       user.follow(user2)
       banish_user

--- a/spec/services/users/cleanup_chat_channels_spec.rb
+++ b/spec/services/users/cleanup_chat_channels_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe Users::CleanupChatChannels, type: :service do
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+  let!(:dm_channel) do
+    ChatChannel.create_with_users([user, other_user])
+  end
+  let!(:open_channel) do
+    ChatChannel.create_with_users([user, other_user], "open")
+  end
+
+  it "deletes direct chat channels" do
+    described_class.call(user)
+
+    expect(ChatChannelMembership.find_by(chat_channel: dm_channel)).to be_nil
+    expect(ChatChannel.find_by(id: dm_channel.id)).to be_nil
+  end
+
+  it "does not delete open chat channels" do
+    described_class.call(user)
+
+    expect(ChatChannelMembership.find_by(chat_channel: open_channel)).to be_nil
+    expect(ChatChannel.find(open_channel.id)).to be_present
+  end
+end

--- a/spec/services/users/cleanup_chat_channels_spec.rb
+++ b/spec/services/users/cleanup_chat_channels_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe Users::CleanupChatChannels, type: :service do
   it "does not delete open chat channels" do
     described_class.call(user)
 
-    expect(ChatChannelMembership.find_by(chat_channel: open_channel)).to be_nil
+    ccm = ChatChannelMembership.find_by(chat_channel: open_channel, user: user)
+    expect(ccm).to be_nil
     expect(ChatChannel.find(open_channel.id)).to be_present
   end
 end

--- a/spec/services/users/delete_articles_spec.rb
+++ b/spec/services/users/delete_articles_spec.rb
@@ -30,6 +30,14 @@ RSpec.describe Users::DeleteArticles, type: :service do
       expect(Comment.where(commentable_id: article.id, commentable_type: "Article").any?).to be false
     end
 
+    it "deletes articles' buffer updates" do
+      BufferUpdate.buff!(article.id, "twitter_buffer_text", "CODE", "twitter")
+
+      described_class.call(user)
+
+      expect(BufferUpdate.where(article_id: article.id).any?).to be false
+    end
+
     it "busts cache" do
       described_class.call(user, buster)
       expect(buster).to have_received(:bust_comment).with(article).twice


### PR DESCRIPTION
Closes #3601 

## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Description

Users who got banished left some dangling associations, most notably direct chat channels. This PR adds code for cleaning them up.

## Related Tickets & Documents

#3601

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

n/a

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed
