### PR TITLE
Change find_by to find for better error messaging on Tags

### DIFF
--- a/app/workers/search/tag_es_index_worker.rb
+++ b/app/workers/search/tag_es_index_worker.rb
@@ -5,7 +5,7 @@ module Search
     sidekiq_options queue: :high_priority
 
     def perform(tag_id)
-      tag = ::Tag.find_by!(id: tag_id)
+      tag = ::Tag.find(tag_id)
       tag.index_to_elasticsearch_inline
     end
   end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Optimization

## Description
@citizen428 made a [great observation](https://github.com/thepracticaldev/dev.to/pull/6132#discussion_r380437346) about using `find` over `find_by!(id: id)` for better error messaging. This is a quick (nitpick) change to keep things in a consistent pattern across all the search workers.

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

![consistency_gif](https://media.giphy.com/media/8PmbPHDRXTffCSeALj/giphy.gif)
