### PR TITLE
Update queue_adapter to Sidekiq round 2

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -47,7 +47,7 @@ module PracticalDeveloper
     config.autoload_paths += Dir["#{config.root}/lib/"]
 
     config.active_record.observers = :article_observer, :reaction_observer, :comment_observer
-    config.active_job.queue_adapter = :delayed_job
+    config.active_job.queue_adapter = :sidekiq
 
     config.middleware.use Rack::Deflater
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Optimization

## Description
We did this once before with #5960 and discovered we were a little eager. Now that [delayed jobs](https://github.com/thepracticaldev/dev.to/tree/master/app/jobs) are all gone, this is round 2 of updating the `queue_adapter` to Sidekiq as part of 🔪 `delayed_job`.

## Related Tickets & Documents
- #5305 
- #5960 
- [Project card](https://github.com/thepracticaldev/dev.to/projects/6#card-32289408)

## Added tests?
- [x] no, they're not needed

## Added to documentation?
- [x] no documentation needed

## Are there any post deployment tasks we need to perform?
We'll want to keep an eye on the Sidekiq queues and our monitors. The last time this was merged, the specs past but old jobs were queuing up in Sidekiq and failing.

![try_again_gif](https://media.giphy.com/media/5QW76Ww9bquHdg1fTv/giphy.gif)
