### PR TITLE
Add more paths for team delightful in CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,30 +2,32 @@
 # see https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 # for further details
 
-/*.md                                         @thepracticaldev/oss
-/app/assets/stylesheets/internal/             @thepracticaldev/snackcase
-/app/controllers/articles_controller.rb       @thepracticaldev/hells-bells
-/app/controllers/internal/                    @thepracticaldev/snackcase
-/app/controllers/notifications/               @thepracticaldev/delightful
-/app/controllers/notifications_controller.rb  @thepracticaldev/delightful
-/app/controllers/pages_controller.rb          @thepracticaldev/cool
-/app/controllers/stories_controller.rb        @thepracticaldev/hells-bells
-/app/jobs/                                    @thepracticaldev/sre
-/app/services/search/                         @thepracticaldev/sre
-/app/views/articles/                          @thepracticaldev/hells-bells
-/app/views/internal/                          @thepracticaldev/snackcase
-/app/views/moderation/                        @thepracticaldev/snackcase
-/app/views/notifications/                     @thepracticaldev/delightful
-/app/views/pages/shecoded.html.erb            @thepracticaldev/cool
-/app/views/partnerships/                      @thepracticaldev/cool
-/app/views/stories/                           @thepracticaldev/hells-bells
-/app/workers/                                 @thepracticaldev/sre
-/config/                                      @thepracticaldev/sre
-/db/                                          @thepracticaldev/sre
-/docs/                                        @thepracticaldev/oss @jacobherrington
-/spec/requests/internal/                      @thepracticaldev/snackcase
-/spec/system/internal/                        @thepracticaldev/snackcase
-Gemfile                                       @thepracticaldev/sre @thepracticaldev/oss
-Gemfile.lock                                  @thepracticaldev/sre @thepracticaldev/oss
-package.json                                  @thepracticaldev/oss
-yarn.lock                                     @thepracticaldev/oss
+/*.md                                               @thepracticaldev/oss
+/app/assets/stylesheets/internal/                   @thepracticaldev/snackcase
+/app/controllers/articles_controller.rb             @thepracticaldev/hells-bells
+/app/controllers/internal/                          @thepracticaldev/snackcase
+/app/services/notifications/                        @thepracticaldev/delightful
+/app/controllers/notifications/                     @thepracticaldev/delightful
+/app/workers/notifications/                         @thepracticaldev/delightful
+/app/controllers/internal/broadcasts_controller.rb  @thepracticaldev/delightful
+/app/controllers/pages_controller.rb                @thepracticaldev/cool
+/app/controllers/stories_controller.rb              @thepracticaldev/hells-bells
+/app/jobs/                                          @thepracticaldev/sre
+/app/services/search/                               @thepracticaldev/sre
+/app/views/articles/                                @thepracticaldev/hells-bells
+/app/views/internal/                                @thepracticaldev/snackcase
+/app/views/moderation/                              @thepracticaldev/snackcase
+/app/views/notifications/                           @thepracticaldev/delightful
+/app/views/pages/shecoded.html.erb                  @thepracticaldev/cool
+/app/views/partnerships/                            @thepracticaldev/cool
+/app/views/stories/                                 @thepracticaldev/hells-bells
+/app/workers/                                       @thepracticaldev/sre
+/config/                                            @thepracticaldev/sre
+/db/                                                @thepracticaldev/sre
+/docs/                                              @thepracticaldev/oss    @jacobherrington
+/spec/requests/internal/                            @thepracticaldev/snackcase
+/spec/system/internal/                              @thepracticaldev/snackcase
+Gemfile                                             @thepracticaldev/sre    @thepracticaldev/oss
+Gemfile.lock                                        @thepracticaldev/sre    @thepracticaldev/oss
+package.json                                        @thepracticaldev/oss
+yarn.lock                                           @thepracticaldev/oss


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization (...i guess?)
- [ ] Documentation Update

## Description

There are a few more sections of the code that impact team delightful's work on revamping (welcome) notifications. Adding them so that @juliannatetreault and I become code owners of these files and are alerted whenever they come up in a relevant PR! 😸 

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
