### PR TITLE
Fix logging for dev and test environments

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -13,14 +13,14 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   def failure
-    logger.error "Omniauth failure",
-                 omniauth_failure: {
-                   error: request.env["omniauth.error"]&.inspect,
-                   error_type: request.env["omniauth.error.type"].to_s,
-                   auth: request.env["omniauth.auth"],
-                   provider: request.env["omniauth.strategy"].to_s,
-                   cookie: request.env["rack.request.cookie_hash"]
-                 }
+    Rails.logger.error "Omniauth failure",
+                       omniauth_failure: {
+                         error: request.env["omniauth.error"]&.inspect,
+                         error_type: request.env["omniauth.error.type"].to_s,
+                         auth: request.env["omniauth.auth"],
+                         provider: request.env["omniauth.strategy"].to_s,
+                         cookie: request.env["rack.request.cookie_hash"]
+                       }
     super
   end
 
@@ -42,17 +42,17 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     else
       session["devise.#{provider}_data"] = request.env["omniauth.auth"]
       user_errors = @user.errors.full_messages
-      logger.error "Log in error: sign in failed. username: #{@user.username} - email: #{@user.email}"
-      logger.error "Log in error: auth data hash - #{request.env['omniauth.auth']}"
-      logger.error "Log in error: auth data hash - #{request.env['omniauth.error']&.inspect}"
-      logger.error "Log in error: user_errors: #{user_errors}"
+      Rails.logger.error "Log in error: sign in failed. username: #{@user.username} - email: #{@user.email}"
+      Rails.logger.error "Log in error: auth data hash - #{request.env['omniauth.auth']}"
+      Rails.logger.error "Log in error: auth data hash - #{request.env['omniauth.error']&.inspect}"
+      Rails.logger.error "Log in error: user_errors: #{user_errors}"
       flash[:alert] = user_errors
       redirect_to new_user_registration_url
     end
   rescue StandardError => e
-    logger.error "Log in error: #{e}"
-    logger.error "Log in error: auth data hash - #{request.env['omniauth.auth']}"
-    logger.error "Log in error: auth data hash - #{request.env['omniauth.error']&.inspect}"
+    Rails.logger.error "Log in error: #{e}"
+    Rails.logger.error "Log in error: auth data hash - #{request.env['omniauth.auth']}"
+    Rails.logger.error "Log in error: auth data hash - #{request.env['omniauth.error']&.inspect}"
     flash[:alert] = "Log in error: #{e}"
     redirect_to new_user_registration_url
   end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -93,12 +93,8 @@ Rails.application.configure do
 
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  # Install the Timber.io logger
-  send_logs_to_timber = ENV["SEND_LOGS_TO_TIMBER"] || "false" # <---- set to false to stop sending dev logs to Timber.io
-  log_device = send_logs_to_timber == "true" ? Timber::LogDevices::HTTP.new(ENV["TIMBER"]) : STDOUT
-  logger = Timber::Logger.new(log_device)
-  logger.level = config.log_level
-  config.logger = ActiveSupport::TaggedLogging.new(logger)
+  # Debug is the default log_level, but can be changed per environment.
+  config.log_level = :debug
 
   # See <https://github.com/flyerhzm/bullet#configuration> for other config options
   config.after_initialize do

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -54,10 +54,8 @@ Rails.application.configure do
 
   config.active_job.queue_adapter = :test
 
-  # Install the Timber.io logger, but do not send logs.
-  logger = Timber::Logger.new(nil)
-  logger.level = config.log_level
-  config.logger = ActiveSupport::TaggedLogging.new(logger)
+  # Debug is the default log_level, but can be changed per environment.
+  config.log_level = :debug
 
   # enable Bullet in testing mode only if requested
   config.after_initialize do

--- a/spec/services/rss_reader_spec.rb
+++ b/spec/services/rss_reader_spec.rb
@@ -6,6 +6,8 @@ vcr_option = {
   allow_playback_repeats: "true"
 }
 
+default_logger = Rails.logger
+
 RSpec.describe RssReader, type: :service, vcr: vcr_option do
   let(:link) { "https://medium.com/feed/@vaidehijoshi" }
   let(:nonmedium_link) { "https://circleci.com/blog/feed.xml" }
