### PR TITLE
Add additional safeguards for config write access

### DIFF
--- a/app/controllers/internal/configs_controller.rb
+++ b/app/controllers/internal/configs_controller.rb
@@ -1,12 +1,13 @@
 class Internal::ConfigsController < Internal::ApplicationController
   layout "internal"
 
+  before_action :extra_authorization_and_confirmation, only: [:create]
+
   def show
     @logo_svg = SiteConfig.logo_svg.html_safe # rubocop:disable Rails/OutputSafety
   end
 
   def create
-    confirmation
     clean_up_params
     config_params.keys.each do |key|
       SiteConfig.public_send("#{key}=", config_params[key].strip) unless config_params[key].nil?
@@ -32,7 +33,7 @@ class Internal::ConfigsController < Internal::ApplicationController
     params.require(:site_config).permit(allowed_params)
   end
 
-  def confirmation
+  def extra_authorization_and_confirmation
     not_authorized unless current_user.has_role?(:single_resource_admin, Config) # Special additional permission
     not_authorized if params[:confirmation] != "My username is @#{current_user.username} and this action is 100% safe and appropriate."
   end

--- a/app/controllers/internal/configs_controller.rb
+++ b/app/controllers/internal/configs_controller.rb
@@ -6,6 +6,7 @@ class Internal::ConfigsController < Internal::ApplicationController
   end
 
   def create
+    confirmation
     clean_up_params
     config_params.keys.each do |key|
       SiteConfig.public_send("#{key}=", config_params[key].strip) unless config_params[key].nil?
@@ -29,6 +30,11 @@ class Internal::ConfigsController < Internal::ApplicationController
       rate_limit_image_upload rate_limit_email_recipient
     ]
     params.require(:site_config).permit(allowed_params)
+  end
+
+  def confirmation
+    not_authorized unless current_user.has_role?(:single_resource_admin, Config) # Special additional permission
+    not_authorized if params[:confirmation] != "My username is @#{current_user.username} and this action is 100% safe and appropriate."
   end
 
   def clean_up_params

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -1,3 +1,16 @@
+<div class="alert alert-warning" role="alert">
+  <p>
+    Only admins with explicit <strong>single resource admin</strong> role may make changes to site config. Even super admins require this permission.
+  <p>
+  <h2>
+    <% if current_user.has_role?(:single_resource_admin, Config) %>
+      <div class="alert alert-primary">You have permission to make config changes. Do so with care.</div>
+    <% else %>
+      You do not have permission to make config changes. (Read Only)
+    <% end %>
+  </h2>
+</div>
+
 <div class="row my-3" id="siteConfig">
   <div class="card w-100">
     <div class="card-header" id="siteConfigHeader">
@@ -9,233 +22,242 @@
     </div>
     <div id="siteConfigBodyContainer" class="collapse show hide" aria-labelledby="siteConfigHeader">
       <%= form_for(SiteConfig.new, url: internal_config_path) do |f| %>
-      <div class="card mt-3">
-        <div class="card-header">Staff</div>
-        <div class="card-body">
-          <div class="form-group">
-            <%= f.label :default_site_email %>
-            <%= f.email_field :default_site_email,
-                              class: "form-control",
-                              value: SiteConfig.default_site_email,
-                              placeholder: "email@staff.com" %>
-            <div class="alert alert-info">Email of the staff account</div>
-          </div>
+        <div class="card mt-3">
+          <div class="card-header">Staff</div>
+          <div class="card-body">
+            <div class="form-group">
+              <%= f.label :default_site_email %>
+              <%= f.email_field :default_site_email,
+                                class: "form-control",
+                                value: SiteConfig.default_site_email,
+                                placeholder: "email@staff.com" %>
+              <div class="alert alert-info">Email of the staff account</div>
+            </div>
 
-          <div class="form-group">
-            <%= f.label :social_networks_handle %>
-            <%= f.text_field :social_networks_handle,
-                             class: "form-control",
-                             value: SiteConfig.social_networks_handle,
-                             placeholder: "thepracticaldev" %>
-            <div class="alert alert-info">Social networks handle (eg. Twitter, GitHub)</div>
+            <div class="form-group">
+              <%= f.label :social_networks_handle %>
+              <%= f.text_field :social_networks_handle,
+                               class: "form-control",
+                               value: SiteConfig.social_networks_handle,
+                               placeholder: "thepracticaldev" %>
+              <div class="alert alert-info">Social networks handle (eg. Twitter, GitHub)</div>
+            </div>
           </div>
         </div>
-      </div>
 
-      <div class="card mt-3">
-        <div class="card-header">Images</div>
-        <div class="card-body">
-          <div class="form-group">
-            <%= f.label :main_social_image %>
-            <%= f.text_field :main_social_image,
-                             class: "form-control",
-                             value: SiteConfig.main_social_image,
-                             placeholder: "https://image.url" %>
-            <div class="row mt-2">
-              <div class="col-12">
-                <img alt="main social image" class="img-fluid" src="<%= SiteConfig.main_social_image %>" />
-              </div>
-              <div class="col-12">
-                <div class="alert alert-info">
-                  <h5>Used as the main image in social networks and OpenGraph</h5>
+        <div class="card mt-3">
+          <div class="card-header">Images</div>
+          <div class="card-body">
+            <div class="form-group">
+              <%= f.label :main_social_image %>
+              <%= f.text_field :main_social_image,
+                               class: "form-control",
+                               value: SiteConfig.main_social_image,
+                               placeholder: "https://image.url" %>
+              <div class="row mt-2">
+                <div class="col-12">
+                  <img alt="main social image" class="img-fluid" src="<%= SiteConfig.main_social_image %>" />
+                </div>
+                <div class="col-12">
+                  <div class="alert alert-info">
+                    <h5>Used as the main image in social networks and OpenGraph</h5>
+                  </div>
                 </div>
               </div>
-            </div>
 
+              <div class="form-group">
+                <%= f.label :favicon_url %>
+                <%= f.text_field :favicon_url,
+                                 class: "form-control",
+                                 value: SiteConfig.favicon_url,
+                                 placeholder: "https://image.url" %>
+                <div class="alert alert-info">Used as the site favicon</div>
+                <img alt="favicon" class="preview" src="<%= SiteConfig.favicon_url %>" />
+              </div>
+
+              <div class="form-group">
+                <%= f.label :logo_svg %>
+                <%= f.text_area :logo_svg,
+                                 class: "form-control",
+                                 value: SiteConfig.logo_svg,
+                                 rows: 6,
+                                 placeholder: "<svg ...></svg>" %>
+                <div class="alert alert-info">Used as the SVG logo of the community</div>
+                <%= @logo_svg %>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="card mt-3">
+          <div class="card-header">Rate limits</div>
+          <div class="card-body">
             <div class="form-group">
-              <%= f.label :favicon_url %>
-              <%= f.text_field :favicon_url,
+              <%= f.label :rate_limit_follow_count_daily %>
+              <%= f.number_field :rate_limit_follow_count_daily,
+                                 class: "form-control",
+                                 value: SiteConfig.rate_limit_follow_count_daily,
+                                 min: 0,
+                                 placeholder: 500 %>
+              <div class="alert alert-info">Used to limit the amount of users a person can follow daily</div>
+            </div>
+          </div>
+          <div class="card-body">
+            <div class="form-group">
+              <%= f.label :rate_limit_comment_creation %>
+              <%= f.number_field :rate_limit_comment_creation,
+                                 class: "form-control",
+                                 value: SiteConfig.rate_limit_comment_creation,
+                                 min: 0,
+                                 placeholder: 9 %>
+              <div class="alert alert-info">Used to limit the amount of comments a user can create within 30 seconds</div>
+            </div>
+          </div>
+          <div class="card-body">
+            <div class="form-group">
+              <%= f.label :rate_limit_published_article_creation %>
+              <%= f.number_field :rate_limit_published_article_creation,
+                                 class: "form-control",
+                                 value: SiteConfig.rate_limit_published_article_creation,
+                                 min: 0,
+                                 placeholder: 9 %>
+              <div class="alert alert-info">Used to limit the amount of articles a user can create within 30 seconds</div>
+            </div>
+          </div>
+          <div class="card-body">
+            <div class="form-group">
+              <%= f.label :rate_limit_image_upload %>
+              <%= f.number_field :rate_limit_image_upload,
+                                 class: "form-control",
+                                 value: SiteConfig.rate_limit_image_upload,
+                                 min: 0,
+                                 placeholder: 9 %>
+              <div class="alert alert-info">Used to limit the amount of images a user can upload within 30 seconds</div>
+            </div>
+          </div>
+          <div class="card-body">
+            <div class="form-group">
+              <%= f.label :rate_limit_email_recipient %>
+              <%= f.number_field :rate_limit_email_recipient,
+                                 class: "form-control",
+                                 value: SiteConfig.rate_limit_email_recipient,
+                                 min: 0,
+                                 placeholder: 5 %>
+              <div class="alert alert-info">Used to limit the amount of emails we send to a user within 2 minutes</div>
+            </div>
+          </div>
+        </div>
+
+        <div class="card mt-3">
+          <div class="card-header">Google Analytics Reporting API v4</div>
+          <div class="card-body">
+            <div class="form-group">
+              <%= f.label :ga_view_id, "View ID" %>
+              <%= f.text_field :ga_view_id,
                                class: "form-control",
-                               value: SiteConfig.favicon_url,
-                               placeholder: "https://image.url" %>
-              <div class="alert alert-info">Used as the site favicon</div>
-              <img alt="favicon" class="preview" src="<%= SiteConfig.favicon_url %>" />
+                               value: SiteConfig.ga_view_id %>
+              <div class="alert alert-info">Google Analytics Reporting API v4 - View ID</div>
             </div>
 
             <div class="form-group">
