### PR TITLE
Update contributor guide with new tag name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,13 +31,13 @@ you may anonymously contact the team with our
 ### Where to contribute
 
 All [issues](https://github.com/thepracticaldev/dev.to/issues) labeled with
-`help wanted` are up for grabs.
+`ready for dev` are up for grabs.
 
 - `good first issue` are issues meant for newer developers.
 - `type: discussion` are issues we haven't decided to move forward with, or need
   more information before proceeding.
 
-While PRs without an associated `help wanted` issue may still be merged, please
+While PRs without an associated `ready for dev` issue may still be merged, please
 note that the core team will prioritize PRs that solve existing issues. We
 strongly encourage creating an issue before working on a PR!
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Documentation Update

## Description

After a recent #team-oss discussion involving @jessleenyc, we decided to rename `help wanted` to `ready for dev`. 

Rationale:  “help wanted” can be a bit ambiguous, whereas “ready for dev” clearly communicates that something can be worked on. It'a also a sort of pun, as in "ready for DEV".

NOTE: after merging this PR we need to actually rename the tag. I was holding off on that for now since I didn't want documentation and issue tracker to be out of sync.

## Related Tickets & Documents

n/a

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [X] `CONTRIBUTING.md`
