### PR TITLE
Remove Foreman gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -110,7 +110,6 @@ group :development do
   gem "derailed_benchmarks", "~> 1.6", require: false # A series of things you can use to benchmark a Rails or Ruby app
   gem "erb_lint", "~> 0.0", require: false # ERB Linter tool
   gem "fix-db-schema-conflicts", "~> 3.0" # Ensures consistent output of db/schema.rb despite local differences in the database
-  gem "foreman", "~> 0.87.0", require: false # Process manager for applications with multiple components
   gem "guard", "~> 2.16", require: false # Guard is a command line tool to easily handle events on file system modifications
   gem "guard-livereload", "~> 2.5", require: false # Guard::LiveReload automatically reloads your browser when 'view' files are modified
   gem "guard-rspec", "~> 4.7", require: false # Guard::RSpec automatically run your specs

--- a/Gemfile
+++ b/Gemfile
@@ -110,8 +110,7 @@ group :development do
   gem "derailed_benchmarks", "~> 1.6", require: false # A series of things you can use to benchmark a Rails or Ruby app
   gem "erb_lint", "~> 0.0", require: false # ERB Linter tool
   gem "fix-db-schema-conflicts", "~> 3.0" # Ensures consistent output of db/schema.rb despite local differences in the database
-  # switch foreman to stable release when thor dependency is updated to 0.20+
-  gem "foreman", github: "thepracticaldev/foreman", ref: "b64e401", require: false # Process manager for applications with multiple components
+  gem "foreman", "~> 0.87.0", require: false # Process manager for applications with multiple components
   gem "guard", "~> 2.16", require: false # Guard is a command line tool to easily handle events on file system modifications
   gem "guard-livereload", "~> 2.5", require: false # Guard::LiveReload automatically reloads your browser when 'view' files are modified
   gem "guard-rspec", "~> 4.7", require: false # Guard::RSpec automatically run your specs

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,14 +6,6 @@ GIT
     acts_as_follower (0.2.1)
       activerecord (>= 4.0)
 
-GIT
-  remote: https://github.com/thepracticaldev/foreman.git
-  revision: b64e4019a8ed3cfae7216c3219dc91833845d9c7
-  ref: b64e401
-  specs:
-    foreman (0.85.0)
-      thor (>= 0.19, < 0.21)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -348,6 +340,7 @@ GEM
     fog-xml (0.1.3)
       fog-core
       nokogiri (>= 1.5.11, < 2.0.0)
+    foreman (0.87.0)
     formatador (0.2.5)
     front_matter_parser (0.2.1)
     gemoji (3.0.1)
@@ -914,7 +907,7 @@ DEPENDENCIES
   figaro (~> 1.1)
   fix-db-schema-conflicts (~> 3.0)
   fog-aws (~> 3.5)
-  foreman!
+  foreman (~> 0.87.0)
   front_matter_parser (~> 0.2)
   gemoji (~> 3.0.1)
   gibbon (~> 3.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -340,7 +340,6 @@ GEM
     fog-xml (0.1.3)
       fog-core
       nokogiri (>= 1.5.11, < 2.0.0)
-    foreman (0.87.0)
     formatador (0.2.5)
     front_matter_parser (0.2.1)
     gemoji (3.0.1)
@@ -907,7 +906,6 @@ DEPENDENCIES
   figaro (~> 1.1)
   fix-db-schema-conflicts (~> 3.0)
   fog-aws (~> 3.5)
-  foreman (~> 0.87.0)
   front_matter_parser (~> 0.2)
   gemoji (~> 3.0.1)
   gibbon (~> 3.3)

--- a/docs/getting-started/start-app.md
+++ b/docs/getting-started/start-app.md
@@ -14,7 +14,8 @@ running:
 bin/startup
 ```
 
-(This just runs `foreman start -f Procfile.dev`)
+(This just runs `foreman start -f Procfile.dev`, for notes on how to install
+Foreman, please see [Other Tools](../installation/others.md))
 
 Then point your browser to http://localhost:3000/ to view the site.
 

--- a/docs/installation/others.md
+++ b/docs/installation/others.md
@@ -1,0 +1,23 @@
+---
+title: Other Tools
+---
+
+# Miscellaneous
+
+## Foreman
+
+We use [Foreman](https://github.com/ddollar/foreman) to manage our application
+through `Procfile` and `Procfile.dev`. As the
+[documentation](https://github.com/ddollar/foreman/blob/master/README.md) points
+out,
+
+> Ruby users should take care _not_ to install foreman in their project's
+> `Gemfile`. See this
+> [wiki article](https://github.com/ddollar/foreman/wiki/Don't-Bundle-Foreman)
+> for more details.
+
+Instead install Foreman globally with the following command:
+
+```sh
+$ gem install foreman
+```

--- a/docs/installation/readme.md
+++ b/docs/installation/readme.md
@@ -6,6 +6,7 @@ items:
   - docker.md
   - gitpod.md
   - postgresql.md
+  - others.md
 ---
 
 # Installation Guide


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Update

## Description

This removes the Foreman gem, as per the author's recommendation:

> Ruby users should take care *not* to install foreman in their project's `Gemfile`. See this [wiki article](https://github.com/ddollar/foreman/wiki/Don't-Bundle-Foreman) for more details.

## Related Tickets & Documents

n/a

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [X] docs.dev.to
- [ ] readme
- [ ] no documentation needed
