### PR TITLE
Add Safety navigators to handle a Missing Comment Reply

### DIFF
--- a/app/views/notifications/shared/_comment_box.html.erb
+++ b/app/views/notifications/shared/_comment_box.html.erb
@@ -25,7 +25,7 @@
         </button>
       <% end %>
       <% cache "comment-box-comment-reply-#{@last_user_comment}-#{json_data['comment']['updated_at']}-#{json_data['comment']['id']}" do %>
-        <% reply = Comment.select(:id, :user_id, :ancestry).find_by(id: json_data["comment"]["id"]).children.find_by(user_id: current_user.id) %>
+        <% reply = Comment.select(:id, :user_id, :ancestry).find_by(id: json_data["comment"]["id"])&.children&.find_by(user_id: current_user.id) %>
         <% if reply %>
           <a class="toggle-reply-form already-replied-link" href="<%= reply.path %>">
             Replied


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
When we are loading comments sometimes there will not be a reply found, in this case, we should fail gracefully and not raise a 500 to Honeybadger. 
Honeybadger: https://app.honeybadger.io/fault/66984/14771d0bde65f71e859dd56b8a3a9390
```
ActionView::Template::Error: undefined method `children' for nil:NilClass
 _comment_box.html.erb  28 block (2 levels) in _app_views_notifications_shared__comment_box_html_erb(...)
[PROJECT_ROOT]/app/views/notifications/shared/_comment_box.html.erb:28:in `block (2 levels) in _app_views_notifications_shared__comment_box_html_erb'
26       <% end %>
27       <% cache "comment-box-comment-reply-#{@last_user_comment}-#{json_data['comment']['updated_at']}-#{json_data['comment']['id']}" do %>
28         <% reply = Comment.select(:id, :user_id, :ancestry).find_by(id: json_data["comment"]["id"]).children.find_by(user_id: current_user.id) %>
29         <% if reply %>
30           <a class="toggle-reply-form already-replied-link" href="<%= reply.path %>">
```

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media.giphy.com/media/1k03DWas9bfbYcbb33/giphy.gif)
