### PR TITLE
Have counters:update_users use a transaction per user and customizable batch size

### DIFF
--- a/lib/tasks/counters.rake
+++ b/lib/tasks/counters.rake
@@ -1,19 +1,20 @@
 namespace :counters do
-  task update_users: :environment do
-    ActiveRecord::Base.transaction do
-      # NOTE: we could bypass Rails by using SQL directly to compute the counts and update these columns
-      User.includes(:counters).find_each do |user|
-        user.build_counters unless user.counters
+  desc "Update users counters"
+  task :update_users, [:batch_size] => :environment do |_t, args|
+    batch_size = args.fetch(:batch_size, 1000).to_i
 
-        relation = user.comments
+    # NOTE: we could bypass Rails by using SQL directly to compute the counts and update these columns
+    User.includes(:counters).find_each(batch_size: batch_size) do |user|
+      user.build_counters unless user.counters
 
-        user.counters.comments_these_7_days = relation.where("created_at > ?", 7.days.ago).size
-        user.counters.comments_prior_7_days = relation.
-          where("created_at > ? AND created_at < ?", 14.days.ago, 7.days.ago).
-          size
+      relation = user.comments
 
-        user.counters.save!
-      end
+      user.counters.comments_these_7_days = relation.where("created_at > ?", 7.days.ago).size
+      user.counters.comments_prior_7_days = relation.
+        where("created_at > ? AND created_at < ?", 14.days.ago, 7.days.ago).
+        size
+
+      user.counters.save!
     end
   end
 end

--- a/lib/tasks/counters.rake
+++ b/lib/tasks/counters.rake
@@ -4,7 +4,7 @@ namespace :counters do
     batch_size = args.fetch(:batch_size, 1000).to_i
 
     # NOTE: we could bypass Rails by using SQL directly to compute the counts and update these columns
-    User.includes(:counters).find_each(batch_size: batch_size) do |user|
+    User.includes(:counters).select(:id).find_each(batch_size: batch_size) do |user|
       user.build_counters unless user.counters
 
       relation = user.comments


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

As discussed with @mstruve, I'm optimizing the `rails counters:update_users` task to do the following:

- use autocommitting transactions (Rails default)
- have the batch size customizable (so we don't need to redeploy if we want to tune this), for example `rails counters:update_users[50]` will load 50 items in memory instead of 1000 (the default)

## Related Tickets & Documents

#5373
