### PR TITLE
Ignore `html_safe` in erb files

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -21,9 +21,11 @@ linters:
         - .rubocop.yml
       Layout/InitialIndentation:
         Enabled: false
+      Layout/LineLength:
+        Max: 289
       Layout/TrailingEmptyLines:
         Enabled: false
       Lint/UselessAssignment:
         Enabled: false
-      Metrics/LineLength:
-        Max: 289
+      Rails/OutputSafety:
+        Enabled: false


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Change

## Description

Our current ERB file linting configuration that is run in pre-commit hooks (.erb-lint.yml) checks for use of `html_safe` in ERB files, but based on a conversation with @rhymes we don't actually have a recommended fix for these issues. In addition: this linter was put into place without fixing existing violations, creating a minefield for any contributors that happen across those files. Our guidance to contributors is to do a `git commit --no-verify` to skip these checks: instead we should just have the linter skip the checks.

## Related Tickets & Documents

https://github.com/thepracticaldev/dev.to/pull/1657

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![safety](https://media.giphy.com/media/qvCSPrrck0Qda/giphy.gif)
