### PR TITLE
Small API controllers refactoring

### DIFF
--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -4,6 +4,8 @@ class Api::V0::ApiController < ApplicationController
   include ValidRequest
   include Pundit
 
+  respond_to :json
+
   def cors_set_access_control_headers
     headers["Access-Control-Allow-Origin"] = "*"
     headers["Access-Control-Allow-Methods"] = "POST, GET, PUT, DELETE, OPTIONS"

--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -1,8 +1,7 @@
-class Api::V0::ApiController < ActionController::Base
+class Api::V0::ApiController < ApplicationController
   protect_from_forgery with: :exception, prepend: true
 
   include ValidRequest
-  include Pundit
 
   respond_to :json
 

--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -1,4 +1,4 @@
-class Api::V0::ApiController < ApplicationController
+class Api::V0::ApiController < ActionController::Base
   protect_from_forgery with: :exception, prepend: true
 
   include ValidRequest

--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -1,4 +1,9 @@
 class Api::V0::ApiController < ApplicationController
+  protect_from_forgery with: :exception, prepend: true
+
+  include ValidRequest
+  include Pundit
+
   def cors_set_access_control_headers
     headers["Access-Control-Allow-Origin"] = "*"
     headers["Access-Control-Allow-Methods"] = "POST, GET, PUT, DELETE, OPTIONS"

--- a/app/controllers/api/v0/articles_controller.rb
+++ b/app/controllers/api/v0/articles_controller.rb
@@ -1,8 +1,6 @@
 module Api
   module V0
     class ArticlesController < ApiController
-      respond_to :json
-
       before_action :authenticate_with_api_key_or_current_user!, only: %i[create update]
       before_action :authenticate!, only: :me
       before_action -> { doorkeeper_authorize! :public }, only: %w[index show], if: -> { doorkeeper_token }
@@ -14,7 +12,6 @@ module Api
       before_action :cors_preflight_check
       after_action :cors_set_access_control_headers
 
-      # skip CSRF checks for create and update
       skip_before_action :verify_authenticity_token, only: %i[create update]
 
       def index

--- a/app/controllers/api/v0/classified_listings_controller.rb
+++ b/app/controllers/api/v0/classified_listings_controller.rb
@@ -3,12 +3,9 @@ module Api
     class ClassifiedListingsController < ApiController
       include ClassifiedListingsToolkit
 
-      respond_to :json
-
       before_action :set_classified_listing, only: %i[update]
       before_action :authenticate_with_api_key_or_current_user!, only: %i[create update]
 
-      # skip CSRF checks for create and update
       skip_before_action :verify_authenticity_token, only: %i[create update]
 
       def index

--- a/app/controllers/api/v0/classified_listings_controller.rb
+++ b/app/controllers/api/v0/classified_listings_controller.rb
@@ -1,6 +1,7 @@
 module Api
   module V0
     class ClassifiedListingsController < ApiController
+      include Pundit
       include ClassifiedListingsToolkit
 
       before_action :set_classified_listing, only: %i[update]

--- a/app/controllers/api/v0/comments_controller.rb
+++ b/app/controllers/api/v0/comments_controller.rb
@@ -1,8 +1,6 @@
 module Api
   module V0
     class CommentsController < ApiController
-      respond_to :json
-
       before_action :set_cache_control_headers, only: %i[index show]
 
       def index

--- a/app/controllers/api/v0/github_repos_controller.rb
+++ b/app/controllers/api/v0/github_repos_controller.rb
@@ -1,6 +1,8 @@
 module Api
   module V0
     class GithubReposController < ApiController
+      include Pundit
+
       def index
         client = create_octokit_client
 

--- a/app/controllers/api/v0/podcast_episodes_controller.rb
+++ b/app/controllers/api/v0/podcast_episodes_controller.rb
@@ -1,8 +1,6 @@
 module Api
   module V0
     class PodcastEpisodesController < ApiController
-      respond_to :json
-
       before_action :cors_preflight_check
       after_action :cors_set_access_control_headers
 

--- a/app/controllers/api/v0/tags_controller.rb
+++ b/app/controllers/api/v0/tags_controller.rb
@@ -1,8 +1,6 @@
 module Api
   module V0
     class TagsController < ApiController
-      respond_to :json
-
       before_action :set_cache_control_headers, only: %i[index onboarding]
 
       def index

--- a/app/controllers/api/v0/tags_controller.rb
+++ b/app/controllers/api/v0/tags_controller.rb
@@ -1,6 +1,6 @@
 module Api
   module V0
-    class TagsController < ApplicationController
+    class TagsController < ApiController
       respond_to :json
 
       before_action :set_cache_control_headers, only: %i[index onboarding]

--- a/app/controllers/api/v0/videos_controller.rb
+++ b/app/controllers/api/v0/videos_controller.rb
@@ -1,8 +1,6 @@
 module Api
   module V0
     class VideosController < ApiController
-      respond_to :json
-
       before_action :cors_preflight_check
       after_action :cors_set_access_control_headers
 

--- a/app/controllers/api/v0/webhooks_controller.rb
+++ b/app/controllers/api/v0/webhooks_controller.rb
@@ -1,9 +1,9 @@
 module Api
   module V0
     class WebhooksController < ApiController
-      respond_to :json
       before_action :authenticate!
       before_action -> { doorkeeper_authorize! :public }, if: -> { doorkeeper_token }
+
       skip_before_action :verify_authenticity_token, only: %w[create destroy]
 
       def index

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,12 +7,6 @@ class ApplicationController < ActionController::Base
 
   rescue_from ActionView::MissingTemplate, with: :routing_error
 
-  def require_http_auth
-    authenticate_or_request_with_http_basic do |username, password|
-      username == ApplicationConfig["APP_NAME"] && password == ApplicationConfig["APP_PASSWORD"]
-    end
-  end
-
   def not_found
     raise ActiveRecord::RecordNotFound, "Not Found"
   end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

- `Api::V0::ApiController` inherits from `ActionController::Base` instead of our `ApplicationController`: I tried using `ActionController::Metal` and `ActionController::API` adding the requested methods but I had some initialization issues with the order of included modules, so I stuck with `ActionController::Base` which is the base class of our `ApplicationController`. The reason for this is that we don't want all modifications to the base UI controller to be inherited to API controllers

- Moved up `respond_to :json` one level
