### PR TITLE
Add DataDog monitors

### DIFF
--- a/app/controllers/stripe_active_cards_controller.rb
+++ b/app/controllers/stripe_active_cards_controller.rb
@@ -11,14 +11,14 @@ class StripeActiveCardsController < ApplicationController
       Rails.logger.info("Stripe Add New Card Success - #{current_user.username}")
       flash[:settings_notice] = "Your billing information has been updated"
     else
-      DatadogStatsClient.increment("stripe.errors.new_subscription")
+      DatadogStatsClient.increment("stripe.errors", tags: ["event:new_subscription", "user_id:#{current_user.id}"])
 
       Rails.logger.error("Stripe Add New Card Failure - #{current_user.username}")
       flash[:error] = "There was a problem updating your billing info."
     end
     redirect_to user_settings_path(:billing)
   rescue Payments::CardError, Payments::InvalidRequestError => e
-    DatadogStatsClient.increment("stripe.errors.new_subscription")
+    DatadogStatsClient.increment("stripe.errors", tags: ["event:new_subscription", "user_id:#{current_user.id}"])
     redirect_to user_settings_path(:billing), flash: { error: e.message }
   end
 
@@ -34,7 +34,7 @@ class StripeActiveCardsController < ApplicationController
       Rails.logger.info("Stripe Card Update Success - #{current_user.username}")
       flash[:settings_notice] = "Your billing information has been updated"
     else
-      DatadogStatsClient.increment("stripe.errors.update_subscription")
+      DatadogStatsClient.increment("stripe.errors", tags: ["event:update_subscription", "user_id:#{current_user.id}"])
 
       Rails.logger.error("Stripe Card Update Failure - #{current_user.username}")
       flash[:error] = "There was a problem updating your billing info."
@@ -42,7 +42,7 @@ class StripeActiveCardsController < ApplicationController
 
     redirect_to user_settings_path(:billing)
   rescue Payments::CardError, Payments::InvalidRequestError => e
-    DatadogStatsClient.increment("stripe.errors.update_subscription")
+    DatadogStatsClient.increment("stripe.errors", tags: ["event:update_subscription", "user_id:#{current_user.id}"])
 
     redirect_to user_settings_path(:billing), flash: { error: e.message }
   end

--- a/app/controllers/stripe_active_cards_controller.rb
+++ b/app/controllers/stripe_active_cards_controller.rb
@@ -11,7 +11,7 @@ class StripeActiveCardsController < ApplicationController
       Rails.logger.info("Stripe Add New Card Success - #{current_user.username}")
       flash[:settings_notice] = "Your billing information has been updated"
     else
-      DatadogStatsClient.increment("stripe.errors")
+      DataDogStatsClient.increment("stripe.errors.new_subscription")
 
       Rails.logger.error("Stripe Add New Card Failure - #{current_user.username}")
       flash[:error] = "There was a problem updating your billing info."
@@ -34,7 +34,7 @@ class StripeActiveCardsController < ApplicationController
       Rails.logger.info("Stripe Card Update Success - #{current_user.username}")
       flash[:settings_notice] = "Your billing information has been updated"
     else
-      DatadogStatsClient.increment("stripe.errors")
+      DataDogStatsClient.increment("stripe.errors.update_subscription")
 
       Rails.logger.error("Stripe Card Update Failure - #{current_user.username}")
       flash[:error] = "There was a problem updating your billing info."

--- a/app/controllers/stripe_active_cards_controller.rb
+++ b/app/controllers/stripe_active_cards_controller.rb
@@ -11,14 +11,14 @@ class StripeActiveCardsController < ApplicationController
       Rails.logger.info("Stripe Add New Card Success - #{current_user.username}")
       flash[:settings_notice] = "Your billing information has been updated"
     else
-      DatadogStatsClient.increment("stripe.errors", tags: ["event:new_subscription", "user_id:#{current_user.id}"])
+      DatadogStatsClient.increment("stripe.errors", tags: ["action:create", "user_id:#{current_user.id}"])
 
       Rails.logger.error("Stripe Add New Card Failure - #{current_user.username}")
       flash[:error] = "There was a problem updating your billing info."
     end
     redirect_to user_settings_path(:billing)
   rescue Payments::CardError, Payments::InvalidRequestError => e
