### PR TITLE
Move edit and delete buttons on chat messages to dropdown menu

### DIFF
--- a/app/assets/stylesheets/chat.scss
+++ b/app/assets/stylesheets/chat.scss
@@ -1120,20 +1120,48 @@
 
 .message__info__actions {
   display: grid;
-  grid-template-columns: 4fr 1fr;
+  grid-template-columns: 19fr 1fr;
 }
 
 .message__actions {
   display: none;
   justify-content: end;
   -webkit-justify-content: flex-end;
-}
 
-.message__actions span {
-  margin-left: 7px;
-  font-size: 13px;
-  font-weight: bold;
-  cursor: pointer;
+  .ellipsis__menubutton {
+    height: 17px;
+    cursor: pointer;
+  }
+
+  &:hover {
+    .messagebody__dropdownmenu {
+      display: block;
+    }
+  }
+
+  img {
+    height: 100%;
+  }
+
+  .messagebody__dropdownmenu {
+    display: none;
+    position: absolute;
+    background-color: white;
+    border-style: solid;
+    border-color: #ccc;
+    border-radius: 5px;
+    border-width: 1px;
+    margin-top: 1em;
+    margin-right: -0.6em;
+
+    span {
+      display: block;
+      padding: 10px;
+      font-size: 15px;
+      font-weight: bold;
+      cursor: pointer;
+    }
+  }
 }
 
 .chatmessage:hover .message__actions {

--- a/app/assets/stylesheets/chat.scss
+++ b/app/assets/stylesheets/chat.scss
@@ -1131,6 +1131,7 @@
   .ellipsis__menubutton {
     height: 17px;
     cursor: pointer;
+    color: var(--theme-color, #0a0a0a);
   }
 
   &:hover {
@@ -1141,14 +1142,15 @@
 
   img {
     height: 100%;
+    opacity: 0.6;
   }
 
   .messagebody__dropdownmenu {
     display: none;
     position: absolute;
-    background-color: white;
+    background-color: var(--theme-container-background, #fff);
     border-style: solid;
-    border-color: #ccc;
+    border-color: var(--theme-color, #0a0a0a);
     border-radius: 5px;
     border-width: 1px;
     margin-top: 1em;
@@ -1160,6 +1162,7 @@
       font-size: 15px;
       font-weight: bold;
       cursor: pointer;
+      color: var(--theme-color, #0a0a0a);
     }
   }
 }

--- a/app/assets/stylesheets/chat.scss
+++ b/app/assets/stylesheets/chat.scss
@@ -1125,6 +1125,7 @@
 
 .message__actions {
   display: none;
+  position: relative;
   justify-content: end;
   -webkit-justify-content: flex-end;
 

--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -48,9 +48,10 @@ body {
 }
 
 @media print {
-   .top-bar, .article-actions {
-      display: none;
-   }
+  .top-bar,
+  .article-actions {
+    display: none;
+  }
 }
 
 .config_minimize_newest_listings {
@@ -190,7 +191,8 @@ input[type='email'] {
   display: none !important;
 }
 
-body.night-theme, body.ten-x-hacker-theme {
+body.night-theme,
+body.ten-x-hacker-theme {
   .on-page-nav-butt img,
   .icon-img,
   .dropdown-icon,
@@ -199,6 +201,7 @@ body.night-theme, body.ten-x-hacker-theme {
   .icon-image,
   .dev-badge,
   .chatchannels__config img,
+  .message__actions img,
   .external-link-img,
   .group-img {
     -webkit-filter: invert(95%);
@@ -252,17 +255,25 @@ body.open-dyslexic-article-body {
     font-family: OpenDyslexic, sans-serif;
     font-size: 0.9em;
   }
-  .body b, .body strong {
+  .body b,
+  .body strong {
     font-family: OpenDyslexic-Bold, sans-serif;
   }
-  
-  .body i, .body em {
+
+  .body i,
+  .body em {
     font-family: OpenDyslexic-Italic, sans-serif;
   }
-  
-  .body b>i, .body b>em, .body strong>i, .body strong>em,
-  .body i>b, .body em>b, .body i>strong, .body em>strong {
-    font-family: OpenDyslexic-Bolditalic
+
+  .body b > i,
+  .body b > em,
+  .body strong > i,
+  .body strong > em,
+  .body i > b,
+  .body em > b,
+  .body i > strong,
+  .body em > strong {
+    font-family: OpenDyslexic-Bolditalic;
   }
 }
 
@@ -295,7 +306,8 @@ body.trusted-status-true .trusted-visible-block {
 }
 
 body.hidden-shell {
-  .top-bar, footer {
+  .top-bar,
+  footer {
     display: none;
   }
   .container {
@@ -360,6 +372,10 @@ body.hidden-shell {
 }
 
 @keyframes loading-fadein {
-  from { opacity: 0; }
-  to   { opacity: 0.6; }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 0.6;
+  }
 }

--- a/app/javascript/chat/__tests__/__snapshots__/message.test.jsx.snap
+++ b/app/javascript/chat/__tests__/__snapshots__/message.test.jsx.snap
@@ -56,19 +56,31 @@ exports[`<Message /> should render and test snapshot 1`] = `
         class="message__actions"
       >
         <span
-          onKeyUp={[Function]}
-          role="button"
-          tabIndex="0"
+          class="ellipsis__menubutton"
         >
-          Delete
+          <img
+            alt="dropdown menu icon"
+            src=""
+          />
         </span>
-        <span
-          onKeyUp={[Function]}
-          role="button"
-          tabIndex="0"
+        <div
+          class="messagebody__dropdownmenu"
         >
-          Edit
-        </span>
+          <span
+            onKeyUp={[Function]}
+            role="button"
+            tabIndex="0"
+          >
+            Edit
+          </span>
+          <span
+            onKeyUp={[Function]}
+            role="button"
+            tabIndex="0"
+          >
+            Delete
+          </span>
+        </div>
       </div>
     </div>
     <div

--- a/app/javascript/chat/chat.jsx
+++ b/app/javascript/chat/chat.jsx
@@ -539,6 +539,7 @@ export default class Chat extends Component {
     const targetValue = e.target.value;
     const messageIsEmpty = targetValue.length === 0;
     const shiftPressed = e.shiftKey;
+    const upArrowPressed = e.keyCode === 38;
 
     if (enterPressed) {
       if (showMemberlist) {
@@ -557,6 +558,19 @@ export default class Chat extends Component {
       if (e.keyCode === 40 || e.keyCode === 38) {
         e.preventDefault();
       }
+    }
+    if (upArrowPressed && messageIsEmpty) {
+      e.preventDefault();
+      const { messages, activeChannelId, currentUserId } = this.state;
+
+      const messagesByCurrentUser = messages[activeChannelId].filter(
+        message => message.user_id === currentUserId,
+      );
+      const lastMessage =
+        messagesByCurrentUser[messagesByCurrentUser.length - 1];
+
+      this.setState({ messageDeleteId: lastMessage.id });
+      this.setState({ showDeleteModal: true });
     }
   };
 

--- a/app/javascript/chat/message.jsx
+++ b/app/javascript/chat/message.jsx
@@ -1,5 +1,7 @@
 import { h } from 'preact';
 import PropTypes from 'prop-types';
+// eslint-disable-next-line import/no-unresolved
+import ThreeDotsIcon from 'images/three-dots.svg';
 import { adjustTimestamp } from './util';
 import ErrorMessage from './messages/errorMessage';
 
@@ -32,6 +34,40 @@ const Message = ({
     />
   );
 
+  const ENTER_KEY_CODE = 13;
+  const dropdown = (
+    <div className="message__actions">
+      <span className="ellipsis__menubutton">
+        <img src={ThreeDotsIcon} alt="dropdown menu icon" />
+      </span>
+
+      <div className="messagebody__dropdownmenu">
+        <span
+          role="button"
+          data-content={id}
+          onClick={onEditMessageTrigger}
+          tabIndex="0"
+          onKeyUp={e => {
+            if (e.keyCode === ENTER_KEY_CODE) onEditMessageTrigger();
+          }}
+        >
+          Edit
+        </span>
+        <span
+          role="button"
+          data-content={id}
+          onClick={onDeleteMessageTrigger}
+          tabIndex="0"
+          onKeyUp={e => {
+            if (e.keyCode === ENTER_KEY_CODE) onDeleteMessageTrigger();
+          }}
+        >
+          Delete
+        </span>
+      </div>
+    </div>
+  );
+
   return (
     <div className="chatmessage">
       <div className="chatmessage__profilepic">
@@ -39,7 +75,7 @@ const Message = ({
           href={`/${user}`}
           target="_blank"
           rel="noopener noreferrer"
-          data-content='sidecar-user'
+          data-content="sidecar-user"
           onClick={onContentTrigger}
         >
           <img
@@ -47,7 +83,7 @@ const Message = ({
             className="chatmessagebody__profileimage"
             src={profileImageUrl}
             alt={`${user} profile`}
-            data-content='sidecar-user'
+            data-content="sidecar-user"
             onClick={onContentTrigger}
           />
         </a>
@@ -59,13 +95,16 @@ const Message = ({
       >
         <div className="message__info__actions">
           <div className="message__info">
-            <span className="chatmessagebody__username not-dark-theme-text-compatible" style={spanStyle}>
+            <span
+              className="chatmessagebody__username not-dark-theme-text-compatible"
+              style={spanStyle}
+            >
               <a
                 className="chatmessagebody__username--link"
                 href={`/${user}`}
                 target="_blank"
                 rel="noopener noreferrer"
-                data-content='sidecar-user'
+                data-content="sidecar-user"
                 onClick={onContentTrigger}
               >
                 {user}
@@ -88,34 +127,7 @@ const Message = ({
               ' '
             )}
           </div>
-          {userID === currentUserId ? (
-            <div className="message__actions">
-              <span
-                role="button"
-                data-content={id}
-                onClick={onDeleteMessageTrigger}
-                tabIndex="0"
-                onKeyUp={e => {
-                  if (e.keyCode === 13) onDeleteMessageTrigger();
-                }}
-              >
-                Delete
-              </span>
-              <span
-                role="button"
-                data-content={id}
-                onClick={onEditMessageTrigger}
-                tabIndex="0"
-                onKeyUp={e => {
-                  if (e.keyCode === 13) onEditMessageTrigger();
-                }}
-              >
-                Edit
-              </span>
-            </div>
-          ) : (
-            ' '
-          )}
+          {userID === currentUserId ? dropdown : ' '}
         </div>
         <div className="chatmessage__bodytext">{messageArea}</div>
       </div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR moves the edit and delete buttons that are revealed when you hover on message into a dropdown menu. I also added the shortcut to delete the last message. I used the up arrow key for the shortcut.

## Related Tickets & Documents
Resolves #5222 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![edit and delete in dropdown](https://user-images.githubusercontent.com/24629960/73587964-6e04a900-4490-11ea-9751-7d6630777cc6.gif)


## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed