### PR TITLE
Add more information about using Elasticsearch to docs

### DIFF
--- a/docs/installation/mac.md
+++ b/docs/installation/mac.md
@@ -63,8 +63,11 @@ DEV requires Elasticsearch version 7 or higher.
 
 We recommend installing from archive on Mac. The following directions were
 [taken from the Elasticsearch docs themselves](https://www.elastic.co/guide/en/elasticsearch/reference/7.5/targz.html#install-macos),
-so check those out if you run into any issues or want further information. NOTE:
-Make sure to download the OSS version, `elasticsearch-oss`.
+so check those out if you run into any issues or want further information. Make
+sure to download **the OSS version** of Elasticsearch, `elasticsearch-oss`.
+
+Please note that you will need `wget` in order to proceed with this installation
+(`brew install wget`).
 
 ```shell
 wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-7.5.2-darwin-x86_64.tar.gz

--- a/docs/tests/readme.md
+++ b/docs/tests/readme.md
@@ -53,3 +53,8 @@ Travis will deploy your pull request to production after CI passes and a member
 of the DEV team has approved it.
 
 Our test suite is not perfect and sometimes a re-run is needed.
+
+Please note that you will need to have Elasticsearch installed and running for
+certain tests in our test suite. You can find instructions on how to install and
+run Elasticsearch specific your environment in the
+[Installation Guide](/installation).


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

It was unclear to me that I explicitly needed Elasticsearch in order for certain tests to run locally. We should specify that in the test section of the docs.

Also added a note about installing `wget`, which is required to install Elasticsearch in our docs.

## Related Tickets & Documents
N/A

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
N/A

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [x] docs.dev.to
- [ ] readme
- [ ] no documentation needed