-    DatadogStatsClient.increment("stripe.errors", tags: ["event:new_subscription", "user_id:#{current_user.id}"])
+    DatadogStatsClient.increment("stripe.errors", tags: ["action:create", "user_id:#{current_user.id}"])
     redirect_to user_settings_path(:billing), flash: { error: e.message }
   end
 
@@ -34,7 +34,7 @@ class StripeActiveCardsController < ApplicationController
       Rails.logger.info("Stripe Card Update Success - #{current_user.username}")
       flash[:settings_notice] = "Your billing information has been updated"
     else
-      DatadogStatsClient.increment("stripe.errors", tags: ["event:update_subscription", "user_id:#{current_user.id}"])
+      DatadogStatsClient.increment("stripe.errors", tags: ["action:update", "user_id:#{current_user.id}"])
 
       Rails.logger.error("Stripe Card Update Failure - #{current_user.username}")
       flash[:error] = "There was a problem updating your billing info."
@@ -42,7 +42,7 @@ class StripeActiveCardsController < ApplicationController
 
     redirect_to user_settings_path(:billing)
   rescue Payments::CardError, Payments::InvalidRequestError => e
-    DatadogStatsClient.increment("stripe.errors", tags: ["event:update_subscription", "user_id:#{current_user.id}"])
+    DatadogStatsClient.increment("stripe.errors", tags: ["action:update", "user_id:#{current_user.id}"])
 
     redirect_to user_settings_path(:billing), flash: { error: e.message }
   end

--- a/app/controllers/stripe_active_cards_controller.rb
+++ b/app/controllers/stripe_active_cards_controller.rb
@@ -11,14 +11,14 @@ class StripeActiveCardsController < ApplicationController
       Rails.logger.info("Stripe Add New Card Success - #{current_user.username}")
       flash[:settings_notice] = "Your billing information has been updated"
     else
-      DatadogStatsClient.increment("stripe.errors", tags: ["action:create", "user_id:#{current_user.id}"])
+      DatadogStatsClient.increment("stripe.errors", tags: ["action:create_card", "user_id:#{current_user.id}"])
 
       Rails.logger.error("Stripe Add New Card Failure - #{current_user.username}")
       flash[:error] = "There was a problem updating your billing info."
     end
     redirect_to user_settings_path(:billing)
   rescue Payments::CardError, Payments::InvalidRequestError => e
-    DatadogStatsClient.increment("stripe.errors", tags: ["action:create", "user_id:#{current_user.id}"])
+    DatadogStatsClient.increment("stripe.errors", tags: ["action:create_card", "user_id:#{current_user.id}"])
     redirect_to user_settings_path(:billing), flash: { error: e.message }
   end
 
@@ -34,7 +34,7 @@ class StripeActiveCardsController < ApplicationController
       Rails.logger.info("Stripe Card Update Success - #{current_user.username}")
       flash[:settings_notice] = "Your billing information has been updated"
     else
-      DatadogStatsClient.increment("stripe.errors", tags: ["action:update", "user_id:#{current_user.id}"])
+      DatadogStatsClient.increment("stripe.errors", tags: ["action:update_card", "user_id:#{current_user.id}"])
 
       Rails.logger.error("Stripe Card Update Failure - #{current_user.username}")
       flash[:error] = "There was a problem updating your billing info."
@@ -42,7 +42,7 @@ class StripeActiveCardsController < ApplicationController
 
     redirect_to user_settings_path(:billing)
   rescue Payments::CardError, Payments::InvalidRequestError => e
-    DatadogStatsClient.increment("stripe.errors", tags: ["action:update", "user_id:#{current_user.id}"])
+    DatadogStatsClient.increment("stripe.errors", tags: ["action:update_card", "user_id:#{current_user.id}"])
 
     redirect_to user_settings_path(:billing), flash: { error: e.message }
   end

