### PR TITLE
Add cache_key helper

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -147,4 +147,8 @@ module ApplicationHelper
   def community_qualified_name
     "The #{ApplicationConfig['COMMUNITY_NAME']} Community"
   end
+
+  def cache_key(path)
+  "#{path}-#{ApplicationConfig['HEROKU_SLUG_COMMIT']}"
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -148,7 +148,10 @@ module ApplicationHelper
     "The #{ApplicationConfig['COMMUNITY_NAME']} Community"
   end
 
-  def cache_key(path)
-  "#{path}-#{ApplicationConfig['HEROKU_SLUG_COMMIT']}"
+  def cache_key_heroku_slug(path)
+    heroku_slug_commit = ApplicationConfig["HEROKU_SLUG_COMMIT"]
+    return path if heroku_slug_commit.blank?
+
+    "#{path}-#{heroku_slug_commit}"
   end
 end

--- a/app/views/articles/_sidebar_additional.html.erb
+++ b/app/views/articles/_sidebar_additional.html.erb
@@ -12,7 +12,7 @@
         </div>
       </div>
     <% end %>
-    <% cache(cache_key("main-article-right-sidebar-discussions-#{params[:timeframe]}"), expires_in: (params[:timeframe].blank? ? 120 : 360).seconds) do %>
+    <% cache(cache_key_heroku_slug("main-article-right-sidebar-discussions-#{params[:timeframe]}"), expires_in: (params[:timeframe].blank? ? 120 : 360).seconds) do %>
       <% @sidebar_ad = DisplayAd.for_display("sidebar_right") %>
       <% if @sidebar_ad %>
         <div class="widget">

--- a/app/views/articles/_sidebar_additional.html.erb
+++ b/app/views/articles/_sidebar_additional.html.erb
@@ -12,7 +12,7 @@
         </div>
       </div>
     <% end %>
-    <% cache("main-article-right-sidebar-discussions-#{params[:timeframe]}-#{ApplicationConfig['HEROKU_SLUG_COMMIT']}", expires_in: (params[:timeframe].blank? ? 120 : 360).seconds) do %>
+    <% cache(cache_key("main-article-right-sidebar-discussions-#{params[:timeframe]}"), expires_in: (params[:timeframe].blank? ? 120 : 360).seconds) do %>
       <% @sidebar_ad = DisplayAd.for_display("sidebar_right") %>
       <% if @sidebar_ad %>
         <div class="widget">

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -25,7 +25,7 @@
 <% end %>
 <%= javascript_pack_tag "homePage", defer: true %>
 
-<% cache("main-stories-index-#{params}-#{user_signed_in?}-#{ApplicationConfig['HEROKU_SLUG_COMMIT']}", expires_in: 90.seconds) do %>
+<% cache(cache_key("main-stories-index-#{params}-#{user_signed_in?}"), expires_in: 90.seconds) do %>
   <div class="home" id="index-container"
       data-params="<%= params.to_json(only: %i[tag username q]) %>" data-which="<%= @list_of %>"
       data-algolia-tag=""

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -25,7 +25,7 @@
 <% end %>
 <%= javascript_pack_tag "homePage", defer: true %>
 
-<% cache(cache_key("main-stories-index-#{params}-#{user_signed_in?}"), expires_in: 90.seconds) do %>
+<% cache(cache_key_heroku_slug("main-stories-index-#{params}-#{user_signed_in?}"), expires_in: 90.seconds) do %>
   <div class="home" id="index-container"
       data-params="<%= params.to_json(only: %i[tag username q]) %>" data-which="<%= @list_of %>"
       data-algolia-tag=""

--- a/app/views/stories/_main_stories_feed.html.erb
+++ b/app/views/stories/_main_stories_feed.html.erb
@@ -1,5 +1,5 @@
 <% if @default_home_feed && user_signed_in? %>
-  <% cache("fetched-home-articles-object-#{ApplicationConfig['HEROKU_SLUG_COMMIT']}", expires_in: 3.minutes) do %>
+  <% cache(cache_key("fetched-home-articles-object"), expires_in: 3.minutes) do %>
     <div id="followed-podcasts" data-episodes="<%= @podcast_episodes.to_json(include: { podcast: { only: %i[slug title id], methods: %i[image_90] } }) %>">
     </div>
     <div id="home-articles-object"

--- a/app/views/stories/_main_stories_feed.html.erb
+++ b/app/views/stories/_main_stories_feed.html.erb
@@ -1,5 +1,5 @@
 <% if @default_home_feed && user_signed_in? %>
-  <% cache(cache_key("fetched-home-articles-object"), expires_in: 3.minutes) do %>
+  <% cache(cache_key_heroku_slug("fetched-home-articles-object"), expires_in: 3.minutes) do %>
     <div id="followed-podcasts" data-episodes="<%= @podcast_episodes.to_json(include: { podcast: { only: %i[slug title id], methods: %i[image_90] } }) %>">
     </div>
     <div id="home-articles-object"

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -25,4 +25,16 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(helper.beautified_url("https://github.com/rails")).to eq("github.com/rails")
     end
   end
+
+  describe "#cache_key_heroku_slug" do
+    it "does nothing when HEROKU_SLUG_COMMIT is not set" do
+      allow(ApplicationConfig).to receive(:[]).with("HEROKU_SLUG_COMMIT").and_return(nil)
+      expect(helper.cache_key_heroku_slug("cache-me")).to eq("cache-me")
+    end
+
+    it "appends the HEROKU_SLUG_COMMIT if it is set" do
+      allow(ApplicationConfig).to receive(:[]).with("HEROKU_SLUG_COMMIT").and_return("abc123")
+      expect(helper.cache_key_heroku_slug("cache-me")).to eq("cache-me-abc123")
+    end
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

Adds a `cache_key` helper which appends `ApplicationConfig['HEROKU_SLUG_COMMIT']` to the provided key.

## Related Tickets & Documents

No ticket, but the result of a [PR discussion with Ben](https://github.com/thepracticaldev/dev.to/pull/6159/files#r381112382).

## Added tests?

- [X] yes

## Added to documentation?

- [X] no documentation needed
