### PR TITLE
Add Elasticsearch index for classified_listings

### DIFF
--- a/app/services/search/classified_listing.rb
+++ b/app/services/search/classified_listing.rb
@@ -1,0 +1,134 @@
+module Search
+  class ClassifiedListing
+    INDEX_NAME = "classified_listings_#{Rails.env}".freeze
+    INDEX_ALIAS = "classified_listings_#{Rails.env}_alias".freeze
+
+    class << self
+      def index(classified_listing__id, serialized_data)
+        SearchClient.index(
+          id: classified_listing__id,
+          index: INDEX_ALIAS,
+          body: serialized_data,
+        )
+      end
+
+      def find_document(classified_listing__id)
+        SearchClient.get(id: classified_listing__id, index: INDEX_ALIAS)
+      end
+
+      def create_index(index_name: INDEX_NAME)
+        SearchClient.indices.create(index: index_name, body: settings)
+      end
+
+      def delete_index(index_name: INDEX_NAME)
+        SearchClient.indices.delete(index: index_name)
+      end
+
+      def add_alias(index_name: INDEX_NAME, index_alias: INDEX_ALIAS)
+        SearchClient.indices.put_alias(index: index_name, name: index_alias)
+      end
+
+      def update_mappings(index_alias: INDEX_ALIAS)
+        SearchClient.indices.put_mapping(index: index_alias, body: mappings)
+      end
+
+      private
+
+      def settings
+        { settings: { index: index_settings } }
+      end
+
+      def index_settings
+        if Rails.env.production?
+          {
+            number_of_shards: 1,
+            number_of_replicas: 1
+          }
+        else
+          {
+            number_of_shards: 1,
+            number_of_replicas: 0
+          }
+        end
+      end
+
+      def mappings
+        # "In Elasticsearch, there is no dedicated array datatype. Any field can
+        # contain zero or more values by default, however, all values in the
+        # array must be of the same datatype."
+        #
+        # https://www.elastic.co/guide/en/elasticsearch/reference/current/array.html
+
+        {
+          dynamic: "strict",
+          properties: {
+            id: {
+              type: "keyword"
+            },
+            author: {
+              dynamic: "strict",
+              type: "object",
+              properties: {
+                username: {
+                  type: "keyword"
+                },
+                name: {
+                  type: "keyword"
+                },
+                profile_image_90: {
+                  type: "keyword"
+                }
+              }
+            },
+            bumped_at: {
+              type: "date"
+            },
+            category: {
+              type: "keyword"
+            },
+            contact_via_connect: {
+              type: "boolean"
+            },
+            expires_at: {
+              type: "date"
+            },
+            location: {
+              type: "text",
+              fields: {
+                raw: {
+                  type: "keyword"
+                }
+              }
+            },
+            processed_html: {
+              type: "text"
+            },
+            slug: {
+              type: "text",
+              fields: {
+                raw: {
+                  type: "keyword"
+                }
+              }
+            },
+            tag_list: {
+              # Think of this as an Array - see comment at the top of this method
+              type: "keyword"
+            },
+            title: {
+              type: "text",
+              fields: {
+                raw: {
+                  type: "keyword"
+                }
+              }
+            },
+            user_id: {
+              type: "keyword"
+            }
+          }
+        }
+      end
+    end
+  end
+end

--- a/app/services/search/classified_listing.rb
+++ b/app/services/search/classified_listing.rb
@@ -52,6 +52,7 @@ module Search
         end
       end
 
+      # rubocop:disable Metrics/MethodLength
       def mappings
         # 1. "In Elasticsearch, there is no dedicated array datatype. Any field can
         #    contain zero or more values by default, however, all values in the
@@ -134,6 +135,8 @@ module Search
           }
         }
       end
+      # rubocop:enable Metrics/MethodLength
+
     end
   end
 end

--- a/app/services/search/classified_listing.rb
+++ b/app/services/search/classified_listing.rb
@@ -41,7 +41,7 @@ module Search
       def index_settings
         if Rails.env.production?
           {
-            number_of_shards: 1,
+            number_of_shards: 2,
             number_of_replicas: 1
           }
         else

