### PR TITLE
Refactor Common Search Methods into a Base Class

### DIFF
--- a/app/services/search/base.rb
+++ b/app/services/search/base.rb
@@ -30,7 +30,7 @@ module Search
       end
 
       def update_mappings(index_alias: self::INDEX_ALIAS)
-        SearchClient.indices.put_mapping(index: index_alias, body: mappings)
+        SearchClient.indices.put_mapping(index: index_alias, body: self::MAPPINGS)
       end
 
       private
@@ -41,10 +41,6 @@ module Search
 
       def index_settings
         raise "Search classes must implement their own index settings"
-      end
-
-      def mappings
-        raise "Search classes must define their own index mappings"
       end
     end
   end

--- a/app/services/search/base.rb
+++ b/app/services/search/base.rb
@@ -1,0 +1,51 @@
+module Search
+  class Base
+    class << self
+      def index(doc_id, serialized_data)
+        SearchClient.index(
+          id: doc_id,
+          index: self::INDEX_ALIAS,
+          body: serialized_data,
+        )
+      end
+
+      def find_document(doc_id)
+        SearchClient.get(id: doc_id, index: self::INDEX_ALIAS)
+      end
+
+      def create_index(index_name: self::INDEX_NAME)
+        SearchClient.indices.create(index: index_name, body: settings)
+      end
+
+      def delete_index(index_name: self::INDEX_NAME)
+        SearchClient.indices.delete(index: index_name)
+      end
+
+      def refresh_index(index_name: self::INDEX_ALIAS)
+        SearchClient.indices.refresh(index: index_name)
+      end
+
+      def add_alias(index_name: self::INDEX_NAME, index_alias: self::INDEX_ALIAS)
+        SearchClient.indices.put_alias(index: index_name, name: index_alias)
+      end
+
+      def update_mappings(index_alias: self::INDEX_ALIAS)
+        SearchClient.indices.put_mapping(index: index_alias, body: mappings)
+      end
+
+      private
+
+      def settings
+        { settings: { index: index_settings } }
+      end
+
+      def index_settings
+        raise "Search classes must implement their own index settings"
+      end
+
+      def mappings
+        raise "Search classes must define their own index mappings"
+      end
+    end
+  end
+end

--- a/app/services/search/classified_listing.rb
+++ b/app/services/search/classified_listing.rb
@@ -1,43 +1,11 @@
 module Search
-  class ClassifiedListing
+  class ClassifiedListing < Base
     INDEX_NAME = "classified_listings_#{Rails.env}".freeze
     INDEX_ALIAS = "classified_listings_#{Rails.env}_alias".freeze
     MAPPINGS = JSON.parse(File.read("config/elasticsearch/mappings/classified_listings.json"), symbolize_names: true).freeze
 
     class << self
-      def index(classified_listing_id, serialized_data)
-        SearchClient.index(
-          id: classified_listing_id,
-          index: INDEX_ALIAS,
-          body: serialized_data,
-        )
-      end
-
-      def find_document(classified_listing_id)
-        SearchClient.get(id: classified_listing_id, index: INDEX_ALIAS)
-      end
-
-      def create_index(index_name: INDEX_NAME)
-        SearchClient.indices.create(index: index_name, body: settings)
-      end
-
-      def delete_index(index_name: INDEX_NAME)
-        SearchClient.indices.delete(index: index_name)
-      end
-
-      def add_alias(index_name: INDEX_NAME, index_alias: INDEX_ALIAS)
-        SearchClient.indices.put_alias(index: index_name, name: index_alias)
-      end
-
-      def update_mappings(index_alias: INDEX_ALIAS)
-        SearchClient.indices.put_mapping(index: index_alias, body: mappings)
-      end
-
       private
-
-      def settings
-        { settings: { index: index_settings } }
-      end
 
       def index_settings
         if Rails.env.production?
@@ -51,10 +19,6 @@ module Search
             number_of_replicas: 0
           }
         end
-      end
-
-      def mappings
-        MAPPINGS
       end
     end
   end

--- a/app/services/search/tag.rb
+++ b/app/services/search/tag.rb
@@ -1,22 +1,10 @@
 module Search
-  class Tag
+  class Tag < Base
     INDEX_NAME = "tags_#{Rails.env}".freeze
     INDEX_ALIAS = "tags_#{Rails.env}_alias".freeze
