### PR TITLE
Remove Unused ChatChannel Indexing

### DIFF
--- a/app/controllers/chat_channel_memberships_controller.rb
+++ b/app/controllers/chat_channel_memberships_controller.rb
@@ -19,7 +19,6 @@ class ChatChannelMembershipsController < ApplicationController
       chat_channel_id: @chat_channel.id,
       status: "pending",
     )
-    @chat_channel.index!
   end
 
   def update
@@ -31,7 +30,6 @@ class ChatChannelMembershipsController < ApplicationController
     else
       @chat_channel_membership.update(status: "rejected")
     end
-    @chat_channel_membership.chat_channel.index!
     @chat_channels_memberships = current_user.
       chat_channel_memberships.includes(:chat_channel).
       where(status: "pending").
@@ -45,7 +43,6 @@ class ChatChannelMembershipsController < ApplicationController
     authorize @chat_channel_membership
     @chat_channel_membership.update(status: "left_channel")
     @chat_channel_membership.remove_from_index!
-    @chat_channel_membership.chat_channel.index!
     @chat_channels_memberships = []
     render json: { result: "left channel" }, status: :created
   end

--- a/app/controllers/chat_channels_controller.rb
+++ b/app/controllers/chat_channels_controller.rb
@@ -38,7 +38,6 @@ class ChatChannelsController < ApplicationController
     membership = @chat_channel.chat_channel_memberships.where(user_id: current_user.id).first
     membership.update(last_opened_at: 1.second.from_now, has_unopened_messages: false)
     send_open_notification
-    @chat_channel.index!
     membership.index!
     render json: { status: "success", channel: params[:id] }, status: :ok
   end

--- a/app/models/chat_channel.rb
+++ b/app/models/chat_channel.rb
@@ -117,14 +117,6 @@ class ChatChannel < ApplicationRecord
     end
   end
 
-  def viewable_by
-    active_memberships.pluck(:user_id)
-  end
-
-  def messages_count
-    messages.size
-  end
-
   def channel_human_names
     active_memberships.
       order("last_opened_at DESC").limit(5).includes(:user).map do |membership|

--- a/app/models/chat_channel.rb
+++ b/app/models/chat_channel.rb
@@ -1,5 +1,4 @@
 class ChatChannel < ApplicationRecord
-  include AlgoliaSearch
   attr_accessor :current_user, :usernames_string
 
   has_many :messages, dependent: :destroy
@@ -18,18 +17,6 @@ class ChatChannel < ApplicationRecord
   validates :channel_type, presence: true, inclusion: { in: %w[open invite_only direct] }
   validates :status, presence: true, inclusion: { in: %w[active inactive blocked] }
   validates :slug, uniqueness: true, presence: true
-
-  algoliasearch index_name: "SecuredChatChannel_#{Rails.env}" do
-    attribute :id, :viewable_by, :slug, :channel_type,
-              :channel_name, :last_message_at, :status,
-              :messages_count, :channel_human_names, :channel_mod_ids, :pending_users_select_fields,
-              :description
-    searchableAttributes %i[channel_name channel_slug channel_human_names]
-    attributesForFaceting ["filterOnly(viewable_by)", "filterOnly(status)", "filterOnly(channel_type)"]
-    ranking ["desc(last_message_at)"]
-  end
-
-  before_destroy :remove_from_index!, prepend: true
 
   def open?
     channel_type == "open"
@@ -90,7 +77,6 @@ class ChatChannel < ApplicationRecord
         status: "active",
       )
       channel.add_users(users)
-      channel.index!
       channel.chat_channel_memberships.map(&:index!)
     end
     channel
@@ -147,7 +133,6 @@ class ChatChannel < ApplicationRecord
   end
 
   def channel_users
-    # Purely for algolia indexing
     obj = {}
     active_memberships.
       order("last_opened_at DESC").includes(:user).each do |membership|

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -27,7 +27,6 @@ class Message < ApplicationRecord
 
   def update_chat_channel_last_message_at
     chat_channel.touch(:last_message_at)
-    chat_channel.index!
     chat_channel.chat_channel_memberships.reindex!
   end
 

--- a/app/services/users/cleanup_chat_channels.rb
+++ b/app/services/users/cleanup_chat_channels.rb
@@ -4,7 +4,6 @@ module Users
       # We only destroy direct message channels, not open and invite-only ones
       direct_channels = user.chat_channels.where(channel_type: "direct")
       direct_channels.each do |direct_channel|
-        direct_channel.remove_from_index!
         cleanup_memberships(direct_channel.chat_channel_memberships)
         direct_channel.destroy!
       end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
We are indexing chat channels but we are never searching for them as far as I can tell. I attempted to confirm this by doing a search of the app for any indication of searching that index. I found none. We only search on the `SecuredChatChannelMembership` index. I then went into Algolia and found that no recent searches had been conducted, only updating documents. 
 
## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-32289313

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media2.giphy.com/media/l3q2AB8t9GClYwp44/giphy.gif)
