### PR TITLE
Add `/embed` to list of disallowed path matches

### DIFF
--- a/app/views/service_worker/index.js.erb
+++ b/app/views/service_worker/index.js.erb
@@ -97,6 +97,7 @@
         !url.href.includes('/api/') && // Don't run on API endpoints.
         !url.href.includes('/users/auth') && // Don't run on authentication.
         !url.href.includes('/shell_') && // Don't fetch for shell.
+        !url.href.includes('/embed/') && // Don't fetch for embeded content.
         !url.href.includes('/admin') && // Don't fetch for administrate dashboard.
         !url.href.includes('/internal') && // Don't fetch for internal dashboard.
         !url.href.includes('/future') && // Skip for /future.


### PR DESCRIPTION
In service workers, we should not be adding the shell to these views.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This will stop serviceworker shell from running in the `/embed/` context.