### PR TITLE
Allow deleting comments if article has already been deleted

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -137,14 +137,14 @@ class CommentsController < ApplicationController
   # DELETE /comments/1.json
   def destroy
     authorize @comment
-    @commentable_path = @comment.commentable.path
     if @comment.is_childless?
       @comment.destroy
     else
       @comment.deleted = true
       @comment.save!
     end
-    redirect_to URI.parse(@commentable_path).path, notice: "Comment was successfully deleted."
+    redirect_path = @comment.commentable&.path || user_path(current_user)
+    redirect_to redirect_path, notice: "Comment was successfully deleted."
   end
 
   def delete_confirm

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -143,8 +143,10 @@ class CommentsController < ApplicationController
       @comment.deleted = true
       @comment.save!
     end
-    redirect_path = @comment.commentable&.path || user_path(current_user)
-    redirect_to redirect_path, notice: "Comment was successfully deleted."
+    redirect = @comment.commentable&.path || user_path(current_user)
+    # NOTE: Brakeman doesn't like redirecting to a path, because of a "possible
+    # unprotected redirect". Using URI.parse().path is the recommended workaround.
+    redirect_to URI.parse(redirect).path, notice: "Comment was successfully deleted."
   end
 
   def delete_confirm

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -278,8 +278,8 @@ RSpec.describe "Comments", type: :request do
       delete "/comments/#{comment.id}"
 
       expect(Comment.find_by(id: comment.id)).to be_nil
+      expect(response).to redirect_to(comment.commentable.path)
       expect(flash[:notice]).to eq("Comment was successfully deleted.")
-      expect(response.location).to eq("http://www.example.com/#{user.username}/#{article.slug}")
     end
 
     it "deletes a comment if the article has been deleted" do
@@ -288,8 +288,8 @@ RSpec.describe "Comments", type: :request do
       delete "/comments/#{comment.id}"
 
       expect(Comment.find_by(id: comment.id)).to be_nil
+      expect(response).to redirect_to(user_path(user))
       expect(flash[:notice]).to eq("Comment was successfully deleted.")
-      expect(response.location).to eq("http://www.example.com/users/#{user.id}")
     end
   end
 end

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -279,6 +279,7 @@ RSpec.describe "Comments", type: :request do
 
       expect(Comment.find_by(id: comment.id)).to be_nil
       expect(flash[:notice]).to eq("Comment was successfully deleted.")
+      expect(response.location).to eq("http://www.example.com/#{user.username}/#{article.slug}")
     end
 
     it "deletes a comment if the article has been deleted" do
@@ -288,6 +289,7 @@ RSpec.describe "Comments", type: :request do
 
       expect(Comment.find_by(id: comment.id)).to be_nil
       expect(flash[:notice]).to eq("Comment was successfully deleted.")
+      expect(response.location).to eq("http://www.example.com/users/#{user.id}")
     end
   end
 end

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Comments", type: :request do
   let(:article) { create(:article, user_id: user.id) }
   let(:podcast) { create(:podcast) }
   let(:podcast_episode) { create(:podcast_episode, podcast_id: podcast.id) }
-  let(:comment) do
+  let!(:comment) do
     create(:comment,
            commentable_id: article.id,
            commentable_type: "Article",
@@ -269,5 +269,25 @@ RSpec.describe "Comments", type: :request do
 
   describe "PATCH /comments/:comment_id/unhide" do
     include_examples "PATCH /comments/:comment_id/hide or unhide", path: "unhide", hidden: "false"
+  end
+
+  describe "DELETE /comments/:comment_id" do
+    before { sign_in user }
+
+    it "deletes a comment if the article is still present" do
+      delete "/comments/#{comment.id}"
+
+      expect(Comment.find_by(id: comment.id)).to be_nil
+      expect(flash[:notice]).to eq("Comment was successfully deleted.")
+    end
+
+    it "deletes a comment if the article has been deleted" do
+      article.destroy!
+
+      delete "/comments/#{comment.id}"
+
+      expect(Comment.find_by(id: comment.id)).to be_nil
+      expect(flash[:notice]).to eq("Comment was successfully deleted.")
+    end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Description

Deleting a comment for an article that had already been deleted failed as we weren't able to construct a `commentable_path`. This PR fixes that by redirecting the user to their profile.

## Related Tickets & Documents

Closes #3967

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed
