### PR TITLE
Removed full_page from the Page TEMPLATE_OPTIONS

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,5 +1,5 @@
 class Page < ApplicationRecord
-  TEMPLATE_OPTIONS = %w[contained full_within_layout full_page].freeze
+  TEMPLATE_OPTIONS = %w[contained full_within_layout].freeze
 
   validates :title, presence: true
   validates :description, presence: true


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
As we discussed in https://github.com/thepracticaldev/dev.to/pull/5952#discussion_r376470025 `full_page` option is not used currently, so I removed it to avoid confusion.
