### PR TITLE
Add the 'approved' attribute to index articles so that we can filter by it later on.

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -94,7 +94,7 @@ class Article < ApplicationRecord
            :video, :user_id, :organization_id, :video_source_url, :video_code,
            :video_thumbnail_url, :video_closed_caption_track_url, :language,
            :experience_level_rating, :experience_level_rating_distribution, :cached_user, :cached_organization,
-           :published_at, :crossposted_at, :boost_states, :description, :reading_time, :video_duration_in_seconds, :approved)
+           :published_at, :crossposted_at, :boost_states, :description, :reading_time, :video_duration_in_seconds)
   }
 
   scope :limited_columns_internal_select, lambda {
@@ -173,7 +173,7 @@ class Article < ApplicationRecord
     add_index "ordered_articles", id: :index_id, per_environment: true, enqueue: :trigger_index do
       attributes :title, :path, :class_name, :comments_count, :reading_time, :language,
                  :tag_list, :positive_reactions_count, :id, :hotness_score, :score, :readable_publish_date, :flare_tag, :user_id,
-                 :organization_id, :cloudinary_video_url, :video_duration_in_minutes, :experience_level_rating, :experience_level_rating_distribution
+                 :organization_id, :cloudinary_video_url, :video_duration_in_minutes, :experience_level_rating, :experience_level_rating_distribution, :approved
       attribute :published_at_int do
         published_at.to_i
       end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -94,7 +94,7 @@ class Article < ApplicationRecord
            :video, :user_id, :organization_id, :video_source_url, :video_code,
            :video_thumbnail_url, :video_closed_caption_track_url, :language,
            :experience_level_rating, :experience_level_rating_distribution, :cached_user, :cached_organization,
-           :published_at, :crossposted_at, :boost_states, :description, :reading_time, :video_duration_in_seconds)
+           :published_at, :crossposted_at, :boost_states, :description, :reading_time, :video_duration_in_seconds, :approved)
   }
 
   scope :limited_columns_internal_select, lambda {
@@ -147,7 +147,7 @@ class Article < ApplicationRecord
                  :featured, :published, :published_at, :featured_number,
                  :comments_count, :reactions_count, :positive_reactions_count,
                  :path, :class_name, :user_name, :user_username, :comments_blob,
-                 :body_text, :tag_keywords_for_search, :search_score, :readable_publish_date, :flare_tag
+                 :body_text, :tag_keywords_for_search, :search_score, :readable_publish_date, :flare_tag, :approved
       attribute :user do
         { username: user.username, name: user.name,
           profile_image_90: ProfileImage.new(user).get(width: 90), pro: user.pro? }


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This is a small PR of a much larger fix. Currently on the #she-coded tag pages we are showing the posts before they are being approved. Algolia is responsible for loading the paginated articles on these pages but it does not seem to have insight into whether the article is approved or not. 

This first step is to make sure that approved is included in the attributes that get sent.

## Related Tickets & Documents
[#372](https://github.com/thepracticaldev/tech-private/issues/372)

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

@benhalpern and I will need to have a manual task to re-index existing articles.

## [optional] What gif best describes this PR or how it makes you feel?

![giphy (37)](https://user-images.githubusercontent.com/2786819/74307787-1fe48500-4d6f-11ea-8799-d955fd440b09.gif)