--- a/app/controllers/stripe_active_cards_controller.rb
+++ b/app/controllers/stripe_active_cards_controller.rb
@@ -11,14 +11,14 @@ class StripeActiveCardsController < ApplicationController
       Rails.logger.info("Stripe Add New Card Success - #{current_user.username}")
       flash[:settings_notice] = "Your billing information has been updated"
     else
-      DataDogStatsClient.increment("stripe.errors.new_subscription")
+      DatadogStatsClient.increment("stripe.errors.new_subscription")
 
       Rails.logger.error("Stripe Add New Card Failure - #{current_user.username}")
       flash[:error] = "There was a problem updating your billing info."
     end
     redirect_to user_settings_path(:billing)
   rescue Payments::CardError, Payments::InvalidRequestError => e
-    DataDogStatsClient.increment("stripe.errors.new_subscription")
+    DatadogStatsClient.increment("stripe.errors.new_subscription")
     redirect_to user_settings_path(:billing), flash: { error: e.message }
   end
 
@@ -34,7 +34,7 @@ class StripeActiveCardsController < ApplicationController
       Rails.logger.info("Stripe Card Update Success - #{current_user.username}")
       flash[:settings_notice] = "Your billing information has been updated"
     else
-      DataDogStatsClient.increment("stripe.errors.update_subscription")
+      DatadogStatsClient.increment("stripe.errors.update_subscription")
 
       Rails.logger.error("Stripe Card Update Failure - #{current_user.username}")
       flash[:error] = "There was a problem updating your billing info."
@@ -42,7 +42,7 @@ class StripeActiveCardsController < ApplicationController
 
     redirect_to user_settings_path(:billing)
   rescue Payments::CardError, Payments::InvalidRequestError => e
-    DataDogStatsClient.increment("stripe.errors.update_subscription")
+    DatadogStatsClient.increment("stripe.errors.update_subscription")
 
     redirect_to user_settings_path(:billing), flash: { error: e.message }
   end

--- a/app/controllers/stripe_active_cards_controller.rb
+++ b/app/controllers/stripe_active_cards_controller.rb
@@ -16,11 +16,9 @@ class StripeActiveCardsController < ApplicationController
       Rails.logger.error("Stripe Add New Card Failure - #{current_user.username}")
       flash[:error] = "There was a problem updating your billing info."
     end
-
     redirect_to user_settings_path(:billing)
   rescue Payments::CardError, Payments::InvalidRequestError => e
-    DatadogStatsClient.increment("stripe.errors")
-
+    DataDogStatsClient.increment("stripe.errors.new_subscription")
     redirect_to user_settings_path(:billing), flash: { error: e.message }
   end
 
@@ -44,7 +42,7 @@ class StripeActiveCardsController < ApplicationController
 
     redirect_to user_settings_path(:billing)
   rescue Payments::CardError, Payments::InvalidRequestError => e
-    DatadogStatsClient.increment("stripe.errors")
+    DataDogStatsClient.increment("stripe.errors.update_subscription")
 
     redirect_to user_settings_path(:billing), flash: { error: e.message }
   end

--- a/app/labor/cache_buster.rb
+++ b/app/labor/cache_buster.rb
@@ -15,6 +15,7 @@ module CacheBuster
                   headers: { "Fastly-Key" => ApplicationConfig["FASTLY_API_KEY"] })
   rescue URI::InvalidURIError => e
     Rails.logger.error("Trying to bust cache of an invalid uri: #{e}")
+    DataDogStatsClient.increment("cache_buster.invalid_uri")
   end
 
   def self.bust_comment(commentable)

--- a/app/labor/cache_buster.rb
+++ b/app/labor/cache_buster.rb
@@ -15,7 +15,7 @@ module CacheBuster
                   headers: { "Fastly-Key" => ApplicationConfig["FASTLY_API_KEY"] })
   rescue URI::InvalidURIError => e
     Rails.logger.error("Trying to bust cache of an invalid uri: #{e}")
-    DataDogStatsClient.increment("cache_buster.invalid_uri")
+    DatadogStatsClient.increment("cache_buster.invalid_uri")
   end
 
   def self.bust_comment(commentable)

