### PR TITLE
Use POST instead of GET for CSRF protection

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -71,7 +71,7 @@ class UsersController < ApplicationController
       flash[:settings_notice] = "You have requested account deletion. Please, check your email for further instructions."
       redirect_to "/settings/#{@tab}"
     else
-      flash[:settings_notice] = "Please, provide an email to delete your account"
+      flash[:settings_notice] = "Please, provide an email to delete your account."
       redirect_to "/settings/account"
     end
   end

--- a/app/views/users/_account.html.erb
+++ b/app/views/users/_account.html.erb
@@ -90,7 +90,7 @@
 <h3>Delete Account</h3>
 <% if current_user.email? %>
   <h4 style="font-weight:400;">
-    <%= form_tag user_request_destroy_path, method: :get, autocomplete: "off", id: "delete__account" do %>
+    <%= form_tag user_request_destroy_path, method: :post, autocomplete: "off", id: "delete__account" do %>
       Deleting your account will:
       <ul class="delete__account">
         <li>delete your profile, along with your Twitter and/or GitHub associations.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -258,7 +258,7 @@ Rails.application.routes.draw do
   post "users/remove_org_admin" => "users#remove_org_admin"
   post "users/remove_from_org" => "users#remove_from_org"
   delete "users/remove_association", to: "users#remove_association"
-  get "users/request_destroy", to: "users#request_destroy", as: :user_request_destroy
+  post "users/request_destroy", to: "users#request_destroy", as: :user_request_destroy
   get "users/confirm_destroy/:token", to: "users#confirm_destroy", as: :user_confirm_destroy
   delete "users/full_delete", to: "users#full_delete", as: :user_full_delete
   post "organizations/generate_new_secret" => "organizations#generate_new_secret"

--- a/spec/requests/user/user_destroy_spec.rb
+++ b/spec/requests/user/user_destroy_spec.rb
@@ -58,13 +58,13 @@ RSpec.describe "UserDestroy", type: :request do
     end
   end
 
-  describe "GET /users/request_destroy" do
+  describe "POST /users/request_destroy" do
     context "when user has an email" do
       before do
         allow(Rails.cache).to receive(:write).and_call_original
         allow(NotifyMailer).to receive(:account_deletion_requested_email).and_call_original
         sign_in user
-        get "/users/request_destroy"
+        post "/users/request_destroy"
       end
 
       it "sends an email" do
@@ -89,7 +89,7 @@ RSpec.describe "UserDestroy", type: :request do
       end
 
       it "redirects to account page" do
-        get "/users/request_destroy"
+        post "/users/request_destroy"
         expect(response).to redirect_to("/settings/account")
         expect(flash[:settings_notice]).to include("provide an email")
       end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This updates the request account deletion route to use POST and not GET for CSRF protection.