### PR TITLE
Add user as reactable

### DIFF
--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -13,7 +13,7 @@ class Reaction < ApplicationRecord
   counter_culture :user
 
   validates :category, inclusion: { in: CATEGORIES }
-  validates :reactable_type, inclusion: { in: %w[Comment Article] }
+  validates :reactable_type, inclusion: { in: %w[Comment Article User] }
   validates :status, inclusion: { in: %w[valid invalid confirmed archived] }
   validates :user_id, uniqueness: { scope: %i[reactable_id reactable_type category] }
   validate  :permissions

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -2,6 +2,8 @@ class Reaction < ApplicationRecord
   include AlgoliaSearch
 
   CATEGORIES = %w[like readinglist unicorn thinking hands thumbsdown vomit].freeze
+  REACTABLE_TYPES = %w[Comment Article User].freeze
+  STATUSES = %w[valid invalid confirmed archived].freeze
 
   belongs_to :reactable, polymorphic: true
   belongs_to :user
@@ -13,8 +15,8 @@ class Reaction < ApplicationRecord
   counter_culture :user
 
   validates :category, inclusion: { in: CATEGORIES }
-  validates :reactable_type, inclusion: { in: %w[Comment Article User] }
-  validates :status, inclusion: { in: %w[valid invalid confirmed archived] }
+  validates :reactable_type, inclusion: { in: REACTABLE_TYPES }
+  validates :status, inclusion: { in: STATUSES }
   validates :user_id, uniqueness: { scope: %i[reactable_id reactable_type category] }
   validate  :permissions
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -478,6 +478,10 @@ class User < ApplicationRecord
       email_follower_notifications
   end
 
+  def title
+    name
+  end
+
   private
 
   def index_id
@@ -601,10 +605,6 @@ class User < ApplicationRecord
     return if uri.host&.in?(Constants::ALLOWED_MASTODON_INSTANCES)
 
     errors.add(:mastodon_url, "is not an allowed Mastodon instance")
-  end
-
-  def title
-    name
   end
 
   def tag_list


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
This allows the `User` model to be a `reactable`. This is part of prepping the backend for easier moderation, such as reporting with reacting to a spam acccount.

## Added to documentation?
- [x] no documentation needed
