### PR TITLE
Flaky Spec Try 2: Article Decorator properly handles Names

### DIFF
--- a/spec/decorators/article_decorator_spec.rb
+++ b/spec/decorators/article_decorator_spec.rb
@@ -57,11 +57,8 @@ RSpec.describe ArticleDecorator, type: :decorator do
     it "creates proper description when it is not present and body is not present and long, and tags are present" do
       body_markdown = "---\ntitle: Title\npublished: false\ndescription:\ntags: heytag\n---\n\n"
       created_article = create_article(body_markdown: body_markdown)
-      parsed_post_by_string = if created_article.user.name.end_with?(".")
-                                "A post by #{created_article.user.name}"
-                              else
-                                "A post by #{created_article.user.name}."
-                              end
+      parsed_post_by_string = "A post by #{created_article.user.name}"
+      parsed_post_by_string += "." unless created_article.user.name.end_with?(".")
       expect(created_article.description_and_tags).to eq("#{parsed_post_by_string} Tagged with heytag.")
     end
   end

--- a/spec/decorators/article_decorator_spec.rb
+++ b/spec/decorators/article_decorator_spec.rb
@@ -57,7 +57,12 @@ RSpec.describe ArticleDecorator, type: :decorator do
     it "creates proper description when it is not present and body is not present and long, and tags are present" do
       body_markdown = "---\ntitle: Title\npublished: false\ndescription:\ntags: heytag\n---\n\n"
       created_article = create_article(body_markdown: body_markdown)
-      expect(created_article.description_and_tags).to eq("A post by #{created_article.user.name.delete('.')}. Tagged with heytag.")
+      parsed_post_by_string = if created_article.user.name.end_with?(".")
+                                "A post by #{created_article.user.name}"
+                              else
+                                "A post by #{created_article.user.name}."
+                              end
+      expect(created_article.description_and_tags).to eq("#{parsed_post_by_string} Tagged with heytag.")
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
In a previous PR(#6029) I attempted to fix this flaky spec by removing any periods that might be in the user name figuring if the name is "Sam Jr." then the final period would be removed and we would be good. HOWEVER that doesnt work for a name "Mr. Sam Jr." bc then all of the periods are removed. This updates the spec to use the same `end_with` logic that the method in the decorator uses so it should be super solid now. 

## Related Tickets & Documents
#4884 

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media.giphy.com/media/fVeo7iZldhfxC94Hwh/giphy-downsized.gif)
