### PR TITLE
Return a Unauthorized Error from API when Current User is Not Found

### DIFF
--- a/app/controllers/api/v0/followings_controller.rb
+++ b/app/controllers/api/v0/followings_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V0
     class FollowingsController < ApiController
-      before_action :authenticate_with_api_key_or_current_user!
+      before_action :authenticate_user!
       before_action -> { limit_per_page(default: 80, max: 1000) }
 
       def users

--- a/app/controllers/api/v0/github_repos_controller.rb
+++ b/app/controllers/api/v0/github_repos_controller.rb
@@ -3,6 +3,8 @@ module Api
     class GithubReposController < ApiController
       include Pundit
 
+      before_action :authenticate_user!
+
       def index
         client = create_octokit_client
 

--- a/spec/requests/api/v0/github_repos_spec.rb
+++ b/spec/requests/api/v0/github_repos_spec.rb
@@ -11,50 +11,63 @@ RSpec.describe "Api::V0::GithubRepos", type: :request do
   before do
     allow(Octokit::Client).to receive(:new).and_return(my_ocktokit_client)
     allow(my_ocktokit_client).to receive(:repositories) { stubbed_github_repos }
-    sign_in user
   end
 
-  describe "GET /api/v0/github_repos" do
-    it "returns 200 on success" do
+  context "when user is unauthorized" do
+    it "returns unauthorized" do
       get api_github_repos_path
 
-      expect(response).to have_http_status(:ok)
-    end
-
-    it "returns 401 if github raises an unauthorized error" do
-      allow(Octokit::Client).to receive(:new).and_raise(Octokit::Unauthorized)
-
-      get api_github_repos_path
       expect(response).to have_http_status(:unauthorized)
-      expect(response.parsed_body["error"]).to include("Github Unauthorized")
-    end
-
-    it "returns repos with the correct json representation" do
-      get api_github_repos_path
-
-      response_repo = response.parsed_body.first
-      expect(response_repo["name"]).to eq(repo.name)
-      expect(response_repo["fork"]).to eq(repo.fork)
-      expect(response_repo["selected"]).to be(false)
     end
   end
 
-  describe "POST /api/v0/github_repos/update_or_create" do
-    it "returns 200 and json response on success" do
-      param = stubbed_github_repos.first.to_h.to_json
-      post update_or_create_api_github_repos_path(github_repo: param)
-
-      expect(response).to have_http_status(:ok)
-      expect(response.content_type).to eq("application/json")
+  context "when user is authorized" do
+    before do
+      sign_in user
     end
 
-    it "returns 404 and json response on error" do
-      allow(Octokit::Client).to receive(:new).and_return(my_ocktokit_client)
-      allow(my_ocktokit_client).to receive(:repositories).and_return([])
+    describe "GET /api/v0/github_repos" do
+      it "returns 200 on success" do
+        get api_github_repos_path
 
-      post update_or_create_api_github_repos_path(github_repo: "{}")
-      expect(response).to have_http_status(:not_found)
-      expect(response.body).to include("Could not find Github repo")
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "returns 401 if github raises an unauthorized error" do
+        allow(Octokit::Client).to receive(:new).and_raise(Octokit::Unauthorized)
+
+        get api_github_repos_path
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.parsed_body["error"]).to include("Github Unauthorized")
+      end
+
+      it "returns repos with the correct json representation" do
+        get api_github_repos_path
+
+        response_repo = response.parsed_body.first
+        expect(response_repo["name"]).to eq(repo.name)
+        expect(response_repo["fork"]).to eq(repo.fork)
+        expect(response_repo["selected"]).to be(false)
+      end
+    end
+
+    describe "POST /api/v0/github_repos/update_or_create" do
+      it "returns 200 and json response on success" do
+        param = stubbed_github_repos.first.to_h.to_json
+        post update_or_create_api_github_repos_path(github_repo: param)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.content_type).to eq("application/json")
+      end
+
+      it "returns 404 and json response on error" do
+        allow(Octokit::Client).to receive(:new).and_return(my_ocktokit_client)
+        allow(my_ocktokit_client).to receive(:repositories).and_return([])
+
+        post update_or_create_api_github_repos_path(github_repo: "{}")
+        expect(response).to have_http_status(:not_found)
+        expect(response.body).to include("Could not find Github repo")
+      end
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Description

This PR fixed incorrect usage of `current_user` instead of `@user` in several API controllers.

## Related Tickets & Documents

Closes #6119

## Added tests?

- [X] yes

## Added to documentation?

- [X] no documentation needed
