### PR TITLE
Refactor ProfileImage

### DIFF
--- a/app/controllers/async_info_controller.rb
+++ b/app/controllers/async_info_controller.rb
@@ -43,7 +43,7 @@ class AsyncInfoController < ApplicationController
         id: @user.id,
         name: @user.name,
         username: @user.username,
-        profile_image_90: ProfileImage.new(@user).get(90),
+        profile_image_90: ProfileImage.new(@user).get(width: 90),
         followed_tag_names: @user.cached_followed_tag_names,
         followed_tags: @user.cached_followed_tags.to_json(only: %i[id name bg_color_hex text_color_hex hotness_score], methods: [:points]),
         followed_user_ids: @user.cached_following_users_ids,

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -91,7 +91,7 @@ class CommentsController < ApplicationController
           id: current_user.id,
           username: current_user.username,
           name: current_user.name,
-          profile_pic: ProfileImage.new(current_user).get(50),
+          profile_pic: ProfileImage.new(current_user).get(width: 50),
           twitter_username: current_user.twitter_username,
           github_username: current_user.github_username
         }

--- a/app/controllers/live_articles_controller.rb
+++ b/app/controllers/live_articles_controller.rb
@@ -14,7 +14,7 @@ class LiveArticlesController < ApplicationController
           tag_list: [],
           user: {
             name: @event.host_name,
-            profile_pic: ProfileImage.new(@event).get(50)
+            profile_pic: ProfileImage.new(@event).get(width: 50)
           }
         }
     elsif @article
@@ -26,7 +26,7 @@ class LiveArticlesController < ApplicationController
           tag_list: @article.tag_list,
           user: {
             name: @article.user.name,
-            profile_pic: ProfileImage.new(@article.user).get(50)
+            profile_pic: ProfileImage.new(@article.user).get(width: 50)
           }
         }
     else

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -88,7 +88,7 @@ class MessagesController < ApplicationController
       chat_channel_adjusted_slug: new_message.chat_channel.adjusted_slug(current_user, "sender"),
       channel_type: new_message.chat_channel.channel_type,
       username: new_message.user.username,
-      profile_image_url: ProfileImage.new(new_message.user).get(90),
+      profile_image_url: ProfileImage.new(new_message.user).get(width: 90),
       message: new_message.message_html,
       markdown: new_message.message_markdown,
       edited_at: new_message.edited_at,

--- a/app/labor/profile_image.rb
+++ b/app/labor/profile_image.rb
@@ -8,7 +8,7 @@ class ProfileImage
     @backup_link = "https://thepracticaldev.s3.amazonaws.com/i/99mvlsfu5tfj9m7ku25d.png"
   end
 
-  def get(width = 120)
+  def get(width: 120)
     cl_image_path(get_link,
                   type: "fetch",
                   crop: "fill",

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -150,7 +150,7 @@ class Article < ApplicationRecord
                  :body_text, :tag_keywords_for_search, :search_score, :readable_publish_date, :flare_tag
       attribute :user do
         { username: user.username, name: user.name,
-          profile_image_90: ProfileImage.new(user).get(90), pro: user.pro? }
+          profile_image_90: ProfileImage.new(user).get(width: 90), pro: user.pro? }
       end
       tags do
         [tag_list,
@@ -180,13 +180,13 @@ class Article < ApplicationRecord
       attribute :user do
         { username: user.username,
           name: user.name,
-          profile_image_90: ProfileImage.new(user).get(90) }
+          profile_image_90: ProfileImage.new(user).get(width: 90) }
       end
       attribute :organization do
         if organization
           { slug: organization.slug,
             name: organization.name,
-            profile_image_90: ProfileImage.new(organization).get(90) }
+            profile_image_90: ProfileImage.new(organization).get(width: 90) }
         end
       end
       tags do

--- a/app/models/chat_channel.rb
+++ b/app/models/chat_channel.rb
@@ -171,7 +171,7 @@ class ChatChannel < ApplicationRecord
 
   def user_obj(membership)
     {
-      profile_image: ProfileImage.new(membership.user).get(90),
+      profile_image: ProfileImage.new(membership.user).get(width: 90),
       darker_color: membership.user.decorate.darker_color,
       name: membership.user.name,
       last_opened_at: membership.last_opened_at,

--- a/app/models/chat_channel_membership.rb
+++ b/app/models/chat_channel_membership.rb
@@ -46,7 +46,7 @@ class ChatChannelMembership < ApplicationRecord
 
   def channel_image
     if chat_channel.channel_type == "direct"
-      ProfileImage.new(other_user).get(90)
+      ProfileImage.new(other_user).get(width: 90)
     else
       ActionController::Base.helpers.asset_path("organization.svg")
     end

--- a/app/models/classified_listing.rb
+++ b/app/models/classified_listing.rb
@@ -42,7 +42,7 @@ class ClassifiedListing < ApplicationRecord
     attribute :author do
       { username: author.username,
         name: author.name,
-        profile_image_90: ProfileImage.new(author).get(90) }
+        profile_image_90: ProfileImage.new(author).get(width: 90) }
     end
     tags do
       [tag_list,

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -74,8 +74,8 @@ class Comment < ApplicationRecord
           username: user.username,
           name: user.name,
           id: user.id,
-          profile_pic: ProfileImage.new(user).get(90),
-          profile_image_90: ProfileImage.new(user).get(90),
+          profile_pic: ProfileImage.new(user).get(width: 90),
+          profile_image_90: ProfileImage.new(user).get(width: 90),
           github_username: user.github_username,
           twitter_username: user.twitter_username
         }

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -100,7 +100,7 @@ class Message < ApplicationRecord
           target='_blank' data-content='sidecar-article'>
             #{"<div class='chatchannels__richlinkmainimage' style='background-image:url(" + cl_path(article.main_image) + ")' data-content='sidecar-article' ></div>" if article.main_image.present?}
           <h1 data-content='sidecar-article'>#{article.title}</h1>
