### PR TITLE
Index Tags to Elasticsearch after they are created

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -26,7 +26,7 @@ class Tag < ActsAsTaggableOn::Tag
   before_validation :evaluate_markdown
   before_validation :pound_it
   before_save :calculate_hotness_score
-  after_commit :bust_cache
+  after_commit :bust_cache, :index_to_elasticsearch
   before_save :mark_as_updated
 
   algoliasearch per_environment: true do
@@ -34,6 +34,22 @@ class Tag < ActsAsTaggableOn::Tag
     attributesForFaceting [:supported]
     customRanking ["desc(hotness_score)"]
     searchableAttributes %w[name short_summary]
+  end
+
+  def index_to_elasticsearch
+    Search::TagEsIndexWorker.perform_async(id)
+  end
+
+  def index_to_elasticsearch_inline
+    Search::Tag.index(id, serialized_search_hash)
+  end
+
+  def serialized_search_hash
+    Search::TagSerializer.new(self).serializable_hash.dig(:data, :attributes)
+  end
+
+  def elasticsearch_doc
+    Search::Tag.get(id)
   end
 
   def submission_template_customized(param_0 = nil)

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -49,7 +49,7 @@ class Tag < ActsAsTaggableOn::Tag
   end
 
   def elasticsearch_doc
-    Search::Tag.get(id)
+    Search::Tag.find_document(id)
   end
 
   def submission_template_customized(param_0 = nil)

--- a/app/serializers/search/tag_serializer.rb
+++ b/app/serializers/search/tag_serializer.rb
@@ -1,0 +1,7 @@
+module Search
+  class TagSerializer
+    include FastJsonapi::ObjectSerializer
+
+    attributes :id, :name, :hotness_score, :supported, :short_summary
+  end
+end

--- a/app/serializers/search/tag_serializer.rb
+++ b/app/serializers/search/tag_serializer.rb
@@ -2,6 +2,6 @@ module Search
   class TagSerializer
     include FastJsonapi::ObjectSerializer
 
-    attributes :id, :name, :hotness_score, :supported, :short_summary
+    attributes :id, :name, :hotness_score, :supported, :short_summary, :rules_html
   end
 end

--- a/app/services/search/tag.rb
+++ b/app/services/search/tag.rb
@@ -75,6 +75,9 @@ module Search
             },
             short_summary: {
               type: "text"
+            },
+            rules_html: {
+              type: "text"
             }
           }
         }

--- a/app/services/search/tag.rb
+++ b/app/services/search/tag.rb
@@ -12,7 +12,7 @@ module Search
         )
       end
 
-      def get(tag_id)
+      def find_document(tag_id)
         SearchClient.get(id: tag_id, index: INDEX_ALIAS)
       end
 

--- a/app/workers/search/tag_es_index_worker.rb
+++ b/app/workers/search/tag_es_index_worker.rb
@@ -1,0 +1,12 @@
+module Search
+  class TagEsIndexWorker
+    include Sidekiq::Worker
+
+    sidekiq_options queue: :high_priority
+
+    def perform(tag_id)
+      tag = ::Tag.find_by!(id: tag_id)
+      tag.index_to_elasticsearch_inline
+    end
+  end
+end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -75,4 +75,44 @@ RSpec.describe Tag, type: :model do
     tag.mod_chat_channel_id = channel.id
     expect(tag.mod_chat_channel).to eq(channel)
   end
+
+  describe "#index_to_elasticsearch" do
+    it "enqueues job to index tag to elasticsearch" do
+      sidekiq_assert_enqueued_with(job: Search::TagEsIndexWorker, args: [tag.id]) do
+        tag.index_to_elasticsearch
+      end
+    end
+  end
+
+  describe "#index_to_elasticsearch_inline" do
+    it "indexed tag to elasticsearch inline" do
+      allow(Search::Tag).to receive(:index)
+      tag.index_to_elasticsearch_inline
+      expect(Search::Tag).to have_received(:index).with(tag.id, hash_including(:id, :name))
+    end
+  end
+
+  describe "#after_commit" do
+    it "enqueues job to index tag to elasticsearch" do
+      tag.save
+      sidekiq_assert_enqueued_with(job: Search::TagEsIndexWorker, args: [tag.id]) do
+        tag.save
+      end
+    end
+  end
+
+  describe "#serialized_search_hash" do
+    it "creates a valid serialized hash to send to elasticsearch" do
+      mapping_keys = Search::Tag.send("mappings").dig(:properties).keys
+      expect(tag.serialized_search_hash.symbolize_keys.keys).to eq(mapping_keys)
+    end
+  end
+
+  describe "#elasticsearch_doc" do
+    it "gets document from elasticsearch", elasticsearch: true do
+      allow(Search::Tag).to receive(:get)
+      tag.elasticsearch_doc
+      expect(Search::Tag).to have_received(:get)
+    end
+  end
 end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -109,10 +109,10 @@ RSpec.describe Tag, type: :model do
   end
 
   describe "#elasticsearch_doc" do
