### PR TITLE
Add placeholder to badge award text area

### DIFF
--- a/app/views/internal/badges/index.html.erb
+++ b/app/views/internal/badges/index.html.erb
@@ -1,18 +1,19 @@
 <h3>Award Badges</h3>
-<div class="alert alert-warning"><strong>Warning: This task will fail silently when supplied with incorrect usernames!<strong></div>
-  <%= form_with(url: internal_badges_award_badges_path, local: true) do |f| %>
-    <div class="form-group">
-      <%= f.label :badge, "Badge" %>
-      <%= f.select("badge", @badges.map { |b| [b.title, b.slug] }, include_blank: true, class: "form-control") %>
-    </div>
-    <div class="form-group">
-      <%= f.label :usernames, "Usernames (Comma Delimited)*" %>
-      <%= f.text_area :usernames, required: true, size: "40x10", class: "form-control" %>
-    </div>
-    <div class="form-group">
-      <%= f.label :message_markdown, "Override Default Message (Supports Markdown)" %>
-      <%= f.text_area :message_markdown, size: "40x10", class: "form-control" %>
-    </div>
-    <%= f.submit "Award Badges", class: "btn btn-primary mb-4" %>
-  <% end %>
+<div class="alert alert-warning"><strong>Warning: This task will fail silently when supplied with incorrect
+    usernames!<strong></div>
+<%= form_with(url: internal_badges_award_badges_path, local: true) do |f| %>
+<div class="form-group">
+  <%= f.label :badge, "Badge" %>
+  <%= f.select("badge", @badges.map { |b| [b.title, b.slug] }, include_blank: true, class: "form-control") %>
+</div>
+<div class="form-group">
+  <%= f.label :usernames, "Usernames (Comma Delimited)*" %>
+  <%= f.text_area :usernames, placeholder: "user1, user2, user3", required: true, size: "40x10", class: "form-control" %>
+</div>
+<div class="form-group">
+  <%= f.label :message_markdown, "Override Default Message (Supports Markdown)" %>
+  <%= f.text_area :message_markdown, size: "40x10", class: "form-control" %>
+</div>
+<%= f.submit "Award Badges", class: "btn btn-primary mb-4" %>
+<% end %>
 </div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Feature

## Description

Adds a placeholder to the badge award text area. These small tasks are great while waiting for Docker build to finish in the background 😄 

## Related Tickets & Documents

Closes #6023 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

<img width="1160" alt="Screen Shot 2020-02-13 at 12 24 15" src="https://user-images.githubusercontent.com/47985/74404139-3288b800-4e5c-11ea-83e2-78a9b2d836c6.png">

## Added tests?

- [X] no, because they aren't needed

## Added to documentation?

- [X] no documentation needed