-              <%= f.label :logo_svg %>
-              <%= f.text_area :logo_svg,
+              <%= f.label :ga_fetch_rate, "Fetch rate" %>
+              <%= f.number_field :ga_fetch_rate,
+                                 class: "form-control",
+                                 value: SiteConfig.ga_fetch_rate,
+                                 min: 1,
+                                 placeholder: 1 %>
+              <div class="alert alert-info">Determines how often the site updates its Google Analytics stats</div>
+            </div>
+          </div>
+        </div>
+
+        <div class="card mt-3">
+          <div class="card-header">Mailchimp Lists IDs</div>
+          <div class="card-body">
+            <div class="form-group">
+              <%= f.label :mailchimp_newsletter_id, "Main Newsletter" %>
+              <%= f.text_field :mailchimp_newsletter_id,
+                               class: "form-control",
+                               value: SiteConfig.mailchimp_newsletter_id %>
+              <div class="alert alert-info">Main Newsletter ID</div>
+            </div>
+
+            <div class="form-group">
+              <%= f.label :mailchimp_sustaining_members_id, "Sustaining Members Newsletter" %>
+              <%= f.text_field :mailchimp_sustaining_members_id,
+                               class: "form-control",
+                               value: SiteConfig.mailchimp_sustaining_members_id %>
+              <div class="alert alert-info">Sustaining Members Newsletter ID</div>
+            </div>
+
+            <div class="form-group">
+              <%= f.label :mailchimp_tag_moderators_id, "Tag Moderators Newsletter" %>
+              <%= f.text_field :mailchimp_tag_moderators_id,
+                               class: "form-control",
+                               value: SiteConfig.mailchimp_tag_moderators_id %>
+              <div class="alert alert-info">Tag Moderators Newsletter ID</div>
+            </div>
+
+            <div class="form-group">
+              <%= f.label :mailchimp_community_moderators_id, "Community Moderators Newsletter" %>
+              <%= f.text_field :mailchimp_community_moderators_id,
                               class: "form-control",
-                              value: SiteConfig.logo_svg,
-                              rows: 6,
-                              placeholder: "<svg ...></svg>" %>
-              <div class="alert alert-info">Used as the SVG logo of the community</div>
-              <%= @logo_svg %>
+                              value: SiteConfig.mailchimp_community_moderators_id %>
+              <div class="alert alert-info">Community Moderators Newsletter ID</div>
             </div>
           </div>
         </div>
-      </div>
 
-      <div class="card mt-3">
-        <div class="card-header">Rate limits</div>
-        <div class="card-body">
-          <div class="form-group">
-            <%= f.label :rate_limit_follow_count_daily %>
-            <%= f.number_field :rate_limit_follow_count_daily,
+        <div class="card mt-3">
+          <div class="card-header">Email digest frequency</div>
+          <div class="card-body">
+            <div class="form-group">
+              <%= f.label :periodic_email_digest_max %>
+              <%= f.number_field :periodic_email_digest_max,
+                                 class: "form-control",
+                                 value: SiteConfig.periodic_email_digest_max,
+                                 placeholder: 0 %>
+              <div class="alert alert-info">Determines the maximum for the periodic email digest</div>
+            </div>
+
+            <div class="form-group">
+              <%= f.label :periodic_email_digest_min %>
+              <%= f.number_field :periodic_email_digest_min,
+                                 class: "form-control",
+                                 value: SiteConfig.periodic_email_digest_min,
+                                 placeholder: 2 %>
+              <div class="alert alert-info">Determines the mininum for the periodic email digest</div>
+            </div>
+          </div>
+        </div>
+
+        <div class="card mt-3">
+          <div class="card-header">Tags</div>
+          <div class="card-body">
+            <div class="form-group">
+              <%= f.label :suggested_tags %>
+              <%= f.text_field :suggested_tags,
                                class: "form-control",
-                               value: SiteConfig.rate_limit_follow_count_daily,
-                               min: 0,
-                               placeholder: 500 %>
-            <div class="alert alert-info">Used to limit the amount of users a person can follow daily</div>
+                               value: SiteConfig.suggested_tags.join(","),
+                               placeholder: "List of valid tags: comma separated, letters only e.g. beginners,javascript,ruby,swift,kotlin" %>
+              <div class="alert alert-info">Determines which tags are suggested to new users during onboarding (comma
+                separated, letters only)</div>
+            </div>
           </div>
         </div>
