### PR TITLE
Enforce slashes for file paths with Rubocop 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -154,6 +154,9 @@ Style/TrailingCommaInArrayLiteral:
   EnforcedStyleForMultiline: comma
   Enabled: true
 
+Rails/FilePath:
+  EnforcedStyle: slashes
+
 # Layout
 
 Layout/DotPosition:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
When I [submitted a PR](https://github.com/thepracticaldev/dev.to/pull/6025) recently Rubcop locally told me to use slashes (see random example below)
```
Offenses:

spec/requests/tags_spec.rb:6:7: C: Rails/FilePath: Please use Rails.root.join('path/to') instead.
      Rails.root.join("app", "models", "concerns")
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
but then codeclimate defaulted to telling me to use arguments. 
![Screen Shot 2020-02-12 at 2 29 38 PM](https://user-images.githubusercontent.com/1813380/74369991-55f02c00-4da4-11ea-8357-e06ed5b902f8.png)

Having this in our rubocop file should carry it over to codeclimate and we should be all set. If there is something else I need to do to get codeclimate to respect it let me know!

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

![alt_text](https://res.cloudinary.com/practicaldev/image/fetch/s--pfQPHmB2--/c_limit%2Cf_auto%2Cfl_progressive%2Cq_66%2Cw_880/https://thepracticaldev.s3.amazonaws.com/i/kfkfmzi3qmfporoa7nsh.gif)
