### PR TITLE
Create dynamic robots.txt page

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,6 +1,6 @@
 class PagesController < ApplicationController
   # No authorization required for entirely public controller
-  before_action :set_cache_control_headers, only: %i[show rlyweb now survey badge shecoded bounty faq]
+  before_action :set_cache_control_headers, only: %i[show rlyweb now survey badge shecoded bounty faq robots]
 
   def show
     @page = Page.find_by!(slug: params[:slug])
@@ -49,6 +49,11 @@ class PagesController < ApplicationController
       reported_url: reported_url&.chomp("?i=i"),
     )
     render "pages/report-abuse"
+  end
+
+  def robots
+    respond_to :text
+    set_surrogate_key_header "robots_page"
   end
 
   def rlyweb

--- a/app/views/pages/robots.text.erb
+++ b/app/views/pages/robots.text.erb
@@ -1,0 +1,6 @@
+User-agent: *
+Disallow: /users/auth/twitter*
+Disallow: /users/auth/github*
+Disallow: /report-abuse?url=*
+
+Sitemap: https://<%= ApplicationConfig["AWS_BUCKET_NAME"] %>.s3.amazonaws.com/sitemaps/sitemap.xml.gz

--- a/config/initializers/initialization_cachebust.rb
+++ b/config/initializers/initialization_cachebust.rb
@@ -2,5 +2,3 @@
 CacheBuster.bust("/shell_top")
 CacheBuster.bust("/shell_bottom")
 CacheBuster.bust("/async_info/shell_version")
-CacheBuster.bust("/serviceworker.js")
-CacheBuster.bust("/robots.txt")

--- a/config/initializers/initialization_cachebust.rb
+++ b/config/initializers/initialization_cachebust.rb
@@ -2,3 +2,5 @@
 CacheBuster.bust("/shell_top")
 CacheBuster.bust("/shell_bottom")
 CacheBuster.bust("/async_info/shell_version")
+CacheBuster.bust("/serviceworker.js")
+CacheBuster.bust("/robots.txt")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -270,6 +270,7 @@ Rails.application.routes.draw do
 
   # You can have the root of your site routed with "root
   get "/about" => "pages#about"
+  get "/robots.:format" => "pages#robots"
   get "/api", to: redirect("https://docs.dev.to/api")
   get "/privacy" => "pages#privacy"
   get "/terms" => "pages#terms"

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,7 +1,0 @@
-# See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
-#
-# To ban all spiders from the entire site uncomment the next two lines:
-# User-agent: *
-# Disallow: /
-
-Sitemap: https://thepracticaldev.s3.amazonaws.com/sitemaps/sitemap.xml.gz

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -114,4 +114,11 @@ RSpec.describe "Pages", type: :request do
       end
     end
   end
+
+  describe "GET /robots.txt" do
+    it "has proper text" do
+      get "/robots.txt"
+      expect(response.body).to include("Sitemap: https://#{ApplicationConfig['AWS_BUCKET_NAME']}.s3.amazonaws.com/sitemaps/sitemap.xml.gz")
+    end
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR moves `robots.txt` from the totally static public folder to an action where code and env vars are available.

This is needed to point robots to the new place for our sitemap download and enable any further dynamic elements in the sitemap.

I also took the moment to add a few new `Disallow:` lines to avoid crawling of a few unnecessary pages which either result in errors or result in an endless list of endpoints which don't need indexing.

If you're reviewing this, just double check the format of the new lines to make sure it is appropriate when checked against instructions for `robots.txt`. We definitely don't want to accidentally instruct the bots to not crawl important pages.

This endpoint will be cached, so for all intents and purposes it will be as if it is static. It will rarely change, so we will have to cachebust it manually if we do change it, but it will also fade from the cache on its own every 24 hours and be re-fetched cold from origin, which I think is fine.