### PR TITLE
Remove actionpack-action_caching gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ group :production do
   gem "rack-host-redirect", "~> 1.3" # Lean and simple host redirection via Rack middleware
 end
 
-gem "actionpack-action_caching", "~> 1.2" # Action caching for Action Pack (removed from core in Rails 4.0)
 gem "active_record_union", "~> 1.3" # Adds proper union and union_all methods to ActiveRecord::Relation
 gem "activerecord-import", "~> 1.0" # Adds ability to bulk create activerecord objects
 gem "acts-as-taggable-on", "~> 6.5" # A tagging plugin for Rails applications that allows for custom tagging along dynamic contexts

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,8 +34,6 @@ GEM
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
-    actionpack-action_caching (1.2.1)
-      actionpack (>= 4.0.0)
     actionview (5.2.4.1)
       activesupport (= 5.2.4.1)
       builder (~> 3.1)
@@ -866,7 +864,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  actionpack-action_caching (~> 1.2)
   active_record_union (~> 1.3)
   activerecord-import (~> 1.0)
   acts-as-taggable-on (~> 6.5)


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Getting rid of this gem has been a long lasting dream of mine, I'm glad we've finally got to it thanks to the work we've been doing on streamlining edge caching. Page caching has been removed from Rails in version 4 (almost 7 years ago I just found out)

Next up is to get rid of `rails-observers` :D 
