### PR TITLE
Fix spelling of Elastiscsearch in docs

### DIFF
--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -88,7 +88,7 @@ Please execute the script itself to view all additional options:
 
 ## Known Problems & Solutions
 
-- Should you experience problems with the ElasticSearch container, try to
+- Should you experience problems with the Elasticsearch container, try to
   increase the memory and/or swap allocation for Docker. On macOS this can be
   done via the GUI:
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Documentation Update

## Description

As @mstruve rightfully pointed out in the already merged PR, it's Elasticsearch, not ElasticSearch.

## Related Tickets & Documents

n/a

## Added tests?

- [X] no, because they aren't needed

## Added to documentation?

- [X] docs.dev.to
