### PR TITLE
Require worker_retries_exhausted_reporter in Sidekiq initializer

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -15,6 +15,8 @@ module Rack
   end
 end
 
+require Rails.root.join("lib/sidekiq/worker_retries_exhausted_reporter")
+
 Sidekiq.configure_server do |config|
   sidekiq_url = ApplicationConfig["REDIS_SIDEKIQ_URL"] || ApplicationConfig["REDIS_URL"]
   # On Heroku this configuration is overridden and Sidekiq will point at the redis


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
For some reason the `Sidekiq::WorkerRetriesExhaustedReporter` is not loading properly in production which is [causing this error] when the Sidekiq dealth handlers are triggered. (https://app.honeybadger.io/fault/66984/9b4d0fd229b813dd9443870cd209b732) when a worker dies:
```
NameError: uninitialized constant Sidekiq::WorkerRetriesExhaustedReporter
 sidekiq.rb  31 block (2 levels) in <main>(...)
[PROJECT_ROOT]/config/initializers/sidekiq.rb:31:in `block (2 levels) in <main>'
29   # of it's retries. For more details: https://github.com/mperham/sidekiq/wiki/Error-Handling#death-notification
30   config.death_handlers << lambda do |job, _ex|
31     Sidekiq::WorkerRetriesExhaustedReporter.report_final_failure(job)
32   end
33 end
```

I was able to reproduce this in a production console and fix it by manually requiring the file. This is not a problem in development which I found interesting but rather than go down the Rails loading rabbit hole I decided to take the easy way out and require. 

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/9#card-33240341

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media1.giphy.com/media/gEo36y1gALoQ/giphy.gif)
