### PR TITLE
Track stripe errors in Datadog so we can alert on them

### DIFF
--- a/app/controllers/stripe_active_cards_controller.rb
+++ b/app/controllers/stripe_active_cards_controller.rb
@@ -11,9 +11,14 @@ class StripeActiveCardsController < ApplicationController
         "Your billing information has been updated"
     else
       logger.info("Stripe Add New Card Failure - #{current_user.username}")
+      DataDogStatsClient.increment("stripe.errors")
       redirect_to "/settings/billing", flash: { error:
         "There was a problem updating your billing info." }
     end
+  rescue Stripe::InvalidRequestError
+    DataDogStatsClient.increment("stripe.errors")
+    redirect_to "/settings/billing", flash: { error:
+        "There was a problem updating your billing info." }
   end
 
   def update
@@ -31,6 +36,7 @@ class StripeActiveCardsController < ApplicationController
         "There was a problem updating your billing info." }
     end
   rescue Stripe::CardError => e
+    DataDogStatsClient.increment("stripe.errors")
     flash[:error] = e.message
     redirect_to "/settings/billing"
   end

--- a/spec/requests/stripe_active_cards_spec.rb
+++ b/spec/requests/stripe_active_cards_spec.rb
@@ -26,6 +26,27 @@ RSpec.describe "StripeSubscriptions", type: :request do
       card = Stripe::Customer.retrieve(user.stripe_id_code).sources.first
       expect(card.is_a?(Stripe::Card)).to eq(true)
     end
+
+    it "increments sidekiq.errors in Datadog on failure" do
+      allow(DataDogStatsClient).to receive(:increment)
+      invalid_error = Stripe::InvalidRequestError.new(nil, nil)
+      allow(Stripe::Customer).to receive(:create).and_raise(invalid_error)
+      post "/stripe_active_cards", params: { stripe_token: stripe_helper.generate_card_token }
+      expect(DataDogStatsClient).to have_received(:increment).with("stripe.errors")
+    end
+  end
+
+  describe "PUT StripeActiveCards#update" do
+    it "increments sidekiq.errors in Datadog on failure" do
+      valid_instance(user)
+      customer = Stripe::Customer.retrieve(user.stripe_id_code)
+      original_card_id = customer.sources.all(object: "card").first.id
+      allow(DataDogStatsClient).to receive(:increment)
+      card_error = Stripe::CardError.new(nil, nil, nil)
+      allow(Stripe::Customer).to receive(:retrieve).and_raise(card_error)
+      put "/stripe_active_cards/#{original_card_id}", params: {}
+      expect(DataDogStatsClient).to have_received(:increment).with("stripe.errors")
+    end
   end
 
   describe "DESTROY StripeActiveCards#destroy" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature
- [x] Bug Fix

## Description
This PR does 2 things:
1) Prevents the `Stripe::InvalidRequestError` from bubbling up to Honeybadger which will solve [this error](https://app.honeybadger.io/fault/66984/25b68173b013c1c37741fbfe2728bfcc)
2) Counts all errors that occur in Datadog so instead of being alerted to one off errors via Honeybadger we instead can be alerted if the number of errors spike which would indicate a possible Stripe issue rather than a one off user problem.
3) BONUS! I added specs! 🙌 

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/issues/4925
https://github.com/thepracticaldev/dev.to/projects/5#card-32287854

## Added to documentation?
- [x] no documentation needed

![alt_text](https://cdn.dribbble.com/users/954572/screenshots/4639677/kill-two-birds-with-one-stone.gif)