-          <h4 data-content='sidecar-article'><img src='#{ProfileImage.new(article.cached_user).get(90)}' /> #{article.cached_user.name}・#{article.readable_publish_date || 'Draft Post'}</h4>
+          <h4 data-content='sidecar-article'><img src='#{ProfileImage.new(article.cached_user).get(width: 90)}' /> #{article.cached_user.name}・#{article.readable_publish_date || 'Draft Post'}</h4>
           </a>".html_safe
       elsif (tag = rich_link_tag(anchor))
         html += "<a href='/t/#{tag.name}'
@@ -116,7 +116,7 @@ class Message < ApplicationRecord
         class='chatchannels__richlink'
           target='_blank' data-content='sidecar-user'>
           <h1 data-content='sidecar-user'>
-            <img src='#{ProfileImage.new(user).get(90)}' data-content='sidecar-user' class='chatchannels__richlinkprofilepic' />
+            <img src='#{ProfileImage.new(user).get(width: 90)}' data-content='sidecar-user' class='chatchannels__richlinkprofilepic' />
             #{user.name}
           </h1>
           </a>".html_safe

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -89,7 +89,7 @@ class Organization < ApplicationRecord
   end
 
   def profile_image_90
-    ProfileImage.new(self).get(90)
+    ProfileImage.new(self).get(width: 90)
   end
 
   def enough_credits?(num_credits_needed)

--- a/app/models/podcast.rb
+++ b/app/models/podcast.rb
@@ -40,7 +40,7 @@ class Podcast < ApplicationRecord
   end
 
   def image_90
-    ProfileImage.new(self).get(90)
+    ProfileImage.new(self).get(width: 90)
   end
 
   private

