### PR TITLE
Stop using legacy user's organization_id and remove followers unused code

### DIFF
--- a/app/assets/javascripts/initializers/initScrolling.js.erb
+++ b/app/assets/javascripts/initializers/initScrolling.js.erb
@@ -105,7 +105,7 @@ function fetchNextFollowingPage(el){
 }
 
 function fetchNextFollowersPage(el) {
-  fetchNext(el, "<%= api_followers_users_path %>", insertNext({ elId: "follows" }, buildFollowsHTML));
+  fetchNext(el, "/api/followers/users", insertNext({ elId: "follows" }, buildFollowsHTML));
 }
 
 function buildVideoArticleHTML(videoArticle) {

--- a/app/assets/javascripts/initializers/initScrolling.js.erb
+++ b/app/assets/javascripts/initializers/initScrolling.js.erb
@@ -107,11 +107,8 @@ function fetchNextFollowingPage(el){
 function fetchNextFollowersPage(el){
   var indexParams = JSON.parse(el.dataset.params);
   var whichEndpoint = indexParams.which;
-  if (whichEndpoint.includes("organization")){
-    fetchNext(el, "/api/followers/organizations", insertNext({ elId: "follows" }, buildFollowsHTML));
-  } else {
-    fetchNext(el, "/api/followers/users", insertNext({ elId: "follows" }, buildFollowsHTML));
-  }
+
+  fetchNext(el, "/api/followers/users", insertNext({ elId: "follows" }, buildFollowsHTML));
 }
 
 function buildVideoArticleHTML(videoArticle) {

--- a/app/assets/javascripts/initializers/initScrolling.js.erb
+++ b/app/assets/javascripts/initializers/initScrolling.js.erb
@@ -104,11 +104,8 @@ function fetchNextFollowingPage(el){
   }
 }
 
-function fetchNextFollowersPage(el){
-  var indexParams = JSON.parse(el.dataset.params);
-  var whichEndpoint = indexParams.which;
-
-  fetchNext(el, "/api/followers/users", insertNext({ elId: "follows" }, buildFollowsHTML));
+function fetchNextFollowersPage(el) {
+  fetchNext(el, "<%= api_followers_users_path %>", insertNext({ elId: "follows" }, buildFollowsHTML));
 }
 
 function buildVideoArticleHTML(videoArticle) {

--- a/app/controllers/api/v0/followers_controller.rb
+++ b/app/controllers/api/v0/followers_controller.rb
@@ -6,9 +6,9 @@ module Api
 
       def organizations
         @follows = Follow.
-          where(followable_id: @user.organization_id, followable_type: "Organization").
+          where(followable_id: @user.organizations.pluck(:id), followable_type: "Organization").
           includes(:follower).
-          select(ATTRIBUTES_FOR_SERIALIZATION).
+          select(ORGANIZATIONS_ATTRIBUTES_FOR_SERIALIZATION).
           order("created_at DESC").
           page(params[:page]).
           per(@follows_limit)
@@ -18,14 +18,17 @@ module Api
         @follows = Follow.
           where(followable_id: @user.id, followable_type: "User").
           includes(:follower).
-          select(ATTRIBUTES_FOR_SERIALIZATION).
+          select(USERS_ATTRIBUTES_FOR_SERIALIZATION).
           order("created_at DESC").
           page(params[:page]).
           per(@follows_limit)
       end
 
-      ATTRIBUTES_FOR_SERIALIZATION = %i[id follower_id follower_type].freeze
-      private_constant :ATTRIBUTES_FOR_SERIALIZATION
+      ORGANIZATIONS_ATTRIBUTES_FOR_SERIALIZATION = %i[id follower_id follower_type followable_id].freeze
+      private_constant :ORGANIZATIONS_ATTRIBUTES_FOR_SERIALIZATION
+
+      USERS_ATTRIBUTES_FOR_SERIALIZATION = %i[id follower_id follower_type].freeze
+      private_constant :USERS_ATTRIBUTES_FOR_SERIALIZATION
 
       private
 

--- a/app/controllers/api/v0/followers_controller.rb
+++ b/app/controllers/api/v0/followers_controller.rb
@@ -6,7 +6,7 @@ module Api
 
       def organizations
         @follows = Follow.
-          where(followable_id: @user.organizations.pluck(:id), followable_type: "Organization").
+          where(followable_id: @user.organization_ids, followable_type: "Organization").
           includes(:follower).
           select(ORGANIZATIONS_ATTRIBUTES_FOR_SERIALIZATION).
           order("created_at DESC").

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -50,13 +50,8 @@ class DashboardsController < ApplicationController
   end
 
   def followers
-    if params[:which] == "user_followers"
-      @follows = Follow.where(followable_id: @user.id, followable_type: "User").
-        includes(:follower).order("created_at DESC").limit(@follows_limit)
-    elsif params[:which] == "organization_user_followers"
-      @follows = Follow.where(followable_id: @user.organization_id, followable_type: "Organization").
-        includes(:follower).order("created_at DESC").limit(@follows_limit)
-    end
+    @follows = Follow.where(followable_id: @user.id, followable_type: "User").
+      includes(:follower).order("created_at DESC").limit(@follows_limit)
   end
 
   def pro

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -18,7 +18,7 @@ class NotificationsController < ApplicationController
       num = @initial_page_size
     end
 
-    @notifications = if (params[:org_id].present? || params[:filter] == "org") && @user.admin?
+    @notifications = if (params[:org_id].present? || params[:filter] == "org") && allowed_user?
                        organization_notifications
                      elsif params[:org_id].blank? && params[:filter].present?
                        filtered_notifications
@@ -75,5 +75,9 @@ class NotificationsController < ApplicationController
     else
       Notification.for_organization(org_id)
     end
+  end
+
+  def allowed_user?
+    @user.organizations.exists?(id: params[:org_id]) || @user.admin?
   end
 end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -18,7 +18,7 @@ class NotificationsController < ApplicationController
       num = @initial_page_size
     end
 
-    @notifications = if (params[:org_id].present? || params[:filter] == "org") && allowed_user?
+    @notifications = if (params[:org_id].present? || params[:filter] == "org") && @user.admin?
                        organization_notifications
                      elsif params[:org_id].blank? && params[:filter].present?
                        filtered_notifications
@@ -75,9 +75,5 @@ class NotificationsController < ApplicationController
     else
       Notification.for_organization(org_id)
     end
-  end
-
-  def allowed_user?
-    @user.organization_id == params[:org_id] || @user.admin?
   end
 end

--- a/app/views/api/v0/followers/organizations.json.jbuilder
+++ b/app/views/api/v0/followers/organizations.json.jbuilder
@@ -1,5 +1,6 @@
 json.array! @follows do |follow|
   json.type_of                 "organization_follower"
   json.id                      follow.id
+  json.organization_id         follow.followable_id
   json.partial! "api/v0/shared/follows", user: follow.follower
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -328,10 +328,7 @@ Rails.application.routes.draw do
   get "dashboard/following_users" => "dashboards#following_users"
   get "dashboard/following_organizations" => "dashboards#following_organizations"
   get "dashboard/following_podcasts" => "dashboards#following_podcasts"
-  get "/dashboard/:which" => "dashboards#followers",
-      :constraints => {
-        which: /organization_user_followers|user_followers/
-      }
+  get "/dashboard/:which" => "dashboards#followers", :constraints => { which: /user_followers/ }
   get "/dashboard/:which/:org_id" => "dashboards#show",
       :constraints => {
         which: /organization/

--- a/spec/requests/api/v0/followers_spec.rb
+++ b/spec/requests/api/v0/followers_spec.rb
@@ -4,15 +4,6 @@ RSpec.describe "Api::V0::FollowersController", type: :request do
   let(:follower) { create(:user) }
 
   describe "GET /api/followers/organizations" do
-    let(:org) { create(:organization) }
-    let(:user) { create(:user, organization_id: org.id) }
-
-    before do
-      follower.follow(org)
-
-      org.reload
-    end
-
     context "when user is unauthorized" do
       it "returns unauthorized" do
         get api_followers_organizations_path
@@ -22,17 +13,37 @@ RSpec.describe "Api::V0::FollowersController", type: :request do
     end
 
     context "when user is authorized" do
+      let(:orgs) { create_list(:organization, 2) }
+      let(:user) { create(:user, organization_id: orgs.first.id) }
+
       before do
+        orgs.each { |org| follower.follow(org) }
+
+        # add the user to each organization
+        orgs.each do |org|
+          create(:organization_membership, user: user, organization: org, type_of_user: "admin")
+        end
+
         sign_in user
       end
 
-      it "returns user's followers list with the correct format" do
+      it "returns all the followers of all organizations the user is part of" do
+        get api_followers_organizations_path
+        expect(response).to have_http_status(:ok)
+
+        followers = response.parsed_body
+        expect(followers.map { |f| f["id"] }).to match_array(follower.follows.pluck(:id))
+        expect(followers.map { |f| f["organization_id"] }).to match_array(orgs.map(&:id))
+      end
+
+      it "returns the followers with the correct format" do
         get api_followers_organizations_path
         expect(response).to have_http_status(:ok)
 
         response_follower = response.parsed_body.first
         expect(response_follower["type_of"]).to eq("organization_follower")
         expect(response_follower["id"]).to eq(follower.follows.last.id)
+        expect(response_follower["organization_id"]).to eq(follower.follows.last.followable.id)
         expect(response_follower["name"]).to eq(follower.name)
         expect(response_follower["path"]).to eq(follower.path)
         expect(response_follower["username"]).to eq(follower.username)

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -3,9 +3,10 @@ require "rails_helper"
 RSpec.describe "NotificationsIndex", type: :request do
   include ActionView::Helpers::DateHelper
 
-  let(:dev_account) { create(:user) }
-  let(:welcoming_account) { create(:user) }
-  let(:user) { create(:user) }
+  let_it_be_readonly(:dev_account) { create(:user) }
+  let_it_be_readonly(:welcoming_account) { create(:user) }
+  let_it_be_changeable(:user) { create(:user) }
+  let_it_be_changeable(:organization) { create(:organization) }
 
   before do
     allow(User).to receive(:dev_account).and_return(dev_account)
@@ -13,7 +14,8 @@ RSpec.describe "NotificationsIndex", type: :request do
   end
 
   def has_both_names(response_body)
-    response_body.include?(CGI.escapeHTML(User.last.name)) && response_body.include?(CGI.escapeHTML(User.second_to_last.name))
+    response_body.include?(CGI.escapeHTML(User.last.name)) &&
+      response_body.include?(CGI.escapeHTML(User.second_to_last.name))
   end
 
   describe "GET /notifications" do
@@ -75,7 +77,7 @@ RSpec.describe "NotificationsIndex", type: :request do
     end
 
     context "when a user's organization has new follow notifications" do
-      let_it_be_changeable(:organization) { create(:organization) }
+      let(:other_org) { create(:organization) }
 
       before do
         create(:organization_membership, user: user, organization: organization, type_of_user: "member")
@@ -128,10 +130,26 @@ RSpec.describe "NotificationsIndex", type: :request do
       end
 
       it "does not render notifications belonging to other orgs" do
-        organization = create(:organization)
+        users = mock_follow_notifications(1, other_org)
+
+        get notifications_path(filter: :org, org_id: other_org.id)
+        expect(response.body).not_to include(CGI.escapeHTML(users.last.name))
+      end
+
+      it "does render notifications belonging to other orgs if admin" do
+        user.add_role(:super_admin)
+        sign_in user
+
+        users = mock_follow_notifications(1, other_org)
+
+        get notifications_path(filter: :org, org_id: other_org.id)
+        expect(response.body).to include(CGI.escapeHTML(users.last.name))
+      end
+
+      it "does not render the proper message for a single notification if :filter is comments" do
         users = mock_follow_notifications(1, organization)
 
-        get notifications_path(filter: :org, org_id: organization.id)
+        get notifications_path(filter: :comments, org_id: organization.id)
         expect(response.body).not_to include(CGI.escapeHTML(users.last.name))
       end
     end
@@ -206,6 +224,118 @@ RSpec.describe "NotificationsIndex", type: :request do
       end
     end
 
+    context "when a user's organization has new reaction notifications" do
+      let(:article1) { create(:article, user: user, organization: organization) }
+      let(:article2) { create(:article, user: user, organization: organization) }
+      let(:special_characters_article) do
+        create(:article, user: user, organization: organization, title: "What's Become of Waring")
+      end
+      let(:other_org) { create(:organization) }
+      let(:other_org_article) { create(:article, user: user, organization: other_org) }
+
+      before do
+        create(:organization_membership, user: user, organization: organization, type_of_user: "member")
+        sign_in user
+      end
+
+      def mock_heart_reaction_notifications(followers_amount, categories, reactable = article1)
+        users = create_list(:user, followers_amount)
+
+        reactions = users.map do |user|
+          create(:reaction, user: user, reactable: reactable, category: categories.sample)
+        end
+        reactions.each { |reaction| Notification.send_reaction_notification_without_delay(reaction, reaction.reactable.organization) }
+
+        users
+      end
+
+      it "renders the correct user for a single reaction" do
+        users = mock_heart_reaction_notifications(1, %w[like unicorn])
+
+        get notifications_path(filter: :org, org_id: organization.id)
+        expect(response.body).to include CGI.escapeHTML(users.last.name)
+      end
+
+      it "renders the correct usernames for two or more reactions" do
+        mock_heart_reaction_notifications(2, %w[like unicorn])
+
+        get notifications_path(filter: :org, org_id: organization.id)
+        expect(has_both_names(response.body)).to be(true)
+      end
+
+      it "renders the proper message for multiple reactions" do
+        random_amount = rand(3..10)
+        mock_heart_reaction_notifications(random_amount, %w[unicorn like])
+
+        get notifications_path(filter: :org, org_id: organization.id)
+        expect(response.body).to include(CGI.escapeHTML("and #{random_amount - 1} others"))
+      end
+
+      it "does group notifications that are on different days but have the same reactable" do
+        mock_heart_reaction_notifications(2, %w[unicorn like readinglist])
+        Notification.last.update(created_at: Notification.last.created_at - 1.day)
+
+        get notifications_path(filter: :org, org_id: organization.id)
+        notifications = controller.instance_variable_get(:@notifications)
+        expect(notifications.count).to eq(1)
+      end
+
+      it "does not group notifications that are on the same day but have different reactables" do
+        mock_heart_reaction_notifications(1, %w[unicorn like readinglist], article1)
+        mock_heart_reaction_notifications(1, %w[unicorn like readinglist], article2)
+
+        get notifications_path(filter: :org, org_id: organization.id)
+        notifications = controller.instance_variable_get(:@notifications)
+        expect(notifications.count).to eq(2)
+      end
+
+      it "properly renders reactable titles" do
+        mock_heart_reaction_notifications(1, %w[unicorn like readinglist], special_characters_article)
+
+        get notifications_path(filter: :org, org_id: organization.id)
+        expect(response.body).to include(ERB::Util.html_escape(special_characters_article.title))
+      end
+
+      it "properly renders reactable titles for multiple reactions" do
+        amount = rand(3..10)
+        mock_heart_reaction_notifications(amount, %w[unicorn like readinglist], special_characters_article)
+
+        get notifications_path(filter: :org, org_id: organization.id)
+        expect(response.body).to include(ERB::Util.html_escape(special_characters_article.title))
+      end
+
+      it "does not render the proper message for a single notification if missing :org_id" do
+        users = mock_heart_reaction_notifications(1, %w[like unicorn])
+
+        get notifications_path(filter: :org)
+        expect(response.body).not_to include(CGI.escapeHTML(users.last.name))
+      end
+
+      it "does not render notifications belonging to other orgs" do
+        users = mock_heart_reaction_notifications(1, %w[like unicorn], other_org_article)
+
+        get notifications_path(filter: :org, org_id: organization.id)
+        expect(response.body).not_to include(CGI.escapeHTML(users.last.name))
+      end
+
+      it "does render notifications belonging to other orgs if admin" do
+        user.add_role(:super_admin)
+        sign_in user
+
+        users = mock_heart_reaction_notifications(1, %w[like unicorn], other_org_article)
+
+        get notifications_path(filter: :org, org_id: other_org_article.organization_id)
+        expect(response.body).to include(CGI.escapeHTML(users.last.name))
+      end
+
+      it "does not render the proper message for a single notification if :filter is comments" do
+        users = mock_heart_reaction_notifications(1, %w[like unicorn])
+
+        get notifications_path(filter: :comments, org_id: organization.id)
+        expect(response.body).not_to include(CGI.escapeHTML(users.last.name))
+      end
+    end
+
     context "when a user has a new comment notification" do
       let(:user2)    { create(:user) }
       let(:article)  { create(:article, :with_notification_subscription, user_id: user.id) }
@@ -245,6 +375,102 @@ RSpec.describe "NotificationsIndex", type: :request do
 
       it "does not render the reaction as reacted if it was not reacted on" do
         expect(response.body).not_to include "reaction-button reacted"
+      end
+    end
+
+    context "when a user's organization has a new comment notification" do
+      let(:user2)    { create(:user) }
+      let(:article)  { create(:article, :with_notification_subscription, user: user, organization: organization) }
+      let(:comment)  { create(:comment, user: user2, commentable: article) }
+      let(:other_org) { create(:organization) }
+      let(:other_org_article) { create(:article, :with_notification_subscription, user: user, organization: other_org) }
+      let(:other_org_comment) { create(:comment, user: user2, commentable: other_org_article) }
+
+      before do
+        sign_in user
+      end
+
+      it "renders the correct message" do
+        Notification.send_new_comment_notifications_without_delay(comment)
+
+        get notifications_path(filter: :org, org_id: organization.id)
+        expect(response.body).to include("commented on")
+      end
+
+      it "does not render incorrect message" do
+        Notification.send_new_comment_notifications_without_delay(comment)
+
+        get notifications_path(filter: :org, org_id: organization.id)
+        expect(response.body).not_to include("replied to a thread in")
+      end
+
+      it "does not render the moderation message" do
+        Notification.send_new_comment_notifications_without_delay(comment)
+
+        get notifications_path(filter: :org, org_id: organization.id)
+        expect(response.body).not_to include("As a trusted member")
+      end
+
+      it "renders the article's path" do
+        Notification.send_new_comment_notifications_without_delay(comment)
+
+        get notifications_path(filter: :org, org_id: organization.id)
+        expect(response.body).to include(article.path)
+      end
+
+      it "renders the comment's processed HTML" do
+        Notification.send_new_comment_notifications_without_delay(comment)
+
+        get notifications_path(filter: :org, org_id: organization.id)
+        expect(response.body).to include(comment.processed_html)
+      end
+
+      it "renders the reaction as previously reacted if it was reacted on" do
+        Notification.send_new_comment_notifications_without_delay(comment)
+        Reaction.create(user: user, reactable: comment, category: "like")
+
+        get notifications_path(filter: :org, org_id: organization.id)
+        expect(response.body).to include("reaction-button reacted")
+      end
+
+      it "does not render the reaction as reacted if it was not reacted on" do
+        Notification.send_new_comment_notifications_without_delay(comment)
+
+        get notifications_path(filter: :org, org_id: organization.id)
+        expect(response.body).not_to include("reaction-button reacted")
+      end
+
+      it "does not render notifications if missing :org_id" do
+        Notification.send_new_comment_notifications_without_delay(comment)
+
+        get notifications_path(filter: :org)
+        notifications = controller.instance_variable_get(:@notifications)
+        expect(notifications.map(&:organization_id).compact.size).to eq(0)
+      end
+
+      it "does not render notifications belonging to other orgs" do
+        Notification.send_new_comment_notifications_without_delay(other_org_comment)
+
+        get notifications_path(filter: :org, org_id: other_org.id)
+        notifications = controller.instance_variable_get(:@notifications)
+        expect(notifications.map(&:organization_id).compact.size).to eq(0)
+      end
+
+      it "does render notifications belonging to other orgs if admin" do
+        user.add_role(:super_admin)
+        sign_in user
+
+        Notification.send_new_comment_notifications_without_delay(other_org_comment)
+
+        get notifications_path(filter: :org, org_id: other_org.id)
+        expect(response.body).to include("commented on")
+      end
+
+      it "does render the proper message for a single notification if :filter is comments" do
+        Notification.send_new_comment_notifications_without_delay(comment)
+
+        get notifications_path(filter: :comments, org_id: organization.id)
+        expect(response.body).to include("commented on")
       end
     end
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Once upon a time a user could belong only to a single organization, but then the mighty @Zhao-Andy submit two PRs - https://github.com/thepracticaldev/dev.to/pull/2471 and https://github.com/thepracticaldev/dev.to/pull/2583 - allowing users to join more than one org.

Some breadcrumbs of those olden times though remain, and as I set to get rid of them I also noticed some oddities in our code:

- we have a `/api/followers/organizations` that returns the list of followers of the original legacy organization of those users that have `users.organization_id` populated (if you don't, as the vast majority of users), it does not return anything

- we don't use `/api/followers/organizations` anywhere in the code, but as it's part of the API we can't remove it, so I set out to simply make it return the followers of all organizations the user belongs to, even though it's not that meaningful 🤷‍♂ 

- there's a page that displays in HTML the results of the legacy HTTP call, https://dev.to/dashboard/organization_user_followers, but it's not linked anywhere aka it's unreachable, so I removed it

- we have an URL, which is reachable from https://dev.to/notifications which returns the organizations notifications, but it only does if the requested organization id is the same of the one in the legacy field (!!) or if the user is an admin. I made it so that the user can view notifications of all the orgs they belong to instead of just that one

Next step would be to remove the column from the DB, but I'd rather do it separately

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
