### PR TITLE
PageView is no longer a valid model to index

### DIFF
--- a/app/workers/search/index_worker.rb
+++ b/app/workers/search/index_worker.rb
@@ -4,7 +4,7 @@ module Search
 
     sidekiq_options queue: :medium_priority, retry: 10
 
-    VALID_RECORD_TYPES = %w[Comment Article User PageView].freeze
+    VALID_RECORD_TYPES = %w[Comment Article User].freeze
 
     def perform(record_type, record_id)
       unless VALID_RECORD_TYPES.include?(record_type)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
We got some Honeybadgers from trying to index PageViews. I could not find anywhere in the code where we still do that but I did notice the job still considers them valid so I removed PageView from the valid list. My best guess is that the jobs were enqueued from a console with old code maybe 🤷‍♀  

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media.giphy.com/media/l1J9O7pA2mdnrtMgU/giphy-downsized.gif)
