### PR TITLE
Add multiplier for seeds and use it for articles and users

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,8 @@
+# we use this to be able to increase the size of the seeded DB at will
+# eg.: `SEEDS_MULTIPLIER=2 rails db:seed` would double the amount of data
+SEEDS_MULTIPLIER = [1, ENV["SEEDS_MULTIPLIER"].to_i].max
+Rails.logger.info "Seeding with multiplication factor: #{SEEDS_MULTIPLIER}"
+
 Rails.logger.info "1. Creating Organizations"
 
 3.times do
@@ -21,7 +26,7 @@ Rails.logger.info "2. Creating Users"
 
 roles = %i[trusted chatroom_beta_tester workshop_pass]
 User.clear_index!
-10.times do |i|
+(10 * SEEDS_MULTIPLIER).times do |i|
   user = User.create!(
     name: name = Faker::Name.unique.name,
     summary: Faker::Lorem.paragraph_by_chars(number: 199, supplemental: false),
@@ -73,7 +78,7 @@ end
 Rails.logger.info "4. Creating Articles"
 
 Article.clear_index!
-25.times do |i|
+(25 * SEEDS_MULTIPLIER).times do |i|
   tags = []
   tags << "discuss" if (i % 3).zero?
   tags.concat Tag.order(Arel.sql("RANDOM()")).select("name").first(3).map(&:name)

--- a/docs/getting-started/db.md
+++ b/docs/getting-started/db.md
@@ -30,45 +30,18 @@ rails db:seed
 
 By default, the amount of articles and users generated is quite tiny so that
 contributors experience a quick installation. If you require more data for your
-local installation, you can modify the `/db/seeds.rb` to tailor the amount of
-data generated. Make these modifications to the seeds file before running
-`bin/setup` or `rails db:setup`.
+local installation, you can tune amount of data generated with the environment
+variable `SEEDS_MULTIPLIER`.
 
-In the code snippet below, you'll see the line `25.times do |i|` which means it
-will loop 25 times creating 25 random articles. So if you wanted to generate 100
-random articles, simply change that line to `100.times do |i|`
+This variable, which defaults to `1`, allows the developer to increase the size
+of their local DB. For example:
 
-```ruby
-Rails.logger.info "4. Creating Articles"
-
-Article.clear_index!
-25.times do |i|
-  tags = []
-  tags << "discuss" if (i % 3).zero?
-  tags.concat Tag.order(Arel.sql("RANDOM()")).select("name").first(3).map(&:name)
-
-  markdown = <<~MARKDOWN
-    ---
-    title:  #{Faker::Book.unique.title}
-    published: true
-    cover_image: #{Faker::Company.logo}
-    tags: #{tags.join(', ')}
-    ---
-
-    #{Faker::Hipster.paragraph(sentence_count: 2)}
-    #{Faker::Markdown.random}
-    #{Faker::Hipster.paragraph(sentence_count: 2)}
-  MARKDOWN
-
-  Article.create!(
-    body_markdown: markdown,
-    featured: true,
-    show_comments: true,
-    user_id: User.order(Arel.sql("RANDOM()")).first.id,
-  )
-end
+```shell
+SEEDS_MULTIPLIER=2 rails db:setup
 ```
 
-The same can be done for generating more users and other entitities. There are
-plans to improve on this so that a developer need not modify the seeds file, but
-nothing concrete has been decided yet.
+will result in creating double the default amount of items in the database.
+
+It's currently used only for `articles` and `users`.
+
+It can also be used for `rails db:seed` and `rails db:reset`.


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

As a follow up to https://github.com/thepracticaldev/dev.to/pull/5948 I've added a "multiplication factor" variable for the seeds file.

You can use it like this:

```shell
$ SEEDS_MULTIPLIER=2 rails db:reset
$ psql PracticalDeveloper_development
PracticalDeveloper_development=# select count(*) from articles; select count(*) from users;
┌───────┐
│ count │
├───────┤
│    50 │
└───────┘
(1 row)

Time: 0.472 ms
┌───────┐
│ count │
├───────┤
│    20 │
└───────┘
(1 row)
```

:)

I haven't added it to the other entities yet, because I wanted to go about it in steps if this approach is deemed the correct one.

## Related Tickets & Documents

- https://github.com/thepracticaldev/dev.to/issues/4149
