### PR TITLE
Returning a error when trying to initialize profile_image with a nil resource

### DIFF
--- a/app/labor/profile_image.rb
+++ b/app/labor/profile_image.rb
@@ -4,6 +4,7 @@ class ProfileImage
 
   def initialize(resource)
     @resource = resource
+    resource&.profile_image_url
     @image_link = resource.profile_image_url
     @backup_link = "https://thepracticaldev.s3.amazonaws.com/i/99mvlsfu5tfj9m7ku25d.png"
   end

--- a/spec/labor/profile_image_spec.rb
+++ b/spec/labor/profile_image_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe ProfileImage, type: :labor do
+  let(:user) { create(:user) }
+
+  it "returns a profile_image" do
+    expect(described_class.new(user).get.size).to be > 0
+  end
+
+  it "renders an error when initializing with a nil object" do
+    expect { described_class.new(nil) }.to raise_error(NoMethodError)
+  end
+end


### PR DESCRIPTION


<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Avoinding to initialize the ProfileImage class with a nil resource.
## Related Tickets & Documents
closes #5792
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/SKT4RlC0uaeYpsmxpt/giphy.gif)
