### PR TITLE
add rescue InvalidURIError in mastodon_url validation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -79,7 +79,7 @@ class User < ApplicationRecord
   validates :experience_level, numericality: { less_than_or_equal_to: 10 }, allow_blank: true
   validates :text_color_hex, format: /\A#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})\z/, allow_blank: true
   validates :bg_color_hex, format: /\A#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})\z/, allow_blank: true
-  validates :website_url, :employer_url, :mastodon_url,
+  validates :website_url, :employer_url,
             url: { allow_blank: true, no_local: true, schemes: %w[https http] }
   validates :facebook_url,
             format: /\A(http(s)?:\/\/)?(www.facebook.com|facebook.com)\/.*\Z/,
@@ -610,6 +610,8 @@ class User < ApplicationRecord
     return if uri.host&.in?(Constants::ALLOWED_MASTODON_INSTANCES)
 
     errors.add(:mastodon_url, "is not an allowed Mastodon instance")
+  rescue URI::InvalidURIError
+    errors.add(:mastodon_url, "is not a valid url")
   end
 
   def tag_list

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -188,9 +188,9 @@ RSpec.describe User, type: :model do
         expect(user).not_to be_valid
       end
 
-      it "does not raise InvalidURIError when url is badly formatted" do
+      it "does not accept an invalid url" do
         user.mastodon_url = "ben .com"
-        expect { user.validate }.not_to raise_error(URI::InvalidURIError)
+        expect(user).not_to be_valid
       end
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -187,6 +187,11 @@ RSpec.describe User, type: :model do
         user.mastodon_url = "mastodon.social/@test"
         expect(user).not_to be_valid
       end
+
+      it "does not raise InvalidURIError when url is badly formatted" do
+        user.mastodon_url = "ben .com"
+        expect { user.validate }.not_to raise_error(URI::InvalidURIError)
+      end
     end
 
     describe "#facebook_url" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
I've also removed mastodon_url validation from
```ruby
validates :website_url, :employer_url,
            url: { allow_blank: true, no_local: true, schemes: %w[https http] }
```
because we've already validated in `validate  :validate_mastodon_url`.

## Related Tickets & Documents
Fixes #6142

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
