### PR TITLE
Campaign settings

### DIFF
--- a/app/controllers/internal/configs_controller.rb
+++ b/app/controllers/internal/configs_controller.rb
@@ -21,6 +21,8 @@ class Internal::ConfigsController < Internal::ApplicationController
   def config_params
     allowed_params = %i[
       default_site_email social_networks_handle
+      campaign_hero_html_variant_name campaign_background_color
+      campaign_text_color campaign_sidebar_enabled campaign_featured_tags
       main_social_image favicon_url logo_svg
       rate_limit_follow_count_daily
       ga_view_id ga_fetch_rate

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -40,17 +40,16 @@ class StoriesController < ApplicationController
 
   def assign_hero_html
     return if SiteConfig.campaign_hero_html_variant_name.blank?
-    @hero_html = HtmlVariant.relevant
-                            .select(:html)
-                            .find_by(group: "campaign", name: SiteConfig.campaign_hero_html_variant_name)
-                            &.html
+
+    @hero_html = HtmlVariant.relevant.select(:html).
+      find_by(group: "campaign", name: SiteConfig.campaign_hero_html_variant_name)&.html
   end
 
   def get_latest_campaign_articles
-    @latest_campaign_articles = Article.tagged_with(SiteConfig.campaign_featured_tags, any: true)
-           .where("published_at > ?", 2.weeks.ago).where(approved: true)
-           .order("hotness_score DESC")
-           .pluck(:path, :title, :comments_count, :created_at)
+    @latest_campaign_articles = Article.tagged_with(SiteConfig.campaign_featured_tags, any: true).
+      where("published_at > ?", 2.weeks.ago).where(approved: true).
+      order("hotness_score DESC").
+      pluck(:path, :title, :comments_count, :created_at)
   end
 
   def redirect_to_changed_username_profile

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -46,6 +46,13 @@ class StoriesController < ApplicationController
                             &.html
   end
 
+  def get_latest_campaign_articles
+    @latest_campaign_articles = Article.tagged_with(SiteConfig.campaign_featured_tags, any: true)
+           .where("published_at > ?", 2.weeks.ago).where(approved: true)
+           .order("hotness_score DESC")
+           .pluck(:path, :title, :comments_count, :created_at)
+  end
+
   def redirect_to_changed_username_profile
     potential_username = params[:username].tr("@", "").downcase
     user_or_org = User.find_by("old_username = ? OR old_old_username = ?", potential_username, potential_username) ||
@@ -136,6 +143,7 @@ class StoriesController < ApplicationController
     assign_hero_html
     assign_podcasts
     assign_classified_listings
+    get_latest_campaign_articles if SiteConfig.campaign_sidebar_enabled?
     @article_index = true
     @featured_story = (@featured_story || Article.new)&.decorate
     @stories = ArticleDecorator.decorate_collection(@stories)

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -40,11 +40,11 @@ class StoriesController < ApplicationController
 
   def assign_hero_html
     return if SiteConfig.campaign_hero_html_variant_name.blank?
-    @hero_html = HtmlVariant.relevant.select(:html)
-                                     .find_by(group: "campaign", name: SiteConfig.campaign_hero_html_variant_name)
-                                     &.html
+    @hero_html = HtmlVariant.relevant
+                            .select(:html)
+                            .find_by(group: "campaign", name: SiteConfig.campaign_hero_html_variant_name)
+                            &.html
   end
-
 
   def redirect_to_changed_username_profile
     potential_username = params[:username].tr("@", "").downcase

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -38,6 +38,14 @@ class StoriesController < ApplicationController
 
   private
 
+  def assign_hero_html
+    return if SiteConfig.campaign_hero_html_variant_name.blank?
+    @hero_html = HtmlVariant.relevant.select(:html)
+                                     .find_by(group: "campaign", name: SiteConfig.campaign_hero_html_variant_name)
+                                     &.html
+  end
+
+
   def redirect_to_changed_username_profile
     potential_username = params[:username].tr("@", "").downcase
     user_or_org = User.find_by("old_username = ? OR old_old_username = ?", potential_username, potential_username) ||
@@ -125,6 +133,7 @@ class StoriesController < ApplicationController
       @default_home_feed = true
       @featured_story, @stories = feed.default_home_feed(user_signed_in: user_signed_in?)
     end
+    assign_hero_html
     assign_podcasts
     assign_classified_listings
     @article_index = true

--- a/app/models/html_variant.rb
+++ b/app/models/html_variant.rb
@@ -1,9 +1,11 @@
 class HtmlVariant < ApplicationRecord
   include CloudinaryHelper
 
+  GROUP_NAMES = %w[article_show_sidebar_cta article_show_below_article_cta badge_landing_page campaign].freeze
+
   validates :html, presence: true
   validates :name, uniqueness: true
-  validates :group, inclusion: { in: %w[article_show_sidebar_cta article_show_below_article_cta badge_landing_page] }
+  validates :group, inclusion: { in: GROUP_NAMES }
   validates :success_rate, presence: true
   validate  :no_edits
 
@@ -12,6 +14,8 @@ class HtmlVariant < ApplicationRecord
   has_many :html_variant_successes
 
   before_save :prefix_all_images
+
+  scope :relevant, -> { where(approved: true, published: true) }
 
   def calculate_success_rate!
     self.success_rate = html_variant_successes.size.to_f / (html_variant_trials.size * 10.0) # x10 because we only capture every 10th

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -13,6 +13,13 @@ class SiteConfig < RailsSettings::Base
   field :default_site_email, type: :string, default: "yo@dev.to"
   field :social_networks_handle, type: :string, default: "thepracticaldev"
 
+  # campaign
+  field :campaign_hero_html_variant_name, type: :string, default: ""
+  field :campaign_background_color, type: :string, default: "FFFFFF"
+  field :campaign_text_color, type: :string, default: "000000"
+  field :campaign_featured_tags, type: :array, default: %w[]
+  field :campaign_sidebar_enabled, type: :boolean, default: 0
+
   # images
   field :main_social_image, type: :string, default: "https://thepracticaldev.s3.amazonaws.com/i/6hqmcjaxbgbon8ydw93z.png"
   field :favicon_url, type: :string, default: "favicon.ico"

--- a/app/views/articles/_sidebar_additional.html.erb
+++ b/app/views/articles/_sidebar_additional.html.erb
@@ -27,6 +27,7 @@
           </div>
         </div>
       <% end %>
+      <%= render "articles/sidebar_campaign" if SiteConfig.campaign_sidebar_enabled? %>
       <% if params[:timeframe].blank? && @classified_listings.any? %>
         <div class="widget" id="sidebar-listings-widget">
           <header class="widget-header-listings">

--- a/app/views/articles/_sidebar_campaign.html.erb
+++ b/app/views/articles/_sidebar_campaign.html.erb
@@ -8,10 +8,7 @@
   </header>
   <div class="widget-body">
     <div class="widget-link-list">
-      <% Article.tagged_with(SiteConfig.campaign_featured_tags, any: true).
-           where("published_at > ?", 2.weeks.ago).where(approved: true).
-           order("hotness_score DESC").pluck(:path, :title, :comments_count, :created_at).
-           each do |plucked_article| %>
+      <% @latest_campaign_articles.each do |plucked_article| %>
         <%= render "articles/widget_list_item", plucked_article: plucked_article, show_comment_count: false %>
       <% end %>
     </div>

--- a/app/views/articles/_sidebar_campaign.html.erb
+++ b/app/views/articles/_sidebar_campaign.html.erb
@@ -1,0 +1,19 @@
+<div class="widget">
+  <header>
+    <h4>
+      <% SiteConfig.campaign_featured_tags.each do |t| %>
+        <%= link_to("##{t}", "/t/#{t}") %>
+      <% end %>
+    </h4>
+  </header>
+  <div class="widget-body">
+    <div class="widget-link-list">
+      <% Article.tagged_with(SiteConfig.campaign_featured_tags, any: true).
+           where("published_at > ?", 2.weeks.ago).where(approved: true).
+           order("hotness_score DESC").pluck(:path, :title, :comments_count, :created_at).
+           each do |plucked_article| %>
+        <%= render "articles/widget_list_item", plucked_article: plucked_article, show_comment_count: false %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/html_variants/_form.html.erb
+++ b/app/views/html_variants/_form.html.erb
@@ -25,7 +25,7 @@
     <%= f.label :published %>
     <%= f.check_box :published %>
     <%= f.label :group %>
-    <%= f.select(:group, options_for_select(["article_show_sidebar_cta", "article_show_below_article_cta", "badge_landing_page"], @html_variant.group || "article_show_sidebar_cta")) %>
+    <%= f.select(:group, options_for_select(HtmlVariant::GROUP_NAMES, @html_variant.group || "article_show_sidebar_cta")) %>
   </div>
   <%= f.submit %>
 <% end %>

--- a/app/views/html_variants/index.html.erb
+++ b/app/views/html_variants/index.html.erb
@@ -10,6 +10,7 @@
     <a href="/html_variants?state=article_show_sidebar_cta" class="<%= "selected" if params[:state] == "article_show_sidebar_cta" %>">Show Page Sidebar</a>
     <a href="/html_variants?state=article_show_below_article_cta" class="<%= "selected" if params[:state] == "article_show_below_article_cta" %>">Show Page Below Article</a>
     <a href="/html_variants?state=badge_landing_page" class="<%= "selected" if params[:state] == "badge_landing_page" %>">Badge Landing Page</a>
+    <a href="/html_variants?state=campaign" class="<%= "selected" if params[:state] == "campaign" %>">Campaign</a>
   </nav>
   <% if params[:state] == "mine" %>
     <h2>My Entries</h2>

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -46,6 +46,53 @@
         </div>
 
         <div class="card mt-3">
+          <div class="card-header">Campaign</div>
+          <div class="card-body">
+            <div class="form-group">
+              <%= f.label :campaign_hero_html_variant_name %>
+              <%= f.text_field :campaign_hero_html_variant_name,
+                               class: "form-control",
+                               value: SiteConfig.campaign_hero_html_variant_name,
+                               placeholder: "" %>
+              <div class="alert alert-info">Hero HtmlVariant name</div>
+            </div>
+
+            <div class="form-group">
+              <%= f.label :campaign_background_color %>
+              <%= f.text_field :campaign_background_color,
+                               class: "form-control",
+                               value: SiteConfig.campaign_background_color,
+                               placeholder: "FFFFFF" %>
+              <div class="alert alert-info">Campaign background color</div>
+            </div>
+
+            <div class="form-group">
+              <%= f.label :campaign_text_color %>
+              <%= f.text_field :campaign_text_color,
+                               class: "form-control",
+                               value: SiteConfig.campaign_text_color,
+                               placeholder: "FFFFFF" %>
+              <div class="alert alert-info">Campaign text color</div>
+            </div>
+
+            <div class="form-group">
+              <%= f.label :campaign_sidebar_enabled %>
+              <%= f.check_box :campaign_sidebar_enabled, checked: SiteConfig.campaign_sidebar_enabled %>
+              <div class="alert alert-info">Campaign sidebar enabled or not</div>
+            </div>
+
+            <div class="form-group">
+              <%= f.label :campaign_featured_tags %>
+              <%= f.text_field :campaign_featured_tags,
+                               class: "form-control",
+                               value: SiteConfig.campaign_featured_tags.join(","),
+                               placeholder: "List of campaign tags: comma separated, letters only e.g. shecoded,theycoded" %>
+              <div class="alert alert-info">Posts with which tags will be featured in the campaign sidebar (comma separated, letters only)</div>
+            </div>
+          </div>
+        </div>
+
+        <div class="card mt-3">
           <div class="card-header">Images</div>
           <div class="card-body">
             <div class="form-group">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,9 @@
     </div>
   <% end %>
   <div id="page-content-inner">
+    <% if @hero_html %>
+      <%= @hero_html.html_safe %>
+    <% end %>
     <%= yield %>
   </div>
 </div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
This is basically Anna's PR which I could not contribute to/edit  (but I needed it merged and also the latest master pulled in to order to move forward whilst she's on vacation). The original PR is  (https://github.com/thepracticaldev/dev.to/pull/5892) and I will close it.  I added her changes and some of the fixes based on some of the suggestions.

**Anna's description:** 

I started working on settings for Shecoded 2020 campaign and further campaigns in this pr:

- added `SiteConfig` settings for campaigns:
  - `campaign_hero_html_variant_name` (name of the html variant that will be used to display campaign banner/hero over the feed)
  - `campaign_background_color`, `campaign_text_color` (these settings will be used to configure a campaign's appearance, not used in the code right now besides setting the values)
  - `campaign_featured_tags` (tags for the campaign's featured posts, not used in the code right now besides setting the values)
- added a new `campaign` group for `HtmlVariant`'s; did the related changes for the `HtmlVariant`s dashboard; improved their validation a bit

To set up a campaign hero and display it over the feed you need to:
- create an `HtmlVariant` record in `/html_variants`, choose group `campaign`. Make sure that the variant's `approved` and `published` fields are set to `true`.
- go to `SiteConfig` settings page (`/internal/config`) and set "Hero HtmlVariant name" in the campaign section to be the same that you have specified while creating an `HtmlVariant`.
- the hero html should be displayed  on the home page

To set up the campaign sidebar:
- set `sidebar_enabled` to true in the campaign section on `/internal/config` page
- set `featured_tags` on the same page
Approved posts tagged with one of the `featured_tags` should show in the sidebar.
We may need to add other settings to configure the sidebar view.
![изображение](https://user-images.githubusercontent.com/30115/74031491-b22d0780-49c2-11ea-85ae-9fb9c63819bd.png)

**TODO:**
-  if a user closes the full-screen display, it will not show them the display again

## Related Tickets & Documents
#5702 #5703 #5701

Rough Examples placeholders of where content would be placed:

<img width="1189" alt="Screenshot 2020-02-18 at 15 14 05" src="https://user-images.githubusercontent.com/2786819/74745914-432a9b00-526d-11ea-9e80-326cb4b808d8.png">
 
<img width="1655" alt="Screenshot 2020-02-18 at 15 05 56" src="https://user-images.githubusercontent.com/2786819/74745825-242c0900-526d-11ea-8429-5561a54e25f3.png">

