### PR TITLE
Change some feed JSON field names

### DIFF
--- a/app/views/stories/feeds/show.json.jbuilder
+++ b/app/views/stories/feeds/show.json.jbuilder
@@ -1,16 +1,18 @@
 article_attributes_to_include = %i[
   title path id user_id comments_count positive_reactions_count organization_id
   reading_time video_thumbnail_url video video_duration_in_minutes language
-  experience_level_rating experience_level_rating_distribution cached_user
-  cached_organization main_image
+  experience_level_rating experience_level_rating_distribution main_image
 ]
 article_methods_to_include = %i[
-  readable_publish_date cached_tag_list_array flare_tag class_name
+  readable_publish_date flare_tag class_name
   cloudinary_video_url video_duration_in_minutes published_at_int
   published_timestamp
 ]
 
 json.array!(@stories) do |article|
   json.extract! article, *article_attributes_to_include
+  json.user article.cached_user
+  json.organization article.cached_organization
+  json.tag_list article.cached_tag_list_array
   json.extract! article, *article_methods_to_include
 end

--- a/spec/requests/stories/feeds_spec.rb
+++ b/spec/requests/stories/feeds_spec.rb
@@ -2,7 +2,9 @@ require "rails_helper"
 
 RSpec.describe "Stories::FeedsIndex", type: :request do
   let(:title) { "My post" }
-  let!(:article) { create(:article, title: title, featured: true) }
+  let(:user) { create(:user, name: "Josh") }
+  let(:organization) { create(:organization, name: "JoshCo") }
+  let!(:article) { create(:article, title: title, featured: true, user: user, organization: organization) }
 
   describe "GET feeds index" do
     let(:response_json) { JSON.parse(response.body) }
@@ -11,9 +13,13 @@ RSpec.describe "Stories::FeedsIndex", type: :request do
     it "renders article list as json" do
       get "/stories/feed", headers: headers
       expect(response.content_type).to eq("application/json")
-      expect(response.body).to include(article.id.to_s)
+      expect(response_article["id"]).to eq article.id
       expect(response_article["title"]).to eq title
-      expect(response_article["class_name"]).to eq "Article"
+      expect(response_article["user_id"]).to eq user.id
+      expect(response_article["user"]["table"]["name"]).to eq user.name
+      expect(response_article["organization_id"]).to eq organization.id
+      expect(response_article["organization"]["table"]["name"]).to eq organization.name
+      expect(response_article["tag_list"]).to eq article.decorate.cached_tag_list_array
     end
 
     context "when timeframe parameter is present" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Changes the names of some fields in the new home page feed JSON to match key names that were being translated in the template. This will let these JSON values flow directly to Preact components on the new home page.

`cached_user` -> `user`
`cached_organization` -> `organization`
`cached_tag_list_array` -> `tag_list`

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![names](https://media.giphy.com/media/3ohc10GA6j4XrLWzZK/giphy.gif)
