### PR TITLE
Add low-value landing pages to robots.txt disallow

### DIFF
--- a/app/views/pages/robots.text.erb
+++ b/app/views/pages/robots.text.erb
@@ -4,7 +4,7 @@ Disallow: /users/auth/github*
 Disallow: /report-abuse?url=*
 Disallow: /connect/@*
 Disallow: /search?q=*
-Disallow: /search/?=*
+Disallow: /search/?q=*
 Disallow: /listings*?q=*
 
 Sitemap: https://<%= ApplicationConfig["AWS_BUCKET_NAME"] %>.s3.amazonaws.com/sitemaps/sitemap.xml.gz

--- a/app/views/pages/robots.text.erb
+++ b/app/views/pages/robots.text.erb
@@ -2,5 +2,9 @@ User-agent: *
 Disallow: /users/auth/twitter*
 Disallow: /users/auth/github*
 Disallow: /report-abuse?url=*
+Disallow: /connect/@*
+Disallow: /search?=*
+Disallow: /search/?=*
+Disallow: /listings*?q=*
 
 Sitemap: https://<%= ApplicationConfig["AWS_BUCKET_NAME"] %>.s3.amazonaws.com/sitemaps/sitemap.xml.gz

--- a/app/views/pages/robots.text.erb
+++ b/app/views/pages/robots.text.erb
@@ -3,7 +3,7 @@ Disallow: /users/auth/twitter*
 Disallow: /users/auth/github*
 Disallow: /report-abuse?url=*
 Disallow: /connect/@*
-Disallow: /search?=*
+Disallow: /search?q=*
 Disallow: /search/?=*
 Disallow: /listings*?q=*
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR helps steer search crawlers away from low value pages which will waste their resources and therefore result in fewer crawls of valuable content due to overall crawl budget allocations. Google is generally not looking to link to _our_ long tail or private endpoints, so if we can help guide, that is best.

Example

Some live robots.txt pages for reference...

https://stackoverflow.com/robots.txt
https://www.buzzfeed.com/robots.txt
https://www.nytimes.com/robots.txt