### PR TITLE
Move HtmlVariantTrialCreateJob from background job to inline

### DIFF
--- a/app/controllers/html_variant_trials_controller.rb
+++ b/app/controllers/html_variant_trials_controller.rb
@@ -2,7 +2,7 @@ class HtmlVariantTrialsController < ApplicationMetalController
   include ActionController::Head
 
   def create
-    HtmlVariantTrialCreateJob.perform_later(html_variant_id: params[:html_variant_id], article_id: params[:article_id])
+    HtmlVariantTrial.create!(html_variant_id: params[:html_variant_id], article_id: params[:article_id])
     head :ok
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Optimization

## Description
This moves `HtmlVariantTrialCreateJob` to run inline. The `create!` call does involve a `before_save` callback to `prefix_all_images`, but it seems it's still performant enough to run inline. If not, just let me know and I'll keep this process in the background and move it to Sidekiq instead.

I'll open a separate PR if/when this is merged to remove the old job and spec.

## Related Tickets & Documents
#5305 

## Added to documentation?

- [x] no documentation needed

![power_rangers_gif](https://media.giphy.com/media/aDDSWPDlrckrS/giphy.gif)