### PR TITLE
[WIP][POC] Add markdown toolbar to main article form

### DIFF
--- a/app/assets/stylesheets/preact/article-form.scss
+++ b/app/assets/stylesheets/preact/article-form.scss
@@ -748,3 +748,20 @@
   color: darken($red, 8%);
   font-size: 0.8em;
 }
+
+markdown-toolbar {
+  position: fixed;
+  left: calc(50% - 500px);
+  top: 150px;
+  width: 80x;
+  .articleform__toolbarbutton {
+    font-size: 16px;
+    display: block;
+    cursor: pointer;
+    border: var(--theme-container-border, 1px solid darken($light-medium-gray, 5%));
+    padding: 3px;
+    width: 50px;
+    margin-top: 3px;
+    border-radius: 3px;
+  }
+}

--- a/app/javascript/article-form/articleForm.jsx
+++ b/app/javascript/article-form/articleForm.jsx
@@ -20,6 +20,7 @@ import Errors from './elements/errors';
 import KeyboardShortcutsHandler from './elements/keyboardShortcutsHandler';
 import Tags from '../shared/components/tags';
 import { OrganizationPicker } from '../organization/OrganizationPicker';
+import '@github/markdown-toolbar-element';
 
 const SetupImageButton = ({
   className,

--- a/app/views/articles/_v2_form.html.erb
+++ b/app/views/articles/_v2_form.html.erb
@@ -50,6 +50,16 @@
     </div>
   </div>
 </div>
+<markdown-toolbar for="article_body_markdown" class="articleform__toolbar">
+  <md-bold class="articleform__toolbarbutton">b</md-bold>
+  <md-header class="articleform__toolbarbutton">h3</md-header>
+  <md-italic class="articleform__toolbarbutton">i</md-italic>
+  <md-quote class="articleform__toolbarbutton">quote</md-quote>
+  <md-code class="articleform__toolbarbutton">code</md-code>
+  <md-link class="articleform__toolbarbutton">link</md-link>
+  <md-unordered-list class="articleform__toolbarbutton">ul</md-unordered-list>
+  <md-ordered-list class="articleform__toolbarbutton">ol</md-ordered-list>
+</markdown-toolbar>
 
 <style>
   #footer-container {

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
   },
   "dependencies": {
     "@github/clipboard-copy-element": "^1.1.2",
+    "@github/markdown-toolbar-element": "^1.1.1",
     "@rails/webpacker": "^3.5.5",
     "babel-plugin-transform-react-jsx": "^6.24.1",
     "babel-preset-preact": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -140,6 +140,11 @@
   resolved "https://registry.yarnpkg.com/@github/clipboard-copy-element/-/clipboard-copy-element-1.1.2.tgz#7a6e8042749471504d4e7cfcc47097a781db2bdb"
   integrity sha512-L6CMrcA5we0udafvoSuRCE/Ci/3xrLWKYRGup2IlhxF771bQYsQ2EB1of182pI8ZWM4oxgwzu37+igMeoZjN/A==
 
+"@github/markdown-toolbar-element@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@github/markdown-toolbar-element/-/markdown-toolbar-element-1.1.1.tgz#05c7525652d819408342f7d5e8e10783e2e064ab"
+  integrity sha512-ZLy9iXIWg/TwS0Q+tx7HJ0zD04BHCwqzu9SFPShhdHbL8dPXLwvg0aQgzjHVWnLlm8kKiMAnbFBJyuKARwWl4Q==
+
 "@jest/types@^24.9.0":
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-24.9.0.tgz#63cb26cb7500d069e5a389441a7c6ab5e909fc59"


### PR DESCRIPTION


<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Clicking a button automatically adds markdown syntax to highlighted area when button is pressed. It works exactly like GitHub's buttons.

This is a quick proof of concept using GitHub's [markdown toolbar element](https://github.com/github/markdown-toolbar-element) of adding style buttons to our editor.

I think if we include this, logically our custom `image` button should be included in this area instead of where it currently is.

I just through this together and didn't fuss the details because it should probably use design eyes and be part of a discussion about the general style of the editor.

I think this adds some functionality _some_ may like and it's not super intrusive. I think we could also maybe make it minimizeable in case some people never use it.

<img width="427" alt="Screen Shot 2020-02-10 at 8 59 12 AM" src="https://user-images.githubusercontent.com/3102842/74156072-9d7b8a00-4be3-11ea-8527-1db0a19abd57.png">

