### PR TITLE
Modify padding for classifiedlisting dropdown

### DIFF
--- a/app/assets/stylesheets/classified_listings.scss
+++ b/app/assets/stylesheets/classified_listings.scss
@@ -419,7 +419,7 @@
     display: flex;
     justify-content: space-between;
     margin: 0px;
-    padding: 9px 15px;
+    padding: 9px 3px 9px 12px;
     position: relative;
     @include themeable(
       background,
@@ -480,7 +480,7 @@
     }
   }
   .single-classified-listing-body {
-    padding: 10px 15px;
+    padding: 10px 12px;
     font-size: 15px;
     .classified-listing-contact-cta {
       border: 2px solid $black;


### PR DESCRIPTION


<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We recently merged #2826 and I thought the menu location was a bit off, but it shouldn't hold up the PR, so this is a follow-up.

Small padding adjustment

Current:

<img width="416" alt="Screen Shot 2020-02-18 at 6 21 12 PM" src="https://user-images.githubusercontent.com/3102842/74786738-7411cc80-527b-11ea-9e82-f985196bf587.png">

New:

<img width="420" alt="Screen Shot 2020-02-18 at 6 20 17 PM" src="https://user-images.githubusercontent.com/3102842/74786686-53e20d80-527b-11ea-9042-086d1dfb5440.png">

