### PR TITLE
Replace the initial migration for strong_migrations gem

### DIFF
--- a/config/initializers/strong_migrations.rb
+++ b/config/initializers/strong_migrations.rb
@@ -1,6 +1,6 @@
 if Rails.env.test? || Rails.env.development?
   # https://github.com/ankane/strong_migrations#existing-migrations
-  StrongMigrations.start_after = 20_191_227_114_543
+  StrongMigrations.start_after = 20_200_106_074_859
 
   # https://github.com/ankane/strong_migrations#target-version
   StrongMigrations.target_postgresql_version = 11


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

After we merged #5373 we unfortunately broke the development environment because its migration is not compatible with the automatic checks that the gem `strong_migrations` does. I guess it was added to the code after that PR was submit

As that PR is already merged and shipped, we need to bump the minimum version that strong migrations considers

