### PR TITLE
Remove hardcoded AWS bucket Name from a Few Files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
   <br>
-  <img alt="DEV" src="https://thepracticaldev.s3.amazonaws.com/i/ro3538by3b2fupbs63sr.png" width="500px">
+  <img alt="DEV" src="https://dev-to-uploads.s3.amazonaws.com/i/ro3538by3b2fupbs63sr.png" width="500px">
   <h1>DEV Community 👩‍💻👨‍💻</h1>
   <strong>The Human Layer of the Stack</strong>
 </div>
@@ -138,7 +138,7 @@ doc or email yo@dev.to
 <br>
 
 <p align="center">
-  <img alt="Sloan, the sloth mascot" width="250px" src="https://thepracticaldev.s3.amazonaws.com/uploads/user/profile_image/31047/af153cd6-9994-4a68-83f4-8ddf3e13f0bf.jpg">
+  <img alt="Sloan, the sloth mascot" width="250px" src="https://dev-to-uploads.s3.amazonaws.com/uploads/user/profile_image/31047/af153cd6-9994-4a68-83f4-8ddf3e13f0bf.jpg">
   <br>
   <strong>Happy Coding</strong> ❤️
 </p>

--- a/app/labor/profile_image.rb
+++ b/app/labor/profile_image.rb
@@ -5,7 +5,7 @@ class ProfileImage
   def initialize(resource)
     @resource = resource
     @image_link = resource.profile_image_url
-    @backup_link = "https://thepracticaldev.s3.amazonaws.com/i/99mvlsfu5tfj9m7ku25d.png"
+    @backup_link = "https://#{ApplicationConfig['AWS_BUCKET_NAME']}.s3.amazonaws.com/i/99mvlsfu5tfj9m7ku25d.png"
   end
 
   def get(width = 120)

--- a/app/lib/html_css_to_image.rb
+++ b/app/lib/html_css_to_image.rb
@@ -2,7 +2,7 @@ module HtmlCssToImage
   AUTH = { username: ApplicationConfig["HCTI_API_USER_ID"],
            password: ApplicationConfig["HCTI_API_KEY"] }.freeze
 
-  FALLBACK_IMAGE = "https://thepracticaldev.s3.amazonaws.com/i/g355ol6qsrg0j2mhngz9.png".freeze
+  FALLBACK_IMAGE = "https://#{ApplicationConfig['AWS_BUCKET_NAME']}.s3.amazonaws.com/i/g355ol6qsrg0j2mhngz9.png".freeze
 
   CACHE_EXPIRATION = 6.weeks
 

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -14,7 +14,7 @@ class SiteConfig < RailsSettings::Base
   field :social_networks_handle, type: :string, default: "thepracticaldev"
 
   # images
-  field :main_social_image, type: :string, default: "https://thepracticaldev.s3.amazonaws.com/i/6hqmcjaxbgbon8ydw93z.png"
+  field :main_social_image, type: :string, default: "https://#{ApplicationConfig['AWS_BUCKET_NAME']}.s3.amazonaws.com/i/6hqmcjaxbgbon8ydw93z.png"
   field :favicon_url, type: :string, default: "favicon.ico"
   field :logo_svg, type: :string, default: ""
 

--- a/app/services/moderator/banish_user.rb
+++ b/app/services/moderator/banish_user.rb
@@ -46,7 +46,7 @@ module Moderator
         twitch_url: nil, feed_url: nil
       )
 
-      user.update_columns(profile_image: "https://thepracticaldev.s3.amazonaws.com/i/99mvlsfu5tfj9m7ku25d.png")
+      user.update_columns(profile_image: "https://#{ApplicationConfig['AWS_BUCKET_NAME']}.s3.amazonaws.com/i/99mvlsfu5tfj9m7ku25d.png")
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
This is only a small number of the places we have hardcoded our old AWS bucket name. I figured I would do these and then make an Issue to handle all of the ones that are in the view and emails which are A LOT and will need some closer attention as some are cloudinary links and some point straight to S3. 

## Related Ticket
Followup for #5771 and #5555 
 
## Added to documentation?
- [x] no documentation needed

![alt_text](https://media1.tenor.com/images/86f2936e3b4e83969d4096dc3a2635b2/tenor.gif?itemid=13763573)