@@ -17,6 +19,8 @@ RSpec.describe RssReader, type: :service, vcr: vcr_option do
     timber_logger = Timber::Logger.new(nil)
     Rails.logger = ActiveSupport::TaggedLogging.new(timber_logger)
   end
+
+  after { Rails.logger = default_logger }
 
   describe "#get_all_articles" do
     before do

--- a/spec/services/rss_reader_spec.rb
+++ b/spec/services/rss_reader_spec.rb
@@ -12,6 +12,12 @@ RSpec.describe RssReader, type: :service, vcr: vcr_option do
   let(:nonpermanent_link) { "https://medium.com/feed/@macsiri/" }
   let(:rss_data) { RSS::Parser.parse(HTTParty.get(link).body, false) }
 
+  # Override the default Rails logger as these tests require the Timber logger.
+  before do
+    timber_logger = Timber::Logger.new(nil)
+    Rails.logger = ActiveSupport::TaggedLogging.new(timber_logger)
+  end
+
   describe "#get_all_articles" do
     before do
       [link, nonmedium_link, nonpermanent_link].each do |feed_url|

--- a/spec/system/user_logs_in_with_twitter_spec.rb
+++ b/spec/system/user_logs_in_with_twitter_spec.rb
@@ -32,11 +32,15 @@ RSpec.describe "Authenticating with twitter" do
     }
   end
 
+  default_logger = Rails.logger
+
   # Override the default Rails logger as these tests require the Timber logger.
   before do
     timber_logger = Timber::Logger.new(nil)
     Rails.logger = ActiveSupport::TaggedLogging.new(timber_logger)
   end
+
+  after { Rails.logger = default_logger }
 
   context "when user is new on dev.to" do
     it "logging in with twitter using valid credentials" do

--- a/spec/system/user_logs_in_with_twitter_spec.rb
+++ b/spec/system/user_logs_in_with_twitter_spec.rb
@@ -32,6 +32,12 @@ RSpec.describe "Authenticating with twitter" do
     }
   end
 
+  # Override the default Rails logger as these tests require the Timber logger.
+  before do
+    timber_logger = Timber::Logger.new(nil)
+    Rails.logger = ActiveSupport::TaggedLogging.new(timber_logger)
+  end
+
   context "when user is new on dev.to" do
     it "logging in with twitter using valid credentials" do
       user_grants_authorization_on_twitter_popup(twitter_callback_hash)

--- a/spec/workers/metrics/record_db_table_counts_worker_spec.rb
+++ b/spec/workers/metrics/record_db_table_counts_worker_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Metrics::RecordDbTableCountsWorker, type: :worker do
+  default_logger = Rails.logger
+
   include_examples "#enqueues_on_correct_queue", "low_priority", 1
 
   describe "#perform" do
@@ -9,6 +11,8 @@ RSpec.describe Metrics::RecordDbTableCountsWorker, type: :worker do
       timber_logger = Timber::Logger.new(nil)
       Rails.logger = ActiveSupport::TaggedLogging.new(timber_logger)
     end
+
+    after { Rails.logger = default_logger }
 
     it "logs estimated counts in Datadog" do
       allow(DataDogStatsClient).to receive(:gauge)

--- a/spec/workers/metrics/record_db_table_counts_worker_spec.rb
+++ b/spec/workers/metrics/record_db_table_counts_worker_spec.rb
@@ -4,6 +4,12 @@ RSpec.describe Metrics::RecordDbTableCountsWorker, type: :worker do
   include_examples "#enqueues_on_correct_queue", "low_priority", 1
 
   describe "#perform" do
+    # Override the default Rails logger as these tests require the Timber logger.
+    before do
+      timber_logger = Timber::Logger.new(nil)
+      Rails.logger = ActiveSupport::TaggedLogging.new(timber_logger)
+    end
+
     it "logs estimated counts in Datadog" do
       allow(DataDogStatsClient).to receive(:gauge)
       described_class.new.perform


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We had some unused code for Timber in our config files for our development and test environments. However, this was completely clobbering Rails' default behavior of logging out to `log/development.log` and `log/test.log`!! 😬 We should allow for logging in these environments in particular since this is expected behavior. And, since we're not using Timber in either of these environments, we can just revert to using the Rails default debugging log levels.

Test this out by pulling down this branch and running `tail -f log/development.log` locally. You should see your local development logs 😻 

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed