### PR TITLE
Flaky Spec Fix: Article Decorator Spec Remove extra period if name ends with it

### DIFF
--- a/spec/decorators/article_decorator_spec.rb
+++ b/spec/decorators/article_decorator_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe ArticleDecorator, type: :decorator do
     it "creates proper description when it is not present and body is not present and long, and tags are present" do
       body_markdown = "---\ntitle: Title\npublished: false\ndescription:\ntags: heytag\n---\n\n"
       created_article = create_article(body_markdown: body_markdown)
-      expect(created_article.description_and_tags).to eq("A post by #{created_article.user.name}. Tagged with heytag.")
+      expect(created_article.description_and_tags).to eq("A post by #{created_article.user.name.delete('.')}. Tagged with heytag.")
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This spec fails any time we create a user that has a name that ends with a period, for example, "Les Schmidt Jr." which you can see below breaks the spec. 
```
 1) ArticleDecorator#description_and_tags creates proper description when it is not present and body is not present and long, and tags are present
     Failure/Error: expect(created_article.description_and_tags).to eq("A post by #{created_article.user.name}. Tagged with heytag.")
     
       expected: "A post by Les Schmidt Jr.. Tagged with heytag."
            got: "A post by Les Schmidt Jr. Tagged with heytag."
     
       (compared using ==)
     # ./spec/decorators/article_decorator_spec.rb:60:in `block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:101:in `block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:101:in `block (2 levels) in <top (required)>'
```
The decorator will not add an extra period but we will in our assertion statement
```
modified_description += "." unless description.end_with?(".")
```
This removes the extra period from the assertion statement to ensure it always matches. 

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media.tenor.com/images/961044341e3bf6d800670e0514f3ce0d/tenor.gif)
