### PR TITLE
Add signin=true as a param correctly if the URL already has params

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -40,9 +40,22 @@ class ApplicationController < ActionController::Base
   end
 
   def after_sign_in_path_for(resource)
-    return "/onboarding?referrer=#{request.env['omniauth.origin'] || 'none'}" unless current_user.saw_onboarding
+    if current_user.saw_onboarding
+      path = request.env["omniauth.origin"] || stored_location_for(resource) || dashboard_path
+      signin_param = { "signin" => "true" } # the "signin" param is used by the service worker
 
-    (request.env["omniauth.origin"] || stored_location_for(resource) || "/dashboard") + "?signin=true" # This signin=true param is used by frontend
+      uri = Addressable::URI.parse(path)
+      uri.query_values = if uri.query_values
+                           uri.query_values.merge(signin_param)
+                         else
+                           signin_param
+                         end
+
+      uri.to_s
+    else
+      referrer = request.env["omniauth.origin"] || "none"
+      onboarding_path(referrer: referrer)
+    end
   end
 
   def raise_banned


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

If the origin URL after signin contains parameters, we can't append `?signin=true` because URL params should be attached with `&`.

This fixes the broken generated URL in case the URL already has params
