### PR TITLE
Allow comments without a commentable to be edited and destroyed

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -143,8 +143,8 @@ class CommentsController < ApplicationController
       @comment.deleted = true
       @comment.save!
     end
-    redirect_to URI.parse(@comment.commentable.path).path, notice: "Comment was successfully deleted." if @comment.commentable
-    redirect_to root_path
+    comment_path = @comment.commentable ? URI.parse(@comment.commentable.path).path : root_path
+    redirect_to comment_path, notice: "Comment was successfully deleted."
   end
 
   def delete_confirm

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -137,16 +137,14 @@ class CommentsController < ApplicationController
   # DELETE /comments/1.json
   def destroy
     authorize @comment
+    @commentable_path = @comment.commentable.path
     if @comment.is_childless?
       @comment.destroy
     else
       @comment.deleted = true
       @comment.save!
     end
-    redirect = @comment.commentable&.path || user_path(current_user)
-    # NOTE: Brakeman doesn't like redirecting to a path, because of a "possible
-    # unprotected redirect". Using URI.parse().path is the recommended workaround.
-    redirect_to URI.parse(redirect).path, notice: "Comment was successfully deleted."
+    redirect_to URI.parse(@commentable_path).path, notice: "Comment was successfully deleted."
   end
 
   def delete_confirm

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -137,14 +137,14 @@ class CommentsController < ApplicationController
   # DELETE /comments/1.json
   def destroy
     authorize @comment
-    @commentable_path = @comment.commentable.path
     if @comment.is_childless?
       @comment.destroy
     else
       @comment.deleted = true
       @comment.save!
     end
-    redirect_to URI.parse(@commentable_path).path, notice: "Comment was successfully deleted."
+    redirect_to URI.parse(@comment.commentable.path).path, notice: "Comment was successfully deleted." if @comment.commentable
+    redirect_to root_path
   end
 
   def delete_confirm

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -143,8 +143,10 @@ class CommentsController < ApplicationController
       @comment.deleted = true
       @comment.save!
     end
-    location = @comment.commentable ? URI.parse(@comment.commentable.path).path : "/"
-    redirect_to location, notice: "Comment was successfully deleted."
+    redirect = @comment.commentable&.path || user_path(current_user)
+    # NOTE: Brakeman doesn't like redirecting to a path, because of a "possible
+    # unprotected redirect". Using URI.parse().path is the recommended workaround.
+    redirect_to URI.parse(redirect).path, notice: "Comment was successfully deleted."
   end
 
   def delete_confirm

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -143,8 +143,8 @@ class CommentsController < ApplicationController
       @comment.deleted = true
       @comment.save!
     end
-    comment_path = @comment.commentable ? URI.parse(@comment.commentable.path).path : root_path
-    redirect_to comment_path, notice: "Comment was successfully deleted."
+    location = @comment.commentable ? URI.parse(@comment.commentable.path).path : "/"
+    redirect_to location, notice: "Comment was successfully deleted."
   end
 
   def delete_confirm

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -3,7 +3,7 @@ class Comment < ApplicationRecord
   resourcify
   include AlgoliaSearch
   include Reactable
-  belongs_to :commentable, polymorphic: true
+  belongs_to :commentable, polymorphic: true, optional: true
   counter_culture :commentable
   belongs_to :user
   counter_culture :user
@@ -34,7 +34,7 @@ class Comment < ApplicationRecord
   before_create  :adjust_comment_parent_based_on_depth
   after_update   :remove_notifications, if: :deleted
   after_update   :update_descendant_notifications, if: :deleted
-  before_validation :evaluate_markdown, if: -> { body_markdown && commentable }
+  before_validation :evaluate_markdown, if: -> { body_markdown }
   validate :permissions, if: :commentable
 
   alias touch_by_reaction save
@@ -213,7 +213,7 @@ class Comment < ApplicationRecord
     fixed_body_markdown = MarkdownFixer.fix_for_comment(body_markdown)
     parsed_markdown = MarkdownParser.new(fixed_body_markdown)
     self.processed_html = parsed_markdown.finalize(link_attributes: { rel: "nofollow" })
-    wrap_timestamps_if_video_present!
+    wrap_timestamps_if_video_present! if commentable
     shorten_urls!
   end
 

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -57,7 +57,7 @@
     <input class="uploaded-image" id="uploaded-image-main" />
   </div>
   <div class="actions" id="submit-wrapper">
