### PR TITLE
Move user deletion by moderator to worker

### DIFF
--- a/app/controllers/internal/users_controller.rb
+++ b/app/controllers/internal/users_controller.rb
@@ -57,7 +57,7 @@ class Internal::UsersController < Internal::ApplicationController
   def full_delete
     @user = User.find(params[:id])
     begin
-      Moderator::DeleteUser.call_deletion(admin: current_user, user: @user, user_params: user_params)
+      Moderator::DeleteUser.call(admin: current_user, user: @user, user_params: user_params)
       flash[:success] = "@" + @user.username + " (email: " + @user.email + ", user_id: " + @user.id.to_s + ") has been fully deleted. If requested, old content may have been ghostified. If this is a GDPR delete, delete them from Mailchimp & Google Analytics."
     rescue StandardError => e
       flash[:danger] = e.message

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -85,7 +85,7 @@ class UsersController < ApplicationController
   def full_delete
     set_tabs("account")
     if @user.email?
-      Users::SelfDeleteWorker.perform_async(@user.id)
+      Users::DeleteWorker.perform_async(@user.id)
       sign_out @user
       flash[:global_notice] = "Your account deletion is scheduled. You'll be notified when it's deleted."
       redirect_to root_path

--- a/app/services/moderator/delete_user.rb
+++ b/app/services/moderator/delete_user.rb
@@ -2,18 +2,18 @@ module Moderator
   class DeleteUser < ManageActivityAndRoles
     attr_reader :user, :admin, :user_params
 
+    def self.call(admin:, user:, user_params:)
+      if user_params[:ghostify] == "true"
+        new(user: user, admin: admin, user_params: user_params).ghostify
+      else
+        Users::DeleteWorker.perform_async(user.id, true)
+      end
+    end
+
     def initialize(admin:, user:, user_params:)
       @user = user
       @admin = admin
       @user_params = user_params
-    end
-
-    def self.call_deletion(admin:, user:, user_params:)
-      if user_params[:ghostify] == "true"
-        new(user: user, admin: admin, user_params: user_params).ghostify
-      else
-        Users::Delete.call(user)
-      end
     end
 
     def ghostify

--- a/app/workers/users/delete_worker.rb
+++ b/app/workers/users/delete_worker.rb
@@ -1,15 +1,15 @@
 module Users
-  class SelfDeleteWorker
+  class DeleteWorker
     include Sidekiq::Worker
 
     sidekiq_options queue: :high_priority, retry: 10
 
-    def perform(user_id)
+    def perform(user_id, admin_delete = false)
       user = User.find_by(id: user_id)
       return unless user
 
       Users::Delete.call(user)
-      NotifyMailer.account_deleted_email(user).deliver
+      NotifyMailer.account_deleted_email(user).deliver unless admin_delete
     rescue StandardError => e
       Rails.logger.error("Error while deleting user: #{e}")
     end

--- a/app/workers/users/delete_worker.rb
+++ b/app/workers/users/delete_worker.rb
@@ -11,6 +11,7 @@ module Users
       Users::Delete.call(user)
       NotifyMailer.account_deleted_email(user).deliver unless admin_delete
     rescue StandardError => e
+      DataDogStatsClient.count("users.delete", 1, tags: ["action:failed", "user_id:#{user.id}"])
       Rails.logger.error("Error while deleting user: #{e}")
     end
   end

--- a/spec/requests/internal/users_banish_spec.rb
+++ b/spec/requests/internal/users_banish_spec.rb
@@ -191,7 +191,9 @@ RSpec.describe "Internal::Users", type: :request do
     end
 
     it "raises a 'record not found' error after deletion" do
-      post "/internal/users/#{user.id}/full_delete", params: { user: { ghostify: "false" } }
+      sidekiq_perform_enqueued_jobs do
+        post "/internal/users/#{user.id}/full_delete", params: { user: { ghostify: "false" } }
+      end
       expect { User.find(user.id) }.to raise_exception(ActiveRecord::RecordNotFound)
     end
 

--- a/spec/requests/user/user_destroy_spec.rb
+++ b/spec/requests/user/user_destroy_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "UserDestroy", type: :request do
       end
 
       it "schedules a user delete job" do
-        sidekiq_assert_enqueued_with(job: Users::SelfDeleteWorker) do
+        sidekiq_assert_enqueued_with(job: Users::DeleteWorker) do
           delete "/users/full_delete"
         end
       end

--- a/spec/services/moderator/delete_user_spec.rb
+++ b/spec/services/moderator/delete_user_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe Moderator::DeleteUser, type: :service do
 
   describe "delete_user" do
     it "deletes user" do
-      described_class.call_deletion(user: user, admin: admin, user_params: {})
+      sidekiq_perform_enqueued_jobs do
+        described_class.call(user: user, admin: admin, user_params: {})
+      end
       expect(User.find_by(id: user.id)).to be_nil
     end
 
@@ -15,13 +17,17 @@ RSpec.describe Moderator::DeleteUser, type: :service do
       create(:follow, followable: user)
 
       expect do
-        described_class.call_deletion(user: user, admin: admin, user_params: {})
+        sidekiq_perform_enqueued_jobs do
+          described_class.call(user: user, admin: admin, user_params: {})
+        end
       end.to change(Follow, :count).by(-2)
     end
 
     it "deletes user's articles" do
       article = create(:article, user: user)
-      described_class.call_deletion(user: user, admin: admin, user_params: {})
+      sidekiq_perform_enqueued_jobs do
+        described_class.call(user: user, admin: admin, user_params: {})
+      end
       expect(Article.find_by(id: article.id)).to be_nil
     end
   end

--- a/spec/system/user/user_self_destroy_spec.rb
+++ b/spec/system/user/user_self_destroy_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "User destroys their profile", type: :system, js: true do
     visit "/users/confirm_destroy/#{token}"
     fill_in "delete__account__username__field", with: user.username
     fill_in "delete__account__verification__field", with: "delete my account"
-    sidekiq_assert_enqueued_with(job: Users::SelfDeleteWorker) do
+    sidekiq_assert_enqueued_with(job: Users::DeleteWorker) do
       click_button "DELETE ACCOUNT"
     end
   end

--- a/spec/workers/users/delete_worker_spec.rb
+++ b/spec/workers/users/delete_worker_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Users::SelfDeleteWorker, type: :worker do
+RSpec.describe Users::DeleteWorker, type: :worker do
   describe "#perform" do
     let(:user) { create(:user) }
     let(:delete) { Users::Delete }
@@ -20,6 +20,12 @@ RSpec.describe Users::SelfDeleteWorker, type: :worker do
         expect do
           worker.perform(user.id)
         end.to change(ActionMailer::Base.deliveries, :count).by(1)
+      end
+
+      it "doesn't send a notification for admin triggered deletion" do
+        expect do
+          worker.perform(user.id, true)
+        end.not_to change(ActionMailer::Base.deliveries, :count)
       end
 
       it "sends the correct notification" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor
- [X] Optimization

## Description

In #5061 we had planned to move deletion of users by admins/moderators to a background worker. When looking around I noticed we already had `User::SelfDeleteWorker`, which used the same service object (`Users::Delete) as the moderator controller. I therefore decided to reuse the same worker and renamed it to `Users::DeleteWorker`.

## Related Tickets & Documents

Closes #5061

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed
