### PR TITLE
Autosize textareas for suggested tweets

### DIFF
--- a/app/javascript/internal/controllers/buffer_controller.js
+++ b/app/javascript/internal/controllers/buffer_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from 'stimulus';
 
 export default class BufferController extends Controller {
-  static targets = ['header'];
+  static targets = ['header', 'bodyText'];
 
   tagBufferUpdateConfirmed() {
     this.headerTarget.innerHTML +=
@@ -18,6 +18,12 @@ export default class BufferController extends Controller {
     setTimeout(() => {
       this.element.classList.remove('highlighted-bg');
     }, 350);
+  }
+
+  autosizeBodyText() {
+    this.bodyTextTarget.rows = this.bodyTextTarget.value.split(
+      /\r\n|\r|\n/,
+    ).length;
   }
 
   get bufferUpdateId() {

--- a/app/views/internal/articles/index.html.erb
+++ b/app/views/internal/articles/index.html.erb
@@ -44,10 +44,10 @@
   </div>
   <div class="col-12 mb-2">
     <details>
-      <summary style="font-size: 1.3em; cursor: pointer;">Suggested tweets (<%= @pending_buffer_updates.size %>)</summary>
+      <summary style="font-size: 1.3em; cursor: pointer;">Suggested Tweets (<%= @pending_buffer_updates.size %>)</summary>
       <% @pending_buffer_updates.each do |buffer_update| %>
         <% next unless buffer_update.article %>
-        <div class="card my-3" id="suggested-tweet-<%= buffer_update.id %>" data-controller="buffer">
+        <div class="card my-3" id="suggested-tweet-<%= buffer_update.id %>" data-controller="buffer" data-action="load@window->buffer#autosizeBodyText">
           <div class="card-header">
             <h2 class="my-0" data-target="buffer.header"><%= buffer_update.article.title %></h2>
           </div>
@@ -66,7 +66,7 @@
                 <input type="hidden" name="authenticity_token" value="<%= form_authenticity_token %>" />
                 <input type="hidden" name="_method" value="patch" />
                 <input type="hidden" name="status" value="confirmed" />
-                <textarea name="body_text" class="form-control"><%= buffer_update.body_text %></textarea>
+                <textarea class="w-100 suggested-tweet-body-text" name="body_text" class="form-control" data-target="buffer.bodyText"><%= buffer_update.body_text %></textarea>
               </div>
               <button value="confirmed" name="status" class="btn btn-success" data-action="buffer#tagBufferUpdateConfirmed">Confirm</button>
             <% end %>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This change auto resizes the suggested tweet textareas to satisfy an issue opened by Peter.

After a lot of searching, I came up with a bit of an odd solution. It turns out this is kind of an annoying problem to solve.

## Related Tickets & Documents

#5831

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![image](https://user-images.githubusercontent.com/11466782/74412451-1573cb00-4e03-11ea-88f4-98d76d8b4501.png)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![external-content duckduckgo com](https://user-images.githubusercontent.com/11466782/74412602-6e436380-4e03-11ea-9b63-80efd0655d0e.gif)