-        <div class="card-body">
-          <div class="form-group">
-            <%= f.label :rate_limit_comment_creation %>
-            <%= f.number_field :rate_limit_comment_creation,
-                               class: "form-control",
-                               value: SiteConfig.rate_limit_comment_creation,
-                               min: 0,
-                               placeholder: 9 %>
-            <div class="alert alert-info">Used to limit the amount of comments a user can create within 30 seconds</div>
+        <% if current_user.has_role?(:single_resource_admin, Config) %>
+          <div class="card mt-3">
+            <div class="card-header">Confirm and Submit</div>
+            <div class="card-body">
+              <div class="form-group">
+                <%= label_tag :confirmation %>
+                <%= text_field_tag :confirmation, nil, class: "form-control", placeholder: "Confirmation text", autocomplete: "off" %>
+                <div class="alert alert-info">Type: My username is @your_username and this action is 100% safe and appropriate.</div>
+                <%= f.submit "Update Site Configuration", class: "btn btn-danger btn-lg" %>
+              </div>
+            </div>
           </div>
-        </div>
-        <div class="card-body">
-          <div class="form-group">
-            <%= f.label :rate_limit_published_article_creation %>
-            <%= f.number_field :rate_limit_published_article_creation,
-                               class: "form-control",
-                               value: SiteConfig.rate_limit_published_article_creation,
-                               min: 0,
-                               placeholder: 9 %>
-            <div class="alert alert-info">Used to limit the amount of articles a user can create within 30 seconds</div>
-          </div>
-        </div>
-        <div class="card-body">
-          <div class="form-group">
-            <%= f.label :rate_limit_image_upload %>
-            <%= f.number_field :rate_limit_image_upload,
-                               class: "form-control",
-                               value: SiteConfig.rate_limit_image_upload,
-                               min: 0,
-                               placeholder: 9 %>
-            <div class="alert alert-info">Used to limit the amount of images a user can upload within 30 seconds</div>
-          </div>
-        </div>
-        <div class="card-body">
-          <div class="form-group">
-            <%= f.label :rate_limit_email_recipient %>
-            <%= f.number_field :rate_limit_email_recipient,
-                               class: "form-control",
-                               value: SiteConfig.rate_limit_email_recipient,
-                               min: 0,
-                               placeholder: 5 %>
-            <div class="alert alert-info">Used to limit the amount of emails we send to a user within 2 minutes</div>
-          </div>
-        </div>
-      </div>
-
-      <div class="card mt-3">
-        <div class="card-header">Google Analytics Reporting API v4</div>
-        <div class="card-body">
-          <div class="form-group">
-            <%= f.label :ga_view_id, "View ID" %>
-            <%= f.text_field :ga_view_id,
-                             class: "form-control",
-                             value: SiteConfig.ga_view_id %>
-            <div class="alert alert-info">Google Analytics Reporting API v4 - View ID</div>
-          </div>
-
-          <div class="form-group">
-            <%= f.label :ga_fetch_rate, "Fetch rate" %>
-            <%= f.number_field :ga_fetch_rate,
-                               class: "form-control",
-                               value: SiteConfig.ga_fetch_rate,
-                               min: 1,
-                               placeholder: 1 %>
-            <div class="alert alert-info">Determines how often the site updates its Google Analytics stats</div>
-          </div>
-        </div>
-      </div>
-
-      <div class="card mt-3">
-        <div class="card-header">Mailchimp Lists IDs</div>
-        <div class="card-body">
-          <div class="form-group">
-            <%= f.label :mailchimp_newsletter_id, "Main Newsletter" %>
-            <%= f.text_field :mailchimp_newsletter_id,
-                             class: "form-control",
-                             value: SiteConfig.mailchimp_newsletter_id %>
-            <div class="alert alert-info">Main Newsletter ID</div>
-          </div>
-
-          <div class="form-group">
-            <%= f.label :mailchimp_sustaining_members_id, "Sustaining Members Newsletter" %>
-            <%= f.text_field :mailchimp_sustaining_members_id,
-                             class: "form-control",
-                             value: SiteConfig.mailchimp_sustaining_members_id %>
-            <div class="alert alert-info">Sustaining Members Newsletter ID</div>
-          </div>
-
-          <div class="form-group">
-            <%= f.label :mailchimp_tag_moderators_id, "Tag Moderators Newsletter" %>
-            <%= f.text_field :mailchimp_tag_moderators_id,
-                             class: "form-control",
-                             value: SiteConfig.mailchimp_tag_moderators_id %>
-            <div class="alert alert-info">Tag Moderators Newsletter ID</div>
-          </div>
-
-          <div class="form-group">
-            <%= f.label :mailchimp_community_moderators_id, "Community Moderators Newsletter" %>
-            <%= f.text_field :mailchimp_community_moderators_id,
-                             class: "form-control",
-                             value: SiteConfig.mailchimp_community_moderators_id %>
-            <div class="alert alert-info">Community Moderators Newsletter ID</div>
-          </div>
-        </div>
-      </div>
-
-      <div class="card mt-3">
-        <div class="card-header">Email digest frequency</div>
-        <div class="card-body">
-          <div class="form-group">
-            <%= f.label :periodic_email_digest_max %>
-            <%= f.number_field :periodic_email_digest_max,
-                               class: "form-control",
-                               value: SiteConfig.periodic_email_digest_max,
-                               placeholder: 0 %>
-            <div class="alert alert-info">Determines the maximum for the periodic email digest</div>
-          </div>
-
-          <div class="form-group">
-            <%= f.label :periodic_email_digest_min %>
-            <%= f.number_field :periodic_email_digest_min,
-                               class: "form-control",
-                               value: SiteConfig.periodic_email_digest_min,
-                               placeholder: 2 %>
-            <div class="alert alert-info">Determines the mininum for the periodic email digest</div>
-          </div>
-        </div>
-      </div>
-
-      <div class="card mt-3">
-        <div class="card-header">Tags</div>
-        <div class="card-body">
-          <div class="form-group">
-            <%= f.label :suggested_tags %>
-            <%= f.text_field :suggested_tags,
-                             class: "form-control",
-                             value: SiteConfig.suggested_tags.join(","),
-                             placeholder: "List of valid tags: comma separated, letters only e.g. beginners,javascript,ruby,swift,kotlin" %>
-            <div class="alert alert-info">Determines which tags are suggested to new users during onboarding (comma
-              separated, letters only)</div>
-          </div>
-        </div>
-      </div>
-
-      <div class="form-group mt-3">
-        <%= f.submit "Update Site Configuration", class: "btn btn-primary" %>
-      </div>
+        <% end %>
       <% end %>
     </div>
   </div>
