### PR TITLE
Remove unavailable gif

### DIFF
--- a/app/labor/random_gif.rb
+++ b/app/labor/random_gif.rb
@@ -19,8 +19,7 @@ class RandomGif
       "l0K4glBiv82lZ0Zuo" => { aspect_ratio: 0.563 },
       "7EcgJbeY0yCRy" => { aspect_ratio: 0.750 },
       "Gf3fU0qPtI6uk" => { aspect_ratio: 0.750 },
-      "5GoVLqeAOo6PK" => { aspect_ratio: 0.780 },
-      "82lalqBsmW56Z6E2oV" => { aspect_ratio: 0.562 }
+      "5GoVLqeAOo6PK" => { aspect_ratio: 0.780 }
     }
   end
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

I removed this gif: https://media.giphy.com/media/82lalqBsmW56Z6E2oV/giphy-downsized.gif

form the rotation because it was not available anymore.

Even if link work in the browser, it does not when displayed in the notifications screen.

See below:

![](https://i.postimg.cc/mD8yWcLL/Capture-d-e-cran-2020-02-19-a-10-43-51.png)

## Related Tickets & Documents

Fixes #4606 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [ ] yes
- [X] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![Doing my part](https://media.giphy.com/media/87CKDqErVfMqY/giphy.gif)
