### PR TITLE
Fix markdown and missing command in rails data_updates:run

### DIFF
--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -99,6 +99,7 @@ Please execute the script itself to view all additional options:
   Data update scripts need to be run before you can start the application. Please run rake data_updates:run (RuntimeError)
   ```
   run the following command:
-  ```sh
-  docker-compose run web data_updates:run
+
+  ```shell
+  docker-compose run web rails data_updates:run
   ```


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [x] Documentation Update

## Description

Recent updates for the Docker `rails data_updates:run` had typos in the command.

## Related Tickets & Documents

https://github.com/thepracticaldev/dev.to/pull/6097
https://github.com/thepracticaldev/dev.to/issues/6094#issuecomment-586807819

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![image](https://user-images.githubusercontent.com/1578766/74698464-e1662480-51cb-11ea-8dfd-e318baa6e604.png)


## Added tests?

- [x] no, because they aren't needed

## Added to documentation?

- [x] docs.dev.to
