### PR TITLE
Use Node lts/erbium (v12) for Netlify builds

### DIFF
--- a/docs/.nvmrc
+++ b/docs/.nvmrc
@@ -1,0 +1,1 @@
+lts/erbium


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

It looks like our Netlify builds are broken - https://app.netlify.com/sites/devto/deploys/5e3b23c6d550dc0008794e8d - because they are trying to use Node 8 which is in maintenance mode and deprecated. This should set Netlify to use the same version we build the DEV's app with.

## Related Tickets & Documents

see failure in https://github.com/thepracticaldev/dev.to/pull/5443
