### PR TITLE
Eager load users when handling chat channel memberships

### DIFF
--- a/app/services/user_blocks/channel_handler.rb
+++ b/app/services/user_blocks/channel_handler.rb
@@ -18,7 +18,7 @@ module UserBlocks
       return if chat_channel.blank?
 
       chat_channel.update(status: "blocked")
-      chat_channel.chat_channel_memberships.each do |membership|
+      chat_channel.chat_channel_memberships.includes([:user]).each do |membership|
         membership.update(status: "left_channel")
         membership.remove_from_index!
       end
@@ -29,7 +29,7 @@ module UserBlocks
       return if chat_channel.blank?
 
       chat_channel.update(status: "active")
-      chat_channel.chat_channel_memberships.each do |membership|
+      chat_channel.chat_channel_memberships.includes([:user]).each do |membership|
         membership.update(status: "active")
         membership.index!
       end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
We have to access the chat channel membership user when we are updating them during the permission validation so we should be eager loading them to save us some db hits. 
Fixes: https://travis-ci.com/thepracticaldev/dev.to/builds/147961924

## Added to documentation?
- [x] no documentation needed

Idk I am loving Schitts Creek these days so you get Schitts Creek gifs 🤷‍♀ 
![alt_text](https://media.giphy.com/media/LSc2GGrC81nq1janRg/giphy.gif)
