### PR TITLE
Copy .ruby-version into Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN gem install bundler:2.0.2
 #------------------------------------------------------------------------------
 ENV PATH=/root/.yarn/bin:$PATH
 RUN apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community \
-        yarn
+  yarn
 
 #------------------------------------------------------------------------------
 #
@@ -36,7 +36,7 @@ WORKDIR /usr/src/app
 # Copy Gemfile and run bundle install
 #
 #------------------------------------------------------------------------------
-COPY Gemfile /usr/src/app/Gemfile
+COPY ./.ruby-version .
 COPY ./Gemfile ./Gemfile.lock ./
 RUN bundle install --jobs 20 --retry 5
 
@@ -81,4 +81,4 @@ VOLUME /usr/src/app/public/uploads
 COPY docker-entrypoint.sh /usr/bin/
 RUN chmod +x /usr/bin/docker-entrypoint.sh
 
-COPY . /usr/src/app
+COPY . .


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Description

It seems we broke our Docker process when merging #5780, as we now can't bundle without a `.ruby-version` file being present.

## Related Tickets & Documents

Closes #5967 

## Added to documentation?

- [X] no documentation needed