### PR TITLE
Remove .first query in services/notifications/update to fix dying jobs

### DIFF
--- a/app/services/notifications/update.rb
+++ b/app/services/notifications/update.rb
@@ -23,7 +23,7 @@ module Notifications
       # to load all of them in memory with `.blank?`, thus we choose `.none?`
       return if notifications.none?
 
-      new_json_data = notifications.first.json_data || {}
+      new_json_data = {}
       new_json_data[notifiable.class.name.downcase] = public_send("#{notifiable.class.name.downcase}_data", notifiable)
       new_json_data[:user] = user_data(notifiable.user)
       add_organization_data = notifiable.is_a?(Article) && notifiable.organization


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
This is a follow-up to the discussion on #5921. Adding the new index wasn't enough, jobs are still dying with the same error.

![Screen Shot 2020-02-05 at 4 02 48 PM](https://user-images.githubusercontent.com/15987080/73986668-0e285b00-48f3-11ea-96ad-e7dcbbf7426e.png)

Following-up on the next hunch (shout out to @mstruve), it seems the issue is `.first`. Since `.first` adds `ORDER BY`, it slows things down. Oddly enough, calling `.last` works in prod.

One idea to fix this was to change the query to:

```ruby
new_json_data = notifications.where.not(json_data: nil).limit(1).json_data || {}
```

This then turned into a discussion of why are we even going through the effort of finding the old `json_data` when all the notifications are going to be updated with `new_json_data` anyways.

This PR removes the query of `notifications.first` altogether and just builds the `json_data` from scratch everytime, which should fix (famous last words) the query timing out.

## Related Tickets & Documents
#5921 

## Added to documentation?
- [x] no documentation needed

![please_gif](https://media.giphy.com/media/l0NwNrl4BtDD7JCx2/giphy.gif)
