### PR TITLE
Style: update height of speakerdeck tag to be avoid scaling

### DIFF
--- a/app/views/liquids/_speakerdeck.html.erb
+++ b/app/views/liquids/_speakerdeck.html.erb
@@ -13,7 +13,7 @@
     src="//speakerdeck.com/player/<%= id %>"
     style="border:0; padding:0; margin:0; background:transparent;position: absolute;
             width: 100%;
-            height: 100%;
+            height: calc(100% - 63px);
             left: 0; top: 0;"
     webkitallowfullscreen="true"
     width="710"

--- a/app/views/liquids/_speakerdeck.html.erb
+++ b/app/views/liquids/_speakerdeck.html.erb
@@ -2,8 +2,7 @@
   style="position: relative;
     width: 100%;
     height: 0;
-    padding-bottom: calc(57% + 58px);
-    margin-bottom:1em auto 1.3em; ">
+    padding-bottom: 56.25%;">
   <iframe allowfullscreen="true"
     allowtransparency="true"
     frameborder="0"
@@ -13,7 +12,7 @@
     src="//speakerdeck.com/player/<%= id %>"
     style="border:0; padding:0; margin:0; background:transparent;position: absolute;
             width: 100%;
-            height: calc(100% - 63px);
+            height: 100%;
             left: 0; top: 0;"
     webkitallowfullscreen="true"
     width="710"

--- a/app/views/liquids/_speakerdeck.html.erb
+++ b/app/views/liquids/_speakerdeck.html.erb
@@ -1,3 +1,4 @@
+<%# Padding bottom set for 16:9 aspect ratio https://benmarshall.me/responsive-iframes/ %>
 <div class="ltag_speakerdeck"
   style="position: relative;
     width: 100%;


### PR DESCRIPTION
Fix #5682 

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The speaker deck tag rendered cuts off horizontal edges due to setting 100% height. I had to remove 63px in order to render slide completely and seems to be fine in all screen sizes, including mobile

Didn't find any tests for this part to update, let me know if I missed it

## Related Tickets & Documents

#5682

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![image](https://user-images.githubusercontent.com/1107223/73474909-8d67dd00-438f-11ea-929f-fbd53377482d.png)

![image](https://user-images.githubusercontent.com/1107223/73474875-7aeda380-438f-11ea-830e-18bf3689f497.png)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
