### PR TITLE
Add index to notifications table to optimize query

### DIFF
--- a/db/migrate/20200205225813_add_notifiable_id_notifiable_type_action_index_to_notifications.rb
+++ b/db/migrate/20200205225813_add_notifiable_id_notifiable_type_action_index_to_notifications.rb
@@ -1,0 +1,10 @@
+class AddNotifiableIdNotifiableTypeActionIndexToNotifications < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :notifications, %i[notifiable_id notifiable_type action],
+              unique: false,
+              name: "index_notifications_on_notifiable_id_notifiable_type_and_action",
+              algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_20_053525) do
+ActiveRecord::Schema.define(version: 2020_02_05_225813) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -581,6 +582,7 @@ ActiveRecord::Schema.define(version: 2020_01_20_053525) do
     t.integer "user_id"
     t.index ["created_at"], name: "index_notifications_on_created_at"
     t.index ["json_data"], name: "index_notifications_on_json_data", using: :gin
+    t.index ["notifiable_id", "notifiable_type", "action"], name: "index_notifications_on_notifiable_id_notifiable_type_and_action"
     t.index ["notifiable_id"], name: "index_notifications_on_notifiable_id"
     t.index ["notifiable_type"], name: "index_notifications_on_notifiable_type"
     t.index ["notified_at"], name: "index_notifications_on_notified_at"


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
### TLDR
[This query](https://github.com/thepracticaldev/dev.to/blob/c6434d377b37e0a15e75736428a62522123ef20c/app/services/notifications/update.rb#L17-L26) in `/services/notification/update.rb` called by `Notifications::UpdateWorker` keeps failing with `PG::QueryCanceled: ERROR: canceling statement due to statement timeout` resulting in several dead Sidekiq workers.

![Screen Shot 2020-02-05 at 4 02 48 PM](https://user-images.githubusercontent.com/15987080/73894503-87f81000-4831-11ea-8e21-f027cc678862.png)

This PR adds an index on the `notifications` table, it looks like an appropriate index was missing.

### Some more details
The query reads:
https://github.com/thepracticaldev/dev.to/blob/c6434d377b37e0a15e75736428a62522123ef20c/app/services/notifications/update.rb#L17-L26

I noticed the indexes on the `notifications` table didn't have an appropriate index. There's not an index for the 3 columns this query is calling for (`notifiable_id`, `notifiable_type`, and `action`). Nor is there an index just for the `action` column.

![Screen Shot 2020-02-05 at 4 13 17 PM](https://user-images.githubusercontent.com/15987080/73894843-9266d980-4832-11ea-887b-5f01ab524612.png)

I then added a handful (1mm+) `Notification` records locally and re-ran the query before and after adding the index. Looking at `EXPLAIN ANALYZE query` in SQL, I found the performance improved (0.786 ms down to 0.080 ms)...hopefully enough for production 🙏.

I'm curious if this is going down the right path or not. My next hunch was that `ORDER BY` caused by calling `.first`.

## Added to documentation?
- [x] no documentation needed

![unsure_gif](https://media.giphy.com/media/7v735rSZA1Szm/giphy.gif)