### PR TITLE
Return NotFound error if ChatChannelMembership is not found

### DIFF
--- a/app/controllers/chat_channel_memberships_controller.rb
+++ b/app/controllers/chat_channel_memberships_controller.rb
@@ -2,7 +2,7 @@ class ChatChannelMembershipsController < ApplicationController
   after_action :verify_authorized
 
   def find_by_chat_channel_id
-    @membership = ChatChannelMembership.where(chat_channel_id: params[:chat_channel_id], user_id: current_user.id).first
+    @membership = ChatChannelMembership.where(chat_channel_id: params[:chat_channel_id], user_id: current_user.id).first!
     authorize @membership
     render json: @membership.to_json(
       only: %i[id status viewable_by chat_channel_id last_opened_at],

--- a/spec/requests/chat_channel_memberships_spec.rb
+++ b/spec/requests/chat_channel_memberships_spec.rb
@@ -88,4 +88,12 @@ RSpec.describe "ChatChannelMemberships", type: :request do
       expect(ChatChannelMembership.find(membership.id).status).to eq("left_channel")
     end
   end
+
+  describe "GET /chat_channel_memberships/find_by_chat_channel_id" do
+    it "renders not_found" do
+      expect do
+        get "/chat_channel_memberships/find_by_chat_channel_id", params: {}
+      end.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Returns `ActiveRecord::RecordNotFound` instead of `Pundit::NotDefinedError` when chat channel membership is not found.

## Related Tickets & Documents
Fixes https://github.com/thepracticaldev/dev.to/issues/5790

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
