### PR TITLE
Ensure user is authenticated before doing onboarding Actions

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,6 +3,7 @@ class UsersController < ApplicationController
   before_action :raise_banned, only: %i[update]
   before_action :set_user, only: %i[update update_twitch_username update_language_settings confirm_destroy request_destroy full_delete remove_association]
   after_action :verify_authorized, except: %i[signout_confirm add_org_admin remove_org_admin remove_from_org]
+  before_action :authenticate_user!, only: %i[onboarding_update onboarding_checkbox_update]
 
   # GET /settings/@tab
   def edit

--- a/spec/requests/users_onboarding_spec.rb
+++ b/spec/requests/users_onboarding_spec.rb
@@ -3,14 +3,29 @@ require "rails_helper"
 RSpec.describe "UsersOnboarding", type: :request do
   let(:user) { create(:user, saw_onboarding: false) }
 
-  before do
-    sign_in user
-  end
-
   describe "PATCH /onboarding_update" do
     it "updates saw_onboarding boolean" do
+      sign_in user
       patch "/onboarding_update.json", params: {}
       expect(user.saw_onboarding).to eq(true)
+    end
+
+    it "returns a not found error if user is not signed in" do
+      patch "/onboarding_update.json", params: {}
+      expect(response.parsed_body["error"]).to include("Please sign in")
+    end
+  end
+
+  describe "PATCH /onboarding_checkbox_update" do
+    it "updates saw_onboarding boolean" do
+      sign_in user
+      patch "/onboarding_checkbox_update.json", params: {}
+      expect(user.saw_onboarding).to eq(true)
+    end
+
+    it "returns a not found error if user is not signed in" do
+      patch "/onboarding_checkbox_update.json", params: {}
+      expect(response.parsed_body["error"]).to include("Please sign in")
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
We recently had two honeybadgers come up that showed us attempting to update a user's onboarding without an actual user. Not sure if these were pentesters or what but we should be making sure we have an authenticated user, aka `current_user` before running these controller methods. 

I am actually surprised we don't authenticate_user for all of these actions in the users controller but for now I wanted to just stick with the ones that were raising errors. 

## Honeybadgers
https://app.honeybadger.io/fault/66984/bb578c35d3383ecd07b204f3a134457a
https://app.honeybadger.io/fault/66984/1dfe25f7fbf3c95456488daf1aca2817

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media1.tenor.com/images/a1e41269f9e47c9ad6d253711429ac2c/tenor.gif?itemid=13395387)
