### PR TITLE
Add unsubscribe option to badge and connect emails

### DIFF
--- a/app/controllers/email_subscriptions_controller.rb
+++ b/app/controllers/email_subscriptions_controller.rb
@@ -1,28 +1,25 @@
 class EmailSubscriptionsController < ApplicationController
-  # No need to authorize this because its implicit when unsubbing
+  PREFERRED_EMAIL_NAME = {
+    email_digest_periodic: "DEV digest emails",
+    email_comment_notifications: "comment notifications",
+    email_follower_notifications: "follower notifications",
+    email_mention_notifications: "mention notifications",
+    email_connect_messages: "DEV connect messages",
+    email_unread_notifications: "unread notifications",
+    email_badge_notifications: "badge notifications"
+  }.freeze
+
   def unsubscribe
     verified_params = Rails.application.message_verifier(:unsubscribe).verify(params[:ut])
 
     if verified_params[:expires_at] > Time.current
       user = User.find(verified_params[:user_id])
       user.update(verified_params[:email_type] => false)
-      @email_type = preferred_email_name(verified_params[:email_type])
+      @email_type = PREFERRED_EMAIL_NAME[verified_params[:email_type]]
     else
       render "invalid_token"
     end
   rescue ActiveSupport::MessageVerifier::InvalidSignature
     not_found
-  end
-
-  def preferred_email_name(given_email_type)
-    emails_type = {
-      email_digest_periodic: "DEV digest emails",
-      email_comment_notifications: "comment notifications",
-      email_follower_notifications: "follower notifications",
-      email_mention_notifications: "mention notifications",
-      email_connect_messages: "connect messages",
-      email_unread_notifications: "unread notifications"
-    }
-    emails_type[given_email_type]
   end
 end

--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -54,6 +54,7 @@ class NotifyMailer < ApplicationMailer
     @badge_achievement = badge_achievement
     @user = @badge_achievement.user
     @badge = @badge_achievement.badge
+    @unsubscribe = generate_unsubscribe_token(@user.id, :email_badge_notifications)
     mail(to: @user.email, subject: "You just got a badge")
   end
 
@@ -69,6 +70,7 @@ class NotifyMailer < ApplicationMailer
     @message = direct_message
     @user = @message.direct_receiver
     subject = "#{@message.user.name} just messaged you"
+    @unsubscribe = generate_unsubscribe_token(@user.id, :email_connect_messages)
     mail(to: @user.email, subject: subject)
   end
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature

## Description
Add unsubscribe option to badge and connect emails
## Related Tickets & Documents
n/a
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
Adds the `Unsubscribe` link to the two types of email
![](https://camo.githubusercontent.com/af000c0a4e9591e9b5a9b168ae5ba5272f04cf41/68747470733a2f2f636c2e6c792f3239363337306362613832622f496d616765253230323032302d30322d3131253230617425323031322e32392e3036253230504d2e706e67)
## Added to documentation?
- [x] no documentation needed

