### PR TITLE
Move Tags::BustCacheJob to Sidekiq

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -26,7 +26,7 @@ class Tag < ActsAsTaggableOn::Tag
   before_validation :evaluate_markdown
   before_validation :pound_it
   before_save :calculate_hotness_score
-  after_save :bust_cache
+  after_commit :bust_cache
   before_save :mark_as_updated
 
   algoliasearch per_environment: true do
@@ -83,7 +83,7 @@ class Tag < ActsAsTaggableOn::Tag
   end
 
   def bust_cache
-    Tags::BustCacheJob.perform_later(name)
+    Tags::BustCacheWorker.perform_async(name)
   end
 
   def validate_alias

--- a/app/workers/tags/bust_cache_worker.rb
+++ b/app/workers/tags/bust_cache_worker.rb
@@ -1,0 +1,14 @@
+module Tags
+  class BustCacheWorker
+    include Sidekiq::Worker
+
+    sidekiq_options queue: :high_priority, retry: 10
+
+    def perform(tag_name)
+      tag = Tag.find_by(name: tag_name)
+      return unless tag
+
+      CacheBuster.bust_tag(tag)
+    end
+  end
+end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -65,6 +65,8 @@ RSpec.describe Tag, type: :model do
   end
 
   it "triggers cache busting on save" do
-    expect { build(:tag).save }.to have_enqueued_job.on_queue("tags_bust_cache")
+    sidekiq_assert_enqueued_with(job: Tags::BustCacheWorker, args: [tag.name]) do
+      tag.save
+    end
   end
 end

--- a/spec/workers/tags/bust_cache_worker_spec.rb
+++ b/spec/workers/tags/bust_cache_worker_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe Tags::BustCacheWorker, type: :worker do
+  let(:worker) { subject }
+
+  before { allow(CacheBuster).to receive(:bust_tag) }
+
+  # Passing in random tag
+  include_examples "#enqueues_on_correct_queue", "high_priority", ["php"]
+
+  describe "#perform_now" do
+    it "busts cache" do
+      tag = create(:tag)
+
+      worker.perform(tag.name)
+
+      expect(CacheBuster).to have_received(:bust_tag).with(tag)
+    end
+
+    it "doesn't call the cache buster if the tag does not exist" do
+      tag_name = "definitelyatagthatdoesnotexist"
+
+      worker.perform(tag_name)
+
+      expect(CacheBuster).not_to have_received(:bust_tag)
+    end
+  end
+end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Optimization

## Description
This creates a new `Tags::BustCacheWorker` (spec included) and starts sending jobs to it. Once this is merged and deployed, I will open a second PR to remove the old job code and spec.

## Related Tickets & Documents
- #5305 

## Added to documentation?

- [x] no documentation needed

![move_over_gif](https://media.giphy.com/media/3ohs4vWKkJObP70lws/giphy.gif)