### PR TITLE
Prevent Elasticsearch auto index creation and Update Destroy Rake Task

### DIFF
--- a/app/services/search/cluster.rb
+++ b/app/services/search/cluster.rb
@@ -9,9 +9,14 @@ module Search
       end
 
       def setup_indexes
+        update_settings
         create_indexes
         add_aliases
         update_mappings
+      end
+
+      def update_settings
+        SearchClient.cluster.put_settings(body: default_settings)
       end
 
       def create_indexes
@@ -38,6 +43,18 @@ module Search
 
           search_class.delete_index
         end
+      end
+
+      private
+
+      def default_settings
+        {
+          persistent: {
+            action: {
+              auto_create_index: false
+            }
+          }
+        }
       end
     end
   end

--- a/lib/tasks/search.rake
+++ b/lib/tasks/search.rake
@@ -16,6 +16,6 @@ namespace :search do
       exit
     end
 
-    Search::Cluster.destroy_indexes
+    SearchClient.indices.delete(index: "*")
   end
 end

--- a/spec/services/search/cluster_spec.rb
+++ b/spec/services/search/cluster_spec.rb
@@ -66,4 +66,13 @@ RSpec.describe Search::Cluster, type: :service do
       expect(described_class::SEARCH_CLASSES).to all(have_received(:update_mappings))
     end
   end
+
+  describe "::update_settings" do
+    it "updates cluster settings" do
+      described_class.update_settings
+      cluster_settings = SearchClient.cluster.get_settings
+      auto_create_setting = cluster_settings.dig("persistent", "action", "auto_create_index")
+      expect(auto_create_setting).to eq("false")
+    end
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature
- [x] Bug Fix

## Description
@rhymes mentioned to me that he had gotten his Elasticsearch cluster into a bad state locally. The reason was because he attemped to index a document before the index was created. Since auto_index_creation is turned on by default the index was created but with the wrong name. This led to a whole lot of things breaking. In this bad state he also had no way to fix it because the destroy rake task was broken(though even in a good state would not have worked). To ensure that the destroy task always works I have updated it to destroy using a wildcard which will ensure any index regardless of name is cleared out and you can start fresh.

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-33018835

## Added tests?
- [x] yes

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media1.tenor.com/images/5bea70f5f19f24a3b1a917fb1b2cd93c/tenor.gif?itemid=8663208)
