### PR TITLE
Fix indentation in search.rake

### DIFF
--- a/lib/tasks/search.rake
+++ b/lib/tasks/search.rake
@@ -6,7 +6,7 @@ namespace :search do
 
   desc "update Elasticsearch index mappings"
   task update_mappings: :environment do
-     Search::Cluster.update_mappings
+    Search::Cluster.update_mappings
   end
 
   desc "tear down Elasticsearch indexes"


### PR DESCRIPTION
# What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR fixes the following rubocop violation.

```
lib/tasks/search.rake:9:3: C: Layout/IndentationWidth: Use 2 (not 3) spaces for indentation. (https://rubystyle.guide#spaces-indentation)
     Search::Cluster.update_mappings
  ^^^
```

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
