### PR TITLE
Made changes to timeAgo function for Preact component usage

### DIFF
--- a/app/assets/javascripts/initializers/initializeFetchFollowedArticles.js.erb
+++ b/app/assets/javascripts/initializers/initializeFetchFollowedArticles.js.erb
@@ -186,10 +186,10 @@ function insertTimes() {
   var elements = document.getElementsByClassName('time-ago-indicator-initial-placeholder');
   for (var i = 0; i < elements.length; i++) {
 
-    // getElementsByClassName will get updated everytime we change DOM  
+    // getElementsByClassName will get updated everytime we change DOM
     // so elements[0] will produce the next unchanged element every iteration
     var element = elements[0];
 
-    element.outerHTML = timeAgo(element.dataset.seconds);
+    element.outerHTML = timeAgo({ oldTimeInSeconds: element.dataset.seconds });
   }
 };

--- a/app/assets/javascripts/utilities/buildArticleHTML.js.erb
+++ b/app/assets/javascripts/utilities/buildArticleHTML.js.erb
@@ -110,7 +110,7 @@ function buildArticleHTML(article) {
 
     var timeAgoInWords = '';
     if (article.published_at_int) {
-      timeAgoInWords = timeAgo(article.published_at_int);
+      timeAgoInWords = timeAgo({ oldTimeInSeconds: article.published_at_int });
     }
 
     return '<div class="single-article single-article-small-pic" data-content-user-id="'+article.user_id+'">\

--- a/app/assets/javascripts/utilities/timeAgo.js
+++ b/app/assets/javascripts/utilities/timeAgo.js
@@ -25,15 +25,34 @@ function secondsToHumanUnitAgo(seconds) {
   return wholeUnits + ' ' + unitName + ' ago';
 }
 
-function timeAgo(oldTimeInSeconds, maxDisplayedAge = 60 * 60 * 24 - 1) {
+/**
+ * Returns a given time in seconds as a human readable form, e.g. (5 min ago)
+ *
+ * @param {object} options
+ * @param {number} options.oldTimeInSeconds
+ * @param {function} [(humanTime) =>
+      `<span class="time-ago-indicator">(${humanTime})</span>`] options.formatter
+ * @param {number} [60 * 60 * 24 - 1] options.maxDisplayedAge The maximum display age in seconds
+ *
+ * @returns {string} A formatted string in human readable form. Note that the default formatter returns a string with markup in it.
+ */
+function timeAgo({
+  oldTimeInSeconds,
+  formatter = humanTime =>
+    `<span class="time-ago-indicator">(${humanTime})</span>`,
+  maxDisplayedAge = 60 * 60 * 24 - 1,
+}) {
   const timeNow = new Date() / 1000;
   const diff = Math.round(timeNow - oldTimeInSeconds);
 
   if (diff > maxDisplayedAge) return '';
 
-  return (
-    "<span class='time-ago-indicator'>(" +
-    secondsToHumanUnitAgo(diff) +
-    ')</span>'
-  );
+  return formatter(secondsToHumanUnitAgo(diff));
+}
+
+// TODO: This is for Storybook/jest.
+// Longterm, this should be a utility function that can be imported.
+// For the time being, duplication of this function is being avoided.
+if (typeof globalThis !== 'undefined') {
+  globalThis.timeAgo = timeAgo; // eslint-disable-line no-undef
 }

--- a/app/javascript/utilities/__tests__/timeAgo.test.js
+++ b/app/javascript/utilities/__tests__/timeAgo.test.js
@@ -1,0 +1,129 @@
+import '../../../assets/javascripts/utilities/timeAgo';
+
+/* global globalThis timeAgo */
+
+describe('timeAgo', () => {
+  afterAll(() => {
+    delete globalThis.timeAgo;
+  });
+
+  it('should return "just now" for a date that is now.', () => {
+    const oldTimeInSeconds = new Date().getTime();
+
+    expect(timeAgo({ oldTimeInSeconds })).toEqual(
+      '<span class="time-ago-indicator">(just now)</span>',
+    );
+  });
+
+  it('should support a custom string formatter for the time.', () => {
+    const oldTimeInSeconds = new Date().getTime();
+
+    expect(
+      timeAgo({
+        oldTimeInSeconds,
+        formatter: x => `[${x}]`,
+      }),
+    ).toEqual('[just now]');
+  });
+
+  it('should return "1 min ago" for a date that is one minute in the past.', () => {
+    const oneMinute = 60000;
+    const oldTimeInSeconds = new Date(new Date().getTime() - oneMinute) / 1000;
+
+    expect(timeAgo({ oldTimeInSeconds })).toEqual(
+      '<span class="time-ago-indicator">(1 min ago)</span>',
+    );
+  });
+
+  it('should return "n mins ago" for a date that is n minutes in the past.', () => {
+    const fiveMinutes = 5 * 60000;
+    const oldTimeInSeconds =
+      new Date(new Date().getTime() - fiveMinutes) / 1000;
+
+    expect(timeAgo({ oldTimeInSeconds })).toEqual(
+      '<span class="time-ago-indicator">(5 mins ago)</span>',
+    );
+  });
+
+  it('should return "1 hour ago" for a date that is one hour in the past.', () => {
+    const oneHour = 60 * 60000;
+    const oldTimeInSeconds = new Date(new Date().getTime() - oneHour) / 1000;
+
+    expect(timeAgo({ oldTimeInSeconds })).toEqual(
+      '<span class="time-ago-indicator">(1 hour ago)</span>',
+    );
+  });
+
+  it('should return "n hours ago" for a date that is n hours in the past', () => {
+    const fiveHours = 5 * 60 * 60000;
+    const oldTimeInSeconds = new Date(new Date().getTime() - fiveHours) / 1000;
+
+    expect(timeAgo({ oldTimeInSeconds })).toEqual(
+      '<span class="time-ago-indicator">(5 hours ago)</span>',
+    );
+  });
+
+  describe('Custom maxDisplayedAge to support days, weeks, months and years', () => {
+    it('should return "1 day ago" for a date is one day in the past.', () => {
+      const oneDay = 24 * 60 * 60000;
+      const oldTimeInSeconds = new Date(new Date().getTime() - oneDay) / 1000;
+      const maxDisplayedAge = oneDay;
+
+      expect(timeAgo({ oldTimeInSeconds, maxDisplayedAge })).toEqual(
+        '<span class="time-ago-indicator">(1 day ago)</span>',
+      );
+    });
+
+    it('should return "n days ago" for a date is that is n days in the past.', () => {
+      const fiveDays = 5 * 24 * 60 * 60000;
+      const oldTimeInSeconds = new Date(new Date().getTime() - fiveDays) / 1000;
+      const maxDisplayedAge = fiveDays;
+
+      expect(timeAgo({ oldTimeInSeconds, maxDisplayedAge })).toEqual(
+        '<span class="time-ago-indicator">(5 days ago)</span>',
+      );
+    });
+
+    it('should return "1 month ago" for a date is one month in the past.', () => {
+      const oneMonth = 31 * 24 * 60 * 60000;
+      const oldTimeInSeconds = new Date(new Date().getTime() - oneMonth) / 1000;
+      const maxDisplayedAge = oneMonth;
+
+      expect(timeAgo({ oldTimeInSeconds, maxDisplayedAge })).toEqual(
+        '<span class="time-ago-indicator">(1 month ago)</span>',
+      );
+    });
+
+    it('should return "n days ago" for a date is that is n months in the past.', () => {
+      const fiveMonths = 31 * 5 * 24 * 60 * 60000;
+      const oldTimeInSeconds =
+        new Date(new Date().getTime() - fiveMonths) / 1000;
+      const maxDisplayedAge = fiveMonths;
+
+      expect(timeAgo({ oldTimeInSeconds, maxDisplayedAge })).toEqual(
+        '<span class="time-ago-indicator">(5 months ago)</span>',
+      );
+    });
+
+    it('should return "1 year ago" for a date is one month in the past.', () => {
+      const oneYear = 365 * 24 * 60 * 60000;
+      const oldTimeInSeconds = new Date(new Date().getTime() - oneYear) / 1000;
+      const maxDisplayedAge = oneYear;
+
+      expect(timeAgo({ oldTimeInSeconds, maxDisplayedAge })).toEqual(
+        '<span class="time-ago-indicator">(1 year ago)</span>',
+      );
+    });
+
+    it('should return "n years ago" for a date is that is n years in the past.', () => {
+      const fiveYears = 365 * 5 * 24 * 60 * 60000;
+      const oldTimeInSeconds =
+        new Date(new Date().getTime() - fiveYears) / 1000;
+      const maxDisplayedAge = fiveYears;
+
+      expect(timeAgo({ oldTimeInSeconds, maxDisplayedAge })).toEqual(
+        '<span class="time-ago-indicator">(5 years ago)</span>',
+      );
+    });
+  });
+});


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature
     and/or include [WIP] in the PR title.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The current `timeAgo` function returns a string that includes markup. In Preact component land, we want to avoid that but still support non-Preact.

This is related to feature work for the homepage makeover. I decided to pull this out of my component PR to make things more bite-sized.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![Unit tests pass](https://media.giphy.com/media/VldGsyiAmMW9a/giphy.gif)
