### PR TITLE
Remove Indexing Helpers from ChatChannel model in seed script

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -192,24 +192,20 @@ Broadcast.create!(
 
 Rails.logger.info "8. Creating Chat Channels and Messages"
 
-ChatChannel.clear_index!
-ChatChannel.without_auto_index do
-  %w[Workshop Meta General].each do |chan|
-    ChatChannel.create!(
-      channel_name: chan,
-      channel_type: "open",
-      slug: chan,
-    )
-  end
-
-  direct_channel = ChatChannel.create_with_users(User.last(2), "direct")
-  Message.create!(
-    chat_channel: direct_channel,
-    user: User.last,
-    message_markdown: "This is **awesome**",
+%w[Workshop Meta General].each do |chan|
+  ChatChannel.create!(
+    channel_name: chan,
+    channel_type: "open",
+    slug: chan,
   )
 end
-ChatChannel.reindex!
+
+direct_channel = ChatChannel.create_with_users(User.last(2), "direct")
+Message.create!(
+  chat_channel: direct_channel,
+  user: User.last,
+  message_markdown: "This is **awesome**",
+)
 
 Rails.logger.info "9. Creating HTML Variants"
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Last week we removed indexing from ChatChannels, #5907 bc we were not using it for anything. This means we also need to remove all indexing methods in the rest of the codebase. 

## Related Tickets & Documents
#5907 

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media0.giphy.com/media/2yA8KXwI7QBykLizf8/giphy.gif)
