### PR TITLE
Rescue Psych::DisallowedClass when parsing frontmatter

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -320,7 +320,7 @@ class Article < ApplicationRecord
     begin
       parsed = FrontMatterParser::Parser.new(:md).call(fixed_body_markdown)
       parsed.front_matter["title"].present?
-    rescue Psych::SyntaxError
+    rescue Psych::SyntaxError, Psych::DisallowedClass
       # if frontmatter is invalid, still render editor with errors instead of 500ing
       true
     end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -355,6 +355,17 @@ RSpec.describe Article, type: :model do
       article.body_markdown = "Hey hey Ho Ho"
       expect(article.has_frontmatter?).to eq(false)
     end
+
+    it "returns true if parser raises a Psych::DisallowedClass error" do
+      allow(FrontMatterParser::Parser).to receive(:new).and_raise(Psych::DisallowedClass.new("msg"))
+      expect(article.has_frontmatter?).to eq(true)
+    end
+
+    it "returns true if parser raises a Psych::SyntaxError error" do
+      syntax_error = Psych::SyntaxError.new("file", 1, 1, 0, "problem", "context")
+      allow(FrontMatterParser::Parser).to receive(:new).and_raise(syntax_error)
+      expect(article.has_frontmatter?).to eq(true)
+    end
   end
 
   describe "#readable_edit_date" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Here we rescue one type of parsing error, but another one has been showing up in Honeybadger, `Psych::DisallowedClass:` and I think we should handle that the same as we handle the Syntax error. 

Honeybadger: https://app.honeybadger.io/fault/66984/599a7871be018f4d14f33909795a9c48

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/5#card-32287912

## Added tests?
- [x] yes

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media0.giphy.com/media/26gsccje7r5WUrXsA/giphy.gif)