--- a/app/services/search/classified_listing.rb
+++ b/app/services/search/classified_listing.rb
@@ -52,7 +52,6 @@ module Search
         end
       end
 
-      # rubocop:disable Metrics/MethodLength
       def mappings
         # 1. "In Elasticsearch, there is no dedicated array datatype. Any field can
         #    contain zero or more values by default, however, all values in the
@@ -135,8 +134,6 @@ module Search
           }
         }
       end
-      # rubocop:enable Metrics/MethodLength
-
     end
   end
 end

--- a/app/services/search/classified_listing.rb
+++ b/app/services/search/classified_listing.rb
@@ -53,26 +53,13 @@ module Search
       end
 
       def mappings
-        # 1. "In Elasticsearch, there is no dedicated array datatype. Any field can
-        #    contain zero or more values by default, however, all values in the
-        #    array must be of the same datatype."
-        #
-        # https://www.elastic.co/guide/en/elasticsearch/reference/current/array.html
-
-        # 2. You don't have to specify type: "object" since it is the default.
-        #    Specifying type: "object" will break specs because when you later
-        #    call the mappings API on Elasticsearch, it will NOT return the
-        #    type: object key, value pair.
-        #
-        # https://www.elastic.co/guide/en/elasticsearch/reference/current/object.html#object
-
         {
           dynamic: "strict",
           properties: {
             id: {
               type: "keyword"
             },
-            author: { # Don't need to specify type: "object" - see comment 2 above
+            author: {
               dynamic: "strict",
               properties: {
                 username: {
@@ -120,7 +107,7 @@ module Search
                 }
               }
             },
-            tags: { # Think of this as an Array - see comment 1 above
+            tags: {
               type: "keyword"
             },
             title: {

--- a/app/services/search/classified_listing.rb
+++ b/app/services/search/classified_listing.rb
@@ -117,7 +117,7 @@ module Search
                 }
               }
             },
-            tag_list: { # Think of this as an Array - see comment 1 above
+            tags: { # Think of this as an Array - see comment 1 above
               type: "keyword"
             },
             title: {

--- a/app/services/search/classified_listing.rb
+++ b/app/services/search/classified_listing.rb
@@ -67,7 +67,12 @@ module Search
             },
             author: {
               dynamic: "strict",
-              type: "object",
+              # You don't have to specify type: "object" since it is the default.
+              # Specifying type: "object" will break specs because when you later
+              # call the mappings API on Elasticsearch, it will NOT return the
+              # type: object key, value pair.
+              #
+              # https://www.elastic.co/guide/en/elasticsearch/reference/current/object.html#object
               properties: {
                 username: {
                   type: "keyword"

--- a/app/services/search/classified_listing.rb
+++ b/app/services/search/classified_listing.rb
@@ -4,16 +4,16 @@ module Search
     INDEX_ALIAS = "classified_listings_#{Rails.env}_alias".freeze
 
     class << self
-      def index(classified_listing__id, serialized_data)
+      def index(classified_listing_id, serialized_data)
         SearchClient.index(
-          id: classified_listing__id,
+          id: classified_listing_id,
           index: INDEX_ALIAS,
           body: serialized_data,
         )
       end
 
-      def find_document(classified_listing__id)
-        SearchClient.get(id: classified_listing__id, index: INDEX_ALIAS)
+      def find_document(classified_listing_id)
+        SearchClient.get(id: classified_listing_id, index: INDEX_ALIAS)
       end
 
       def create_index(index_name: INDEX_NAME)

--- a/app/services/search/classified_listing.rb
+++ b/app/services/search/classified_listing.rb
@@ -86,6 +86,9 @@ module Search
                 }
               }
             },
+            body_markdown: {
+              type: "text"
+            },
             bumped_at: {
               type: "date"
             },
@@ -107,7 +110,7 @@ module Search
               }
             },
             processed_html: {
-              type: "text"
+              type: "keyword"
             },
             slug: {
               type: "text",

--- a/app/services/search/classified_listing.rb
+++ b/app/services/search/classified_listing.rb
@@ -53,11 +53,18 @@ module Search
       end
 
       def mappings
-        # "In Elasticsearch, there is no dedicated array datatype. Any field can
-        # contain zero or more values by default, however, all values in the
-        # array must be of the same datatype."
+        # 1. "In Elasticsearch, there is no dedicated array datatype. Any field can
+        #    contain zero or more values by default, however, all values in the
+        #    array must be of the same datatype."
         #
         # https://www.elastic.co/guide/en/elasticsearch/reference/current/array.html
+
+        # 2. You don't have to specify type: "object" since it is the default.
+        #    Specifying type: "object" will break specs because when you later
+        #    call the mappings API on Elasticsearch, it will NOT return the
+        #    type: object key, value pair.
+        #
+        # https://www.elastic.co/guide/en/elasticsearch/reference/current/object.html#object
 
         {
           dynamic: "strict",
@@ -65,14 +72,8 @@ module Search
             id: {
               type: "keyword"
             },
-            author: {
+            author: { # Don't need to specify type: "object" - see comment 2 above
               dynamic: "strict",
-              # You don't have to specify type: "object" since it is the default.
-              # Specifying type: "object" will break specs because when you later
-              # call the mappings API on Elasticsearch, it will NOT return the
-              # type: object key, value pair.
-              #
-              # https://www.elastic.co/guide/en/elasticsearch/reference/current/object.html#object
               properties: {
                 username: {
                   type: "keyword"
@@ -116,8 +117,7 @@ module Search
                 }
               }
             },
-            tag_list: {
-              # Think of this as an Array - see comment at the top of this method
+            tag_list: { # Think of this as an Array - see comment 1 above
               type: "keyword"
             },
             title: {

--- a/app/services/search/cluster.rb
+++ b/app/services/search/cluster.rb
@@ -1,6 +1,9 @@
 module Search
   class Cluster
-    SEARCH_CLASSES = [Search::Tag].freeze
+    SEARCH_CLASSES = [
+      Search::Tag,
+      Search::ClassifiedListing,
+    ].freeze
 
     class << self
       def recreate_indexes

--- a/spec/services/search/classified_listing_spec.rb
+++ b/spec/services/search/classified_listing_spec.rb
@@ -1,0 +1,88 @@
+require "rails_helper"
+
+RSpec.describe Search::ClassifiedListing, type: :service, elasticsearch: true do
+  describe "::index" do
+    it "indexes a classified_listing to elasticsearch" do
+      classified_listing = FactoryBot.create(:classified_listing)
+      expect { described_class.find_document(classified_listing.id) }.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound)
+      described_class.index(classified_listing.id, id: classified_listing.id)
+      expect(described_class.find_document(classified_listing.id)).not_to be_nil
+    end
+  end
+
+  describe "::find_document" do
+    it "fetches a document for a given ID from elasticsearch" do
+      classified_listing = FactoryBot.create(:classified_listing)
+      described_class.index(classified_listing.id, id: classified_listing.id)
+      expect { described_class.find_document(classified_listing.id) }.not_to raise_error
+    end
+  end
+
+  describe "::create_index" do
+    it "creates an elasticsearch index with INDEX_NAME" do
+      described_class.delete_index
+      expect(SearchClient.indices.exists(index: described_class::INDEX_NAME)).to eq(false)
+      described_class.create_index
+      expect(SearchClient.indices.exists(index: described_class::INDEX_NAME)).to eq(true)
+    end
+
+    it "creates an elasticsearch index with name argument" do
+      other_name = "random"
+      expect(SearchClient.indices.exists(index: other_name)).to eq(false)
+      described_class.create_index(index_name: other_name)
+      expect(SearchClient.indices.exists(index: other_name)).to eq(true)
+
+      # Have to cleanup index since it wont automatically be handled by our cluster class bc of the unexpected name
+      described_class.delete_index(index_name: other_name)
+    end
+  end
+
+  describe "::delete_index" do
+    it "deletes an elasticsearch index with INDEX_NAME" do
+      expect(SearchClient.indices.exists(index: described_class::INDEX_NAME)).to eq(true)
+      described_class.delete_index
+      expect(SearchClient.indices.exists(index: described_class::INDEX_NAME)).to eq(false)
+    end
+
+    it "deletes an elasticsearch index with name argument" do
+      other_name = "random"
+      described_class.create_index(index_name: other_name)
+      expect(SearchClient.indices.exists(index: other_name)).to eq(true)
+
+      described_class.delete_index(index_name: other_name)
+      expect(SearchClient.indices.exists(index: other_name)).to eq(false)
+    end
+  end
+
+  describe "::add_alias" do
+    it "adds alias INDEX_ALIAS to elasticsearch index with INDEX_NAME" do
+      SearchClient.indices.delete_alias(index: described_class::INDEX_NAME, name: described_class::INDEX_ALIAS)
+      expect(SearchClient.indices.exists(index: described_class::INDEX_ALIAS)).to eq(false)
+      described_class.add_alias
+      expect(SearchClient.indices.exists(index: described_class::INDEX_ALIAS)).to eq(true)
+    end
+
+    it "adds custom alias to elasticsearch index with INDEX_NAME" do
+      other_alias = "random"
+      expect(SearchClient.indices.exists(index: other_alias)).to eq(false)
+      described_class.add_alias(index_name: described_class::INDEX_NAME, index_alias: other_alias)
+      expect(SearchClient.indices.exists(index: other_alias)).to eq(true)
+    end
+  end
+
+  describe "::update_mappings" do
+    it "updates index mappings for classified_listing index", :aggregate_failures do
+      other_name = "random"
+      described_class.create_index(index_name: other_name)
+      initial_mapping = SearchClient.indices.get_mapping(index: other_name).dig(other_name, "mappings")
+      expect(initial_mapping).to be_empty
+
+      described_class.update_mappings(index_alias: other_name)
+      mapping = SearchClient.indices.get_mapping(index: other_name).dig(other_name, "mappings")
+      expect(mapping.deep_stringify_keys).to include(described_class.send("mappings").deep_stringify_keys)
+
+      # Have to cleanup index since it wont automatically be handled by our cluster class bc of the unexpected name
+      described_class.delete_index(index_name: other_name)
+    end
+  end
+end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)
- [x] Feature

## Description
This PR creates mappings for the `classifieds_listings` index on Elasticsearch and adds the index to Elasticsearch. This is part 1/4 in the process of getting `classified_listings` on Elasticsearch.

One thing I'd like to call attention to for review is the mappings...I may have gotten a little _"mappy happy"_ by adding the raw fields to certain attributes 🙈For example, `slug`. Since `slug` is based on the original title of the `ClassifiedListing` and doesn't change, I could see where it might be nice to do a full-text search on that field if someone were searching by an original `ClassifiedListing` title that had changed. Maybe?

- [x] 1. [Setup ClassifiedListing Index and Mappings](https://github.com/thepracticaldev/dev.to/projects/6#card-32289262)
- [ ] 2. [Index ClassifiedListing into Elasticsearch](https://github.com/thepracticaldev/dev.to/projects/6#card-32289256)
- [ ] 3. [Search ClassifiedListing in Elasticsearch](https://github.com/thepracticaldev/dev.to/projects/6#card-32289262)
- [ ] 4. [Remove Algolia from ClassifiedListing](https://github.com/thepracticaldev/dev.to/projects/6#card-32955601)

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-32289262

## Added tests?
- [x] yes

## Added to documentation?
- [x] no documentation needed

## Are there any post deployment tasks we need to perform?
No, because of the way we have it set up (#5939), the index will automatically be added on deployment.

_Technically, not a post-deployment task that needs to be performed, but figured it was worth the reminder since Elasticsearch is new and touching a lot._

![jimmy_fallon_searching_gif](https://media.giphy.com/media/9r4UgVsKKJuKavWoql/giphy.gif)