-    MAPPING = JSON.parse(File.read("config/elasticsearch/mappings/tags.json"), symbolize_names: true).freeze
+    MAPPINGS = JSON.parse(File.read("config/elasticsearch/mappings/tags.json"), symbolize_names: true).freeze
 
     class << self
-      def index(tag_id, serialized_data)
-        SearchClient.index(
-          id: tag_id,
-          index: INDEX_ALIAS,
-          body: serialized_data,
-        )
-      end
-
-      def find_document(tag_id)
-        SearchClient.get(id: tag_id, index: INDEX_ALIAS)
-      end
-
       def search(query_string)
         SearchClient.search(
           index: INDEX_ALIAS,
@@ -40,31 +28,7 @@ module Search
         results.dig("hits", "hits").map { |tag_doc| tag_doc.dig("_source") }
       end
 
-      def create_index(index_name: INDEX_NAME)
-        SearchClient.indices.create(index: index_name, body: settings)
-      end
-
-      def delete_index(index_name: INDEX_NAME)
-        SearchClient.indices.delete(index: index_name)
-      end
-
-      def refresh_index(index_name: INDEX_ALIAS)
-        SearchClient.indices.refresh(index: index_name)
-      end
-
-      def add_alias(index_name: INDEX_NAME, index_alias: INDEX_ALIAS)
-        SearchClient.indices.put_alias(index: index_name, name: index_alias)
-      end
-
-      def update_mappings(index_alias: INDEX_ALIAS)
-        SearchClient.indices.put_mapping(index: index_alias, body: mappings)
-      end
-
       private
-
-      def settings
-        { settings: { index: index_settings } }
-      end
 
       def index_settings
         if Rails.env.production?
@@ -78,10 +42,6 @@ module Search
             number_of_replicas: 0
           }
         end
-      end
-
-      def mappings
-        MAPPING
       end
     end
   end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Tag, type: :model do
 
   describe "#serialized_search_hash" do
     it "creates a valid serialized hash to send to elasticsearch" do
-      mapping_keys = described_class::MAPPINGS.dig(:properties).keys
+      mapping_keys = Search::Tag::MAPPINGS.dig(:properties).keys
       expect(tag.serialized_search_hash.symbolize_keys.keys).to eq(mapping_keys)
     end
   end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Tag, type: :model do
 
   describe "#serialized_search_hash" do
     it "creates a valid serialized hash to send to elasticsearch" do
-      mapping_keys = Search::Tag.send("mappings").dig(:properties).keys
+      mapping_keys = described_class::MAPPINGS.dig(:properties).keys
       expect(tag.serialized_search_hash.symbolize_keys.keys).to eq(mapping_keys)
     end
   end

--- a/spec/services/search/classified_listing_spec.rb
+++ b/spec/services/search/classified_listing_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Search::ClassifiedListing, type: :service, elasticsearch: true do
 
       described_class.update_mappings(index_alias: other_name)
       mapping = SearchClient.indices.get_mapping(index: other_name).dig(other_name, "mappings")
-      expect(mapping.deep_stringify_keys).to include(described_class.send("mappings").deep_stringify_keys)
+      expect(mapping.deep_stringify_keys).to include(described_class::MAPPINGS.deep_stringify_keys)
 
       # Have to cleanup index since it wont automatically be handled by our cluster class bc of the unexpected name
       described_class.delete_index(index_name: other_name)

--- a/spec/services/search/tag_spec.rb
+++ b/spec/services/search/tag_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe Search::Tag, type: :service, elasticsearch: true do
 
       described_class.update_mappings(index_alias: other_name)
       mapping = SearchClient.indices.get_mapping(index: other_name).dig(other_name, "mappings")
-      expect(mapping.deep_stringify_keys).to include(described_class.send("mappings").deep_stringify_keys)
+      expect(mapping.deep_stringify_keys).to include(described_class::MAPPINGS.deep_stringify_keys)
 
       # Have to cleanup index since it wont automatically be handled by our cluster class bc of the unexpected name
       described_class.delete_index(index_name: other_name)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
Refactor the common search methods into a single search based class that other search models can inherit from. I choose to do this now bc I am getting ready to roll over our third Elasticsearch model and didn't want to repeat all this logic a 3rd time. I did not refactor the specs in this PR but that should be done at some point. 

## Added tests?
- [x] no, because they aren't needed
Spec coverage is still handled by the individual classes

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media1.giphy.com/media/jQnU8XA7Nuv9SdZW7f/giphy.gif)