@@ -263,7 +285,7 @@
           <% if v.group.in?(ENVied.required_groups) %>
           <tr>
             <td><%= v.name %></td>
-            <td><%= ApplicationConfig[v.name] %></td>
+            <td style="max-width: 750px;"><%= ApplicationConfig[v.name] %></td>
           </tr>
           <% end %>
           <% end %>

--- a/app/views/internal/permissions/index.html.erb
+++ b/app/views/internal/permissions/index.html.erb
@@ -18,7 +18,13 @@
           <tr>
             <td><%= user.id %></td>
             <td><%= link_to "@#{user.username}", user.path %></td>
-            <td><%= user.roles.pluck(:name) %></td>
+            <td>
+              <ul>
+                <% user.roles.pluck(:name, :resource_type, :resource_id).each do |role| %>
+                  <li><%= role[0] %><%= ": #{role[1]}" if role[1] %><%= "/#{role[2]}" if role[2] %></li>
+                <% end %>
+              </ul>
+            </td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/layouts/internal.html.erb
+++ b/app/views/layouts/internal.html.erb
@@ -40,7 +40,7 @@
 
   <div class="container mt-3">
     <% flash.each do |type, message| %>
-      <div class="alert alert-<%= type %>">
+      <div class="alert alert-<%= type == "notice" ? "success" : "danger" %>">
         <button class="close" data-dismiss="alert">
           <i class="fa fa-times" aria-hidden="true"></i>
         </button>

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -46,6 +46,18 @@ FactoryBot.define do
       after(:build) { |user, options| user.add_role(:single_resource_admin, options.resource) }
     end
 
+    trait :super_plus_single_resource_admin do
+      transient do
+        resource { nil }
+      end
+
+      after(:build) do |user, options|
+        user.add_role(:super_admin)
+        user.add_role(:single_resource_admin, options.resource)
+      end
+    end
+
+
     trait :trusted do
       after(:build) { |user| user.add_role(:trusted) }
     end

--- a/spec/requests/internal/configs_spec.rb
+++ b/spec/requests/internal/configs_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "/internal/config", type: :request do
   end
 
   describe "POST internal/events" do
-    context "when admin has full permissions" do
+    context "when admin has typical admin permissions but not single resource" do
       before do
         sign_in(admin)
       end
@@ -33,7 +33,7 @@ RSpec.describe "/internal/config", type: :request do
       end
     end
 
-    context "when admin has full permissions" do
+    context "when admin has full permissions including single resource" do
       before do
         sign_in(admin_plus_config)
       end

--- a/spec/requests/internal/configs_spec.rb
+++ b/spec/requests/internal/configs_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.describe "/internal/config", type: :request do
   let_it_be(:user) { create(:user) }
   let_it_be(:admin) { create(:user, :super_admin) }
+  let_it_be(:admin_plus_config) { create(:user, :super_plus_single_resource_admin, resource: Config) }
+  let_it_be(:confirmation_message) { "My username is @#{admin_plus_config.username} and this action is 100% safe and appropriate." }
 
   describe "POST internal/events as a user" do
     before do
@@ -15,137 +17,166 @@ RSpec.describe "/internal/config", type: :request do
   end
 
   describe "POST internal/events" do
