### PR TITLE
Fix bin/startup to use globally installed foreman

### DIFF
--- a/bin/startup
+++ b/bin/startup
@@ -12,5 +12,5 @@ end
 
 chdir APP_ROOT do
   puts "== STARTING UP =="
-  system! "bundle exec foreman start -f Procfile.dev"
+  system! "foreman start -f Procfile.dev"
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

After #5821 we can't use the bundled foreman anymore, thus we need to fix `bin/startup` for that

## Related Tickets & Documents

#5821
