### PR TITLE
Render main image in article preview for v2 editor

### DIFF
--- a/app/javascript/article-form/elements/__tests__/__snapshots__/bodyPreview.test.jsx.snap
+++ b/app/javascript/article-form/elements/__tests__/__snapshots__/bodyPreview.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<bodyPreview /> v1: renders properly 1`] = `
+exports[`<bodyPreview version="v1" /> renders properly with an image 1`] = `
 <div
   class="container"
   style={
@@ -66,7 +66,65 @@ exports[`<bodyPreview /> v1: renders properly 1`] = `
 </div>
 `;
 
-exports[`<bodyPreview /> v2: renders properly 1`] = `
+exports[`<bodyPreview version="v1" /> renders properly without an image 1`] = `
+<div
+  class="container"
+  style={
+    Object {
+      "border": "0px",
+      "boxShadow": "0px 0px 0px #fff",
+      "marginTop": "10px",
+      "minHeight": "508px",
+      "overflow": "hidden",
+    }
+  }
+>
+  <div>
+    <div
+      class="title"
+      style={
+        Object {
+          "maxWidth": "1000px",
+          "width": "90%",
+        }
+      }
+    >
+      <h1>
+        My Awesome Post
+      </h1>
+      <h3>
+        <img
+          alt="profile"
+          class="profile-pic"
+          src="/uploads/user/profile_image/41/0841dbe2-208c-4daa-b498-b2f01f3d37b2.png"
+        />
+         
+        <span>
+          Guy Fieri
+        </span>
+      </h3>
+      <div
+        class="tags"
+      />
+    </div>
+  </div>
+  <div
+    class="body"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "<p>My Awesome Post! Not very long, but still very awesome.</p>↵↵",
+      }
+    }
+    style={
+      Object {
+        "width": "90%",
+      }
+    }
+  />
+</div>
+`;
+
+exports[`<bodyPreview version="v2" /> renders properly with an image 1`] = `
 <div
   class="container"
   style={
@@ -88,6 +146,64 @@ exports[`<bodyPreview /> v2: renders properly 1`] = `
         src="http://lorempixel.com/400/200/"
       />
     </div>
