### PR TITLE
Remove References to rake jobs:work

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,3 @@
 release: ./release-tasks.sh
 web: bin/start-pgbouncer bundle exec puma -C config/puma.rb
-worker: bundle exec rails jobs:work
 sidekiq_worker: bundle exec sidekiq -t 25

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,4 +1,3 @@
 web: bin/rails s -p 3000
 webpacker: ./bin/webpack-dev-server
-job: bin/rake jobs:work
 sidekiq: bundle exec sidekiq

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,16 +17,6 @@ services:
     volumes:
       - .:/usr/src/app
     command: bundle exec rails server -b 0.0.0.0 -p 3000
-  jobs:
-    build: .
-    command: rails jobs:work
-    depends_on:
-      - db
-      - redis
-    environment:
-      RAILS_ENV: development
-      DATABASE_URL: postgres://postgres:mysecretpassword@db:5432/postgres
-      REDIS_URL: redis://redis:6379
   webpacker:
     build: .
     command: ./bin/webpack-dev-server

--- a/docs/backend/notification.md
+++ b/docs/backend/notification.md
@@ -5,7 +5,7 @@ title: Notifications
 # Notifications
 
 Since notifications are run asynchronously, we'll want to make sure jobs are
-running: `bin/rails jobs:work`. If that's not running, you won't receive any
+running: `bundle exec sidekiq`. If that's not running, you won't receive any
 notifications. You might need to create another account to pass notifications
 back and forth if you're doing this all through the UI.
 

--- a/docs/getting-started/start-app.md
+++ b/docs/getting-started/start-app.md
@@ -32,10 +32,8 @@ If you're using **`pry`** for debugging in Rails, note that using `foreman` and
 Here are some singleton commands you may need, usually in a separate
 instance/tab of your shell.
 
-- Running the job server (if using `bin/rails server`) -- this is mostly for
-  notifications and emails: **`bin/rails jobs:work`**
-- Clearing jobs (in case you don't want to wait for the backlog of jobs):
-  **`bin/rails jobs:clear`**
+- Running the job Sidekiq server (if using `bin/rails server`) -- this is mostly
+  for notifications and emails: **`bundle exec sidekiq`**
 
 Current gotchas: potential environment issues with external services need to be
 worked out.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
Since we no longer need to run `rake jobs:work` at boot up we can remove references to it from our Procfiles, docs, and docker compose file.

## Related Tickets & Documents
#5305 

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media0.giphy.com/media/1pA8bP2BfZFG9hg4uM/giphy.gif)
