### PR TITLE
Add comment around previewing with v1 vs. v2 editors

### DIFF
--- a/app/javascript/article-form/elements/bodyPreview.jsx
+++ b/app/javascript/article-form/elements/bodyPreview.jsx
@@ -29,6 +29,10 @@ function titleArea(previewResponse, version, articleState) {
     });
   }
 
+  // The v2 editor stores its cover image in articleState.mainImage, while the v1 editor
+  // stores it as previewRespose.cover_image. When previewing, we handle both by
+  // defaulting to setting the cover image to the mainImage on the article (v2),
+  //  and only using the cover image from the previewResponse if it exists (v1).
   let coverImage = articleState.mainImage || '';
   if (articleState.previewShowing) {
     // In preview state, use the cover_image from previewResponse.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description
As requested by @rhymes, adds a comment to highlight difference between previewing in v1 and v2 editors.

## Related Tickets & Documents

A follow-up to https://github.com/thepracticaldev/dev.to/pull/5873.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [ ] no documentation needed
