### PR TITLE
Replace dev.to with ApplicationConfig in a few locations

### DIFF
--- a/app/controllers/feedback_messages_controller.rb
+++ b/app/controllers/feedback_messages_controller.rb
@@ -37,7 +37,7 @@ class FeedbackMessagesController < ApplicationController
     <<~HEREDOC
       #{generate_user_detail}
       Category: #{feedback_message_params[:category]}
-      Internal Report: https://dev.to/internal/reports
+      Internal Report: https://#{ApplicationConfig['APP_DOMAIN']}/internal/reports
       *_ Reported URL: #{feedback_message_params[:reported_url]} _*
       -----
       *Message:* #{feedback_message_params[:message]}
@@ -49,7 +49,7 @@ class FeedbackMessagesController < ApplicationController
 
     <<~HEREDOC
       *Logged in user:*
-      reporter: #{current_user.username} - https://dev.to/#{current_user.username}
+      reporter: #{current_user.username} - https://#{ApplicationConfig['APP_DOMAIN']}/#{current_user.username}
       email: <mailto:#{current_user.email}|#{current_user.email}>
     HEREDOC
   end

--- a/app/controllers/internal/tools_controller.rb
+++ b/app/controllers/internal/tools_controller.rb
@@ -39,7 +39,7 @@ class Internal::ToolsController < Internal::ApplicationController
   end
 
   def bust_link(link)
-    link.sub!("https://dev.to", "") if link.starts_with?("https://dev.to")
+    link.sub!("https://#{ApplicationConfig['APP_DOMAIN']}", "") if link.starts_with?("https://#{ApplicationConfig['APP_DOMAIN']}")
     CacheBuster.bust(link)
     CacheBuster.bust("#{link}/")
     CacheBuster.bust("#{link}?i=i")

--- a/app/controllers/internal/welcome_controller.rb
+++ b/app/controllers/internal/welcome_controller.rb
@@ -24,7 +24,7 @@ class Internal::WelcomeController < Internal::ApplicationController
       tags: welcome
       ---
 
-      Hey there! Welcome to dev.to!
+      Hey there! Welcome to #{ApplicationConfig['COMMUNITY_NAME']}!
 
       ![WELCOME TO THE INTERNET](https://slack-imgs.com/?c=1&url=http%3A%2F%2Fmedia0.giphy.com%2Fmedia%2FzhbrTTpmSCYog%2Fgiphy-downsized.gif)
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -266,10 +266,10 @@ class UsersController < ApplicationController
 
   def handle_account_tab
     @email_body = <<~HEREDOC
-      Hello DEV Team,
+      Hello #{ApplicationConfig['COMMUNITY_NAME']} Team,
       %0A
       %0A
-      I would like to delete my dev.to account.
+      I would like to delete my account.
       %0A%0A
       You can keep any comments and discussion posts under the Ghost account.
       %0A

--- a/app/labor/badge_rewarder.rb
+++ b/app/labor/badge_rewarder.rb
@@ -20,7 +20,7 @@ module BadgeRewarder
     # ID 3 is the proper ID in prod. We should change in future to ENV var.
     badge_id = Badge.find_by(slug: "beloved-comment")&.id || 3
     Comment.where("positive_reactions_count > ?", 24).find_each do |comment|
-      message = "You're DEV famous! [This is the comment](https://dev.to#{comment.path}) for which you are being recognized. 😄"
+      message = "You're DEV famous! [This is the comment](https://#{ApplicationConfig['APP_DOMAIN']}#{comment.path}) for which you are being recognized. 😄"
       achievement = BadgeAchievement.create(
         user_id: comment.user_id,
         badge_id: badge_id,

--- a/app/labor/badge_rewarder.rb
+++ b/app/labor/badge_rewarder.rb
@@ -20,7 +20,7 @@ module BadgeRewarder
     # ID 3 is the proper ID in prod. We should change in future to ENV var.
     badge_id = Badge.find_by(slug: "beloved-comment")&.id || 3
     Comment.where("positive_reactions_count > ?", 24).find_each do |comment|
-      message = "You're DEV famous! [This is the comment](https://#{ApplicationConfig['APP_DOMAIN']}#{comment.path}) for which you are being recognized. 😄"
+      message = "You're famous! [This is the comment](https://#{ApplicationConfig['APP_DOMAIN']}#{comment.path}) for which you are being recognized. 😄"
       achievement = BadgeAchievement.create(
         user_id: comment.user_id,
         badge_id: badge_id,

--- a/app/labor/cache_buster.rb
+++ b/app/labor/cache_buster.rb
@@ -9,9 +9,9 @@ module CacheBuster
   def self.bust(path)
     return unless Rails.env.production?
 
-    HTTParty.post("https://api.fastly.com/purge/https://dev.to#{path}",
+    HTTParty.post("https://api.fastly.com/purge/https://#{ApplicationConfig['APP_DOMAIN']}#{path}",
                   headers: { "Fastly-Key" => ApplicationConfig["FASTLY_API_KEY"] })
-    HTTParty.post("https://api.fastly.com/purge/https://dev.to#{path}?i=i",
+    HTTParty.post("https://api.fastly.com/purge/https://#{ApplicationConfig['APP_DOMAIN']}#{path}?i=i",
                   headers: { "Fastly-Key" => ApplicationConfig["FASTLY_API_KEY"] })
   rescue URI::InvalidURIError => e
     Rails.logger.error("Trying to bust cache of an invalid uri: #{e}")


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This changes some hardcoded instances of `dev.to` to the `ApplicationConfig['APP_DOMAIN']` version.

The only critical bug this was causing was in `CacheBuster` which causes non-dev.to versions of the site to fail in pinging Fastly.

I decifed to dip in and change some other low-hanging fruit on the backend