### PR TITLE
Change error styling from syntax highlighting for a better UI in all themes

### DIFF
--- a/app/assets/stylesheets/syntax.scss
+++ b/app/assets/stylesheets/syntax.scss
@@ -16,7 +16,7 @@ div.inner-comment div.body div.highlight pre.highlight {
 .highlight .hll { background-color: #49483e }
 .highlight  { background: #29292e; color: #f8f8f2 }
 .highlight .c { color: #75715e } /* Comment */
-.highlight .err { color: #960050; background-color: #1e0010 } /* Error */
+.highlight .err { } /* Error */
 .highlight .k { color: #66d9ef } /* Keyword */
 .highlight .l { color: #ae81ff } /* Literal */
 .highlight .n { color: #f8f8f2 } /* Name */

--- a/app/assets/stylesheets/syntax.scss
+++ b/app/assets/stylesheets/syntax.scss
@@ -16,7 +16,7 @@ div.inner-comment div.body div.highlight pre.highlight {
 .highlight .hll { background-color: #49483e }
 .highlight  { background: #29292e; color: #f8f8f2 }
 .highlight .c { color: #75715e } /* Comment */
-.highlight .err { } /* Error */
+.highlight .err { text-shadow: 0 0 3px #ff3030, 0 0 5px #ff3030, 0 0 10px #ff3030; } /* Error */
 .highlight .k { color: #66d9ef } /* Keyword */
 .highlight .l { color: #ae81ff } /* Literal */
 .highlight .n { color: #f8f8f2 } /* Name */


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This fixes a bug we have in syntax highlighting where lines that are marked as an error from the parser are not easiliy readable in the two dark modes:

![Screenshot_2020-02-10 Test syntax highlighting dark mode(1)](https://user-images.githubusercontent.com/146201/74174704-b6f8f200-4c34-11ea-8d04-4776efbe2a5b.png)

I followed @benhalpern suggestion to actually remove the styling: https://github.com/thepracticaldev/dev.to/pull/4669#issuecomment-548408741

Disclaimer: there's a PR that was started by a contributor https://github.com/thepracticaldev/dev.to/pull/4669 - but as the contributor has seemingly abandoned it (they haven't responded to it for more than 2 months). I also tried to commit to "takeover" the PR but I'm not allowed to commit to it

## Related Tickets & Documents

- closes https://github.com/thepracticaldev/dev.to/issues/4577
- supersedes https://github.com/thepracticaldev/dev.to/pull/4669

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

This is how it looks now in the two dark modes:

![Screenshot_2020-02-10 Test syntax highlighting dark mode(2)](https://user-images.githubusercontent.com/146201/74174730-c2e4b400-4c34-11ea-8367-271d14d1945c.png)

![Screenshot_2020-02-10 Test syntax highlighting dark mode(3)](https://user-images.githubusercontent.com/146201/74174738-c710d180-4c34-11ea-9e58-b55be48576dc.png)

