### PR TITLE
Create DataUpdateScript to Index all Tags

### DIFF
--- a/lib/data_update_scripts/20200214171607_index_tags_to_elasticsearch.rb
+++ b/lib/data_update_scripts/20200214171607_index_tags_to_elasticsearch.rb
@@ -1,0 +1,9 @@
+module DataUpdateScripts
+  class IndexTagsToElasticsearch
+    def run
+      # Choose to do inline so development envs are ready
+      # immediately after this is run
+      Tag.find_each(&:index_to_elasticsearch_inline)
+    end
+  end
+end

--- a/spec/lib/data_update_scripts/index_tags_to_elasticsearch_spec.rb
+++ b/spec/lib/data_update_scripts/index_tags_to_elasticsearch_spec.rb
@@ -1,12 +1,11 @@
 require "rails_helper"
 require Rails.root.join("lib/data_update_scripts/20200214171607_index_tags_to_elasticsearch.rb")
 
-describe DataUpdateScripts::IndexTagsToElasticsearch do
+describe DataUpdateScripts::IndexTagsToElasticsearch, elasticsearch: true do
   it "indexes tags to Elasticsearch" do
     tag = FactoryBot.create(:tag)
-    expect(tag).to respond_to(:index_to_elasticsearch_inline)
-    allow(Tag).to receive(:find_each)
+    expect { tag.elasticsearch_doc }.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound)
     described_class.new.run
-    expect(Tag).to have_received(:find_each) { [tag] }
+    expect(tag.elasticsearch_doc).not_to be_nil
   end
 end

--- a/spec/lib/data_update_scripts/index_tags_to_elasticsearch_spec.rb
+++ b/spec/lib/data_update_scripts/index_tags_to_elasticsearch_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+require Rails.root.join("lib/data_update_scripts/20200214171607_index_tags_to_elasticsearch.rb")
+
+describe DataUpdateScripts::IndexTagsToElasticsearch do
+  it "indexes tags to Elasticsearch" do
+    tag = FactoryBot.create(:tag)
+    expect(tag).to respond_to(:index_to_elasticsearch_inline)
+    allow(Tag).to receive(:find_each)
+    described_class.new.run
+    expect(Tag).to have_received(:find_each) { [tag] }
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
This DataUpdateScript will index all Tags to ensure environments are ready for Searching tags via Elasticsearch. Added a spec so in the future if we change the tag model in such away that this script breaks we will know to update or remove it. Hopefully, at some point, we will version the app so that doesnt happen but for now better safe than sorry.

## Related Tickets & Documents
#6024 

## Added tests?
- [x] yes

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media2.giphy.com/media/VEzlrMWk3F7uuFuRSq/giphy.gif)
