### PR TITLE
Remove quotes from broadcast options in internal form

### DIFF
--- a/app/views/internal/broadcasts/_form.html.erb
+++ b/app/views/internal/broadcasts/_form.html.erb
@@ -7,7 +7,7 @@
 </div>
 <div class="form-group">
   <%= label_tag :type, "Type:" %>
-  <%= select_tag "type_of", options_for_select(%w["Onboarding Announcement"]) %>
+  <%= select_tag "type_of", options_for_select(%w[Onboarding Announcement]) %>
 </div>
 <div class="form-gorup">
   <%= label_tag :sent, "Sent:" %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Found some weird formatting while poking around in the `/internal` pages. Removed the quotes so that the dropdown options would format correctly! 💪 

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
BEFORE:
<img width="456" alt="Screen Shot 2020-02-04 at 12 08 24 PM" src="https://user-images.githubusercontent.com/6921610/73782617-3ecb9180-4747-11ea-958b-ab1fa5118364.png">

AFTER:
<img width="472" alt="Screen Shot 2020-02-04 at 12 08 40 PM" src="https://user-images.githubusercontent.com/6921610/73782635-468b3600-4747-11ea-8fc2-7d6b2173913d.png">

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?


![](https://media3.giphy.com/media/8o0bpqiHyFNdu/giphy.gif?cid=5a38a5a21b073d7ae05aa21f1812965f8e7debf153a7b25e&rid=giphy.gif)

