### PR TITLE
Add notification_id to honeybadger context

### DIFF
--- a/app/views/notifications/_notifications_list.html.erb
+++ b/app/views/notifications/_notifications_list.html.erb
@@ -5,7 +5,7 @@
     <%= render notification.notifiable_type.downcase.to_s, notification: notification %>
   </div>
 <% rescue => e %>
-  <% Honeybadger.notify(e) %>
+  <% Honeybadger.notify(e, context: { notification_id: notification.id }) %>
 
   <div class="small-pic">
     <img src="https://res.cloudinary.com/practicaldev/image/fetch/s--LnVw15KE--/c_fill,f_auto,fl_progressive,h_90,q_auto,w_90/https://thepracticaldev.s3.amazonaws.com/uploads/user/profile_image/31047/af153cd6-9994-4a68-83f4-8ddf3e13f0bf.jpg"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
Adding `notification_id` to a Honeybadger error so that I/we can track it better. :)

See: https://docs.honeybadger.io/lib/ruby/getting-started/adding-context-to-errors.html