### PR TITLE
Index ChatChannelMemberships to Elasticsearch 

### DIFF
--- a/app/models/chat_channel_membership.rb
+++ b/app/models/chat_channel_membership.rb
@@ -4,7 +4,7 @@ class ChatChannelMembership < ApplicationRecord
   include Searchable
   SEARCH_INDEX_WORKER = Search::ChatChannelMembershipEsIndexWorker
   SEARCH_SERIALIZER = Search::ChatChannelMembershipSerializer
-  SEARCH_CLASS = Search::ChatChannelMembershipSerializer
+  SEARCH_CLASS = Search::ChatChannelMembership
 
   belongs_to :chat_channel
   belongs_to :user

--- a/app/models/chat_channel_membership.rb
+++ b/app/models/chat_channel_membership.rb
@@ -1,5 +1,11 @@
 class ChatChannelMembership < ApplicationRecord
   include AlgoliaSearch
+
+  include Searchable
+  SEARCH_INDEX_WORKER = Search::ChatChannelMembershipEsIndexWorker
+  SEARCH_SERIALIZER = Search::ChatChannelMembershipSerializer
+  SEARCH_CLASS = Search::ChatChannelMembershipSerializer
+
   belongs_to :chat_channel
   belongs_to :user
 
@@ -20,10 +26,7 @@ class ChatChannelMembership < ApplicationRecord
     ranking ["desc(channel_last_message_at)"]
   end
 
-  include Searchable
-  SEARCH_INDEX_WORKER = Search::ChatChannelMembershipEsIndexWorker
-  SEARCH_SERIALIZER = Search::ChatChannelMembershipSerializer
-  SEARCH_CLASS = Search::ChatChannelMembership
+  delegate :channel_type, to: :chat_channel
 
   def channel_last_message_at
     chat_channel.last_message_at
@@ -32,8 +35,6 @@ class ChatChannelMembership < ApplicationRecord
   def channel_status
     chat_channel.status
   end
-
-  delegate :channel_type, to: :chat_channel
 
   def channel_text
     "#{chat_channel.channel_name} #{chat_channel.slug} #{chat_channel.channel_human_names}"

--- a/app/serializers/search/chat_channel_membership_serializer.rb
+++ b/app/serializers/search/chat_channel_membership_serializer.rb
@@ -1,0 +1,10 @@
+module Search
+  class ChatChannelMembershipSerializer
+    include FastJsonapi::ObjectSerializer
+
+    attributes :id, :status, :viewable_by, :chat_channel_id, :last_opened_at,
+               :channel_text, :channel_last_message_at, :channel_status,
+               :channel_status, :channel_type, :channel_username, :channel_name,
+               :channel_image, :channel_modified_slug, :channel_messages_count
+  end
+end

--- a/app/workers/search/chat_channel_membership_es_index_worker.rb
+++ b/app/workers/search/chat_channel_membership_es_index_worker.rb
@@ -5,7 +5,7 @@ module Search
     sidekiq_options queue: :high_priority
 
     def perform(chat_channel_membership_id)
-      chat_channel_membership = ::ChatChannelMembership.find_by!(id: chat_channel_membership_id)
+      chat_channel_membership = ::ChatChannelMembership.find(chat_channel_membership_id)
       chat_channel_membership.index_to_elasticsearch_inline
     end
   end

--- a/app/workers/search/chat_channel_membership_es_index_worker.rb
+++ b/app/workers/search/chat_channel_membership_es_index_worker.rb
@@ -1,0 +1,12 @@
+module Search
+  class ChatChannelMembershipEsIndexWorker
+    include Sidekiq::Worker
+
+    sidekiq_options queue: :high_priority
+
+    def perform(chat_channel_membership_id)
+      chat_channel_membership = ::ChatChannelMembership.find_by!(id: chat_channel_membership_id)
+      chat_channel_membership.index_to_elasticsearch_inline
+    end
+  end
+end

--- a/lib/data_update_scripts/20200218195023_index_chat_channel_memberships_to_elasticsearch.rb
+++ b/lib/data_update_scripts/20200218195023_index_chat_channel_memberships_to_elasticsearch.rb
@@ -1,0 +1,7 @@
+module DataUpdateScripts
+  class IndexChatChannelMembershipsToElasticsearch
+    def run
+      ChatChannelMembership.find_each(&:index_to_elasticsearch_inline)
+    end
+  end
+end

