### PR TITLE
Consolidate server side main article feed logic

### DIFF
--- a/app/assets/javascripts/initializers/initializeFetchFollowedArticles.js.erb
+++ b/app/assets/javascripts/initializers/initializeFetchFollowedArticles.js.erb
@@ -23,62 +23,10 @@ function insertArticle(article,parent,insertPlace) {
 
 function insertInitialArticles(user) {
   var el = document.getElementById("home-articles-object");
-  if (!el) {return}
+ if (!el) {return}
   el.innerHTML = "";
-  insertNewArticles(user);
   insertTopArticles(user);
   el.outerHTML = "";
-}
-
-function insertNewArticles(user){
-  var el = document.getElementById("new-articles-object");
-  var articlesJSON = JSON.parse(el.dataset.articles);
-  var insertPlace = document.getElementById("article-index-hidden-div");
-  if (insertPlace) {
-      articlesJSON.forEach(function(article){
-      var articlePoints = 0
-      var containsUserID = findOne([article.user_id], user.followed_user_ids || [])
-      var containsOrganizationID = findOne([article.organization_id], user.followed_organization_ids || [])
-      var intersectedTags = intersect_arrays(user.followed_tag_names, article.cached_tag_list_array)
-      var followedPoints = 1
-      var experienceDifference = Math.abs(article['experience_level_rating'] - user.experience_level || 5)
-      var containsPreferredLanguage = findOne([article.language || 'en'], user.preferred_languages_array || ['en']);
-      JSON.parse(user.followed_tags).map(function(tag) {
-        if (intersectedTags.includes(tag.name)) {
-          followedPoints = followedPoints + tag.points
-        }
-      })
-      articlePoints = articlePoints + (followedPoints*2) + article.positive_reactions_count
-      if (containsUserID || article.user_id === user.id) {
-        articlePoints = articlePoints + 16
-      }
-      if (containsOrganizationID) {
-        articlePoints = articlePoints + 16
-      }
-      if (containsPreferredLanguage) {
-        articlePoints = articlePoints + 1
-      } else {
-        articlePoints = articlePoints - 10
-      }
-      var rand = Math.random();
-      if (rand < 0.3) {
-        articlePoints = articlePoints + 3
-      } else if (rand < 0.6) {
-        articlePoints = articlePoints + 6
-      }
-      articlePoints = articlePoints - (experienceDifference/2);
-      article['points'] = articlePoints
-    });
-    var sortedArticles = articlesJSON.sort(function(a, b) {
-      return b.points - a.points;
-    });
-    sortedArticles.forEach(function(article){
-      var parent = insertPlace.parentNode;
-      if ( article.points > 12 && !document.getElementById("article-link-"+article.id) ) {
-        insertArticle(article,parent,insertPlace);
-      }
-    });
-  }
 }
 
 function insertTopArticles(user){

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -111,6 +111,10 @@ class StoriesController < ApplicationController
     @page = (params[:page] || 1).to_i
     num_articles = 35
     @stories = article_finder(num_articles)
+    @new_stories = Article.published.
+      where("published_at > ? AND score > ?", rand(2..6).hours.ago, -15).
+      limited_column_select.order("published_at DESC").limit(rand(15..80)).
+      decorate
     if %w[week month year infinity].include?(params[:timeframe])
       @stories = @stories.where("published_at > ?", Timeframer.new(params[:timeframe]).datetime).
         order("score DESC")

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -87,7 +87,7 @@ class StoriesController < ApplicationController
       return
     end
 
-    @stories = article_finder(8)
+    @stories = Articles::Feed.new(number_of_articles: 8, tag: @tag).published_articles_by_tag
 
     @stories = @stories.where(approved: true) if @tag_model&.requires_approval
 
@@ -112,7 +112,7 @@ class StoriesController < ApplicationController
     number_of_articles = 35
     feed = Articles::Feed.new(number_of_articles: number_of_articles, page: @page, tag: params[:tag])
     if %w[week month year infinity].include?(params[:timeframe])
-      @stories = feed.time_based_feed(timeframe: params[:timeframe])
+      @stories = feed.top_articles_by_timeframe(timeframe: params[:timeframe])
     elsif params[:timeframe] == "latest"
       @stories = feed.latest_feed
     else

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -123,6 +123,7 @@ class StoriesController < ApplicationController
       @stories = @stories.
         where("score > ? OR featured = ?", 9, true).
         order("hotness_score DESC")
+      @featured_story = @stories.where.not(main_image: nil).first
       if user_signed_in?
         offset = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 3, 3, 4, 5, 6, 7, 8, 9, 10, 11].sample # random offset, weighted more towards zero
         @stories = @stories.offset(offset)
@@ -131,6 +132,8 @@ class StoriesController < ApplicationController
     assign_podcasts
     assign_classified_listings
     @article_index = true
+    @featured_story = (@featured_story || Article.new)&.decorate
+    @stories = @stories&.decorate
     set_surrogate_key_header "main_app_home_page"
     response.headers["Surrogate-Control"] = "max-age=600, stale-while-revalidate=30, stale-if-error=86400"
     render template: "articles/index"

--- a/app/services/articles/feed.rb
+++ b/app/services/articles/feed.rb
@@ -1,0 +1,43 @@
+module Articles
+  class Feed
+    attr_reader :stories
+
+    def initialize(number_of_articles:, page:, tag: nil)
+      @number_of_articles = number_of_articles
+      @page = page
+      @tag = tag
+      @stories = published_articles_by_tag
+    end
+
+    def published_articles_by_tag
+      articles = Article.published.limited_column_select.page(@page).per(@num_articles)
+      articles = articles.cached_tagged_with(@tag) if @tag.present? # More efficient than tagged_with
+      articles
+    end
+
+    def time_based_feed(timeframe:)
+      stories.where("published_at > ?", Timeframer.new(timeframe).datetime).
+        order("score DESC")
+    end
+
+    def latest_feed
+      stories.order("published_at DESC").
+        where("featured_number > ? AND score > ?", 1_449_999_999, -40)
+    end
+
+    def default_home_feed(user_signed_in: false)
+      hot_stories = stories.
+        where("score > ? OR featured = ?", 9, true).
+        order("hotness_score DESC")
+      featured_story = hot_stories.where.not(main_image: nil).first
+      if user_signed_in
+        offset = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 3, 3, 4, 5, 6, 7, 8, 9, 10, 11].sample # random offset, weighted more towards zero
+        hot_stories = hot_stories.offset(offset)
+      end
+      new_stories = Article.published.
+        where("published_at > ? AND score > ?", rand(2..6).hours.ago, -15).
+        limited_column_select.order("published_at DESC").limit(rand(15..80))
+      [featured_story, (hot_stories.to_a + new_stories.to_a)]
+    end
+  end
+end

--- a/app/services/articles/feed.rb
+++ b/app/services/articles/feed.rb
@@ -1,12 +1,9 @@
 module Articles
   class Feed
-    attr_reader :stories
-
-    def initialize(number_of_articles:, page:, tag: nil)
+    def initialize(number_of_articles:, page: 1, tag: nil)
       @number_of_articles = number_of_articles
       @page = page
       @tag = tag
-      @stories = published_articles_by_tag
     end
 
     def published_articles_by_tag
@@ -15,29 +12,31 @@ module Articles
       articles
     end
 
-    def time_based_feed(timeframe:)
-      stories.where("published_at > ?", Timeframer.new(timeframe).datetime).
+    # Timeframe values dome from Timeframer::DATETIMES
+    def top_articles_by_timeframe(timeframe:)
+      published_articles_by_tag.where("published_at > ?", Timeframer.new(timeframe).datetime).
         order("score DESC")
     end
 
     def latest_feed
-      stories.order("published_at DESC").
+      published_articles_by_tag.order("published_at DESC").
         where("featured_number > ? AND score > ?", 1_449_999_999, -40)
     end
 
     def default_home_feed(user_signed_in: false)
-      hot_stories = stories.
+      hot_stories = published_articles_by_tag.
         where("score > ? OR featured = ?", 9, true).
         order("hotness_score DESC")
       featured_story = hot_stories.where.not(main_image: nil).first
       if user_signed_in
         offset = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 3, 3, 4, 5, 6, 7, 8, 9, 10, 11].sample # random offset, weighted more towards zero
         hot_stories = hot_stories.offset(offset)