-    <%= link_to((:back if request.referer.present?) || (commentable.path if commentable) || @comment.path), "aria-label": "Cancel action") do %>
+    <%= link_to((:back if request.referer.present?) || (commentable.path if commentable) || @comment.path, "aria-label": "Cancel action") do %>
       <button id="cancel-button" class="comment-action-button comment-action-cancel">CANCEL</button>
     <% end %>
     <button id="preview-button" class="comment-action-button comment-action-preview">PREVIEW</button>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -25,7 +25,7 @@
   <input type="hidden" name="authenticity_token" value="NOTHING" id="new_comment_authenticity_token">
 
   <% unless @comment.persisted? %>
-    <%= f.hidden_field :commentable_id, value: commentable.id %>
+    <%= f.hidden_field :commentable_id, value: commentable&.id %>
     <%= f.hidden_field :commentable_type, value: commentable_type %>
     <%= f.hidden_field :parent_id, value: @parent_comment.id if @parent_comment %>
   <% end %>
@@ -57,7 +57,7 @@
     <input class="uploaded-image" id="uploaded-image-main" />
   </div>
   <div class="actions" id="submit-wrapper">
-    <%= link_to(request.referer.present? ? :back : commentable.path, "aria-label": "Cancel action") do %>
+    <%= link_to((:back if request.referer.present?) || (commentable.path if commentable) || @comment.path), "aria-label": "Cancel action") do %>
       <button id="cancel-button" class="comment-action-button comment-action-cancel">CANCEL</button>
     <% end %>
     <button id="preview-button" class="comment-action-button comment-action-preview">PREVIEW</button>

--- a/app/views/comments/deleted_commentable_comment.html.erb
+++ b/app/views/comments/deleted_commentable_comment.html.erb
@@ -56,7 +56,14 @@
             <span class="reactions-count"><%= @root_comment.reactions_count %></span>
           </button>
         </div>
-        <div class="actions"></div>
+        <div class="actions">
+          <% if @root_comment.user_id == current_user&.id %>
+            <span class="current-user-actions">
+              <a href="<%= @root_comment.path %>/delete_confirm" class="edit-butt" rel="nofollow">DELETE</a>
+              <a href="<%= @root_comment.path %>//edit" class="edit-butt" rel="nofollow">EDIT</a>
+            </span>
+          <% end %>
+        </div>
       </div>
     <% end %>
   </div>

--- a/app/views/comments/deleted_commentable_comment.html.erb
+++ b/app/views/comments/deleted_commentable_comment.html.erb
@@ -60,7 +60,7 @@
           <% if @root_comment.user_id == current_user&.id %>
             <span class="current-user-actions">
               <a href="<%= @root_comment.path %>/delete_confirm" class="edit-butt" rel="nofollow">DELETE</a>
-              <a href="<%= @root_comment.path %>//edit" class="edit-butt" rel="nofollow">EDIT</a>
+              <a href="<%= @root_comment.path %>/edit" class="edit-butt" rel="nofollow">EDIT</a>
             </span>
           <% end %>
         </div>

--- a/app/views/comments/edit.html.erb
+++ b/app/views/comments/edit.html.erb
@@ -1,10 +1,10 @@
 <div
   class="comments-container"
   id="comments-container"
-  data-commentable-id="<%= @commentable.id %>"
-  data-commentable-type="<%= @commentable.class.name %>">
+  data-commentable-id="<%= @comment.commentable_id %>"
+  data-commentable-type="<%= @comment.commentable_type %>">
   <h1 style="padding-top:8%;text-align:center">Editing comment</h1>
   <%= render "form",
              commentable: @commentable,
-             commentable_type: @commentable.class.name %>
+             commentable_type: @comment.commentable_type %>
 </div>

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Comment, type: :model do
 
   describe "validations" do
     it { is_expected.to belong_to(:user) }
-    it { is_expected.to belong_to(:commentable) }
+    it { is_expected.to belong_to(:commentable).optional }
     it { is_expected.to have_many(:reactions).dependent(:destroy) }
     it { is_expected.to have_many(:mentions).dependent(:destroy) }
     it { is_expected.to have_many(:notifications).dependent(:delete_all) }

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -290,38 +290,6 @@ RSpec.describe "Comments", type: :request do
     end
   end
 
-  describe "DELETE /comments/:id" do
-    before do
-      sign_in user
-      comment
-    end
-
-    it "deletes" do
-      expect do
-        delete "/comments/#{comment.id}",
-               params: { comment: { body_markdown: "{edited comment}" } }
-      end.to change(Comment, :count).by(-1)
-      expect(response).to have_http_status(:redirect)
-    end
-
-    context "when the article is deleted" do
-      before do
-        article.destroy
-        put "/comments/#{comment.id}",
-            params: { comment: { body_markdown: "{edited comment}" } }
-        comment.reload
-      end
-
-      it "deletes" do
-        expect do
-          delete "/comments/#{comment.id}",
-                 params: { comment: { body_markdown: "{edited comment}" } }
-        end.to change(Comment, :count).by(-1)
-        expect(response).to have_http_status(:redirect)
-      end
-    end
-  end
-
   describe "PATCH /comments/:comment_id/hide" do
     include_examples "PATCH /comments/:comment_id/hide or unhide", path: "hide", hidden: "true"
   end

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -253,12 +253,12 @@ RSpec.describe "Comments", type: :request do
       before do
         comment
         article.destroy
-        put "/comments/#{comment.id}",
-            params: { comment: { body_markdown: "{edited comment}" } }
-        comment.reload
       end
 
       it "updates body markdown" do
+        put "/comments/#{comment.id}",
+            params: { comment: { body_markdown: "{edited comment}" } }
+        comment.reload
         expect(comment.processed_html).to include("edited comment")
       end
     end
@@ -286,6 +286,38 @@ RSpec.describe "Comments", type: :request do
 
       it "returns json" do
         expect(response.content_type).to eq("application/json")
+      end
+    end
+  end
+
+  describe "DELETE /comments/:id" do
+    before do
+      sign_in user
+      comment
+    end
+
+    it "deletes" do
+      expect do
+        delete "/comments/#{comment.id}",
+               params: { comment: { body_markdown: "{edited comment}" } }
+      end.to change(Comment, :count).by(-1)
+      expect(response).to have_http_status(:redirect)
+    end
+
+    context "when the article is deleted" do
+      before do
+        article.destroy
+        put "/comments/#{comment.id}",
+            params: { comment: { body_markdown: "{edited comment}" } }
+        comment.reload
+      end
+
+      it "deletes" do
+        expect do
+          delete "/comments/#{comment.id}",
+                 params: { comment: { body_markdown: "{edited comment}" } }
+        end.to change(Comment, :count).by(-1)
+        expect(response).to have_http_status(:redirect)
       end
     end
   end

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -176,10 +176,10 @@ RSpec.describe "Comments", type: :request do
       before do
         comment
         article.destroy
-        get comment.path
       end
 
-      it "renders deleted article comment view" do
+      it "index action renders deleted_commentable_comment view" do
+        get comment.path
         expect(response.body).to include("Comment from a deleted article or podcast")
       end
     end
@@ -188,10 +188,10 @@ RSpec.describe "Comments", type: :request do
       before do
         podcast_comment
         podcast_episode.destroy
-        get podcast_comment.path
       end
 
-      it "renders deleted article comment view" do
+      it "renders deleted_commentable_comment view" do
+        get podcast_comment.path
         expect(response.body).to include("Comment from a deleted article or podcast")
       end
     end
@@ -221,6 +221,19 @@ RSpec.describe "Comments", type: :request do
         expect(response.body).to include CGI.escapeHTML(comment.body_markdown)
       end
     end
+
+    context "when the article is deleted" do
+      before do
+        sign_in user
+        comment
+        article.destroy
+      end
+
+      it "edit action returns 200" do
+        get "/#{user.username}/#{article.slug}/comments/#{comment.id_code_generated}/edit"
+        expect(response).to have_http_status(:ok)
+      end
+    end
   end
 
   describe "PUT /comments/:id" do
@@ -234,6 +247,20 @@ RSpec.describe "Comments", type: :request do
 
       expect(response).to have_http_status(:ok)
       expect(flash[:error]).not_to be_nil
+    end
+
+    context "when the article is deleted" do
+      before do
+        comment
+        article.destroy
+        put "/comments/#{comment.id}",
+            params: { comment: { body_markdown: "{edited comment}" } }
+        comment.reload
+      end
+
+      it "updates body markdown" do
+        expect(comment.processed_html).to include("edited comment")
+      end
     end
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Allows comments from a deleted articles or podcasts to be edited.  Currently, they are able to be viewed but not edited.

I noticed #5889 had fixed for allowing destroy, so I removed the code for it. It is now only for edit.
## Related Tickets & Documents
#5511 
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
