### PR TITLE
Do not allow staff_user_id to be mutated

### DIFF
--- a/app/controllers/internal/configs_controller.rb
+++ b/app/controllers/internal/configs_controller.rb
@@ -18,7 +18,7 @@ class Internal::ConfigsController < Internal::ApplicationController
 
   def config_params
     allowed_params = %i[
-      staff_user_id default_site_email social_networks_handle
+      default_site_email social_networks_handle
       main_social_image favicon_url logo_svg
       rate_limit_follow_count_daily
       ga_view_id ga_fetch_rate

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -13,16 +13,6 @@
         <div class="card-header">Staff</div>
         <div class="card-body">
           <div class="form-group">
-            <%= f.label :staff_user_id %>
-            <%= f.number_field :staff_user_id,
-                               class: "form-control",
-                               value: SiteConfig.staff_user_id,
-                               min: 1,
-                               placeholder: "1" %>
-            <div class="alert alert-info">User ID of the staff account</div>
-          </div>
-
-          <div class="form-group">
             <%= f.label :default_site_email %>
             <%= f.email_field :default_site_email,
                               class: "form-control",

--- a/spec/requests/internal/configs_spec.rb
+++ b/spec/requests/internal/configs_spec.rb
@@ -20,9 +20,10 @@ RSpec.describe "/internal/config", type: :request do
     end
 
     describe "staff" do
-      it "updates staff_user_id" do
+      it "does not allow the staff_user_id to be updated" do
+        expect(SiteConfig.staff_user_id).to eq(1)
         post "/internal/config", params: { site_config: { staff_user_id: 2 } }
-        expect(SiteConfig.staff_user_id).to eq(2)
+        expect(SiteConfig.staff_user_id).to eq(1)
       end
 
       it "updates default_site_email" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Allowing ids to be mutated by admins from the `/internal/config` pages is dangerous.
This could cause issues if an admin tries to update the `SiteConfig.staff_user_id` to an id that is another user's id, or to an id that isn't valid.

We probably don't want to allow admins to do this at all.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?


![](https://media3.giphy.com/media/EX6wKXVM9IOlO/giphy.gif?cid=5a38a5a21f13274f67dde9f19f82c6b1610722a878167f5d&rid=giphy.gif)

