### PR TITLE
Enable bread crumbs for Honeybadger

### DIFF
--- a/config/initializers/honeybadger.rb
+++ b/config/initializers/honeybadger.rb
@@ -23,6 +23,7 @@ Honeybadger.configure do |config|
   config.request.filter_keys += %w[authorization]
   config.delayed_job.attempt_threshold = 10
   config.sidekiq.attempt_threshold = 10
+  config.breadcrumbs.enabled = true
 
   config.before_notify do |notice|
     notice.fingerprint = if notice.error_message&.include?("SIGTERM") && notice.component&.include?("fetch_all_rss")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
Honeybadger has a [breadcrumbs feature](https://docs.honeybadger.io/lib/ruby/getting-started/breadcrumbs.html#enabling-breadcrumbs) that will record additional context for you around an error when it happens which hopefully can help with debugging. Per the docs
> As of version 4.4.0, Breadcrumbs are available yet disabled by default. You must explicitly enable them if you want breadcrumbs to be reported. We plan on enabling breadcrumbs by default in version 5.0.0

So I figured we should probably turn it on and see what its all about! 

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/5#card-33094836

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media.giphy.com/media/mxzX5n0NyQls4/giphy.gif)