--- a/app/labor/cache_buster.rb
+++ b/app/labor/cache_buster.rb
@@ -15,7 +15,7 @@ module CacheBuster
                   headers: { "Fastly-Key" => ApplicationConfig["FASTLY_API_KEY"] })
   rescue URI::InvalidURIError => e
     Rails.logger.error("Trying to bust cache of an invalid uri: #{e}")
-    DatadogStatsClient.increment("cache_buster.invalid_uri")
+    DatadogStatsClient.increment("cache_buster.invalid_uri", tags: ["path:#{path}"])
   end
 
   def self.bust_comment(commentable)

--- a/app/services/payments/customer.rb
+++ b/app/services/payments/customer.rb
@@ -65,14 +65,14 @@ module Payments
       def request
         yield
       rescue Stripe::InvalidRequestError => e
-        DataDogStatsClient.increment("stripe.errors")
+        DatadogStatsClient.increment("stripe.errors")
         raise InvalidRequestError, e.message
       rescue Stripe::CardError => e
-        DataDogStatsClient.increment("stripe.errors")
+        DatadogStatsClient.increment("stripe.errors")
         raise CardError, e.message
       rescue Stripe::StripeError => e
         Rails.logger.error(e)
-        DataDogStatsClient.increment("stripe.errors")
+        DatadogStatsClient.increment("stripe.errors")
         raise PaymentsError, e.message
       end
     end

--- a/app/services/payments/customer.rb
+++ b/app/services/payments/customer.rb
@@ -65,14 +65,14 @@ module Payments
       def request
         yield
       rescue Stripe::InvalidRequestError => e
-        DatadogStatsClient.increment("stripe.errors")
+        DatadogStatsClient.increment("stripe.errors", tags: ["error:InvalidRequestError"])
         raise InvalidRequestError, e.message
       rescue Stripe::CardError => e
-        DatadogStatsClient.increment("stripe.errors")
+        DatadogStatsClient.increment("stripe.errors", tags: ["error:CardError"])
         raise CardError, e.message
       rescue Stripe::StripeError => e
         Rails.logger.error(e)
-        DatadogStatsClient.increment("stripe.errors")
+        DatadogStatsClient.increment("stripe.errors", tags: ["error:StripeError"])
         raise PaymentsError, e.message
       end
     end

--- a/app/services/payments/customer.rb
+++ b/app/services/payments/customer.rb
@@ -65,11 +65,14 @@ module Payments
       def request
         yield
       rescue Stripe::InvalidRequestError => e
+        DataDogStatsClient.increment("stripe.errors")
         raise InvalidRequestError, e.message
       rescue Stripe::CardError => e
+        DataDogStatsClient.increment("stripe.errors")
         raise CardError, e.message
       rescue Stripe::StripeError => e
         Rails.logger.error(e)
+        DataDogStatsClient.increment("stripe.errors")
         raise PaymentsError, e.message
       end
     end

--- a/spec/requests/stripe_active_cards_spec.rb
+++ b/spec/requests/stripe_active_cards_spec.rb
@@ -64,6 +64,14 @@ RSpec.describe "StripeActiveCards", type: :request do
 
       expect(user.reload.updated_at.to_i > old_updated_at.to_i).to be(true)
     end
+
+    it "increments sidekiq.errors.new_subscription in Datadog on failure" do
+      allow(DataDogStatsClient).to receive(:increment)
+      invalid_error = Stripe::InvalidRequestError.new(nil, nil)
+      allow(Stripe::Customer).to receive(:create).and_raise(invalid_error)
+      post "/stripe_active_cards", params: { stripe_token: stripe_helper.generate_card_token }
+      expect(DataDogStatsClient).to have_received(:increment).with("stripe.errors.new_subscription")
+    end
   end
 
   describe "PUT /stripe_active_cards/:card_id" do
@@ -116,6 +124,17 @@ RSpec.describe "StripeActiveCards", type: :request do
       end
 
       expect(user.reload.updated_at.to_i > old_updated_at.to_i).to be(true)
+    end
+
+    it "increments sidekiq.errors.update_subscription in Datadog on failure" do
+      valid_instance(user)
+      customer = Stripe::Customer.retrieve(user.stripe_id_code)
+      original_card_id = customer.sources.all(object: "card").first.id
+      allow(DataDogStatsClient).to receive(:increment)
+      card_error = Stripe::CardError.new(nil, nil, nil)
+      allow(Stripe::Customer).to receive(:retrieve).and_raise(card_error)
+      put "/stripe_active_cards/#{original_card_id}", params: {}
+      expect(DataDogStatsClient).to have_received(:increment).with("stripe.errors.update_subscription")
     end
   end
 

--- a/spec/requests/stripe_active_cards_spec.rb
+++ b/spec/requests/stripe_active_cards_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "StripeActiveCards", type: :request do
       allow(Stripe::Customer).to receive(:create).and_raise(invalid_error)
       post "/stripe_active_cards", params: { stripe_token: stripe_helper.generate_card_token }
 
-      tags = hash_including(tags: array_including("action:create", "user_id:#{user.id}"))
+      tags = hash_including(tags: array_including("action:create_card", "user_id:#{user.id}"))
       expect(DatadogStatsClient).to have_received(:increment).with("stripe.errors", tags)
     end
   end
@@ -141,7 +141,7 @@ RSpec.describe "StripeActiveCards", type: :request do
       put stripe_active_card_path(id: original_card_id)
       expect(response).to redirect_to(user_settings_path(:billing))
       expect(flash[:error]).to eq(card_error.message)
-      tags = hash_including(tags: array_including("action:update", "user_id:#{user.id}"))
+      tags = hash_including(tags: array_including("action:update_card", "user_id:#{user.id}"))
       expect(DatadogStatsClient).to have_received(:increment).with("stripe.errors", tags)
     end
   end

--- a/spec/requests/stripe_active_cards_spec.rb
+++ b/spec/requests/stripe_active_cards_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "StripeActiveCards", type: :request do
       allow(Stripe::Customer).to receive(:create).and_raise(invalid_error)
       post "/stripe_active_cards", params: { stripe_token: stripe_helper.generate_card_token }
 
-      tags = hash_including(tags: array_including("action:crate", "user_id:#{user.id}"))
+      tags = hash_including(tags: array_including("action:create", "user_id:#{user.id}"))
       expect(DatadogStatsClient).to have_received(:increment).with("stripe.errors", tags)
     end
   end

--- a/spec/requests/stripe_active_cards_spec.rb
+++ b/spec/requests/stripe_active_cards_spec.rb
@@ -66,11 +66,11 @@ RSpec.describe "StripeActiveCards", type: :request do
     end
 
     it "increments sidekiq.errors.new_subscription in Datadog on failure" do
-      allow(DataDogStatsClient).to receive(:increment)
+      allow(DatadogStatsClient).to receive(:increment)
       invalid_error = Stripe::InvalidRequestError.new(nil, nil)
       allow(Stripe::Customer).to receive(:create).and_raise(invalid_error)
       post "/stripe_active_cards", params: { stripe_token: stripe_helper.generate_card_token }
-      expect(DataDogStatsClient).to have_received(:increment).with("stripe.errors.new_subscription")
+      expect(DatadogStatsClient).to have_received(:increment).with("stripe.errors.new_subscription")
     end
   end
 
@@ -130,11 +130,11 @@ RSpec.describe "StripeActiveCards", type: :request do
       valid_instance(user)
       customer = Stripe::Customer.retrieve(user.stripe_id_code)
       original_card_id = customer.sources.all(object: "card").first.id
-      allow(DataDogStatsClient).to receive(:increment)
+      allow(DatadogStatsClient).to receive(:increment)
       card_error = Stripe::CardError.new(nil, nil, nil)
       allow(Stripe::Customer).to receive(:retrieve).and_raise(card_error)
       put "/stripe_active_cards/#{original_card_id}", params: {}
-      expect(DataDogStatsClient).to have_received(:increment).with("stripe.errors.update_subscription")
+      expect(DatadogStatsClient).to have_received(:increment).with("stripe.errors.update_subscription")
     end
   end
 

