### PR TITLE
Soft save notification_subscription and then check persisted

### DIFF
--- a/app/controllers/notification_subscriptions_controller.rb
+++ b/app/controllers/notification_subscriptions_controller.rb
@@ -22,7 +22,7 @@ class NotificationSubscriptionsController < ApplicationController
       @notification_subscription.config = params[:config] || "all_comments"
       receive_notifications = (params[:config] == "all_comments" && current_user_is_author?)
       @notification_subscription.notifiable.update(receive_notifications: true) if receive_notifications
-      @notification_subscription.save!
+      @notification_subscription.save
     end
     result = @notification_subscription.persisted?
     respond_to do |format|


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Here we are saving with a bang which will raise an error if any validations fail and sometimes they do which causes this error:
Honeybadger: https://app.honeybadger.io/fault/66984/4a1644c910a2cb05033dfc47bb35e395
```
ActiveRecord::RecordInvalid: Validation failed: User has already been taken
monitor.rb  235 mon_synchronize(...)
[PROJECT_ROOT]/vendor/ruby-2.6.5/lib/ruby/2.6.0/monitor.rb:235:in `mon_synchronize'
233     Thread.handle_interrupt(EXCEPTION_NEVER){ mon_enter }
234     begin
235       yield
236     ensure
237       Thread.handle_interrupt(EXCEPTION_NEVER){ mon_exit }
notification_subscriptions_controller.rb  25 upsert(...)
[PROJECT_ROOT]/app/controllers/notification_subscriptions_controller.rb:25:in `upsert'
```
Since in the next line we are checking if the `notification_subscription` is persisted and then returning that result in the json there is no reason to raise an error, instead it would be more useful to return a valid json response. 

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media3.giphy.com/media/l0ExbcOSoFGQMssF2/giphy.gif)
