### PR TITLE
Fix API documentation link

### DIFF
--- a/app/views/users/_account.html.erb
+++ b/app/views/users/_account.html.erb
@@ -17,7 +17,7 @@
 <% end %>
 
 <h2>DEV API Keys</h2>
-<p>You can generate personal API keys to use for authentication with the DEV API. The API is still in early beta though. The <a href="/api">DEV API documentation</a> contains further information.</a></p>
+<p>You can generate personal API keys to use for authentication with the DEV API. The API is still in early beta though. The <a href="https://docs.dev.to/api/">DEV API documentation</a> contains further information.</a></p>
 <h3>Generate a new Key</h3>
 <%= form_tag users_api_secrets_path, method: :post do %>
   <%= fields_for :api_secret do |api_secret| %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

This PR updates the link to the API documentation in the `_account` partial. 

@michael-tharrington I know this would have been a good first issue, but I was doing a `docker build` on my computer and this PR was easy enough to do from Github's web editor while waiting for that to finish. 😃 

## Related Tickets & Documents

Closes #6030 

## Added tests?

- [X] no, because they aren't needed

## Added to documentation?

- [X] no documentation needed
