### PR TITLE
Skips verify_authenticity_token in MailchimpUnsubscribesController

### DIFF
--- a/app/controllers/incoming_webhooks/mailchimp_unsubscribes_controller.rb
+++ b/app/controllers/incoming_webhooks/mailchimp_unsubscribes_controller.rb
@@ -1,4 +1,6 @@
 class IncomingWebhooks::MailchimpUnsubscribesController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
   class InvalidListID < StandardError; end
 
   LIST_MAPPINGS = {


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [x] Feature

## Description
This controller does not need verify authenticity token

## Related Tickets & Documents
n/a
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
n/a
## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed
