### PR TITLE
Allow dynamic authoring of welcome notifications

### DIFF
--- a/Envfile
+++ b/Envfile
@@ -163,7 +163,8 @@ variable :TWITCH_WEBHOOK_SECRET, :String, default: "Optional"
 # (https://api.stackexchange.com/docs)
 variable :STACK_EXCHANGE_APP_KEY, :String, default: ""
 
-# For setting the ID of the welcoming user
+# For setting the IDs of the staff and welcoming users
+variable :STAFF_USER_ID, :Integer, default: 1
 variable :WELCOMING_USER_ID, :Integer, default: 1
 
 group :production do

--- a/Envfile
+++ b/Envfile
@@ -163,6 +163,9 @@ variable :TWITCH_WEBHOOK_SECRET, :String, default: "Optional"
 # (https://api.stackexchange.com/docs)
 variable :STACK_EXCHANGE_APP_KEY, :String, default: ""
 
+# For setting the ID of the welcoming user
+variable :WELCOMING_USER_ID, :Integer, default: 1
+
 group :production do
   variable :SECRET_KEY_BASE, :String
 

--- a/app/models/broadcast.rb
+++ b/app/models/broadcast.rb
@@ -4,7 +4,7 @@ class Broadcast < ApplicationRecord
   has_many :notifications, as: :notifiable, inverse_of: :notifiable
 
   validates :title, :type_of, :processed_html, presence: true
-  validates :type_of, inclusion: { in: %w[Announcement Onboarding] }
+  validates :type_of, inclusion: { in: %w[Announcement Onboarding Welcome] }
 
   def get_inner_body(content)
     Nokogiri::HTML(content).at("body").inner_html

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -74,8 +74,8 @@ class Notification < ApplicationRecord
       Notifications::MentionWorker.perform_async(mention.id)
     end
 
-    def send_welcome_notification(receiver_id)
-      Notifications::WelcomeNotificationWorker.perform_async(receiver_id)
+    def send_welcome_notification(receiver_id, broadcast_id)
+      Notifications::WelcomeNotificationWorker.perform_async(receiver_id, broadcast_id)
     end
 
     def send_moderation_notification(notifiable)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -498,7 +498,9 @@ class User < ApplicationRecord
   end
 
   def send_welcome_notification
-    Notification.send_welcome_notification(id)
+    return unless (welcome_broadcast = Broadcast.find_by(title: "Welcome Notification"))
+
+    Notification.send_welcome_notification(id, welcome_broadcast.id)
   end
 
   def verify_twitter_username

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -155,6 +155,7 @@ class User < ApplicationRecord
   validate  :unique_including_orgs_and_podcasts, if: :username_changed?
 
   scope :dev_account, -> { find_by(id: SiteConfig.staff_user_id) }
+  scope :welcoming_account, -> { find_by(id: ApplicationConfig["WELCOMING_USER_ID"]) }
 
   scope :with_this_week_comments, lambda { |number|
     includes(:counters).joins(:counters).where("(user_counters.data -> 'comments_these_7_days')::int >= ?", number)

--- a/app/services/notifications/welcome_notification/send.rb
+++ b/app/services/notifications/welcome_notification/send.rb
@@ -14,9 +14,9 @@ module Notifications
       end
 
       def call
-        dev_account = User.dev_account
+        welcoming_account = User.welcoming_account
         json_data = {
-          user: user_data(dev_account),
+          user: user_data(welcoming_account),
           broadcast: {
             title: welcome_broadcast.title,
             processed_html: welcome_broadcast.processed_html

--- a/app/services/notifications/welcome_notification/send.rb
+++ b/app/services/notifications/welcome_notification/send.rb
@@ -22,7 +22,7 @@ module Notifications
             processed_html: welcome_broadcast.processed_html
           }
         }
-        Notification.create(
+        Notification.create!(
           user_id: receiver_id,
           notifiable_id: welcome_broadcast.id,
           notifiable_type: "Broadcast",

--- a/app/views/internal/broadcasts/_form.html.erb
+++ b/app/views/internal/broadcasts/_form.html.erb
@@ -7,9 +7,9 @@
 </div>
 <div class="form-group">
   <%= label_tag :type, "Type:" %>
-  <%= select_tag "type_of", options_for_select(%w[Onboarding Announcement]) %>
+  <%= select_tag "type_of", options_for_select(%w[Onboarding Announcement Welcome]) %>
 </div>
-<div class="form-gorup">
+<div class="form-group">
   <%= label_tag :sent, "Sent:" %>
   <%= select_tag :sent, options_for_select([true, false]) %>
 </div>

--- a/app/workers/notifications/welcome_notification_worker.rb
+++ b/app/workers/notifications/welcome_notification_worker.rb
@@ -3,10 +3,10 @@ module Notifications
     include Sidekiq::Worker
     sidekiq_options queue: :low_priority, retry: 10
 
-    def perform(receiver_id)
-      welcome_broadcast = Broadcast.find_by(title: "Welcome Notification")
+    def perform(receiver_id, broadcast_id)
+      return unless (welcome_broadcast = Broadcast.find_by(id: broadcast_id))
 
-      Notifications::WelcomeNotification::Send.call(receiver_id, welcome_broadcast) if welcome_broadcast
+      Notifications::WelcomeNotification::Send.call(receiver_id, welcome_broadcast)
     end
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -96,6 +96,8 @@ Rails.application.configure do
   # Debug is the default log_level, but can be changed per environment.
   config.log_level = :debug
 
+  config.welcoming_user_id = ENV["WELCOMING_USER_ID"]
+
   # See <https://github.com/flyerhzm/bullet#configuration> for other config options
   config.after_initialize do
     Bullet.enable = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -120,6 +120,8 @@ Rails.application.configure do
     enable_starttls_auto: true
   }
 
+  config.welcoming_user_id = ENV["WELCOMING_USER_ID"]
+
   config.middleware.use Rack::HostRedirect,
                         ENV["HEROKU_APP_URL"] => ENV["APP_DOMAIN"]
 end

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -292,14 +292,13 @@ RSpec.describe "NotificationsIndex", type: :request do
     end
 
     context "when a user has a new welcome notification" do
-      before do
-        sign_in user
-      end
+      let(:broadcast) { create(:broadcast, :onboarding) }
+
+      before { sign_in user }
 
       it "renders the welcome notification" do
-        broadcast = create(:broadcast, :onboarding)
         sidekiq_perform_enqueued_jobs do
-          Notification.send_welcome_notification(user.id)
+          Notification.send_welcome_notification(user.id, broadcast.id)
         end
         get "/notifications"
         expect(response.body).to include broadcast.processed_html

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -4,10 +4,12 @@ RSpec.describe "NotificationsIndex", type: :request do
   include ActionView::Helpers::DateHelper
 
   let(:dev_account) { create(:user) }
+  let(:welcoming_account) { create(:user) }
   let(:user) { create(:user) }
 
   before do
     allow(User).to receive(:dev_account).and_return(dev_account)
+    allow(User).to receive(:welcoming_account).and_return(welcoming_account)
   end
 
   def has_both_names(response_body)
@@ -302,6 +304,8 @@ RSpec.describe "NotificationsIndex", type: :request do
         get "/notifications"
         expect(response.body).to include broadcast.processed_html
       end
+
+      xit "it renders a welcome notification with a type of Welcome"
     end
 
     context "when a user has a new badge notification" do

--- a/spec/services/notifications/welcome_notification/send_spec.rb
+++ b/spec/services/notifications/welcome_notification/send_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Notifications::WelcomeNotification::Send, type: :service do
   describe "::call" do
     before do
-      allow(User).to receive(:dev_account).and_return(create(:user))
+      allow(User).to receive(:welcoming_account).and_return(create(:user))
     end
 
     it "checks a newly created welcome notification", :aggregate_failures do

--- a/spec/workers/notifications/welcome_notification_worker_spec.rb
+++ b/spec/workers/notifications/welcome_notification_worker_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Notifications::WelcomeNotificationWorker, type: :worker do
     end
 
     it "calls a service" do
-      worker.perform(user.id)
+      worker.perform(user.id, broadcast.id)
       expect(service).to have_received(:call).with(user.id, broadcast).once
     end
 
@@ -21,7 +21,7 @@ RSpec.describe Notifications::WelcomeNotificationWorker, type: :worker do
       end
 
       it "does nothing" do
-        worker.perform(user.id)
+        worker.perform(user.id, broadcast.id)
         expect(service).not_to have_received(:call)
       end
     end


### PR DESCRIPTION
This is the initial work to [port over](https://github.com/thepracticaldev/dev.to/projects/7#card-32224049) the current welcome notification into a new "welcome notification" workflow. 

- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

It's worth noting that this doesn't change the current behavior of the one welcome notification that we send out. It focuses more on setting up a new structure for welcome notifications and maintaining feature parity of the single notification we have on production currently!

Here are the main changes introduced by this PR:
- [x] Adds a new `"Welcome"` type to the `Broadcast` model. Notably, this isn't being used just yet, but as we add new notifications to the "welcome notification flow", we'll categorize them by making them all of the same type.
- [x] Adds a concept of a "welcoming user", which can be set via an ENV var. This is the user whose account will "send" the welcome notifications; in production, we plan for this to be [Sloan](http://dev.to/sloan).
- [x] Allows us to send different kinds of "broadcast" notifications using one single worker (`Notifications::WelcomeNotificationWorker`), and abstracts out the logic of which notification to send. This will help us send many different kinds of welcome notifications using one, reusable worker class.
- [x] Explicitly `raise`s if a Notification can't be created.
- [x] Adds a `STAFF_USER_ID` ENV var, in preparation for [moving away from](https://github.com/thepracticaldev/dev.to/pull/6009) using the SiteConfig to set this. 


⚠️ **Before this PR can be merged, we need to do the following:** ⚠️
- [x] ~Set the WELCOMING_USER_ID on production. In order to keep parity with what we _currently_ do on production, the value of this should be the id for the `/thepracticaldev` staff account (which should be the value of `SiteConfig.staff_user_id`). We will change this later on once we turn on the new welcome notifications feature.~ DONE by @Zhao-Andy 😄 
- [x] ~While we're at it, we should also set the STAFF_USER_ID on production. Nothing will break if we don't do this, but I'll have a separate PR to change over `SiteConfig.staff_user_id` to rely on this ENV var, so it would be good to just have it set correctly.~ DONE by @Zhao-Andy 😄 
## What type of PR is this? (check all applicable)

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/7#card-32224049
https://github.com/thepracticaldev/dev.to/projects/7#card-32917275

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
N/A

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## Are there any post deployment tasks we need to perform?
**No _post-deployment_ tasks, but there ARE some pre-deployment tasks! See the above description with the  ⚠️icon.**

## What gif best describes this PR or how it makes you feel?


![](https://media0.giphy.com/media/FQyQEYd0KlYQ/giphy.gif?cid=5a38a5a24cd4df2eb4c0ee657899fea5b2997ace8f800d37&rid=giphy.gif)