+        new_stories = Article.published.
+          where("published_at > ? AND score > ?", rand(2..6).hours.ago, -15).
+          limited_column_select.order("published_at DESC").limit(rand(15..80))
+        hot_stories = hot_stories.to_a + new_stories.to_a
       end
-      new_stories = Article.published.
-        where("published_at > ? AND score > ?", rand(2..6).hours.ago, -15).
-        limited_column_select.order("published_at DESC").limit(rand(15..80))
-      [featured_story, (hot_stories.to_a + new_stories.to_a)]
+      [featured_story, hot_stories]
     end
   end
 end

--- a/app/views/articles/_sticky_nav.html.erb
+++ b/app/views/articles/_sticky_nav.html.erb
@@ -103,7 +103,7 @@
               <img src="<%= ProfileImage.new(article.user).get(90) %>" class="primary-sticky-nav-profile-image" loading="lazy" alt="<%= article.user.name %> profile image">
               <%= article.title %>
               <div class="primary-sticky-nav-element-details">
-                <% article.decorate.cached_tag_list_array.each do |tag| %>
+                <% article.cached_tag_list_array.each do |tag| %>
                   <span>#<%= tag %></span>
                 <% end %>
               </div>
@@ -123,7 +123,7 @@
               <img src="<%= ProfileImage.new(article.user).get(90) %>" class="primary-sticky-nav-profile-image" loading="lazy" alt="<%= article.user.name %> profile image">
               <%= article.title %>
               <div class="primary-sticky-nav-element-details">
-                <% article.decorate.cached_tag_list_array.each do |tag| %>
+                <% article.cached_tag_list_array.each do |tag| %>
                   <span>#<%= tag %></span>
                 <% end %>
               </div>

--- a/app/views/articles/_sticky_nav.html.erb
+++ b/app/views/articles/_sticky_nav.html.erb
@@ -103,7 +103,7 @@
               <img src="<%= ProfileImage.new(article.user).get(90) %>" class="primary-sticky-nav-profile-image" loading="lazy" alt="<%= article.user.name %> profile image">
               <%= article.title %>
               <div class="primary-sticky-nav-element-details">
-                <% article.cached_tag_list_array.each do |tag| %>
+                <% article.decorate.cached_tag_list_array.each do |tag| %>
                   <span>#<%= tag %></span>
                 <% end %>
               </div>
@@ -123,7 +123,7 @@
               <img src="<%= ProfileImage.new(article.user).get(90) %>" class="primary-sticky-nav-profile-image" loading="lazy" alt="<%= article.user.name %> profile image">
               <%= article.title %>
               <div class="primary-sticky-nav-element-details">
-                <% article.cached_tag_list_array.each do |tag| %>
+                <% article.decorate.cached_tag_list_array.each do |tag| %>
                   <span>#<%= tag %></span>
                 <% end %>
               </div>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -83,11 +83,6 @@
         </button>
       </div>
 
-      <% if @home_page %>
-        <% @featured_story ||= @stories.where.not(main_image: nil).first&.decorate || Article.new %>
-        <% @stories = @stories.decorate %>
-      <% end %>
-
       <% if @featured_story.id %>
         <div id="featured-story-marker" data-featured-article="articles-<%= @featured_story.id %>"></div>
         <img src="<%= cloud_cover_url(@featured_story.main_image) %>" style="display:none" alt="<%= @featured_story.title %>" />

--- a/app/views/stories/_main_stories_feed.html.erb
+++ b/app/views/stories/_main_stories_feed.html.erb
@@ -1,11 +1,5 @@
 <% if @default_home_feed && user_signed_in? %>
   <% cache("fetched-home-articles-object", expires_in: 3.minutes) do %>