-    before do
-      sign_in(admin)
-    end
-
-    describe "staff" do
-      it "does not allow the staff_user_id to be updated" do
-        expect(SiteConfig.staff_user_id).to eq(1)
-        post "/internal/config", params: { site_config: { staff_user_id: 2 } }
-        expect(SiteConfig.staff_user_id).to eq(1)
+    context "when admin has full permissions" do
+      before do
+        sign_in(admin)
       end
 
-      it "updates default_site_email" do
-        expected_email = "foo@bar.com"
-        post "/internal/config", params: { site_config: { default_site_email: expected_email } }
-        expect(SiteConfig.default_site_email).to eq(expected_email)
-      end
-
-      it "updates social_networks_handle" do
-        expected_handle = "tpd"
-        post "/internal/config", params: { site_config: { social_networks_handle: expected_handle } }
-        expect(SiteConfig.social_networks_handle).to eq(expected_handle)
-      end
-    end
-
-    describe "images" do
-      it "updates main_social_image" do
+      it "does not allow user to update config if they have proper confirmation" do
         expected_image_url = "https://dummyimage.com/300x300"
-        post "/internal/config", params: { site_config: { main_social_image: expected_image_url } }
-        expect(SiteConfig.main_social_image).to eq(expected_image_url)
+        expect { post "/internal/config", params: { site_config: { favicon_url: expected_image_url }, confirmation: confirmation_message } }.to raise_error Pundit::NotAuthorizedError
       end
 
-      it "updates favicon_url" do
+      it "does not allow user to update config if they do not have proper confirmation" do
         expected_image_url = "https://dummyimage.com/300x300"
-        post "/internal/config", params: { site_config: { favicon_url: expected_image_url } }
-        expect(SiteConfig.favicon_url).to eq(expected_image_url)
-      end
-
-      it "updates logo_svg" do
-        expected_image_url = "https://dummyimage.com/300x300"
-        post "/internal/config", params: { site_config: { logo_svg: expected_image_url } }
-        expect(SiteConfig.logo_svg).to eq(expected_image_url)
+        expect { post "/internal/config", params: { site_config: { favicon_url: expected_image_url }, confirmation: "Not proper" } }.to raise_error Pundit::NotAuthorizedError
       end
     end
 
-    describe "rate limits" do
-      it "updates rate_limit_follow_count_daily" do
-        expect do
-          post "/internal/config", params: { site_config: { rate_limit_follow_count_daily: 3 } }
-        end.to change(SiteConfig, :rate_limit_follow_count_daily).from(500).to(3)
+    context "when admin has full permissions" do
+      before do
+        sign_in(admin_plus_config)
+      end
+      describe "staff" do
+        it "does not allow the staff_user_id to be updated" do
+          expect(SiteConfig.staff_user_id).to eq(1)
+          post "/internal/config", params: { site_config: { staff_user_id: 2 }, confirmation: confirmation_message }
+          expect(SiteConfig.staff_user_id).to eq(1)
+        end
+
+        it "updates default_site_email" do
+          expected_email = "foo@bar.com"
+          post "/internal/config", params: { site_config: { default_site_email: expected_email },
+                                             confirmation: confirmation_message }
+          expect(SiteConfig.default_site_email).to eq(expected_email)
+        end
+
+        it "updates social_networks_handle" do
+          expected_handle = "tpd"
+          post "/internal/config", params: { site_config: { social_networks_handle: expected_handle },
+                                             confirmation: confirmation_message }
+          expect(SiteConfig.social_networks_handle).to eq(expected_handle)
+        end
       end
 
-      it "updates rate_limit_comment_creation" do
-        expect do
-          post "/internal/config", params: { site_config: { rate_limit_comment_creation: 3 } }
-        end.to change(SiteConfig, :rate_limit_comment_creation).from(9).to(3)
+      describe "images" do
+        it "updates main_social_image" do
+          expected_image_url = "https://dummyimage.com/300x300"
+          post "/internal/config", params: { site_config: { main_social_image: expected_image_url }, confirmation: confirmation_message }
+          expect(SiteConfig.main_social_image).to eq(expected_image_url)
+        end
+
+        it "updates favicon_url" do
+          expected_image_url = "https://dummyimage.com/300x300"
+          post "/internal/config", params: { site_config: { favicon_url: expected_image_url }, confirmation: confirmation_message }
+          expect(SiteConfig.favicon_url).to eq(expected_image_url)
+        end
+
+        it "updates logo_svg" do
+          expected_image_url = "https://dummyimage.com/300x300"
+          post "/internal/config", params: { site_config: { logo_svg: expected_image_url }, confirmation: confirmation_message }
+          expect(SiteConfig.logo_svg).to eq(expected_image_url)
+        end
+
+        it "rejects update without proper confirmation" do
+          expected_image_url = "https://dummyimage.com/300x300"
+          expect { post "/internal/config", params: { site_config: { logo_svg: expected_image_url }, confirmation: "Incorrect yo!" } }.to raise_error Pundit::NotAuthorizedError
+        end
       end
 
