### PR TITLE
Skip moderation notification if the user is the moderator

### DIFF
--- a/app/services/notifications/moderation.rb
+++ b/app/services/notifications/moderation.rb
@@ -4,7 +4,9 @@ module Notifications
     SUPPORTED = [Comment].freeze
 
     def self.available_moderators
-      User.with_role(:trusted).where("last_moderation_notification < ?", MODERATORS_AVAILABILITY_DELAY.ago).where(mod_roundrobin_notifications: true)
+      User.with_role(:trusted).
+        where("last_moderation_notification < ?", MODERATORS_AVAILABILITY_DELAY.ago).
+        where(mod_roundrobin_notifications: true)
     end
   end
 end

--- a/app/services/notifications/moderation/send.rb
+++ b/app/services/notifications/moderation/send.rb
@@ -17,6 +17,9 @@ module Notifications
         # notifiable is currently only comment
         return unless notifiable_supported?(notifiable)
 
+        # do not create the notification if the comment was created by the moderator
+        return if moderator == notifiable.user
+
         json_data = { user: user_data(User.dev_account) }
         json_data[notifiable.class.name.downcase] = public_send "#{notifiable.class.name.downcase}_data", notifiable
         new_notification = Notification.create!(
@@ -35,7 +38,7 @@ module Notifications
       attr_reader :notifiable, :moderator
 
       def notifiable_supported?(notifiable)
-        SUPPORTED.include? notifiable.class
+        SUPPORTED.include?(notifiable.class)
       end
     end
   end

--- a/app/workers/notifications/moderation_notification_worker.rb
+++ b/app/workers/notifications/moderation_notification_worker.rb
@@ -13,6 +13,8 @@ module Notifications
       return unless notifiable
 
       random_moderators.each do |mod|
+        next if mod == notifiable.user
+
         Notifications::Moderation::Send.call(mod, notifiable)
       end
     end

--- a/spec/services/notifications/moderation/send_spec.rb
+++ b/spec/services/notifications/moderation/send_spec.rb
@@ -46,4 +46,12 @@ RSpec.describe Notifications::Moderation::Send, type: :service do
       described_class.call(moderator, comment)
     end.to change(moderator, :last_moderation_notification)
   end
+
+  it "does not create a notification if the moderator is the comment's author" do
+    comment = create(:comment, user: moderator, commentable: article)
+
+    expect do
+      described_class.call(moderator, comment)
+    end.to change(Notification, :count).by(0)
+  end
 end

--- a/spec/workers/notifications/moderation_notification_worker_spec.rb
+++ b/spec/workers/notifications/moderation_notification_worker_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Notifications::ModerationNotificationWorker do
       end
     end
 
-    describe "When moderator is the comment author" do
+    describe "when moderator is the comment author" do
       it "does not call the service" do
         comment = create(:comment, user: mod, commentable: create(:article))
         worker.perform(comment.id)

--- a/spec/workers/notifications/moderation_notification_worker_spec.rb
+++ b/spec/workers/notifications/moderation_notification_worker_spec.rb
@@ -1,18 +1,30 @@
 require "rails_helper"
 
 RSpec.describe Notifications::ModerationNotificationWorker do
-  describe "#perform" do
-    let(:id) { rand(1000) }
-    let(:comment) do
-      comment = double
-      allow(Comment).to receive(:find_by).and_return(comment)
-    end
-    let(:mod) do
-      last_moderation_time = Time.zone.now - Notifications::Moderation::MODERATORS_AVAILABILITY_DELAY - 2.hours
-      create(:user, :trusted, last_moderation_notification: last_moderation_time)
-    end
-    let(:worker) { subject }
+  let(:id) { rand(1000) }
+  let(:comment) do
+    comment = double
+    allow(Comment).to receive(:find_by).and_return(comment)
+    allow(comment).to receive(:user)
+    comment
+  end
+  let(:mod) do
+    last_moderation_time = Time.current - Notifications::Moderation::MODERATORS_AVAILABILITY_DELAY - 2.hours
+    create(:user, :trusted, last_moderation_notification: last_moderation_time)
+  end
+  let(:worker) { subject }
 
+  def check_received_call
+    worker.perform(id)
+    expect(Notifications::Moderation::Send).to have_received(:call)
+  end
+
+  def check_non_received_call
+    worker.perform(id)
+    expect(Notifications::Moderation::Send).not_to have_received(:call)
+  end
+
+  describe "#perform" do
     before do
       allow(Notifications::Moderation::Send).to receive(:call)
     end
@@ -45,14 +57,12 @@ RSpec.describe Notifications::ModerationNotificationWorker do
       end
     end
 
-    def check_received_call
-      worker.perform(id)
-      expect(Notifications::Moderation::Send).to have_received(:call)
-    end
-
-    def check_non_received_call
-      worker.perform(id)
-      expect(Notifications::Moderation::Send).not_to have_received(:call)
+    describe "When moderator is the comment author" do
+      it "does not call the service" do
+        comment = create(:comment, user: mod, commentable: create(:article))
+        worker.perform(comment.id)
+        expect(Notifications::Moderation::Send).not_to have_received(:call)
+      end
     end
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

While testing another PR I noticed how I got a moderation notification for a comment that I just left:

![Screenshot_2020-02-20 Notifications - DEV(local) Community 👩‍💻👨‍💻](https://user-images.githubusercontent.com/146201/74926199-cff06880-53d5-11ea-9038-2f77375de203.png)

The chances for this to appear in production are slim given that we manually select who's a moderator, though we should probably guard against this anyway

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
