### PR TITLE
Allow broadcasts to be created from internal/broadcasts

### DIFF
--- a/app/controllers/internal/broadcasts_controller.rb
+++ b/app/controllers/internal/broadcasts_controller.rb
@@ -2,13 +2,13 @@ class Internal::BroadcastsController < Internal::ApplicationController
   layout "internal"
 
   def create
-    @broadcast = Broadcast.new(broadcast_params)
+    @broadcast = Broadcast.create!(broadcast_params)
     redirect_to "/internal/broadcasts"
   end
 
   def update
-    @broadcast = Broadcast.find(params[:id])
-    @broadcast.update(broadcast_params)
+    @broadcast = Broadcast.find_by!(id: params[:id])
+    @broadcast.update!(broadcast_params)
     redirect_to "/internal/broadcasts"
   end
 
@@ -17,7 +17,7 @@ class Internal::BroadcastsController < Internal::ApplicationController
   end
 
   def edit
-    @broadcast = Broadcast.find(params[:id])
+    @broadcast = Broadcast.find_by!(id: params[:id])
   end
 
   def index
@@ -28,8 +28,6 @@ class Internal::BroadcastsController < Internal::ApplicationController
 
   def broadcast_params
     params.permit(:title, :processed_html, :type_of, :sent)
-    # left out body_markdown and processed_html attributes
-    #   until we decide we're using them
   end
 
   def authorize_admin

--- a/spec/requests/internal/broadcasts_spec.rb
+++ b/spec/requests/internal/broadcasts_spec.rb
@@ -1,62 +1,90 @@
 require "rails_helper"
 require "requests/shared_examples/internal_policy_dependant_request"
 
-RSpec.describe "/internal/Broadcasts", type: :request do
+RSpec.describe "/internal/broadcasts", type: :request do
+  let(:get_resource) { get "/internal/broadcasts" }
+  let(:params) { { title: "Hello!", processed_html: "<pHello!</p>", type_of: "Onboarding", sent: true } }
+  let(:post_resource) { post "/internal/broadcasts", params: params }
+
   it_behaves_like "an InternalPolicy dependant request", Broadcast do
-    let(:request) { get "/internal/broadcasts" }
+    let(:request) { get_resource }
   end
 
   context "when the user is not an admin" do
     let(:user) { create(:user) }
 
-    before do
-      sign_in user
+    before { sign_in user }
+
+    describe "GET /internal/broadcasts" do
+      it "blocks the request" do
+        expect { get_resource }.to raise_error(Pundit::NotAuthorizedError)
+      end
     end
 
-    it "blocks the request" do
-      expect do
-        get "/internal/broadcasts"
-      end.to raise_error(Pundit::NotAuthorizedError)
+    describe "POST /internal/broadcasts" do
+      it "blocks the request" do
+        expect { post_resource }.to raise_error(Pundit::NotAuthorizedError)
+      end
     end
   end
 
   context "when the user is a super admin" do
     let(:super_admin) { create(:user, :super_admin) }
 
-    before do
-      sign_in super_admin
-      get "/internal/broadcasts"
+    before { sign_in super_admin }
+
+    describe "GET /internal/broadcasts" do
+      it "allows the request" do
+        get_resource
+        expect(response).to have_http_status(:ok)
+      end
     end
 
-    it "allows the request" do
-      expect(response).to have_http_status(:ok)
+    describe "POST /internal/broadcasts" do
+      it "creates a new broadcast" do
+        expect do
+          post_resource
+        end.to change { Broadcast.all.count }.by(1)
+      end
     end
   end
 
   context "when the user is a single resource admin" do
     let(:single_resource_admin) { create(:user, :single_resource_admin, resource: Broadcast) }
 
-    before do
-      sign_in single_resource_admin
-      get "/internal/broadcasts"
+    before { sign_in single_resource_admin }
+
+    describe "GET /internal/broadcasts" do
+      it "allows the request" do
+        get_resource
+        expect(response).to have_http_status(:ok)
+      end
     end
 
-    it "allows the request" do
-      expect(response).to have_http_status(:ok)
+    describe "POST /internal/broadcasts" do
+      it "creates a new broadcast" do
+        expect do
+          post_resource
+        end.to change { Broadcast.all.count }.by(1)
+      end
     end
   end
 
   context "when the user is the wrong single resource admin" do
     let(:single_resource_admin) { create(:user, :single_resource_admin, resource: Article) }
 
-    before do
-      sign_in single_resource_admin
+    before { sign_in single_resource_admin }
+
+    describe "GET /internal/broadcasts" do
+      it "blocks the request" do
+        expect { get_resource }.to raise_error(Pundit::NotAuthorizedError)
+      end
     end
 
-    it "blocks the request" do
-      expect do
-        get "/internal/broadcasts"
-      end.to raise_error(Pundit::NotAuthorizedError)
+    describe "POST /internal/broadcasts" do
+      it "blocks the request" do
+        expect { post_resource }.to raise_error(Pundit::NotAuthorizedError)
+      end
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Was poking around in the notification code again and trying to see how notifications connect to broadcasts. In process, tried to create a new broadcast, and was confused when nothing happened. Turned out, we had a bug (typo?) and no test to catch it! So, I fixed it. 

I also decided to raise errors when necessary in all broadcast endpoints, and cleaned up the tests and add specs for the endpoint that was borked!

To try it out, go to `/internal/broadcasts` and make sure you can create a new one.

Probably no one uses broadcasts but at least the next time someone goes to play with it in some other capacity, it will work 😄 

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