-      it "updates rate_limit_published_article_creation" do
-        expect do
-          post "/internal/config", params: { site_config: { rate_limit_published_article_creation: 3 } }
-        end.to change(SiteConfig, :rate_limit_published_article_creation).from(9).to(3)
+      describe "rate limits" do
+        it "updates rate_limit_follow_count_daily" do
+          expect do
+            post "/internal/config", params: { site_config: { rate_limit_follow_count_daily: 3 }, confirmation: confirmation_message }
+          end.to change(SiteConfig, :rate_limit_follow_count_daily).from(500).to(3)
+        end
+
+        it "updates rate_limit_comment_creation" do
+          expect do
+            post "/internal/config", params: { site_config: { rate_limit_comment_creation: 3 }, confirmation: confirmation_message }
+          end.to change(SiteConfig, :rate_limit_comment_creation).from(9).to(3)
+        end
+
+        it "updates rate_limit_published_article_creation" do
+          expect do
+            post "/internal/config", params: { site_config: { rate_limit_published_article_creation: 3 }, confirmation: confirmation_message }
+          end.to change(SiteConfig, :rate_limit_published_article_creation).from(9).to(3)
+        end
+
+        it "updates rate_limit_image_upload" do
+          expect do
+            post "/internal/config", params: { site_config: { rate_limit_image_upload: 3 }, confirmation: confirmation_message }
+          end.to change(SiteConfig, :rate_limit_image_upload).from(9).to(3)
+        end
+
+        it "updates rate_limit_email_recipient" do
+          expect do
+            post "/internal/config", params: { site_config: { rate_limit_email_recipient: 3 }, confirmation: confirmation_message }
+          end.to change(SiteConfig, :rate_limit_email_recipient).from(5).to(3)
+        end
       end
 
-      it "updates rate_limit_image_upload" do
-        expect do
-          post "/internal/config", params: { site_config: { rate_limit_image_upload: 3 } }
-        end.to change(SiteConfig, :rate_limit_image_upload).from(9).to(3)
+      describe "Google Analytics Reporting API v4" do
+        it "updates ga_view_id" do
+          post "/internal/config", params: { site_config: { ga_view_id: "abc" }, confirmation: confirmation_message }
+          expect(SiteConfig.ga_view_id).to eq("abc")
+        end
+
+        it "updates ga_fetch_rate" do
+          post "/internal/config", params: { site_config: { ga_fetch_rate: 3 }, confirmation: confirmation_message }
+          expect(SiteConfig.ga_fetch_rate).to eq(3)
+        end
       end
 
-      it "updates rate_limit_email_recipient" do
-        expect do
-          post "/internal/config", params: { site_config: { rate_limit_email_recipient: 3 } }
-        end.to change(SiteConfig, :rate_limit_email_recipient).from(5).to(3)
-      end
-    end
+      describe "Mailchimp lists IDs" do
+        it "updates mailchimp_newsletter_id" do
+          post "/internal/config", params: { site_config: { mailchimp_newsletter_id: "abc" }, confirmation: confirmation_message }
+          expect(SiteConfig.mailchimp_newsletter_id).to eq("abc")
+        end
 
-    describe "Google Analytics Reporting API v4" do
-      it "updates ga_view_id" do
-        post "/internal/config", params: { site_config: { ga_view_id: "abc" } }
-        expect(SiteConfig.ga_view_id).to eq("abc")
-      end
+        it "updates mailchimp_sustaining_members_id" do
+          post "/internal/config", params: { site_config: { mailchimp_sustaining_members_id: "abc" }, confirmation: confirmation_message }
+          expect(SiteConfig.mailchimp_sustaining_members_id).to eq("abc")
+        end
 
-      it "updates ga_fetch_rate" do
-        post "/internal/config", params: { site_config: { ga_fetch_rate: 3 } }
-        expect(SiteConfig.ga_fetch_rate).to eq(3)
-      end
-    end
+        it "updates mailchimp_tag_moderators_id" do
+          post "/internal/config", params: { site_config: { mailchimp_tag_moderators_id: "abc" }, confirmation: confirmation_message }
+          expect(SiteConfig.mailchimp_tag_moderators_id).to eq("abc")
+        end
 
-    describe "Mailchimp lists IDs" do
-      it "updates mailchimp_newsletter_id" do
-        post "/internal/config", params: { site_config: { mailchimp_newsletter_id: "abc" } }
-        expect(SiteConfig.mailchimp_newsletter_id).to eq("abc")
+        it "updates mailchimp_community_moderators_id" do
+          post "/internal/config", params: { site_config: { mailchimp_community_moderators_id: "abc" }, confirmation: confirmation_message }
+          expect(SiteConfig.mailchimp_community_moderators_id).to eq("abc")
+        end
       end
 