--- a/spec/requests/stripe_active_cards_spec.rb
+++ b/spec/requests/stripe_active_cards_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "StripeActiveCards", type: :request do
       allow(Stripe::Customer).to receive(:create).and_raise(invalid_error)
       post "/stripe_active_cards", params: { stripe_token: stripe_helper.generate_card_token }
 
-      tags = hash_including(tags: array_including("event:new_subscription", "user_id:#{user.id}"))
+      tags = hash_including(tags: array_including("action:crate", "user_id:#{user.id}"))
       expect(DatadogStatsClient).to have_received(:increment).with("stripe.errors", tags)
     end
   end
@@ -141,7 +141,7 @@ RSpec.describe "StripeActiveCards", type: :request do
       put stripe_active_card_path(id: original_card_id)
       expect(response).to redirect_to(user_settings_path(:billing))
       expect(flash[:error]).to eq(card_error.message)
-      tags = hash_including(tags: array_including("event:update_subscription", "user_id:#{user.id}"))
+      tags = hash_including(tags: array_including("action:update", "user_id:#{user.id}"))
       expect(DatadogStatsClient).to have_received(:increment).with("stripe.errors", tags)
     end
   end

--- a/spec/services/payments/customer_spec.rb
+++ b/spec/services/payments/customer_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe Payments::Customer, type: :service do
       allow(DatadogStatsClient).to receive(:increment)
 
       expect { described_class.get("foobar") }.to raise_error(Payments::InvalidRequestError)
-      expect(DatadogStatsClient).to have_received(:increment).with("stripe.errors")
+      tags = hash_including(tags: array_including("error:InvalidRequestError"))
+      expect(DatadogStatsClient).to have_received(:increment).with("stripe.errors", tags)
     end
 
     it "raises Payments::PaymentsError for any other known error" do
@@ -37,7 +38,8 @@ RSpec.describe Payments::Customer, type: :service do
       allow(Stripe::Customer).to receive(:retrieve).with("foobar").and_raise(Stripe::StripeError)
 
       expect { described_class.get("foobar") }.to raise_error(Payments::PaymentsError)
-      expect(DatadogStatsClient).to have_received(:increment).with("stripe.errors")
+      tags = hash_including(tags: array_including("error:StripeError"))
+      expect(DatadogStatsClient).to have_received(:increment).with("stripe.errors", tags)
     end
   end
 
@@ -77,7 +79,8 @@ RSpec.describe Payments::Customer, type: :service do
       allow(DatadogStatsClient).to receive(:increment)
 
       expect { described_class.create_source("customer_id", "token") }.to raise_error(Payments::InvalidRequestError)
-      expect(DatadogStatsClient).to have_received(:increment).with("stripe.errors")
+      tags = hash_including(tags: array_including("error:InvalidRequestError"))
+      expect(DatadogStatsClient).to have_received(:increment).with("stripe.errors", tags)
     end
 
     it "raises Payments::PaymentsError for any other known error" do
@@ -90,7 +93,8 @@ RSpec.describe Payments::Customer, type: :service do
       allow(DatadogStatsClient).to receive(:increment)
 
       expect { described_class.create_source("customer_id", "token") }.to raise_error(Payments::PaymentsError)
-      expect(DatadogStatsClient).to have_received(:increment).with("stripe.errors")
+      tags = hash_including(tags: array_including("error:StripeError"))
+      expect(DatadogStatsClient).to have_received(:increment).with("stripe.errors", tags)
     end
   end
 
@@ -171,7 +175,8 @@ RSpec.describe Payments::Customer, type: :service do
       expect do
         described_class.charge(customer: customer, amount: 1, description: "Test charge", card_id: card.id)
       end.to raise_error(Payments::CardError)
-      expect(DatadogStatsClient).to have_received(:increment).with("stripe.errors")
+      tags = hash_including(tags: array_including("error:CardError"))
+      expect(DatadogStatsClient).to have_received(:increment).with("stripe.errors", tags)
     end
   end
 end

