### PR TITLE
Improve dropdown UX for internal/badges

### DIFF
--- a/app/controllers/internal/badges_controller.rb
+++ b/app/controllers/internal/badges_controller.rb
@@ -1,5 +1,6 @@
 class Internal::BadgesController < Internal::ApplicationController
   layout "internal"
+  before_action :ensure_badge, only: :award_badges
 
   def index
     @badges = Badge.all
@@ -7,16 +8,22 @@ class Internal::BadgesController < Internal::ApplicationController
 
   def award_badges
     usernames = permitted_params[:usernames].split(/\s*,\s*/)
-    badge_slug = permitted_params[:badge]
     message = permitted_params[:message_markdown].presence || "Congrats!"
-    BadgeRewarder.award_badges(usernames, badge_slug, message)
+    BadgeRewarder.award_badges(usernames, permitted_params[:badge], message)
     flash[:success] = "BadgeRewarder task ran!"
     redirect_to internal_badges_url
+  rescue ArgumentError => e
+    flash[:danger] = e
+    redirect_to "/internal/badges"
   end
 
   private
 
   def permitted_params
     params.permit(:usernames, :badge, :message_markdown)
+  end
+
+  def ensure_badge
+    raise ArgumentError, "You must choose a badge to award" if permitted_params[:badge].blank?
   end
 end

--- a/app/controllers/internal/badges_controller.rb
+++ b/app/controllers/internal/badges_controller.rb
@@ -1,19 +1,20 @@
 class Internal::BadgesController < Internal::ApplicationController
   layout "internal"
-  before_action :ensure_badge, only: :award_badges
 
   def index
     @badges = Badge.all
   end
 
   def award_badges
+    raise ArgumentError, "Please choose a badge to award" if permitted_params[:badge].blank?
+
     usernames = permitted_params[:usernames].split(/\s*,\s*/)
     message = permitted_params[:message_markdown].presence || "Congrats!"
     BadgeRewarder.award_badges(usernames, permitted_params[:badge], message)
     flash[:success] = "BadgeRewarder task ran!"
     redirect_to internal_badges_url
   rescue ArgumentError => e
-    flash[:danger] = e
+    flash[:danger] = e.message
     redirect_to "/internal/badges"
   end
 
@@ -21,9 +22,5 @@ class Internal::BadgesController < Internal::ApplicationController
 
   def permitted_params
     params.permit(:usernames, :badge, :message_markdown)
-  end
-
-  def ensure_badge
-    raise ArgumentError, "You must choose a badge to award" if permitted_params[:badge].blank?
   end
 end

--- a/app/controllers/internal/tools_controller.rb
+++ b/app/controllers/internal/tools_controller.rb
@@ -16,7 +16,7 @@ class Internal::ToolsController < Internal::ApplicationController
                       end
     redirect_to "/internal/tools"
   rescue StandardError => e
-    flash[:danger] = e
+    flash[:danger] = e.message
     redirect_to "/internal/tools"
   end
 

--- a/app/views/internal/badges/index.html.erb
+++ b/app/views/internal/badges/index.html.erb
@@ -3,7 +3,7 @@
   <%= form_with(url: internal_badges_award_badges_path, local: true) do |f| %>
     <div class="form-group">
       <%= f.label :badge, "Badge" %>
-      <%= f.select("badge", @badges.map { |b| [b.title, b.slug] }, class: "form-control") %>
+      <%= f.select("badge", @badges.map { |b| [b.title, b.slug] }, include_blank: true, class: "form-control") %>
     </div>
     <div class="form-group">
       <%= f.label :usernames, "Usernames (Comma Delimited)*" %>

--- a/spec/requests/internal/badges_spec.rb
+++ b/spec/requests/internal/badges_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "/internal/badges", type: :request do
           usernames: "#{user.username}, #{user2.username}",
           message_markdown: ""
         }
-      end.to change { user.badges.count }.by(0).and raise_error(ArgumentError, "You must choose a badge to award")
+      end.to change { user.badges.count }.by(0)
     end
   end
 end

--- a/spec/requests/internal/badges_spec.rb
+++ b/spec/requests/internal/badges_spec.rb
@@ -30,5 +30,14 @@ RSpec.describe "/internal/badges", type: :request do
         }
       end.to change { user.badges.count }.by(1).and change { user2.badges.count }.by(1)
     end
+
+    it "does not award a badge and raises an error if a badge is not specified" do
+      expect do
+        post internal_badges_award_badges_path, params: {
+          usernames: "#{user.username}, #{user2.username}",
+          message_markdown: ""
+        }
+      end.to change { user.badges.count }.by(0).and raise_error(ArgumentError, "You must choose a badge to award")
+    end
   end
 end

--- a/spec/system/internal/admin_awards_badges_spec.rb
+++ b/spec/system/internal/admin_awards_badges_spec.rb
@@ -13,6 +13,12 @@ RSpec.describe "Admin awards badges", type: :system do
     click_on "Award Badges"
   end
 
+  def award_no_badges
+    fill_in "usernames", with: "#{user.username}, #{user2.username}"
+    fill_in "message_markdown", with: "He who controls the spice controls the universe."
+    click_on "Award Badges"
+  end
+
   before do
     create_list :badge, 5
     sign_in admin
@@ -45,5 +51,9 @@ RSpec.describe "Admin awards badges", type: :system do
         award_two_badges
       end
     end
+  end
+
+  it "does not award badges if no badge is selected" do
+    expect { award_no_badges }.to raise_exception(ArgumentError)
   end
 end

--- a/spec/system/internal/admin_awards_badges_spec.rb
+++ b/spec/system/internal/admin_awards_badges_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe "Admin awards badges", type: :system do
   end
 
   it "does not award badges if no badge is selected" do
-    expect { award_no_badges }.to raise_exception(ArgumentError)
+    expect { award_no_badges }.to change { user.badges.count }.by(0)
+    expect(page).to have_content("Please choose a badge to award")
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

As requested by @michael-tharrington!!
Adds a "blank" option to the dropdown to list of badges on internal/badges route.
Also add some checks to handle if an admin accidentally tries to award a "blank" badge.

## Related Tickets & Documents

Fixes https://github.com/thepracticaldev/dev.to/issues/5876

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Adds a blank option to the badges dropdown for `internal/badges`:
<img width="350" alt="Screen Shot 2020-02-03 at 3 37 28 PM" src="https://user-images.githubusercontent.com/6921610/73700343-2d2cb000-469b-11ea-8479-121c4de7db96.png">


## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?


![](https://media2.giphy.com/media/xT9IgEWjZcEhMlzL3i/giphy.gif?cid=5a38a5a244d6f62953dd2496b4649e464e43fcb6d15f67ad&rid=giphy.gif)