-    <% @new_stories = Article.published.
-         where("published_at > ? AND score > ?", rand(2..6).hours.ago, -15).
-         limited_column_select.
-         order("published_at DESC").
-         limit(rand(15..80)).
-         decorate %>
     <div id="followed-podcasts" data-episodes="<%= @podcast_episodes.to_json(include: { podcast: { only: %i[slug title id], methods: %i[image_90] } }) %>">
     </div>
     <div id="new-articles-object" data-articles="

--- a/app/views/stories/_main_stories_feed.html.erb
+++ b/app/views/stories/_main_stories_feed.html.erb
@@ -2,16 +2,6 @@
   <% cache("fetched-home-articles-object", expires_in: 3.minutes) do %>
     <div id="followed-podcasts" data-episodes="<%= @podcast_episodes.to_json(include: { podcast: { only: %i[slug title id], methods: %i[image_90] } }) %>">
     </div>
-    <div id="new-articles-object" data-articles="
-      <%= @new_stories.to_json(
-            only: %i[title path id user_id comments_count positive_reactions_count organization_id
-                     reading_time video_thumbnail_url video video_duration_in_minutes language
-                     experience_level_rating experience_level_rating_distribution cached_user cached_organization],
-            methods: %i[readable_publish_date cached_tag_list_array flare_tag class_name
-                        cloudinary_video_url video_duration_in_minutes published_at_int
-                        published_timestamp],
-          ) %>">
-    </div>
     <div id="home-articles-object" data-articles="
       <%= @stories.to_json(
             only: %i[title path id user_id comments_count positive_reactions_count organization_id

--- a/spec/services/articles/feed_spec.rb
+++ b/spec/services/articles/feed_spec.rb
@@ -1,0 +1,96 @@
+require "rails_helper"
+
+RSpec.describe Articles::Feed, type: :service do
+  let!(:feed) { described_class.new(number_of_articles: 100, page: 1) }
+  let!(:article) { create(:article) }
+
+  describe "#initialize" do
+    it "requires number of pages argument" do
+      expect { described_class.new(number_of_articles: 1, tag: "foo") }.to raise_error(ArgumentError)
+    end
+
+    it "requires number of articles argument" do
+      expect { described_class.new(tag: "foo", page: 1) }.to raise_error(ArgumentError)
+    end
+
+    it "does not require the tag argument" do
+      expect { described_class.new(number_of_articles: 1, page: 1) }.not_to raise_error
+    end
+  end
+
+  describe "#published_articles_by_tag" do
+    let(:unpublished_article) { create(:article, published: false) }
+    let(:tag) { "foo" }
+    let(:tagged_article) { create(:article, tags: [tag]) }
+
+    it "returns published articles" do
+      expect(described_class.new(number_of_articles: 1, page: 1).stories).to eq [article]
+    end
+
+    context "with tag" do
+      it "returns articles with the specified tag" do
+        expect(described_class.new(number_of_articles: 1, page: 1, tag: tag).stories).to eq [tagged_article]
+      end
+    end
+  end
+
+  describe "#time_based_feed" do
+    let!(:high_scoring_article) { create(:article, score: 100) }
+
+    it "returns articles ordered by score" do
+      expect(feed.time_based_feed(timeframe: "week")).to eq [high_scoring_article, article]
+    end
+
+    context "with week article timeframe specified" do
+      let!(:month_old_article) { create(:article, published_at: 1.month.ago) }
+
+      it "only returns articles from this week" do
+        expect(feed.time_based_feed(timeframe: "week")).not_to include(month_old_article)
+      end
+    end
+  end
+
+  describe "#latest_feed" do
+    let!(:low_scoring_article) { create(:article, score: -1000) }
+    let!(:new_article) { create(:article) }
+
+    before { article.update(published_at: 1.week.ago) }
+
+    it "only returns articles with scores above -40" do
+      expect(feed.latest_feed).not_to include(low_scoring_article)
+    end
+
+    it "returns articles ordered by publishing date descending" do
+      expect(feed.latest_feed).to eq [new_article, article]
+    end
+  end
+
+  describe "#default_home_feed" do
+    let!(:hot_story) { create(:article, hotness_score: 100, score: 100, published_at: 1.day.ago) }
+    let!(:new_story) { create(:article, published_at: 1.minute.ago) }
+    let!(:low_scoring_article) { create(:article, score: -1000) }
+
+    let(:featured_story) { feed.default_home_feed.first }
+    let(:stories) { feed.default_home_feed.second }
+
+    before { article.update(published_at: 1.week.ago) }
+
+    it "returns a featured article and array of other articles" do
+      expect(featured_story).to be_a(Article)
+      expect(stories).to be_a(Array)
+    end
+
+    it "chooses a featured story with a main image" do
+      expect(featured_story).to eq hot_story
+    end
+
+    it "doesn't include low scoring stories" do
+      expect(stories).not_to include(low_scoring_article)
+    end
+
+    it "only includes stories from more than 6 hours ago" do
+      expect(stories).not_to include(article)
+      expect(stories).to include(new_story)
+    end
+  end
+end

--- a/spec/system/homepage/user_visits_homepage_articles_spec.rb
+++ b/spec/system/homepage/user_visits_homepage_articles_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 RSpec.describe "User visits a homepage", type: :system do
   let!(:article) { create(:article, reactions_count: 12, featured: true) }
   let!(:article2) { create(:article, reactions_count: 20, featured: true) }
-  let!(:unreacted_article) { create(:article, reactions_count: 0) }
   let!(:timestamp) { "2019-03-04T10:00:00Z" }
 
   context "when no options specified" do
@@ -39,7 +38,6 @@ RSpec.describe "User visits a homepage", type: :system do
         expect(page).to have_selector(".single-article", count: 2)
         expect(page).to have_text(article.title)
         expect(page).to have_text(article2.title)
-        expect(page.all(".single-article").last).to have_text(unreacted_article.title)
       end
 
       it "shows all articles dates", js: true do

--- a/spec/system/homepage/user_visits_homepage_articles_spec.rb
+++ b/spec/system/homepage/user_visits_homepage_articles_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "User visits a homepage", type: :system do
       end
 
       it "shows correct articles " do
-        expect(page).to have_selector(".single-article", count: 3)
+        expect(page).to have_selector(".single-article", count: 2)
         expect(page).to have_text(article.title)
         expect(page).to have_text(article2.title)
         expect(page.all(".single-article").last).to have_text(unreacted_article.title)

--- a/spec/system/homepage/user_visits_homepage_articles_spec.rb
+++ b/spec/system/homepage/user_visits_homepage_articles_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "User visits a homepage", type: :system do
   let!(:article) { create(:article, reactions_count: 12, featured: true) }
   let!(:article2) { create(:article, reactions_count: 20, featured: true) }
-  let!(:bad_article) { create(:article, reactions_count: 0) }
+  let!(:unreacted_article) { create(:article, reactions_count: 0) }
   let!(:timestamp) { "2019-03-04T10:00:00Z" }
 
   context "when no options specified" do
@@ -35,11 +35,11 @@ RSpec.describe "User visits a homepage", type: :system do
         visit "/"
       end
 
-      it "shows correct articles" do
-        expect(page).to have_selector(".single-article", count: 2)
+      it "shows correct articles " do
+        expect(page).to have_selector(".single-article", count: 3)
         expect(page).to have_text(article.title)
         expect(page).to have_text(article2.title)
-        expect(page).not_to have_text(bad_article.title)
+        expect(page.all(".single-article").last).to have_text(unreacted_article.title)
       end
 
       it "shows all articles dates", js: true do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This consolidates a few methods sprinkled throughout the server side Ruby code used to grab articles for the initial load of the main article feed to a single spot in `Article::Feed` service. This is part of the _Article Feed Content_ scope in the _Home Page Revamp_ project: future PRs will tweak this functionality to make the home page feed more relevant 

## Related Tickets & Documents

Great post from community [piannaf](https://dev.to/piannaf) breaking down how the feed is currently assembled: https://dev.to/piannaf/the-dev-to-feed-algorithm-5em5

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![coming together](https://media.giphy.com/media/KEYEpIngcmXlHetDqz/giphy.gif)
