### PR TITLE
Add missing sha512 to ES mac docs

### DIFF
--- a/docs/installation/mac.md
+++ b/docs/installation/mac.md
@@ -68,7 +68,7 @@ Make sure to download the OSS version, `elasticsearch-oss`.
 
 ```shell
 wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-7.5.2-darwin-x86_64.tar.gz
-wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-7.5.2-darwin-x86_64.tar.gz
+wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-7.5.2-darwin-x86_64.tar.gz.sha512
 shasum -a 512 -c elasticsearch-oss-7.5.2-darwin-x86_64.tar.gz.sha512
 tar -xzf elasticsearch-oss-7.5.2-darwin-x86_64.tar.gz
 cd elasticsearch-7.5.2/


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Documentation Update

## Description
Missed a `.sha512` in the mac ES docs

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-32124912

## Added to documentation?
- [x] readme

![alt_text](https://media0.giphy.com/media/q8PmC7ppZpwMU/source.gif)
