### PR TITLE
Handle Reactions Without Users When Sending Notifications

### DIFF
--- a/app/services/notifications/reactions/send.rb
+++ b/app/services/notifications/reactions/send.rb
@@ -24,8 +24,8 @@ module Notifications
 
         reaction_siblings = Reaction.where(reactable_id: reaction.reactable_id, reactable_type: reaction.reactable_type).
           where.not(reactions: { user_id: reaction.reactable_user_id }).
-          includes(:reactable, :user).
-          order("created_at DESC")
+          preload(:reactable).includes(:user).where.not(users: { id: nil }).
+          order("reactions.created_at DESC")
 
         aggregated_reaction_siblings = reaction_siblings.map { |reaction| { category: reaction.category, created_at: reaction.created_at, user: user_data(reaction.user) } }
 

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -292,6 +292,18 @@ RSpec.describe Notification, type: :model do
           end
         end.to change(article.user.notifications, :count).by(1)
       end
+
+      it "does not send a notification to the author of an article if the reaction owner is deleted" do
+        user4 = create(:user)
+        reaction = create(:reaction, reactable: article, user: user4)
+        user4.delete
+
+        expect do
+          sidekiq_perform_enqueued_jobs do
+            described_class.send_reaction_notification(reaction, reaction.reactable.user)
+          end
+        end.not_to change(article.user.notifications, :count)
+      end
     end
 
     context "when a reaction is destroyed" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
I tried to fix #5508 by checking the reaction owners' existence in the database when creating `reaction_siblings`. The problem is that the query becomes slower compared to the original code.
If this solution is not acceptable, could you please give me some guidance to improve it?

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [ ] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
