### PR TITLE
Move HtmlVariantSuccessesCreate from background job to inline

### DIFF
--- a/app/controllers/html_variant_successes_controller.rb
+++ b/app/controllers/html_variant_successes_controller.rb
@@ -2,7 +2,7 @@ class HtmlVariantSuccessesController < ApplicationMetalController
   include ActionController::Head
 
   def create
-    HtmlVariantSuccessCreateJob.perform_later(html_variant_id: params[:html_variant_id], article_id: params[:article_id])
+    HtmlVariantSuccess.create(html_variant_id: params[:html_variant_id], article_id: params[:article_id])
     head :ok
   end
 end

--- a/app/jobs/html_variant_success_create_job.rb
+++ b/app/jobs/html_variant_success_create_job.rb
@@ -1,7 +1,0 @@
-class HtmlVariantSuccessCreateJob < ApplicationJob
-  queue_as :html_variant_success_create
-
-  def perform(html_variant_id:, article_id:)
-    HtmlVariantSuccess.create(html_variant_id: html_variant_id, article_id: article_id)
-  end
-end

--- a/spec/jobs/html_variant_success_create_job_spec.rb
+++ b/spec/jobs/html_variant_success_create_job_spec.rb
@@ -1,6 +1,0 @@
-require "rails_helper"
-require "jobs/shared_examples/enqueues_job"
-
-RSpec.describe HtmlVariantSuccessCreateJob, type: :job do
-  include_examples "#enqueues_job", "html_variant_success_create", [{ html_variant_id: 789, article_id: 456 }]
-end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Optimization

## Description
I first started moving `HtmlVariantSuccessesCreateJob` to Sidekiq and I'm wondering if we need a background job for this at all. I dug through some history and old PRs and I couldn't see anything that jumped out as to why or why not this was done this way.

If I'm way off base and this should still be delayed in the background I have the PR (#5878) completed for that route as well but marked it as WIP. I figured if nothing else this might prompt some helpful discussion for reference later.

## Related Tickets & Documents
- #5305 
- #5878

## Added to documentation?

- [x] no documentation needed

![unsure_power_rangers_gif](https://media.giphy.com/media/y65VoOlimZaus/giphy.gif)