### PR TITLE
Add health check endpoint for Mailchimp unsubscribe webhook

### DIFF
--- a/app/controllers/incoming_webhooks/mailchimp_unsubscribes_controller.rb
+++ b/app/controllers/incoming_webhooks/mailchimp_unsubscribes_controller.rb
@@ -8,6 +8,10 @@ class IncomingWebhooks::MailchimpUnsubscribesController < ApplicationController
     mailchimp_community_moderators_id: :email_community_mod_newsletter
   }.freeze
 
+  def index
+    head :ok
+  end
+
   def create
     not_authorized unless valid_secret?
     user = User.find_by!(email: params.dig(:data, :email))

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -151,6 +151,7 @@ Rails.application.routes.draw do
   end
 
   namespace :incoming_webhooks do
+    get "/mailchimp/:secret/unsubscribe", to: "mailchimp_unsubscribes#index", as: :mailchimp_unsubscribe_check
     post "/mailchimp/:secret/unsubscribe", to: "mailchimp_unsubscribes#create", as: :mailchimp_unsubscribe
   end
 

--- a/spec/requests/incoming_webhooks/mailchimp/unsubscribe_spec.rb
+++ b/spec/requests/incoming_webhooks/mailchimp/unsubscribe_spec.rb
@@ -2,15 +2,22 @@ require "rails_helper"
 
 RSpec.describe "IncomingWebhooks::MailchimpUnsubscribesController", type: :request do
   let(:user) { create(:user, email_digest_periodic: true) }
+  let(:secret) { "secret" }
+
+  before do
+    allow(SiteConfig).to receive(:mailchimp_incoming_webhook_secret).and_return(secret)
+  end
+
+  describe "GET /webhooks/mailchimp/:secret/unsubscribe" do
+    it "provides a health check endpoint for Mailchimp to verify the webhook" do
+      get "/incoming_webhooks/mailchimp/wrong_secret/unsubscribe"
+      expect(response).to have_http_status(:ok)
+    end
+  end
 
   describe "POST /webhooks/mailchimp/:secret/unsubscribe" do
-    let(:secret) { "secret" }
     let(:list_id) { "1234" }
     let(:params) { { data: { email: user.email, list_id: list_id } } }
-
-    before do
-      allow(SiteConfig).to receive(:mailchimp_incoming_webhook_secret).and_return(secret)
-    end
 
     it "return not authorized if the secret is incorrect" do
       expect do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Feature

## Description

When experimenting with the Mailchimp unsubscribe webhook, @maestromac made the following discovery:

> [Mailchimp] sends a `GET` request to verify the URL. We only have a `#create` and it only accepts `POST`. Should we have an `#index` just for this purpose?

This PR adds the corresponding endpoint.

## Related Tickets & Documents

https://github.com/thepracticaldev/tech-private/issues/289

## Added tests?

- [X] yes

## Added to documentation?

- [X] no documentation needed
