### PR TITLE
Combine Rack::Timeout::RequestTimeoutErrors with Exceptions in Honeybadger

### DIFF
--- a/config/initializers/honeybadger.rb
+++ b/config/initializers/honeybadger.rb
@@ -4,6 +4,7 @@
 MESSAGE_FINGERPRINTS = {
   "BANNED" => "banned",
   "Rack::Timeout::RequestTimeoutException" => "rack_timeout",
+  "Rack::Timeout::RequestTimeoutError" => "rack_timeout",
   "PG::QueryCanceled" => "pg_query_canceled"
 }.freeze
 

--- a/spec/initializers/honeybadger_spec.rb
+++ b/spec/initializers/honeybadger_spec.rb
@@ -1,34 +1,8 @@
 require "rails_helper"
 
 describe Honeybadger do
-  context "when a fetch_all_rss SIGTERM error is raised" do
-    it "sets fingerprint to error_message" do
-      notice = Honeybadger::Notice.new(
-        described_class.config, error_message: "SignalException: SIGTERM", component: "rake fetch_all_rss"
-      )
-      described_class.config.before_notify_hooks.first.call(notice)
-      expect(notice.fingerprint).to eq(notice.error_message)
-    end
-  end
-
-  context "when BANNED error is raised" do
-    it "sets fingerprint to banned" do
-      notice = Honeybadger::Notice.new(
-        described_class.config, error_message: "RuntimeError: BANNED"
-      )
-      described_class.config.before_notify_hooks.first.call(notice)
-      expect(notice.fingerprint).to eq("banned")
-    end
-  end
-
-  context "when Rack::Timeout::RequestTimeoutException is raised" do
-    it "sets fingerprint to rack_timeout" do
-      notice = Honeybadger::Notice.new(
-        described_class.config, error_message: "Rack::Timeout::RequestTimeoutException happened"
-      )
-      described_class.config.before_notify_hooks.first.call(notice)
-      expect(notice.fingerprint).to eq("rack_timeout")
-    end
+  MESSAGE_FINGERPRINTS.each do |error_key, fingerprint|
+    include_examples "#sets_correct_honeybadger_fingerprint", error_key, fingerprint
   end
 
   context "when error is raised from an internal route" do
@@ -38,16 +12,6 @@ describe Honeybadger do
       )
       described_class.config.before_notify_hooks.first.call(notice)
       expect(notice.fingerprint).to eq("internal")
-    end
-  end
-
-  context "when a PG::QueryCanceled error is raised" do
-    it "sets fingerprint to pg_query_cancel" do
-      notice = Honeybadger::Notice.new(
-        described_class.config, error_message: "ActionView::Template::Error: PG::QueryCanceled:"
-      )
-      described_class.config.before_notify_hooks.first.call(notice)
-      expect(notice.fingerprint).to eq("pg_query_canceled")
     end
   end
 end

--- a/spec/initializers/shared_examples/sets_correct_honeybadger_fingerprint.rb
+++ b/spec/initializers/shared_examples/sets_correct_honeybadger_fingerprint.rb
@@ -1,0 +1,9 @@
+RSpec.shared_examples "#sets_correct_honeybadger_fingerprint" do |error_key, fingerprint|
+  it "raises an error" do
+    notice = Honeybadger::Notice.new(
+      described_class.config, error_message: "CRAP! #{error_key} Bail!"
+    )
+    described_class.config.before_notify_hooks.first.call(notice)
+    expect(notice.fingerprint).to eq(fingerprint)
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -34,6 +34,7 @@ Dir[Rails.root.join("spec/system/shared_examples/**/*.rb")].sort.each { |f| requ
 Dir[Rails.root.join("spec/models/shared_examples/**/*.rb")].sort.each { |f| require f }
 Dir[Rails.root.join("spec/jobs/shared_examples/**/*.rb")].sort.each { |f| require f }
 Dir[Rails.root.join("spec/workers/shared_examples/**/*.rb")].sort.each { |f| require f }
+Dir[Rails.root.join("spec/initializers/shared_examples/**/*.rb")].sort.each { |f| require f }
 
 # Checks for pending migrations before tests are run.
 # If you are not using ActiveRecord, you can remove this line.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
Combine Rack::Timeout::RequestTimeoutErrors with Exceptions in Honeybadger since they are indicative of the same thing. Also did a little spec refractor which I am pretty happy with. 

## Ticket
https://github.com/thepracticaldev/dev.to/projects/5#card-32287886

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media.giphy.com/media/C6JQPEUsZUyVq/giphy.gif)