+    <div
+      class="title"
+      style={
+        Object {
+          "maxWidth": "1000px",
+          "width": "90%",
+        }
+      }
+    >
+      <h1>
+        My Awesome Post
+      </h1>
+      <h3>
+        <img
+          alt="profile"
+          class="profile-pic"
+          src="/uploads/user/profile_image/41/0841dbe2-208c-4daa-b498-b2f01f3d37b2.png"
+        />
+         
+        <span>
+          Guy Fieri
+        </span>
+      </h3>
+      <div
+        class="tags"
+      />
+    </div>
+  </div>
+  <div
+    class="body"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "<p>My Awesome Post! Not very long, but still very awesome.</p>↵↵",
+      }
+    }
+    style={
+      Object {
+        "width": "90%",
+      }
+    }
+  />
+</div>
+`;
+
+exports[`<bodyPreview version="v2" /> renders properly without an image 1`] = `
+<div
+  class="container"
+  style={
+    Object {
+      "border": "0px",
+      "boxShadow": "0px 0px 0px #fff",
+      "marginTop": "10px",
+      "minHeight": "508px",
+      "overflow": "hidden",
+    }
+  }
+>
+  <div>
     <div
       class="title"
       style={

--- a/app/javascript/article-form/elements/__tests__/bodyPreview.test.jsx
+++ b/app/javascript/article-form/elements/__tests__/bodyPreview.test.jsx
@@ -15,10 +15,11 @@ global.window.currentUser = {
     '/uploads/user/profile_image/41/0841dbe2-208c-4daa-b498-b2f01f3d37b2.png',
 };
 
-describe('<bodyPreview />', () => {
-  let previewResponse;
-  let articleState;
+let previewResponse;
+let articleState;
 
+describe('<bodyPreview version="v1" />', () => {
+  const version = 'v1';
   beforeEach(() => {
     previewResponse = {
       processed_html:
@@ -40,33 +41,22 @@ describe('<bodyPreview />', () => {
     };
   });
 
-  it('v1: renders properly', () => {
+  it('renders properly with an image', () => {
     const tree = render(
       <BodyPreview
         previewResponse={previewResponse}
-        version="v1"
+        version={version}
         articleState={articleState}
       />,
     );
     expect(tree).toMatchSnapshot();
   });
 
-  it('v2: renders properly', () => {
-    const tree = render(
-      <BodyPreview
-        previewResponse={previewResponse}
-        version="v2"
-        articleState={articleState}
-      />,
-    );
-    expect(tree).toMatchSnapshot();
-  });
-
-  it('v1: shows a cover image in preview if one exists', () => {
+  it('shows an image in preview if one exists', () => {
     const container = shallow(
       <BodyPreview
         previewResponse={previewResponse}
-        version="v1"
+        version={version}
         articleState={articleState}
       />,
     );
@@ -75,12 +65,24 @@ describe('<bodyPreview />', () => {
     );
   });
 
-  it('v1: does not show a cover image in preview if one does not exist', () => {
+  it('renders properly without an image', () => {
+    previewResponse.cover_image = null;
+    const tree = render(
+      <BodyPreview
+        previewResponse={previewResponse}
+        version={version}
+        articleState={articleState}
+      />,
+    );
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('does not show an image in preview if one does not exist', () => {
     previewResponse.cover_image = null;
     const container = shallow(
       <BodyPreview
         previewResponse={previewResponse}
-        version="v1"
+        version={version}
         articleState={articleState}
       />,
     );
@@ -88,12 +90,45 @@ describe('<bodyPreview />', () => {
       false,
     );
   });
+});
 
-  it('v2: shows a cover image in preview if one exists', () => {
+describe('<bodyPreview version="v2" />', () => {
+  const version = 'v2';
+  beforeEach(() => {
+    previewResponse = {
+      processed_html:
+        '<p>My Awesome Post! Not very long, but still very awesome.</p>↵↵',
+    };
+
+    articleState = {
+      id: 1,
+      title: 'My Awesome Post',
+      tagList: '',
+      bodyMarkdown:
+        '---↵title: My Awesome Post↵published: false↵description: ↵tags: ↵---↵↵My Awesome Post Not very long, but still very awesome! ↵',
+      mainImage: 'http://lorempixel.com/400/200/',
+      published: false,
+      previewShowing: true,
+      previewResponse,
+    };
+  });
+
+  it('renders properly with an image', () => {
+    const tree = render(
+      <BodyPreview
+        previewResponse={previewResponse}
+        version={version}
+        articleState={articleState}
+      />,
+    );
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('shows an image in preview if one exists', () => {
     const container = shallow(
       <BodyPreview
         previewResponse={previewResponse}
-        version="v2"
+        version={version}
         articleState={articleState}
       />,
     );
@@ -102,12 +137,24 @@ describe('<bodyPreview />', () => {
     );
   });
 
-  it('v2: does not show a cover image in preview if one does not exist', () => {
-    previewResponse.cover_image = null;
+  it('renders properly without an image', () => {
+    articleState.mainImage = null;
+    const tree = render(
+      <BodyPreview
+        previewResponse={previewResponse}
+        version={version}
+        articleState={articleState}
+      />,
+    );
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('does not show an image in preview if one does not exist', () => {
+    articleState.mainImage = null;
     const container = shallow(
       <BodyPreview
         previewResponse={previewResponse}
-        version="v2"
+        version={version}
         articleState={articleState}
       />,
     );

--- a/app/javascript/article-form/elements/bodyPreview.jsx
+++ b/app/javascript/article-form/elements/bodyPreview.jsx
@@ -29,15 +29,12 @@ function titleArea(previewResponse, version, articleState) {
     });
   }
 
-  let coverImage = '';
+  let coverImage = articleState.mainImage || '';
   if (articleState.previewShowing) {
     // In preview state, use the cover_image from previewResponse.
     if (previewResponse.cover_image && previewResponse.cover_image.length > 0) {
       coverImage = previewResponse.cover_image;
     }
-  } else if (articleState.mainImage) {
-    // Otherwise, use the mainImage from the article if it exists.
-    coverImage = articleState.mainImage;
   }
 
   const previewTitle = previewResponse.title || articleState.title || '';


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Previewing a main image on an article was broken in v2 of the editor 😞 I actually did some work around this last week in [a separate PR](https://github.com/thepracticaldev/dev.to/pull/5660), but I was pretty new and didn't realize all the differences between the metadata of an article in the context of the v1 editor versus the v2 editor! 🙈 

Funnily enough, we actually [had some tests for this](https://github.com/thepracticaldev/dev.to/pull/5660/files#diff-0ef7c0748e1c101451bdd270fbfcc714) (which I wrote!), so I didn't catch this bug until I ran into it manually on the v2 editor. As it turns out, the setup for the tests wasn't quite right! This PR fixes the preview bug, and also refactors and cleans up our tests quite a bit.

It also adds some snapshots for both v1 and v2 editors in a "no image" preview state. 💪

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

1. To test this out, you'll want to make a post using the v2 editor!
2. Add an image to the post:
<img width="898" alt="Screen Shot 2020-02-03 at 12 08 57 PM" src="https://user-images.githubusercontent.com/6921610/73687098-2e031900-467e-11ea-9f10-7c8f72e3ed9f.png">
3. Then, click the preview button. The image should still be there 👀:
<img width="887" alt="Screen Shot 2020-02-03 at 12 09 08 PM" src="https://user-images.githubusercontent.com/6921610/73687114-32c7cd00-467e-11ea-8e23-cbf87584d478.png">

This is contrast to the current behavior on master, where the image disappears!! 😬 

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?


![](https://media0.giphy.com/media/vIqU5gwdCPKO4/giphy.gif?cid=5a38a5a2fa90eb5b3bda20c45199145aeb7d30fc7666e0a9&rid=giphy.gif)