-      it "updates mailchimp_sustaining_members_id" do
-        post "/internal/config", params: { site_config: { mailchimp_sustaining_members_id: "abc" } }
-        expect(SiteConfig.mailchimp_sustaining_members_id).to eq("abc")
+      describe "Email digest frequency" do
+        it "updates periodic_email_digest_max" do
+          post "/internal/config", params: { site_config: { periodic_email_digest_max: 1 }, confirmation: confirmation_message }
+          expect(SiteConfig.periodic_email_digest_max).to eq(1)
+        end
+
+        it "updates periodic_email_digest_min" do
+          post "/internal/config", params: { site_config: { periodic_email_digest_min: 3 }, confirmation: confirmation_message }
+          expect(SiteConfig.periodic_email_digest_min).to eq(3)
+        end
+
+        it "rejects update without proper confirmation" do
+          expect { post "/internal/config", params: { site_config: { periodic_email_digest_min: 6 }, confirmation: "Incorrect yo!" } }.to raise_error Pundit::NotAuthorizedError
+          expect(SiteConfig.periodic_email_digest_min).not_to eq(6)
+        end
       end
 
-      it "updates mailchimp_tag_moderators_id" do
-        post "/internal/config", params: { site_config: { mailchimp_tag_moderators_id: "abc" } }
-        expect(SiteConfig.mailchimp_tag_moderators_id).to eq("abc")
-      end
+      describe "Tags" do
+        it "removes space suggested_tags" do
+          post "/internal/config", params: { site_config: { suggested_tags: "hey, haha,hoho, bobo fofo" }, confirmation: confirmation_message }
+          expect(SiteConfig.suggested_tags).to eq(%w[hey haha hoho bobofofo])
+        end
 
-      it "updates mailchimp_community_moderators_id" do
-        post "/internal/config", params: { site_config: { mailchimp_community_moderators_id: "abc" } }
-        expect(SiteConfig.mailchimp_community_moderators_id).to eq("abc")
-      end
-    end
-
-    describe "Email digest frequency" do
-      it "updates periodic_email_digest_max" do
-        post "/internal/config", params: { site_config: { periodic_email_digest_max: 1 } }
-        expect(SiteConfig.periodic_email_digest_max).to eq(1)
-      end
-
-      it "updates periodic_email_digest_min" do
-        post "/internal/config", params: { site_config: { periodic_email_digest_min: 3 } }
-        expect(SiteConfig.periodic_email_digest_min).to eq(3)
-      end
-    end
-
-    describe "Tags" do
-      it "removes space suggested_tags" do
-        post "/internal/config", params: { site_config: { suggested_tags: "hey, haha,hoho, bobo fofo" } }
-        expect(SiteConfig.suggested_tags).to eq(%w[hey haha hoho bobofofo])
-      end
-
-      it "downcases suggested_tags" do
-        post "/internal/config", params: { site_config: { suggested_tags: "hey, haha,hoHo, Bobo Fofo" } }
-        expect(SiteConfig.suggested_tags).to eq(%w[hey haha hoho bobofofo])
+        it "downcases suggested_tags" do
+          post "/internal/config", params: { site_config: { suggested_tags: "hey, haha,hoHo, Bobo Fofo" }, confirmation: confirmation_message }
+          expect(SiteConfig.suggested_tags).to eq(%w[hey haha hoho bobofofo])
+        end
       end
     end
   end


### PR DESCRIPTION

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This related to this issue: #6049

I wouldn't want to say it fully closes it, but is a step in safeguarding this area.

This pull request adds extra safeguards for the `/internal/config` area of the site. This area contains values which could cause big problems if accidentally changed. It makes sense to restrict them even more thoroughly than other parts of the internal experience.

It now makes it so that anyone with `admin`,  `super_admin` or `single_resource_admin Config` can _view_ this area, but only users with the role `single_resource_admin Config` can write to it. And they need to submit this phrase when making a change as confirmation:

`My username is @your_username and this action is 100% safe and appropriate.`

The details here really should not change very often, so I think this is all pretty reasonable.

Added a message to make it clear:

<img width="1156" alt="Screen Shot 2020-02-13 at 1 22 20 PM" src="https://user-images.githubusercontent.com/3102842/74465693-df1a6800-4e63-11ea-9d78-97128e5fd808.png">

<img width="1152" alt="Screen Shot 2020-02-13 at 1 21 52 PM" src="https://user-images.githubusercontent.com/3102842/74465648-ce69f200-4e63-11ea-8110-df97b4ebc916.png">


<img width="1183" alt="Screen Shot 2020-02-13 at 1 30 45 PM" src="https://user-images.githubusercontent.com/3102842/74466379-150c1c00-4e65-11ea-8295-7cbeed49daf0.png">

Also made a small tweak to `/internal/permissions` to make it clearer which exact permissions folks have.

<img width="700" alt="Screen Shot 2020-02-13 at 1 22 51 PM" src="https://user-images.githubusercontent.com/3102842/74465735-f22d3800-4e63-11ea-9aaf-325014db40ed.png">
