### PR TITLE
Removed !important from some CSS properties set on body tag

### DIFF
--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -7,9 +7,9 @@ body {
   @include themeable(color, theme-color, $black);
   font-family: $helvetica;
   font-size: 18px;
-  padding: 0 !important;
-  margin: 0 !important;
-  margin-top: -20px !important;
+  padding: 0;
+  margin: 0;
+  margin-top: -20px;
   overflow-y: scroll;
 }
 
@@ -48,9 +48,10 @@ body {
 }
 
 @media print {
-   .top-bar, .article-actions {
-      display: none;
-   }
+  .top-bar,
+  .article-actions {
+    display: none;
+  }
 }
 
 .config_minimize_newest_listings {
@@ -190,7 +191,8 @@ input[type='email'] {
   display: none !important;
 }
 
-body.night-theme, body.ten-x-hacker-theme {
+body.night-theme,
+body.ten-x-hacker-theme {
   .on-page-nav-butt img,
   .icon-img,
   .dropdown-icon,
@@ -252,17 +254,25 @@ body.open-dyslexic-article-body {
     font-family: OpenDyslexic, sans-serif;
     font-size: 0.9em;
   }
-  .body b, .body strong {
+  .body b,
+  .body strong {
     font-family: OpenDyslexic-Bold, sans-serif;
   }
-  
-  .body i, .body em {
+
+  .body i,
+  .body em {
     font-family: OpenDyslexic-Italic, sans-serif;
   }
-  
-  .body b>i, .body b>em, .body strong>i, .body strong>em,
-  .body i>b, .body em>b, .body i>strong, .body em>strong {
-    font-family: OpenDyslexic-Bolditalic
+
+  .body b > i,
+  .body b > em,
+  .body strong > i,
+  .body strong > em,
+  .body i > b,
+  .body em > b,
+  .body i > strong,
+  .body em > strong {
+    font-family: OpenDyslexic-Bolditalic;
   }
 }
 
@@ -295,7 +305,8 @@ body.trusted-status-true .trusted-visible-block {
 }
 
 body.hidden-shell {
-  .top-bar, footer {
+  .top-bar,
+  footer {
     display: none;
   }
   .container {
@@ -360,6 +371,10 @@ body.hidden-shell {
 }
 
 @keyframes loading-fadein {
-  from { opacity: 0; }
-  to   { opacity: 0.6; }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 0.6;
+  }
 }


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

There are a few CSS properties on the `body` marked as `!important`. I came across this while integrating styles for articles into Storybook.

I'm trying to modify glaring issues in CSS in very small doses. I've tested this locally and removing the `!importants` does not appear to affect any pages.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![A giant cat fixing the Leaning Tower of Pisa](https://media.giphy.com/media/AeUcmWquAI8tW/giphy.gif)
