### PR TITLE
Setup Elasticsearch indexes during Deploy and Local App Setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -28,6 +28,9 @@ chdir APP_ROOT do
   puts "\n== Preparing database =="
   system! 'bin/rails db:setup'
 
+  puts "\n== Preparing Elasticsearch =="
+  system! 'bin/rails search:setup'
+
   puts "\n== Removing old logs and tempfiles =="
   system! 'bin/rails log:clear tmp:clear'
 

--- a/bin/update
+++ b/bin/update
@@ -23,6 +23,9 @@ chdir APP_ROOT do
   puts "\n== Updating database =="
   system! 'bin/rails db:migrate'
 
+  puts "\n== Update Elasticsearch =="
+  system! 'bin/rails search:setup'
+
   puts "\n== Removing old logs and tempfiles =="
   system! 'bin/rails log:clear tmp:clear'
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -26,7 +26,8 @@ Some of the steps will be parallelized in the future:
 1. `bundle-audit` checks for any known vulnerability.
 1. Travis builds Storybook to ensure its integrity.
 1. Travis deploys code to Heroku.
-   - Heroku runs the database migrations before deployment.
+   - Heroku runs the database migrations and Elasticsearch updates before
+     deployment.
 1. Travis notifies the team that the process completed.
 
 ## Deploying to Heroku
@@ -44,13 +45,16 @@ This will cause the release script to exit with a code of 1 which will halt the
 deploy. This ensures that we don't accidentally push out code while we are
 waiting for a fix or running other tasks. Next, we run any outstanding
 migrations. This ensures that a migration finishes successfully before the code
-that uses it goes live. After running migrations, we use the Rails runner to
-output a simple string. Executing a Rails runner command ensures that we can
-boot up the entire app successfully before it is deployed. We deploy
-asynchronously, so the website is running the new code a few minutes after
-deploy. A new instance of Heroku Rails console will immediately run a new code.
-We deploy asynchronously, so the website is running the new code a few minutes
-after deploy. A new instance of Heroku Rails console will immediately run a new
-code.
+that uses it goes live. After running migrations, we update Elasticsearch.
+Elasticsearch contains indexes which have mappings. Mappings are similar to
+database schema. The same way we run a migration to update our database we have
+to run a setup task to update any Elasticsearch mappings. Following updating all
+of our datastores we use the Rails runner to output a simple string. Executing a
+Rails runner command ensures that we can boot up the entire app successfully
+before it is deployed. We deploy asynchronously, so the website is running the
+new code a few minutes after deploy. A new instance of Heroku Rails console will
+immediately run a new code. We deploy asynchronously, so the website is running
+the new code a few minutes after deploy. A new instance of Heroku Rails console
+will immediately run a new code.
 
 ![](https://devcenter0.assets.heroku.com/article-images/1494371187-release-phase-diagram-3.png)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -53,7 +53,6 @@ of our datastores we use the Rails runner to output a simple string. Executing a
 Rails runner command ensures that we can boot up the entire app successfully
 before it is deployed. We deploy asynchronously, so the website is running the
 new code a few minutes after deploy. A new instance of Heroku Rails console will
-immediately run a new code. We deploy asynchronously, so the website is running
-the new code a few minutes after deploy.
+immediately run a new code.
 
 ![](https://devcenter0.assets.heroku.com/article-images/1494371187-release-phase-diagram-3.png)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -54,7 +54,6 @@ Rails runner command ensures that we can boot up the entire app successfully
 before it is deployed. We deploy asynchronously, so the website is running the
 new code a few minutes after deploy. A new instance of Heroku Rails console will
 immediately run a new code. We deploy asynchronously, so the website is running
-the new code a few minutes after deploy. A new instance of Heroku Rails console
-will immediately run a new code.
+the new code a few minutes after deploy.
 
 ![](https://devcenter0.assets.heroku.com/article-images/1494371187-release-phase-diagram-3.png)

--- a/release-tasks.sh
+++ b/release-tasks.sh
@@ -6,6 +6,8 @@ set -x
 # abort release if deploy status equals "blocked"
 [[ $DEPLOY_STATUS = "blocked" ]] && echo "Deploy blocked" && exit 1
 
-# runs migration and boots the app to check there are no errors
+# runs migration for Postgres, setups/updates Elasticsearch
+# and boots the app to check there are no errors
 STATEMENT_TIMEOUT=180000 bundle exec rails db:migrate && \
+  bundle exec rake search:setup && \
   bundle exec rails runner "puts 'app load success'"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature
- [x] Documentation Update

## Description
Now that Elasticsearch foundation has been laid, #5919 . This adds the `search:setup` rake task to the deployment pipeline as well as the local app setup and update pipeline. This setup is safe to run multiple times bc we check for the existence of indexes before attempting to create them. Further, if you try to add an alias multiple times Elasticsearch returns true but there is still only 1 alias in Elasticsearch. 

Following this I will [PR the code to index tags!](https://github.com/thepracticaldev/dev.to/compare/mstruve/index-tags-to-es)

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-32288297

## Added to documentation?
- [x] readme

![alt_text](https://media0.giphy.com/media/L9pjsBKjNKrXa/giphy.gif)
