### PR TITLE
Enable CORS preflight caching for API

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -69,8 +69,10 @@ module PracticalDeveloper
 
         # allowed public APIs
         %w[articles comments listings podcast_episodes tags users videos].each do |resource_name|
-          # allow read operations, disallow custom headers (eg. api-key) and disable preflight caching
-          resource "/api/#{resource_name}/*", methods: %i[head get options], headers: [], max_age: -1
+          # allow read operations, disallow custom headers (eg. api-key) and enable preflight caching
+          # NOTE: Chrome caps preflight caching at 2 hours, Firefox at 24 hours
+          # see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age#Directives
+          resource "/api/#{resource_name}/*", methods: %i[head get options], headers: [], max_age: 2.hours.to_i
         end
       end
     end

--- a/spec/requests/api/v0/articles_spec.rb
+++ b/spec/requests/api/v0/articles_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Api::V0::Articles", type: :request do
       expect(response.headers["Access-Control-Allow-Origin"]).to eq(origin)
       expect(response.headers["Access-Control-Allow-Methods"]).to eq("HEAD, GET, OPTIONS")
       expect(response.headers["Access-Control-Expose-Headers"]).to be_empty
-      expect(response.headers["Access-Control-Max-Age"]).to be_present
+      expect(response.headers["Access-Control-Max-Age"]).to eq(2.hours.to_i.to_s)
     end
 
     it "has correct keys in the response" do
@@ -271,7 +271,7 @@ RSpec.describe "Api::V0::Articles", type: :request do
       expect(response.headers["Access-Control-Allow-Origin"]).to eq(origin)
       expect(response.headers["Access-Control-Allow-Methods"]).to eq("HEAD, GET, OPTIONS")
       expect(response.headers["Access-Control-Expose-Headers"]).to be_empty
-      expect(response.headers["Access-Control-Max-Age"]).to be_present
+      expect(response.headers["Access-Control-Max-Age"]).to eq(2.hours.to_i.to_s)
     end
 
     it "has correct keys in the response" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Now that CORS has been enabled on public APIs - https://github.com/thepracticaldev/dev.to/pull/6116 - I went ahead and tested manually to check if it was working live and it is.

We can now re-enable the CORS preflight cache to a default value. I chose 2 hours because it's the default for `rack-cors` and it's also the lowest maximum value between Chromium and Firefox (Chromium caps the cache to 2 hours, Firefox to 24 hours).

FYI: CORS preflight caching means that the client doesn't have to re-issue the `OPTIONS` HTTP call to query the capabilities of the server before each call that requires CORS

## Related Tickets & Documents

#6116 
#4195 

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
