### PR TITLE
Fix homepage campaign hero spec escaping

### DIFF
--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -76,27 +76,37 @@ RSpec.describe "StoriesIndex", type: :request do
     end
 
     context "with campaign hero" do
-      let!(:hero_html) do
-        create(:html_variant, group: "campaign", name: "hero", html: Faker::Book.title, published: true, approved: true)
+      let_it_be_readonly(:hero_html) do
+        create(
+          :html_variant,
+          group: "campaign",
+          name: "hero",
+          html: "<em>#{Faker::Book.title}'s</em>",
+          published: true,
+          approved: true,
+        )
       end
 
       it "displays hero html when it exists and is set in config" do
         SiteConfig.campaign_hero_html_variant_name = "hero"
-        get "/"
-        expect(response.body).to include(CGI.escapeHTML(hero_html.html))
+
+        get root_path
+        expect(response.body).to include(hero_html.html)
       end
 
       it "doesn't display when campaign_hero_html_variant_name is not set" do
         SiteConfig.campaign_hero_html_variant_name = ""
-        get "/"
-        expect(response.body).not_to include(CGI.escapeHTML(hero_html.html))
+
+        get root_path
+        expect(response.body).not_to include(hero_html.html)
       end
 
       it "doesn't display when hero html is not approved" do
         SiteConfig.campaign_hero_html_variant_name = "hero"
         hero_html.update_column(:approved, false)
-        get "/"
-        expect(response.body).not_to include(CGI.escapeHTML(hero_html.html))
+
+        get root_path
+        expect(response.body).not_to include(hero_html.html)
       end
     end
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Some specs randomly fail with:

```text
1) StoriesIndex GET stories index with campaign hero doesn't display when hero html is not approved

   Failure/Error: expect(response.body).not_to include(CGI.escapeHTML(hero_html.html))
     expected "<!DOCTYPE html>\n<html lang=\"en\">\n  <head>\n    <meta charset=\"utf-8\">\n    <title>DEV(local) C...6a5bca60a4ebf959a6df7f08217acd07ac2bc285164fae041eacb8a148b1bab9.svg\" />\n  </body>\n  </html>\n\n" not to include "A Monstrous Regiment of Women"
   # ./spec/requests/stories_index_spec.rb:99:in `block (4 levels) in <top (required)>'
   # ./spec/rails_helper.rb:101:in `block (3 levels) in <top (required)>'
   # ./spec/rails_helper.rb:101:in `block (2 levels) in <top (required)>'
```

this happens because when the text contains an escapable char, `CGI.escapeHTML` will change its value. 

The thing is, the hero HTML is not escaped, coming from a trusted source, thus the test itself shouldn't assume it is escaped.

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
