### PR TITLE
Add history as a reserved word

### DIFF
--- a/config/initializers/reserved_words.rb
+++ b/config/initializers/reserved_words.rb
@@ -82,6 +82,7 @@ class ReservedWords
     hackers
     haskell
     help
+    history
     infinite
     infiniteloop
     internal


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

In #6127 we removed `dev.to/history` - I think we should add it as a reserved word before it gets "squatted" :D 