--- a/app/models/podcast_episode.rb
+++ b/app/models/podcast_episode.rb
@@ -42,7 +42,7 @@ class PodcastEpisode < ApplicationRecord
       attribute :user do
         { name: podcast.name,
           username: user_username,
-          profile_image_90: ProfileImage.new(user).get(90) }
+          profile_image_90: ProfileImage.new(user).get(width: 90) }
       end
       searchableAttributes ["unordered(title)",
                             "body_text",

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -445,7 +445,7 @@ class User < ApplicationRecord
   end
 
   def profile_image_90
-    ProfileImage.new(self).get(90)
+    ProfileImage.new(self).get(width: 90)
   end
 
   def remove_from_algolia_index

--- a/app/serializers/webhook/user_serializer.rb
+++ b/app/serializers/webhook/user_serializer.rb
@@ -5,10 +5,10 @@ module Webhook
     attributes :name, :username, :twitter_username, :github_username
     attribute :website_url, &:processed_website_url
     attribute :profile_image do |user|
-      ProfileImage.new(user).get(640)
+      ProfileImage.new(user).get(width: 640)
     end
     attribute :profile_image_90 do |user|
-      ProfileImage.new(user).get(90)
+      ProfileImage.new(user).get(width: 90)
     end
   end
 end

--- a/app/views/additional_content_boxes/_article_content_area.html.erb
+++ b/app/views/additional_content_boxes/_article_content_area.html.erb
@@ -3,7 +3,7 @@
 </h2>
 <div class="content-author">
   <a href="<%= article.user.path + article.decorate.internal_utm_params %>">
-    <img class="profile-pic" src="<%= ProfileImage.new(article.user).get(50) %>" alt="<%= article.user.username %> profile image" />
+    <img class="profile-pic" src="<%= ProfileImage.new(article.user).get(width: 50) %>" alt="<%= article.user.username %> profile image" />
     <span><%= article.user.name %></span>
     <%= render "shared/pro_checkmark" if article.user.pro? %>
   </a>

--- a/app/views/additional_content_boxes/_article_followable_area.html.erb
+++ b/app/views/additional_content_boxes/_article_followable_area.html.erb
@@ -20,7 +20,7 @@
        class="<%= "partner-link" if classification == "boosted" %>"
        data-details="<%= followable&.slug if classification == "boosted" %>__PROFILE">
       <img class="profile-image"
-           src="<%= ProfileImage.new(followable).get(200) %>"
+           src="<%= ProfileImage.new(followable).get(width: 200) %>"
            alt="<%= followable.name %> profile image"
            loading="lazy"
            data-details="<%= followable&.slug if classification == "boosted" %>__PROFILE"

--- a/app/views/api/v0/articles/onboarding.json.jbuilder
+++ b/app/views/api/v0/articles/onboarding.json.jbuilder
@@ -9,6 +9,6 @@ json.array! @articles do |article|
 
   json.user do
     json.name                     article.user.name
-    json.profile_image_url        ProfileImage.new(article.user).get(90)
+    json.profile_image_url        ProfileImage.new(article.user).get(width: 90)
   end
 end

--- a/app/views/api/v0/shared/_follows.json.jbuilder
+++ b/app/views/api/v0/shared/_follows.json.jbuilder
@@ -1,4 +1,4 @@
 json.name                    user.name
 json.path                    "/" + user.path.delete_prefix("/")
 json.username                user.try(:username) || user.name
-json.profile_image           ProfileImage.new(user).get(60)
+json.profile_image           ProfileImage.new(user).get(width: 60)

--- a/app/views/api/v0/shared/_organization.json.jbuilder
+++ b/app/views/api/v0/shared/_organization.json.jbuilder
@@ -4,6 +4,6 @@ json.organization do
   json.name             organization.name
   json.username         organization.username
   json.slug             organization.slug
-  json.profile_image    organization_profile_image.get(640)
-  json.profile_image_90 organization_profile_image.get(90)
+  json.profile_image    organization_profile_image.get(width: 640)
+  json.profile_image_90 organization_profile_image.get(width: 90)
 end

--- a/app/views/api/v0/shared/_user.json.jbuilder
+++ b/app/views/api/v0/shared/_user.json.jbuilder
@@ -6,6 +6,6 @@ json.user do
   json.twitter_username user.twitter_username
   json.github_username  user.github_username
   json.website_url      user.processed_website_url
-  json.profile_image    user_profile_image.get(640)
-  json.profile_image_90 user_profile_image.get(90)
+  json.profile_image    user_profile_image.get(width: 640)
+  json.profile_image_90 user_profile_image.get(width: 90)
 end

--- a/app/views/api/v0/users/index.json.jbuilder
+++ b/app/views/api/v0/users/index.json.jbuilder
@@ -3,6 +3,6 @@ json.array! @users.each do |user|
   json.name                   user.name
   json.username               user.username
   json.summary                truncate(user.summary.presence || "Active DEV author", length: 100)
-  json.profile_image_url      ProfileImage.new(user).get(90)
+  json.profile_image_url      ProfileImage.new(user).get(width: 90)
   json.following              false
 end

--- a/app/views/api/v0/users/show.json.jbuilder
+++ b/app/views/api/v0/users/show.json.jbuilder
@@ -8,4 +8,4 @@ json.github_username    @user.github_username
 json.website_url        @user.website_url
 json.location           @user.location
 json.joined_at          @user.created_at.strftime("%b %e, %Y")
-json.profile_image      ProfileImage.new(@user).get(320)
+json.profile_image      ProfileImage.new(@user).get(width: 320)

--- a/app/views/articles/_about_author.html.erb
+++ b/app/views/articles/_about_author.html.erb
@@ -1,7 +1,7 @@
 <div class="about-the-author" id="about-the-author">
   <div class="left-column">
     <a href="/<%= @user.username %>">
-      <img class="profile-pic" src="<%= ProfileImage.new(@user).get(180) %>" alt="<%= @user.username %> profile" />
+      <img class="profile-pic" src="<%= ProfileImage.new(@user).get(width: 180) %>" alt="<%= @user.username %> profile" />
     </a>
   </div>
   <div class="main-content">

--- a/app/views/articles/_liquid.html.erb
+++ b/app/views/articles/_liquid.html.erb
@@ -8,7 +8,7 @@
   <% end %>
   <a href='<%= article.user.path %>' class='ltag__link__link'>
     <div class='ltag__link__pic'>
-      <img src='<%= ProfileImage.new(article.user).get(150) %>' alt='<%= article.user.username + " " + "image"%>'/>
+      <img src='<%= ProfileImage.new(article.user).get(width: 150) %>' alt='<%= article.user.username + " " + "image"%>'/>
     </div>
   </a>
   <a href='<%= article.path %>' class='ltag__link__link'>

--- a/app/views/articles/_single_story.html.erb
+++ b/app/views/articles/_single_story.html.erb
@@ -16,7 +16,7 @@
   <% end %>
   <a href="/<%= story.cached_user.username %>" class="small-pic-link-wrapper">
     <div class="small-pic">
-      <img src="<%= ProfileImage.new(story.cached_user).get(90) %>" alt="<%= story.cached_user.username %> profile" />
+      <img src="<%= ProfileImage.new(story.cached_user).get(width: 90) %>" alt="<%= story.cached_user.username %> profile" />
     </div>
   </a>
   <a href="<%= story.path %>" class="small-pic-link-wrapper index-article-link" data-preload-image="<%= cloud_cover_url(story.main_image) %>" id="article-link-<%= story.id %>">

--- a/app/views/articles/_special_sidebar.html.erb
+++ b/app/views/articles/_special_sidebar.html.erb
@@ -10,7 +10,7 @@
       <header>
         <h4><span class="emoji">💪</span> <%= article.title %></h4>
       </header>
-      <img src="<%= ProfileImage.new(article.user).get(420) %>" style="cursor:pointer;" alt="<%= article.user.username %>" />
+      <img src="<%= ProfileImage.new(article.user).get(width: 420) %>" style="cursor:pointer;" alt="<%= article.user.username %>" />
     </div>
   </a>
 <% end %>

--- a/app/views/articles/_sticky_nav.html.erb
+++ b/app/views/articles/_sticky_nav.html.erb
@@ -36,7 +36,7 @@
 
 <div class="primary-sticky-nav" id="article-show-primary-sticky-nav">
   <div class="primary-sticky-nav-element primary-sticky-nav-author">
-    <a href="<%= @actor.path %>"><img src="<%= ProfileImage.new(@actor).get(90) %>" class="primary-sticky-nav-author-top-profile-image" alt="<%= @actor.name %> profile image"></a>
+    <a href="<%= @actor.path %>"><img src="<%= ProfileImage.new(@actor).get(width: 90) %>" class="primary-sticky-nav-author-top-profile-image" alt="<%= @actor.name %> profile image"></a>
     <div style="display:inline-block">
       <div class="primary-sticky-nav-author-name">
         <a href="<%= @actor.path %>">
@@ -100,7 +100,7 @@
               </div>
             <% end %>
             <a class="primary-sticky-nav-element primary-sticky-nav-author-element" href="<%= article.path %>">
-              <img src="<%= ProfileImage.new(article.user).get(90) %>" class="primary-sticky-nav-profile-image" loading="lazy" alt="<%= article.user.name %> profile image">
+              <img src="<%= ProfileImage.new(article.user).get(width: 90) %>" class="primary-sticky-nav-profile-image" loading="lazy" alt="<%= article.user.name %> profile image">
               <%= article.title %>
               <div class="primary-sticky-nav-element-details">
                 <% article.decorate.cached_tag_list_array.each do |tag| %>
@@ -120,7 +120,7 @@
               </div>
             <% end %>
             <a class="primary-sticky-nav-element" href="<%= article.path %>">
-              <img src="<%= ProfileImage.new(article.user).get(90) %>" class="primary-sticky-nav-profile-image" loading="lazy" alt="<%= article.user.name %> profile image">
+              <img src="<%= ProfileImage.new(article.user).get(width: 90) %>" class="primary-sticky-nav-profile-image" loading="lazy" alt="<%= article.user.name %> profile image">
               <%= article.title %>
               <div class="primary-sticky-nav-element-details">
                 <% article.decorate.cached_tag_list_array.each do |tag| %>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -100,7 +100,7 @@
               </h3>
             </div>
             <a href="/<%= @featured_story.cached_user.username %>" class="featured-profile-button">
-              <img class="featured-profile-pic" src="<%= ProfileImage.new(@featured_story.cached_user).get(90) %>" alt="<%= @featured_story.title %>" />
+              <img class="featured-profile-pic" src="<%= ProfileImage.new(@featured_story.cached_user).get(width: 90) %>" alt="<%= @featured_story.title %>" />
             </a>
             <div class="featured-user-name">
               <a href="/<%= @featured_story.cached_user.username %>">

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -111,7 +111,7 @@
         <% if @organization %>
           <a href="<%= @organization.path %>" class="org-branded-title-link">
             <div class="org-branded-title">
-              <img src="<%= ProfileImage.new(@organization).get(50) %>" class="org-pic" alt="<%= @organization.name %> profile image"> <%= @organization.name %>
+              <img src="<%= ProfileImage.new(@organization).get(width: 50) %>" class="org-pic" alt="<%= @organization.name %> profile image"> <%= @organization.name %>
             </div>
           </a>
         <% end %>
@@ -122,7 +122,7 @@
           <span itemprop="author" itemscope itemtype="http://schema.org/Person">
             <meta itemprop="url" content="https://dev.to/<%= @user.username %>">
             <a href="/<%= @user.username %>" class="author">
-              <img class="profile-pic" src="<%= ProfileImage.new(@user).get(50) %>" alt="<%= @user.username %> profile image" />
+              <img class="profile-pic" src="<%= ProfileImage.new(@user).get(width: 50) %>" alt="<%= @user.username %> profile image" />
               <span itemprop="name"><%= @user.name %></span>
             </a>
           </span>

--- a/app/views/articles/tags/_sidebar.html.erb
+++ b/app/views/articles/tags/_sidebar.html.erb
@@ -54,7 +54,7 @@
             <% @moderators.each do |user| %>
               <div class="widget-user-pic">
                 <a href="/<%= user.username %>" title="<%= user.username %>">
-                  <img src="<%= ProfileImage.new(user).get(90) %>" alt="<%= user.username %> profile image">
+                  <img src="<%= ProfileImage.new(user).get(width: 90) %>" alt="<%= user.username %> profile image">
                 </a>
               </div>
             <% end %>

--- a/app/views/chat_channels/show.json.jbuilder
+++ b/app/views/chat_channels/show.json.jbuilder
@@ -2,7 +2,7 @@ json.messages @chat_messages.reverse do |message|
   json.id message.id
   json.user_id message.user_id
   json.username message.user.username
-  json.profile_image_url ProfileImage.new(message.user).get(90)
+  json.profile_image_url ProfileImage.new(message.user).get(width: 90)
   json.message message.message_html
   json.markdown message.message_markdown
   json.edited_at message.edited_at

--- a/app/views/comments/_comment_proper.html.erb
+++ b/app/views/comments/_comment_proper.html.erb
@@ -33,7 +33,7 @@
 
       <div class="details <%= "low-quality-comment" if decorated_comment.low_quality %>">
         <a href="/<%= comment.user.username %>">
-          <img class="profile-pic" src="<%= ProfileImage.new(comment.user).get(50) %>" alt="<%= comment.user.username %> profile image" />
+          <img class="profile-pic" src="<%= ProfileImage.new(comment.user).get(width: 50) %>" alt="<%= comment.user.username %> profile image" />
           <span class="comment-username">
             <span class="comment-username-inner">
               <%= comment.user.name %>

--- a/app/views/comments/_liquid.html.erb
+++ b/app/views/comments/_liquid.html.erb
@@ -1,7 +1,7 @@
 <div class="liquid-comment">
   <div class="details">
     <a href="/<%= comment.user.username %>">
-      <img class="profile-pic" src="<%= ProfileImage.new(comment.user).get(50) %>" alt="<%= comment.user.username %> profile image" />
+      <img class="profile-pic" src="<%= ProfileImage.new(comment.user).get(width: 50) %>" alt="<%= comment.user.username %> profile image" />
     </a>
     <a href="/<%= comment.user.username %>">
       <span class="comment-username"><%= comment.user.name %></span>

--- a/app/views/comments/deleted_commentable_comment.html.erb
+++ b/app/views/comments/deleted_commentable_comment.html.erb
@@ -31,7 +31,7 @@
 
         <div class="details <%= "low-quality-comment" if decorated_comment.low_quality %>">
           <a href="/<%= @user.username %>">
-            <img class="profile-pic" src="<%= ProfileImage.new(@user).get(50) %>" alt="<%= @user.username %> profile image" />
+            <img class="profile-pic" src="<%= ProfileImage.new(@user).get(width: 50) %>" alt="<%= @user.username %> profile image" />
             <span class="comment-username">
               <span class="comment-username-inner">
                 <%= @user.name %>

--- a/app/views/dashboards/followers.html.erb
+++ b/app/views/dashboards/followers.html.erb
@@ -26,7 +26,7 @@
         <div id="follows-<%= follow.id %>" class="single-article">
           <a href="<%= user.path %>" class="block-link">
             <h2>
-              <img alt="<%= user.username %> profile image" src="<%= ProfileImage.new(user).get(60) %>" />
+              <img alt="<%= user.username %> profile image" src="<%= ProfileImage.new(user).get(width: 60) %>" />
               <%= user.name %>
               <span class="dashboard-username">@<%= user.username %></span>
             </h2>

--- a/app/views/dashboards/following_organizations.html.erb
+++ b/app/views/dashboards/following_organizations.html.erb
@@ -13,7 +13,7 @@
       <div id="follows-<%= follow.id %>" class="single-article">
         <a href="<%= organization.path %>" class="block-link">
           <h2>
-            <img alt="<%= organization.name %> profile image" src="<%= ProfileImage.new(organization).get(60) %>" />
+            <img alt="<%= organization.name %> profile image" src="<%= ProfileImage.new(organization).get(width: 60) %>" />
             <%= organization.name %>
             <span class="dashboard-username">@<%= organization.username %></span>
           </h2>

--- a/app/views/dashboards/following_users.html.erb
+++ b/app/views/dashboards/following_users.html.erb
@@ -14,7 +14,7 @@
         <div id="follows-<%= follow.id %>" class="single-article">
           <a href="<%= user.path %>" class="block-link">
             <h2>
-              <img alt="<%= user.username %> profile image" src="<%= ProfileImage.new(user).get(60) %>" />
+              <img alt="<%= user.username %> profile image" src="<%= ProfileImage.new(user).get(width: 60) %>" />
               <%= user.name %>
               <span class="dashboard-username">@<%= user.username %></span>
             </h2>

--- a/app/views/internal/comments/index.html.erb
+++ b/app/views/internal/comments/index.html.erb
@@ -19,7 +19,7 @@
           <h5 class="card-title text-center">
             <% if comment.user %>
               <a href="<%= comment.user.path %>" target="_blank">
-                <img class="rounded" height="30" src="<%= ProfileImage.new(comment.user).get(50) %>" alt="<%= comment.user.username %> profile" /> <%= comment.user.username %>
+                <img class="rounded" height="30" src="<%= ProfileImage.new(comment.user).get(width: 50) %>" alt="<%= comment.user.username %> profile" /> <%= comment.user.username %>
               </a>
             <% end %>
             <% if comment.user && comment.user.twitter_username.present? %>

--- a/app/views/moderations/index.html.erb
+++ b/app/views/moderations/index.html.erb
@@ -64,7 +64,7 @@
         </div>
         <div class="mod-index-actions-and-details">
           <button class="quick-mod-button cta" data-path="<%= article.path %>">Quick Mod</button>
-          <a href="/<%= article.cached_user.username %>"><img src="<%= ProfileImage.new(article.cached_user).get(90) %>" /><%= article.cached_user.name %></a>
+          <a href="/<%= article.cached_user.username %>"><img src="<%= ProfileImage.new(article.cached_user).get(width: 90) %>" /><%= article.cached_user.name %></a>
           ・ <%= article.readable_publish_date %>
           <% if article.nth_published_by_author > 0 && article.nth_published_by_author < 4 %>
             ・ 👋 <strong><%= article.nth_published_by_author.ordinalize %> post by this user</strong>

--- a/app/views/organizations/_liquid.html.erb
+++ b/app/views/organizations/_liquid.html.erb
@@ -8,7 +8,7 @@
   </style>
   <a href="<%= organization.path %>" class="ltag__user__link profile-image-link">
     <div class="ltag__user__pic">
-      <img src="<%= ProfileImage.new(organization).get(150) %>" alt="<%= organization.slug + " image" %>" />
+      <img src="<%= ProfileImage.new(organization).get(width: 150) %>" alt="<%= organization.slug + " image" %>" />
     </div>
   </a>
   <div class="ltag__user__content">

--- a/app/views/organizations/_sidebar_additional.html.erb
+++ b/app/views/organizations/_sidebar_additional.html.erb
@@ -18,7 +18,7 @@
             <% @organization.users.find_each do |user| %>
               <div class="widget-user-pic">
                 <a href="/<%= user.username %>">
-                  <img src="<%= ProfileImage.new(user).get(90) %>" alt="<%= user.username %> profile image">
+                  <img src="<%= ProfileImage.new(user).get(width: 90) %>" alt="<%= user.username %> profile image">
                 </a>
               </div>
             <% end %>

--- a/app/views/pages/shecoded.html.erb
+++ b/app/views/pages/shecoded.html.erb
@@ -257,7 +257,7 @@
       <div class="posts">
         <% @top_articles.each do |article| %>
           <a href="<%= article.path %>" class="single-post">
-            <img src="<%= ProfileImage.new(article.user).get(150) %>" alt="<%= article.user.name %> profile image">
+            <img src="<%= ProfileImage.new(article.user).get(width: 150) %>" alt="<%= article.user.name %> profile image">
             <h3>
               <%= article.title %>
             </h3>
@@ -271,7 +271,7 @@
         <% end %>
         <% @articles.each do |article| %>
           <a href="<%= article.path %>" class="single-post">
-            <img src="<%= ProfileImage.new(article.user).get(150) %>" alt="<%= article.user.name %> profile image">
+            <img src="<%= ProfileImage.new(article.user).get(width: 150) %>" alt="<%= article.user.name %> profile image">
             <h3>
               <%= article.title %>
             </h3>

--- a/app/views/partnerships/_form.html.erb
+++ b/app/views/partnerships/_form.html.erb
@@ -15,7 +15,7 @@
     <% if !org.enough_credits?(Sponsorship::CREDITS[level]) %>
       <div class="partner-credits-explainer">
         <h4>What next?</h4>
-        <h3><img src="<%= ProfileImage.new(org).get(90) %>" /> Purchase Credits for @<%= org.slug %></h3>
+        <h3><img src="<%= ProfileImage.new(org).get(width: 90) %>" /> Purchase Credits for @<%= org.slug %></h3>
         <% if org.credits.unspent.size > 0 %>
           <div style="font-size: 0.88em;">
             <em>This organization account has <%= org.credits.unspent.size %> credits available</em>
@@ -35,7 +35,7 @@
     <% else %>
       <div class="partner-credits-explainer">
         <% if Sponsorship::LEVELS_WITH_EXPIRATION.include?(level) %>
-          <h3><img src="<%= ProfileImage.new(org).get(90) %>" />@<%= org.slug %></h3>
+          <h3><img src="<%= ProfileImage.new(org).get(width: 90) %>" />@<%= org.slug %></h3>
           <div style="font-size: 0.88em;"><em>This organization account has <%= org.credits.unspent.size %> credits available</em></div>
           <% sponsorships = org.sponsorships.where(level: Sponsorship::LEVELS_WITH_EXPIRATION) %>
           <% level_sponsorship = sponsorships.where(level: level).take %>
@@ -69,7 +69,7 @@
             <% end %>
           <% end %>
         <% elsif level == "tag" %>
-          <h3><img src="<%= ProfileImage.new(org).get(90) %>" />@<%= org.slug %></h3>
+          <h3><img src="<%= ProfileImage.new(org).get(width: 90) %>" />@<%= org.slug %></h3>
           <div style="font-size: 0.88em;"><em>This organization account has <%= org.credits.unspent.size %> credits available</em></div>
           <br />
           <%= form_tag "/partnerships" do %>
@@ -97,7 +97,7 @@
           <% end %>
         <%# NOTE: this currently can't be reached %>
         <% elsif level == "media" %>
-          <h3><img src="<%= ProfileImage.new(org).get(90) %>" />@<%= org.slug %></h3>
+          <h3><img src="<%= ProfileImage.new(org).get(width: 90) %>" />@<%= org.slug %></h3>
           <div style="font-size: 0.88em;"><em>This organization account has <%= org.credits.unspent.size %> credits available</em></div>
           <br />
           <%= form_tag "/partnerships" do %>
@@ -113,7 +113,7 @@
           <% end %>
         <%# NOTE: this currently can't be reached %>
         <% elsif level == "devrel" %>
-          <h3><img src="<%= ProfileImage.new(org).get(90) %>" />@<%= org.slug %></h3>
+          <h3><img src="<%= ProfileImage.new(org).get(width: 90) %>" />@<%= org.slug %></h3>
           <div style="font-size: 0.88em;"><em>This organization account has <%= org.credits.unspent.size %> credits available</em></div>
           <br />
           <%= form_tag "/partnerships" do %>

--- a/app/views/social_previews/article.html.erb
+++ b/app/views/social_previews/article.html.erb
@@ -127,7 +127,7 @@
       <h1 style="font-size:<%= font_size %>vw;"><%= @article.title %></h1>
     </div>
     <div class="preview-user">
-      <img src="<%= ProfileImage.new(@article.user).get(90) %>" />
+      <img src="<%= ProfileImage.new(@article.user).get(width: 90) %>" />
       <%= truncate @article.user.name, length: 28 %>・<%= @article.readable_publish_date %>
     </div>
     <div class="badge-images">

--- a/app/views/social_previews/comment.html.erb
+++ b/app/views/social_previews/comment.html.erb
@@ -120,7 +120,7 @@
       <h1 style="font-size:<%= font_size %>vw;"><%= @comment.title %></h1>
     </div>
     <div class="preview-user">
-      <img src="<%= ProfileImage.new(@comment.user).get(90) %>" />
+      <img src="<%= ProfileImage.new(@comment.user).get(width: 90) %>" />
       <%= truncate @comment.user.name, length: 28 %>・<%= @comment.readable_publish_date %>
     </div>
     <div class="badge-images">

--- a/app/views/social_previews/shecoded.html.erb
+++ b/app/views/social_previews/shecoded.html.erb
@@ -39,7 +39,7 @@
 
 <div class="preview-div-wrapper">
   <div class="avatar">
-    <img src="<%= ProfileImage.new(@article.user).get(320) %>" alt="<%= @article.user.name %> profile image">
+    <img src="<%= ProfileImage.new(@article.user).get(width: 320) %>" alt="<%= @article.user.name %> profile image">
   </div>
   <div class="title">
     <strong><%= @article.title %></strong>

--- a/app/views/social_previews/user.html.erb
+++ b/app/views/social_previews/user.html.erb
@@ -110,7 +110,7 @@
           <% font_size = 4.6 %>
         <% end %>
       <h1 style="font-size:<%= font_size %>vw;">
-        <img src="<%= ProfileImage.new(@user).get(640) %>" alt="<%= @user.name %> profile image">
+        <img src="<%= ProfileImage.new(@user).get(width: 640) %>" alt="<%= @user.name %> profile image">
         <%= truncate @user.name, length: 32 %>
         <br />
         <span style="font-size: 0.4em;display: inline-block; margin-left: 5.4em; margin-top: -1.7em">@<%= @user.username %></span>

--- a/app/views/users/_liquid.html.erb
+++ b/app/views/users/_liquid.html.erb
@@ -8,7 +8,7 @@
   </style>
   <a href="<%= user.path %>" class="ltag__user__link profile-image-link">
     <div class="ltag__user__pic">
-      <img src="<%= ProfileImage.new(user).get(150) %>" alt="<%= user.username + " image" %>" />
+      <img src="<%= ProfileImage.new(user).get(width: 150) %>" alt="<%= user.username + " image" %>" />
     </div>
   </a>
   <div class="ltag__user__content">

--- a/app/views/users/_organizations_area.html.erb
+++ b/app/views/users/_organizations_area.html.erb
@@ -8,7 +8,7 @@
         <% @user.organizations.each do |organization| %>
           <div class="widget-user-pic">
             <a href="/<%= organization.slug %>">
-              <img src="<%= ProfileImage.new(organization).get(90) %>" alt="<%= organization.name %> profile image">
+              <img src="<%= ProfileImage.new(organization).get(width: 90) %>" alt="<%= organization.name %> profile image">
             </a>
           </div>
         <% end %>

--- a/app/views/users/_profile.html.erb
+++ b/app/views/users/_profile.html.erb
@@ -45,7 +45,7 @@
   <div class="field">
     <% if @user.profile_image_url.present? %>
       <span class="image-present">
-        <img alt="<%= @user.username %> profile image" src="<%= ProfileImage.new(@user).get(50) %>" />
+        <img alt="<%= @user.username %> profile image" src="<%= ProfileImage.new(@user).get(width: 50) %>" />
         <%= f.file_field :profile_image %>
       </span>
     <% end %>

--- a/app/views/users/_profile_header.html.erb
+++ b/app/views/users/_profile_header.html.erb
@@ -14,7 +14,7 @@
   <meta itemprop="url" content="https://dev.to/<%= @user.username %>">
   <div class="user-profile-header-container">
     <div class="profile-pic-wrapper">
-      <img class="profile-pic" src="<%= ProfileImage.new(@user).get(320) %>" itemprop="image" alt="<%= @user.username %> profile" style="border-color:<%= user_colors(@user)[:bg] %>;background:<%= user_colors(@user)[:bg] %>" />
+      <img class="profile-pic" src="<%= ProfileImage.new(@user).get(width: 320) %>" itemprop="image" alt="<%= @user.username %> profile" style="border-color:<%= user_colors(@user)[:bg] %>;background:<%= user_colors(@user)[:bg] %>" />
     </div>
     <div class="profile-details">
       <h1 style="color:<%= HexComparer.new([user_colors(@user)[:bg], user_colors(@user)[:text]]).brightness(0.78) %>">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -28,7 +28,7 @@
     <meta itemprop="url" content="https://dev.to/<%= @user.username %>">
     <div class="user-profile-header-container">
       <div class="profile-pic-wrapper">
-        <img class="profile-pic" src="<%= ProfileImage.new(@user).get(320) %>" itemprop="image" alt="<%= @user.username %> profile" style="border-color:<%= user_colors(@user)[:bg] %>;background:<%= user_colors(@user)[:bg] %>" />
+        <img class="profile-pic" src="<%= ProfileImage.new(@user).get(width: 320) %>" itemprop="image" alt="<%= @user.username %> profile" style="border-color:<%= user_colors(@user)[:bg] %>;background:<%= user_colors(@user)[:bg] %>" />
       </div>
       <div class="profile-details">
         <h1>

--- a/spec/liquid_tags/link_tag_spec.rb
+++ b/spec/liquid_tags/link_tag_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe LinkTag, type: :liquid_tag do
       <div class='ltag__link'>
         <a href='#{article.user.path}' class='ltag__link__link'>
           <div class='ltag__link__pic'>
-            <img src='#{ProfileImage.new(article.user).get(150)}' alt='#{article.user.username} image'/>
+            <img src='#{ProfileImage.new(article.user).get(width: 150)}' alt='#{article.user.username} image'/>
           </div>
         </a>
         <a href='#{article.path}' class='ltag__link__link'>

--- a/spec/requests/api/v0/chat_channels_spec.rb
+++ b/spec/requests/api/v0/chat_channels_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe "Api::V0::ChatChannels", type: :request do
         expected_last_opened_at = Time.zone.parse(response_channel_users[user.username]["last_opened_at"]).to_i
         response_user = response_channel_users[user.username]
 
-        expect(response_user["profile_image"]).to eq(ProfileImage.new(user).get(90))
+        expect(response_user["profile_image"]).to eq(ProfileImage.new(user).get(width: 90))
         expect(response_user["darker_color"]).to eq(user.decorate.darker_color)
         expect(response_user["name"]).to eq(user.name)
         expect(expected_last_opened_at).to eq(membership.last_opened_at.to_i)

--- a/spec/requests/api/v0/followers_spec.rb
+++ b/spec/requests/api/v0/followers_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "Api::V0::FollowersController", type: :request do
         expect(response_follower["name"]).to eq(follower.name)
         expect(response_follower["path"]).to eq(follower.path)
         expect(response_follower["username"]).to eq(follower.username)
-        expect(response_follower["profile_image"]).to eq(ProfileImage.new(follower).get(60))
+        expect(response_follower["profile_image"]).to eq(ProfileImage.new(follower).get(width: 60))
       end
     end
   end
@@ -73,7 +73,7 @@ RSpec.describe "Api::V0::FollowersController", type: :request do
         expect(response_follower["name"]).to eq(follower.name)
         expect(response_follower["path"]).to eq(follower.path)
         expect(response_follower["username"]).to eq(follower.username)
-        expect(response_follower["profile_image"]).to eq(ProfileImage.new(follower).get(60))
+        expect(response_follower["profile_image"]).to eq(ProfileImage.new(follower).get(width: 60))
       end
     end
   end

--- a/spec/requests/api/v0/followings_spec.rb
+++ b/spec/requests/api/v0/followings_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "Api::V0::FollowingsController", type: :request do
         expect(response_following["name"]).to eq(followed.name)
         expect(response_following["path"]).to eq(followed.path)
         expect(response_following["username"]).to eq(followed.username)
-        expect(response_following["profile_image"]).to eq(ProfileImage.new(followed).get(60))
+        expect(response_following["profile_image"]).to eq(ProfileImage.new(followed).get(width: 60))
       end
     end
   end
@@ -111,7 +111,7 @@ RSpec.describe "Api::V0::FollowingsController", type: :request do
         expect(response_following["name"]).to eq(followed.name)
         expect(response_following["path"]).to eq(followed.path)
         expect(response_following["username"]).to eq(followed.username)
-        expect(response_following["profile_image"]).to eq(ProfileImage.new(followed).get(60))
+        expect(response_following["profile_image"]).to eq(ProfileImage.new(followed).get(width: 60))
       end
     end
   end
@@ -148,7 +148,7 @@ RSpec.describe "Api::V0::FollowingsController", type: :request do
         expect(response_following["name"]).to eq(followed.name)
         expect(response_following["path"]).to eq("/#{followed.path}")
         expect(response_following["username"]).to eq(followed.name)
-        expect(response_following["profile_image"]).to eq(ProfileImage.new(followed).get(60))
+        expect(response_following["profile_image"]).to eq(ProfileImage.new(followed).get(width: 60))
       end
     end
   end

--- a/spec/requests/api/v0/users_spec.rb
+++ b/spec/requests/api/v0/users_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Api::V0::Users", type: :request do
       expect(response_user["name"]).to eq(user.name)
       expect(response_user["username"]).to eq(user.username)
       expect(response_user["summary"]).to eq(user.summary)
-      expect(response_user["profile_image_url"]).to eq(ProfileImage.new(user).get(90))
+      expect(response_user["profile_image_url"]).to eq(ProfileImage.new(user).get(width: 90))
       expect(response_user["following"]).to be(false)
     end
 
@@ -84,7 +84,7 @@ RSpec.describe "Api::V0::Users", type: :request do
       end
 
       expect(response_user["joined_at"]).to eq(user.created_at.strftime("%b %e, %Y"))
-      expect(response_user["profile_image"]).to eq(ProfileImage.new(user).get(320))
+      expect(response_user["profile_image"]).to eq(ProfileImage.new(user).get(width: 320))
     end
   end
 
@@ -112,7 +112,7 @@ RSpec.describe "Api::V0::Users", type: :request do
         end
 
         expect(response_user["joined_at"]).to eq(user.created_at.strftime("%b %e, %Y"))
-        expect(response_user["profile_image"]).to eq(ProfileImage.new(user).get(320))
+        expect(response_user["profile_image"]).to eq(ProfileImage.new(user).get(width: 320))
       end
     end
   end

--- a/spec/requests/api/v0/webhooks_spec.rb
+++ b/spec/requests/api/v0/webhooks_spec.rb
@@ -94,8 +94,8 @@ RSpec.describe "Api::V0::Webhooks", type: :request do
       expect(response_webhook_user["twitter_username"]).to eq(webhook.user.twitter_username)
       expect(response_webhook_user["github_username"]).to eq(webhook.user.github_username)
       expect(response_webhook_user["website_url"]).to eq(webhook.user.processed_website_url)
-      expect(response_webhook_user["profile_image"]).to eq(user_profile_image.get(640))
-      expect(response_webhook_user["profile_image_90"]).to eq(user_profile_image.get(90))
+      expect(response_webhook_user["profile_image"]).to eq(user_profile_image.get(width: 640))
+      expect(response_webhook_user["profile_image_90"]).to eq(user_profile_image.get(width: 90))
     end
   end
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
As suggested by @citizen428, here's the minor refactor to go from `ProfileImage.new.get(150)` to `ProfileImage.new.get(width: 150)`. This makes the `get` method more explicit on what it actually does and also allows later, if needed, to easily add more optional arguments like `height`.

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/pull/5583#discussion_r369931445

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
