### PR TITLE
[MarkdownFixer] Do not escape username with underscores in code or codeblocks

### DIFF
--- a/app/labor/markdown_fixer.rb
+++ b/app/labor/markdown_fixer.rb
@@ -47,10 +47,28 @@ class MarkdownFixer
     end
 
     def underscores_in_usernames(markdown)
-      markdown.gsub(/(@)(_\w+)(_)/, '\1\\\\\2\\\\\3')
+      return markdown unless markdown.match?(USERNAME_WITH_UNDERSCORE_REGEXP)
+
+      traverser = MarkdownTraverser.new(markdown)
+      traverser.each do |line|
+        next if traverser.in_codeblock?
+
+        escape_underscored_username_in_line!(line)
+      end.join
     end
 
     private
+
+    # Match @_username_ that is not preceded by backtick
+    USERNAME_WITH_UNDERSCORE_REGEXP = /(?<!`)@_\w+_/.freeze
+
+    # Escapes underscored username that is not in code
+    def escape_underscored_username_in_line!(line)
+      line.scan(USERNAME_WITH_UNDERSCORE_REGEXP).each do |to_escape|
+        line.sub!(to_escape, to_escape.gsub("_", "\\_"))
+      end
+      line
+    end
 
     def add_quotes_to_section(markdown, section:)
       # Only add quotes to front matter, or text between triple dashes

--- a/app/labor/markdown_traverser.rb
+++ b/app/labor/markdown_traverser.rb
@@ -1,0 +1,37 @@
+# To go through a markdown document. Mainly used to decide if we are in
+# code blocks to decide if we should escape underscored usernames.
+class MarkdownTraverser
+  def initialize(markdown)
+    @lines = markdown.dup.lines
+    init_position
+  end
+
+  def each
+    lines.each do |line|
+      update_position(line.include?(CODEBLOCK_MARKER))
+      yield(line)
+    end
+  end
+
+  def in_codeblock?
+    prev == true && current == false
+  end
+
+  private
+
+  CODEBLOCK_MARKER = "```".freeze
+  private_constant :CODEBLOCK_MARKER
+
+  attr_reader :lines
+  attr_accessor :prev, :current
+
+  def init_position
+    self.prev = false
+    self.current = lines.first.include?(CODEBLOCK_MARKER)
+  end
+
+  def update_position(current)
+    self.current = current
+    self.prev = current ? !prev : prev
+  end
+end

--- a/spec/labor/markdown_fixer_spec.rb
+++ b/spec/labor/markdown_fixer_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe MarkdownFixer, type: :labor do
       test_string1 = "@_xy_"
       expected_result1 = "@\\_xy\\_"
       test_string2 = "@_x_y_"
-      expected_result2 = "@\\_x_y\\_"
+      expected_result2 = "@\\_x\\_y\\_"
 
       expect(described_class.underscores_in_usernames(test_string1)).to eq(expected_result1)
       expect(described_class.underscores_in_usernames(test_string2)).to eq(expected_result2)
@@ -140,6 +140,23 @@ RSpec.describe MarkdownFixer, type: :labor do
       test_string = "_make this cursive_"
       expected_result = "_make this cursive_"
       expect(described_class.underscores_in_usernames(test_string)).to eq(expected_result)
+    end
+
+    it "escapes correctly and ignores underscored username in code and code block" do
+      input = <<~INPUT
+        @_dev_
+
+        ```ruby
+        @_no_escape_codeblock
+        ```
+
+        `@_no_escape_code`
+      INPUT
+
+      result = described_class.underscores_in_usernames(input)
+
+      expect(result).to include("@\\_dev\\_")
+      expect(result).to include("@_no_escape_codeblock", "@_no_escape_code")
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Tests are passing 

  ```shell
  bundle exec rspec spec/labor/markdown_fixer_spec.rb spec/requests/api/v0/articles_spec.rb spec/services/articles/creator_spec.rb spec/services/mentions/create_all_spec.rb
  ```
- [x] I‘ve verified it works on development
  starts the server at local, sign in, new post, copy the following to preview and see if things work as expected. You should not see `\` in code and codeblock, and underscored username renders correctly.
  <details>
  <summary>Code for testing at development</summary>

  <pre>
  @_dev_

  ```
  @_dev_
  ```

  `@_dev_`

  @_dev_
  </pre>
  </details>

## Description

The underscored username got escaped in code and code blocks. We probably do not want that. The fix is only to escape underscored username if they are not in code or code blocks.

Other possible approaches:

- Write regexp that only pull out underscored usernames not in code or code blocks
- Turn markdown into HTML and use Nokogiri to work on text of ancestors not `pre` or `code`

## Related Tickets & Documents

Fixes #5739.  

## Screenshots

### Current on dev (2019.01.28, 26e4412)

<img width="466" alt="スクリーンショット 2020-01-28 17 41 26" src="https://user-images.githubusercontent.com/1000669/73248000-755c5600-41f5-11ea-83bf-cbae11a8e0f3.png">

### After this Pull Request (tested against 432885f)

<img width="260" alt="スクリーンショット 2020-02-09 22 49 42" src="https://user-images.githubusercontent.com/1000669/74103332-98d8b680-4b8e-11ea-99b7-e4c0aff80a28.png">

<img width="187" alt="スクリーンショット 2020-02-09 22 36 07" src="https://user-images.githubusercontent.com/1000669/74103163-3632eb00-4b8d-11ea-837b-02fa662cf22c.png">

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
- [x] code comments added

## [optional] What gif best describes this PR or how it makes you feel?

![](https://media.giphy.com/media/Vuw9m5wXviFIQ/giphy.gif)