### PR TITLE
Fix uniqueness generator when too much data is seeded

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,6 +3,8 @@
 SEEDS_MULTIPLIER = [1, ENV["SEEDS_MULTIPLIER"].to_i].max
 Rails.logger.info "Seeding with multiplication factor: #{SEEDS_MULTIPLIER}"
 
+##############################################################################
+
 Rails.logger.info "1. Creating Organizations"
 
 3.times do
@@ -22,13 +24,19 @@ end
 
 ##############################################################################
 
-Rails.logger.info "2. Creating Users"
+num_users = 10 * SEEDS_MULTIPLIER
+
+Rails.logger.info "2. Creating #{num_users} Users"
+
+User.clear_index!
 
 roles = %i[trusted chatroom_beta_tester workshop_pass]
-User.clear_index!
-(10 * SEEDS_MULTIPLIER).times do |i|
+
+num_users.times do |i|
+  name = "#{Faker::Name.name} #{Faker::Lorem.word.titleize}"
+
   user = User.create!(
-    name: name = Faker::Name.unique.name,
+    name: name,
     summary: Faker::Lorem.paragraph_by_chars(number: 199, supplemental: false),
     profile_image: File.open(Rails.root.join("app/assets/images/#{rand(1..40)}.png")),
     website_url: Faker::Internet.url,
@@ -40,7 +48,7 @@ User.clear_index!
     password: "password",
   )
 
-  user.add_role(roles[rand(0..3)]) # includes chance of having no role
+  user.add_role(roles[rand(0..roles.length)]) # includes chance of having no role
 
   Identity.create!(
     provider: "twitter",
@@ -75,17 +83,20 @@ end
 
 ##############################################################################
 
-Rails.logger.info "4. Creating Articles"
+num_articles = 25 * SEEDS_MULTIPLIER
+
+Rails.logger.info "4. Creating #{num_articles} Articles"
 
 Article.clear_index!
-(25 * SEEDS_MULTIPLIER).times do |i|
+
+num_articles.times do |i|
   tags = []
   tags << "discuss" if (i % 3).zero?
   tags.concat Tag.order(Arel.sql("RANDOM()")).select("name").first(3).map(&:name)
 
   markdown = <<~MARKDOWN
     ---
-    title:  #{Faker::Book.unique.title}
+    title:  #{Faker::Book.title} #{Faker::Lorem.sentence(word_count: 2).chomp(".")}
     published: true
     cover_image: #{Faker::Company.logo}
     tags: #{tags.join(', ')}
@@ -106,16 +117,20 @@ end
 
 ##############################################################################
 
-Rails.logger.info "5. Creating Comments"
+num_comments = 30 * SEEDS_MULTIPLIER
+
+Rails.logger.info "5. Creating #{num_comments} Comments"
 
 Comment.clear_index!
-30.times do
+
+num_comments.times do
   attributes = {
     body_markdown: Faker::Hipster.paragraph(sentence_count: 1),
     user_id: User.order(Arel.sql("RANDOM()")).first.id,
     commentable_id: Article.order(Arel.sql("RANDOM()")).first.id,
     commentable_type: "Article"
   }
+
   Comment.create!(attributes)
 end
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

After #6003 we introduced a "multiplication factor" to increase the size of the seeded DB.

Unfortunately, this triggers the uniqueness limitations of Faker, the gem we use to generate unique text.

```shell
Faker::UniqueGenerator::RetryLimitExceeded: Retry limit exceeded for title
/Users/rhymes/.rvm/gems/ruby-2.6.5/gems/faker-2.10.1/lib/helpers/unique_generator.rb:30:in `method_missing'
/Users/rhymes/Development/devto/db/seeds.rb:88:in `block in <main>'
```

This PR fixes that by combining multiple random generators and also adds the multiplier to comments

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
