### PR TITLE
Remove unnecessary eager loading in internal comments controller

### DIFF
--- a/app/controllers/internal/comments_controller.rb
+++ b/app/controllers/internal/comments_controller.rb
@@ -6,7 +6,6 @@ class Internal::CommentsController < Internal::ApplicationController
                   Comment.
                     includes(:user).
                     includes(:commentable).
-                    includes(:reactions).
                     order("positive_reactions_count DESC").
                     where("created_at > ?", params[:state].split("-").last.to_i.days.ago).
                     page(params[:page] || 1).per(50)
@@ -14,7 +13,6 @@ class Internal::CommentsController < Internal::ApplicationController
                   Comment.
                     includes(:user).
                     includes(:commentable).
-                    includes(:reactions).
                     order("created_at DESC").
                     page(params[:page] || 1).per(50)
                 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Bullet doesn't seem to like this, and it makes sense because we don't
want to load ALL reactions, just some of them.

Co-authored-by: nspinazz89 <nspinazz89@gmail.com>

## Related Tickets & Documents

N/A

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![giphy](https://user-images.githubusercontent.com/11466782/74464489-349d4780-4e59-11ea-810d-41e162d488ab.gif)

