### PR TITLE
Correct startup script and docs

### DIFF
--- a/bin/startup
+++ b/bin/startup
@@ -12,5 +12,5 @@ end
 
 chdir APP_ROOT do
   puts "== STARTING UP =="
-  system! "bundle exec foreman start -f Procfile.dev"
+  system! "foreman start -f Procfile.dev"
 end

--- a/docs/getting-started/start-app.md
+++ b/docs/getting-started/start-app.md
@@ -15,7 +15,7 @@ bin/startup
 ```
 
 (This just runs `foreman start -f Procfile.dev`, for notes on how to install
-Foreman, please see [Other Tools](../installation/others.md))
+Foreman, please see [Other Tools](../installation/others))
 
 Then point your browser to http://localhost:3000/ to view the site.
 


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [X] Documentation Update

## Description

PR https://docs.dev.to/installation/others/ removed the `foreman` gem, but the startup script at `bin/startup` wasn't adjusted to match documentation. This PR also fixes a link in said documentation.

## Related Tickets & Documents

https://docs.dev.to/installation/others/

## Added to documentation?

- [X] docs.dev.to
- [ ] readme
- [ ] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![foreman](https://media.giphy.com/media/PLlnVqPqBnieY/giphy.gif)
