### PR TITLE
Enable Elasticsearch Tracing with Datadog APM

### DIFF
--- a/config/initializers/datadog_apm.rb
+++ b/config/initializers/datadog_apm.rb
@@ -6,6 +6,7 @@ Datadog.configure do |c|
   c.tracer enabled: Rails.env.production?
   c.tracer partial_flush: true
   c.tracer priority_sampling: true
+  c.use :elasticsearch
   c.use :sidekiq
   c.use :redis
   c.use :rails


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
This should allow us to track and monitor [our requests to Elasticsearch via Datadog.](https://docs.datadoghq.com/tracing/setup/ruby/#elastic-search)

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-33076445

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media2.giphy.com/media/BtedgmzGNCiuk/giphy.gif)
