### PR TITLE
Gemfile should be installable from wherever

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 git_source(:github) { |name| "https://github.com/#{name}.git" }
 source "https://rubygems.org"
-ruby File.read(".ruby-version").strip
+ruby File.read(File.join(File.dirname(__FILE__), ".ruby-version")).strip
 
 group :production do
   gem "nakayoshi_fork", "~> 0.0.4" # solves CoW friendly problem on MRI 2.2 and later


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

`bundle install` used to work from any directory but we kind of broke this behavior when we merged #5780 as now it requires `bundle install` to be run in the same folder where `Gemfile` resides:

```shell
$ cd app; bundle install
[!] There was an error parsing `Gemfile`: No such file or directory @ rb_sysopen - .ruby-version. Bundler cannot continue.

 #  from /devto/Gemfile:5
 #  -------------------------------------------
 #  source "https://rubygems.org"
 >  ruby File.read(".ruby-version").strip
 #
 #  -------------------------------------------
```

This restores it by using a full path