--- a/spec/services/payments/customer_spec.rb
+++ b/spec/services/payments/customer_spec.rb
@@ -21,10 +21,10 @@ RSpec.describe Payments::Customer, type: :service do
     end
 
     it "increments stripe.errors if the customer does not exist" do
-      allow(DataDogStatsClient).to receive(:increment)
+      allow(DatadogStatsClient).to receive(:increment)
 
       expect { described_class.get("foobar") }.to raise_error(Payments::InvalidRequestError)
-      expect(DataDogStatsClient).to have_received(:increment).with("stripe.errors")
+      expect(DatadogStatsClient).to have_received(:increment).with("stripe.errors")
     end
 
     it "raises Payments::PaymentsError for any other known error" do
@@ -33,11 +33,11 @@ RSpec.describe Payments::Customer, type: :service do
     end
 
     it "increments stripe.errors for any other known error" do
-      allow(DataDogStatsClient).to receive(:increment)
+      allow(DatadogStatsClient).to receive(:increment)
       allow(Stripe::Customer).to receive(:retrieve).with("foobar").and_raise(Stripe::StripeError)
 
       expect { described_class.get("foobar") }.to raise_error(Payments::PaymentsError)
-      expect(DataDogStatsClient).to have_received(:increment).with("stripe.errors")
+      expect(DatadogStatsClient).to have_received(:increment).with("stripe.errors")
     end
   end
 
@@ -74,10 +74,10 @@ RSpec.describe Payments::Customer, type: :service do
     it "increments stripe.errors if anything in the params is invalid" do
       error = Stripe::InvalidRequestError.new("message", :token)
       allow(Stripe::Customer).to receive(:create_source).and_raise(error)
-      allow(DataDogStatsClient).to receive(:increment)
+      allow(DatadogStatsClient).to receive(:increment)
 
       expect { described_class.create_source("customer_id", "token") }.to raise_error(Payments::InvalidRequestError)
-      expect(DataDogStatsClient).to have_received(:increment).with("stripe.errors")
+      expect(DatadogStatsClient).to have_received(:increment).with("stripe.errors")
     end
 
     it "raises Payments::PaymentsError for any other known error" do
@@ -87,10 +87,10 @@ RSpec.describe Payments::Customer, type: :service do
 
     it "increments stripe.errors for any other known error" do
       allow(Stripe::Customer).to receive(:create_source).and_raise(Stripe::StripeError)
-      allow(DataDogStatsClient).to receive(:increment)
+      allow(DatadogStatsClient).to receive(:increment)
 
       expect { described_class.create_source("customer_id", "token") }.to raise_error(Payments::PaymentsError)
-      expect(DataDogStatsClient).to have_received(:increment).with("stripe.errors")
+      expect(DatadogStatsClient).to have_received(:increment).with("stripe.errors")
     end
   end
 
@@ -162,7 +162,7 @@ RSpec.describe Payments::Customer, type: :service do
 
     it "increments stripe.errors if the card has any troubles" do
       StripeMock.prepare_card_error(:expired_card)
-      allow(DataDogStatsClient).to receive(:increment)
+      allow(DatadogStatsClient).to receive(:increment)
 
       customer = Stripe::Customer.create
       token = stripe_helper.generate_card_token
@@ -171,7 +171,7 @@ RSpec.describe Payments::Customer, type: :service do
       expect do
         described_class.charge(customer: customer, amount: 1, description: "Test charge", card_id: card.id)
       end.to raise_error(Payments::CardError)
-      expect(DataDogStatsClient).to have_received(:increment).with("stripe.errors")
+      expect(DatadogStatsClient).to have_received(:increment).with("stripe.errors")
     end
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Feature

## Description
In an effort to move alerts setup on Timber to DataDog, this PR is adding some DataDog monitors that we can set up alerts for.

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/5#card-33313304

## Added tests?
- [x] yes

## Added to documentation?
- [x] no documentation needed

## Post-deployment instructions
We'll need to trigger these added errors manually in production after this is deployed so DataDog picks up on it and then I can create a monitor for it.

![heartbeat_monitor_gif](https://media.giphy.com/media/ZKw0NDn10ljSE/giphy.gif)