-    it "gets document from elasticsearch", elasticsearch: true do
-      allow(Search::Tag).to receive(:get)
+    it "finds document in elasticsearch", elasticsearch: true do
+      allow(Search::Tag).to receive(:find_document)
       tag.elasticsearch_doc
-      expect(Search::Tag).to have_received(:get)
+      expect(Search::Tag).to have_received(:find_document)
     end
   end
 end

--- a/spec/services/search/tag_spec.rb
+++ b/spec/services/search/tag_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Search::Tag, type: :service, elasticsearch: true do
     it "indexes a tag to elasticsearch" do
       tag = FactoryBot.create(:tag)
       expect { described_class.get(tag.id) }.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound)
-      described_class.index(tag.id, id: tag.id)
+      described_class.index(tag.id, tag.serialized_search_hash)
       expect(described_class.get(tag.id)).not_to be_nil
     end
   end
@@ -13,7 +13,7 @@ RSpec.describe Search::Tag, type: :service, elasticsearch: true do
   describe "::get" do
     it "fetches a document for a given ID from elasticsearch" do
       tag = FactoryBot.create(:tag)
-      described_class.index(tag.id, id: tag.id)
+      described_class.index(tag.id, tag.serialized_search_hash)
       expect { described_class.get(tag.id) }.not_to raise_error
     end
   end

--- a/spec/services/search/tag_spec.rb
+++ b/spec/services/search/tag_spec.rb
@@ -4,17 +4,17 @@ RSpec.describe Search::Tag, type: :service, elasticsearch: true do
   describe "::index" do
     it "indexes a tag to elasticsearch" do
       tag = FactoryBot.create(:tag)
-      expect { described_class.get(tag.id) }.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound)
+      expect { described_class.find_document(tag.id) }.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound)
       described_class.index(tag.id, tag.serialized_search_hash)
-      expect(described_class.get(tag.id)).not_to be_nil
+      expect(described_class.find_document(tag.id)).not_to be_nil
     end
   end
 
-  describe "::get" do
+  describe "::find_document" do
     it "fetches a document for a given ID from elasticsearch" do
       tag = FactoryBot.create(:tag)
       described_class.index(tag.id, tag.serialized_search_hash)
-      expect { described_class.get(tag.id) }.not_to raise_error
+      expect { described_class.find_document(tag.id) }.not_to raise_error
     end
   end
 

--- a/spec/workers/search/tag_es_index_worker_spec.rb
+++ b/spec/workers/search/tag_es_index_worker_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe Search::TagEsIndexWorker, type: :worker, elasticsearch: true do
+  let(:worker) { subject }
+
+  include_examples "#enqueues_on_correct_queue", "high_priority", [1]
+
+  it "raises an error if record is not found" do
+    expect { worker.perform(1234) }.to raise_error(ActiveRecord::RecordNotFound)
+  end
+
+  it "indexes tag" do
+    tag = FactoryBot.create(:tag)
+    expect { tag.elasticsearch_doc }.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound)
+    worker.perform(tag.id)
+    expect(tag.elasticsearch_doc.dig("_source")).to eq(
+      tag.serialized_search_hash.stringify_keys,
+    )
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
This PR begins indexing Tags into Elasticsearch! The Index and everything is already set up in production so all that is left is to fill it up! Once this goes out I will reindex all the Tags manually from a console and then going forward they should reindex themselves as they are created or updated. NOTE: We are still indexing to Algolia as well since that is where we are searching them still. Algolia will be the last thing removed once the search is rolled over to Elasticsearch

Performance: I realize this is very brute force, ie we are not checking if Elasticsearch attributes actually need to be updated before we reindex, we just do it automatically. I think this is absolutely fine in this instance since we are not creating tags at a rapid rate and they are very quick to index. I also am a big believer in not trying to over-optimize before we need to so I went with the simple approach, index a tag when it's updated. 

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-32289408

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media.giphy.com/media/xUA7beo4MLNP5DZuus/giphy.gif)