--- a/spec/lib/data_update_scripts/index_chat_channel_memberships_to_elasticsearch_spec.rb
+++ b/spec/lib/data_update_scripts/index_chat_channel_memberships_to_elasticsearch_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+require Rails.root.join("lib/data_update_scripts/20200218195023_index_chat_channel_memberships_to_elasticsearch.rb")
+
+describe DataUpdateScripts::IndexChatChannelMembershipsToElasticsearch, elasticsearch: true do
+  it "indexes chat channel memberships to Elasticsearch" do
+    chat_channel_membership = FactoryBot.create(:chat_channel_membership)
+    expect { chat_channel_membership.elasticsearch_doc }.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound)
+    described_class.new.run
+    expect(chat_channel_membership.elasticsearch_doc).not_to be_nil
+  end
+end

--- a/spec/models/chat_channel_membership_spec.rb
+++ b/spec/models/chat_channel_membership_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe ChatChannelMembership, type: :model do
+  let(:chat_channel_membership) { FactoryBot.create(:chat_channel_membership) }
+
+  describe "#index_to_elasticsearch" do
+    it "enqueues job to index tag to elasticsearch" do
+      sidekiq_assert_enqueued_with(job: Search::ChatChannelMembershipEsIndexWorker, args: [chat_channel_membership.id]) do
+        chat_channel_membership.index_to_elasticsearch
+      end
+    end
+  end
+
+  describe "#index_to_elasticsearch_inline" do
+    it "indexed chat_channel_membership to elasticsearch inline" do
+      allow(Search::ChatChannelMembership).to receive(:index)
+      chat_channel_membership.index_to_elasticsearch_inline
+      expect(Search::ChatChannelMembership).to have_received(:index).with(chat_channel_membership.id, hash_including(:id, :channel_name))
+    end
+  end
+
+  describe "#after_commit" do
+    it "enqueues job to index chat_channel_membership to elasticsearch" do
+      chat_channel_membership.save
+      sidekiq_assert_enqueued_with(job: Search::ChatChannelMembershipEsIndexWorker, args: [chat_channel_membership.id]) do
+        chat_channel_membership.save
+      end
+    end
+  end
+
+  describe "#serialized_search_hash" do
+    it "creates a valid serialized hash to send to elasticsearch" do
+      mapping_keys = Search::ChatChannelMembership::MAPPINGS.dig(:properties).keys
+      expect(chat_channel_membership.serialized_search_hash.symbolize_keys.keys).to eq(mapping_keys)
+    end
+  end
+
+  describe "#elasticsearch_doc" do
+    it "finds document in elasticsearch", elasticsearch: true do
+      allow(Search::ChatChannelMembership).to receive(:find_document)
+      chat_channel_membership.elasticsearch_doc
+      expect(Search::ChatChannelMembership).to have_received(:find_document)
+    end
+  end
+end

--- a/spec/workers/search/chat_channel_membership_es_index_worker_spec.rb
+++ b/spec/workers/search/chat_channel_membership_es_index_worker_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe Search::ChatChannelMembershipEsIndexWorker, type: :worker, elasticsearch: true do
+  let(:worker) { subject }
+
+  include_examples "#enqueues_on_correct_queue", "high_priority", [1]
+
+  it "raises an error if record is not found" do
+    expect { worker.perform(1234) }.to raise_error(ActiveRecord::RecordNotFound)
+  end
+
+  it "indexes chat_channel_membership" do
+    chat_channel_membership = FactoryBot.create(:chat_channel_membership)
+    expect { chat_channel_membership.elasticsearch_doc }.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound)
+    worker.perform(chat_channel_membership.id)
+    expected_hash = chat_channel_membership.serialized_search_hash.stringify_keys
+    expect(chat_channel_membership.elasticsearch_doc.dig("_source")).to include(
+      expected_hash,
+    )
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
This PR begins indexing all ChatChannelMemberships when they are created or updated. It also has a DataUpdateScript to index all existing ones.

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-32289280

## Added tests?
- [x] yes

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media.giphy.com/media/4QF3DLl5JuYnjR2YzG/giphy-downsized.gif)
