### PR TITLE
Fixed false negative of a frontend test suite failing.

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,4 +10,7 @@ module.exports = {
     '\\.(svg|png)$': '<rootDir>/empty-module.js',
   },
   snapshotSerializers: ['preact-render-spy/snapshot'],
+  // The webpack config folder for webpacker is excluded as it has a test.js file that gets
+  // picked up by jest if this folder is not excluded causing a false negative of a test suite failing.
+  testPathIgnorePatterns: ['/node_modules/', './config/webpack'],
 };


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

While looking into a frontend issue for Molly, I cam across this error.

![screenshot](https://user-images.githubusercontent.com/833231/74181604-9e2a1580-4c0f-11ea-9207-15f1a970c19a.png)

The issue occurs because jest is running a file that it thinks is a test suite that is not. The fix is to exlcude the `./config/webpack` from tests.

![screenshot2](https://user-images.githubusercontent.com/833231/74181707-c0bc2e80-4c0f-11ea-8e29-9eb999107bd3.png)

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![Person talking on a cellphone with a fake astronaut helmet on](https://media.giphy.com/media/3ofSBeKWr6TKcczmXS/giphy.gif)
