### PR TITLE
Adds explicit 0.0.0.0 bind option to Procfile.dev

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,3 @@
-web: bin/rails s -p 3000
+web: bin/rails s -p 3000 -b 0.0.0.0
 webpacker: ./bin/webpack-dev-server
 sidekiq: bundle exec sidekiq


### PR DESCRIPTION
## What type of PR is this? 

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

When working on a local environment there's limited access to a "mobile device experience". I've used [xip.io](https://xip.io) before and works like a charm to access your localhost environment from within your LAN using your mobile device.

For those who are not familiar: If your workstation has a DEV server running on `localhost` and your IP address is `192.168.0.100` you can access it from your mobile devices (within the same LAN) by browsing `192.168.0.100.xip.io:3000`.

The problem here is that an explicit bind to `0.0.0.0` is required, because rails connects to the `127.0.0.1` interface only and this is not accessible from within the LAN.

## Related Tickets & Documents

None that I could find

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

N/A

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

##  Are there any post deployment tasks we need to perform?

Nope, this is a change that only affects local environments

## What gif best describes this PR or how it makes you feel?

![unlock all the phones](https://media.giphy.com/media/w2C7attGZhe0/giphy.gif)
