### PR TITLE
Upgrade gemoji to support disability emojis

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ gem "feedjira", "~> 3.1" # A feed fetching and parsing library
 gem "figaro", "~> 1.1" # Simple, Heroku-friendly Rails app configuration using ENV and a single YAML file
 gem "fog-aws", "~> 3.5" # 'fog' gem to support Amazon Web Services
 gem "front_matter_parser", "~> 0.2" # Parse a front matter from syntactically correct strings or files
-gem "gemoji", "~> 3.0.1" # Character information and metadata for standard and custom emoji
+gem "gemoji", "~> 4.0.0.rc2" # Character information and metadata for standard and custom emoji
 gem "gibbon", "~> 3.3" # API wrapper for MailChimp's API
 gem "google-api-client", "~> 0.36" # Client for accessing Google APIs
 gem "honeybadger", "~> 4.5" # Used for tracking application errors

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -350,7 +350,7 @@ GEM
       nokogiri (>= 1.5.11, < 2.0.0)
     formatador (0.2.5)
     front_matter_parser (0.2.1)
-    gemoji (3.0.1)
+    gemoji (4.0.0.rc2)
     get_process_mem (0.2.5)
       ffi (~> 1.0)
     gibbon (3.3.2)
@@ -916,7 +916,7 @@ DEPENDENCIES
   fog-aws (~> 3.5)
   foreman!
   front_matter_parser (~> 0.2)
-  gemoji (~> 3.0.1)
+  gemoji (~> 4.0.0.rc2)
   gibbon (~> 3.3)
   google-api-client (~> 0.36)
   guard (~> 2.16)

--- a/spec/labor/emoji_converter_spec.rb
+++ b/spec/labor/emoji_converter_spec.rb
@@ -1,5 +1,7 @@
 require "rails_helper"
 
+# rubocop:disable Rails/DynamicFindBy
+
 RSpec.describe EmojiConverter, type: :labor do
   def convert_emoji(html)
     EmojiConverter.call(html)
@@ -7,8 +9,21 @@ RSpec.describe EmojiConverter, type: :labor do
 
   describe "#convert" do
     it "converts emoji names wrapped in colons into unicode" do
-      joy_emoji_unicode = Emoji.find_by_alias("joy").raw # rubocop:disable Rails/DynamicFindBy
+      joy_emoji_unicode = Emoji.find_by_alias("joy").raw
       expect(convert_emoji(":joy:")).to include(joy_emoji_unicode)
+    end
+
+    it "converts disability emojis as well", :aggregate_failures do
+      disability_emojis = %w[
+        guide_dog service_dog person_with_probing_cane man_with_probing_cane woman_with_probing_cane probing_cane
+        person_in_motorized_wheelchair man_in_motorized_wheelchair woman_in_motorized_wheelchair
+        person_in_manual_wheelchair man_in_manual_wheelchair woman_in_manual_wheelchair manual_wheelchair
+        motorized_wheelchair wheelchair
+      ]
+      disability_emojis.each do |emoji|
+        unicode = Emoji.find_by_alias(emoji).raw
+        expect(convert_emoji(":#{emoji}:")).to include(unicode)
+      end
     end
 
     it "leaves original text between colons when no emoji is found" do
@@ -17,3 +32,5 @@ RSpec.describe EmojiConverter, type: :labor do
     end
   end
 end
+
+# rubocop:enable Rails/DynamicFindBy

--- a/spec/labor/markdown_parser_spec.rb
+++ b/spec/labor/markdown_parser_spec.rb
@@ -263,7 +263,7 @@ RSpec.describe MarkdownParser, type: :labor do
   context "when a colon emoji is used" do
     it "doesn't change text in codeblock" do
       result = generate_and_parse_markdown("<span>:o:<code>:o:</code>:o:<code>:o:</code>:o:<span>:o:</span>:o:</span>")
-      expect(result).to include("<span>⭕️<code>:o:</code>⭕️<code>:o:</code>⭕️<span>⭕️</span>⭕️</span>")
+      expect(result).to include("<span>⭕<code>:o:</code>⭕<code>:o:</code>⭕<span>⭕</span>⭕</span>")
     end
   end
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The version of [gemoji](https://github.com/github/gemoji) we currently use does not support the new disability emojis that were included in the latest Unicode standards.

The test I added if ran with gemoji 3 (the one use now) would fail like this:

```shell
1) EmojiConverter#convert converts disability emojis as well
   Failure/Error: unicode = Emoji.find_by_alias(emoji).raw

   NoMethodError:
     undefined method `raw' for nil:NilClass
```

Note: these new emojis won't render on macOS Mojave because the operating system itself won't render them, but they are supported at least in Windows 10 and in macOS Catalina, see discussion in https://github.com/thepracticaldev/dev.to/issues/5835

In the meantime we add server side support for those :)

## Related Tickets & Documents

Closes #5835

