### PR TITLE
Make sure profile images show up in onboarding

### DIFF
--- a/app/controllers/api/v0/users_controller.rb
+++ b/app/controllers/api/v0/users_controller.rb
@@ -37,12 +37,12 @@ module Api
         render :show
       end
 
-      INDEX_ATTRIBUTES_FOR_SERIALIZATION = %i[id name username summary].freeze
+      INDEX_ATTRIBUTES_FOR_SERIALIZATION = %i[id name username summary profile_image].freeze
       private_constant :INDEX_ATTRIBUTES_FOR_SERIALIZATION
 
       SHOW_ATTRIBUTES_FOR_SERIALIZATION = %i[
         id username name summary twitter_username github_username website_url
-        location created_at
+        location created_at profile_image
       ].freeze
       private_constant :SHOW_ATTRIBUTES_FOR_SERIALIZATION
 

--- a/spec/requests/api/v0/users_spec.rb
+++ b/spec/requests/api/v0/users_spec.rb
@@ -42,6 +42,22 @@ RSpec.describe "Api::V0::Users", type: :request do
       expect(response_user["id"]).to eq(other_user.id)
     end
 
+    it "returns follow suggestions that have profile images" do
+      user = create(:user)
+      tag = create(:tag)
+      user.follow(tag)
+
+      other_user = create(:user)
+      create(:article, user: other_user, tags: [tag.name])
+
+      sign_in user
+
+      get api_users_path(state: "follow_suggestions")
+
+      response_user = response.parsed_body.first
+      expect(response_user["profile_image_url"]).to eq(other_user.profile_image_url)
+    end
+
     it "returns no sidebar suggestions for an authenticated user" do
       sign_in create(:user)
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Onboarding was not showing profile pic images—Failing silently with our backup awkward smileyface.

<img width="1679" alt="Screenshot 2020-02-17 15 28 31" src="https://user-images.githubusercontent.com/3102842/74694838-b7a70080-51bf-11ea-8223-ec147a52353a.png">
