### PR TITLE
Ignore User.organization_id

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  self.ignored_columns = ["organization_id"]
+
   include CloudinaryHelper
 
   attr_accessor(

--- a/spec/liquid_tags/classified_listing_tag_spec.rb
+++ b/spec/liquid_tags/classified_listing_tag_spec.rb
@@ -31,7 +31,11 @@ RSpec.describe ClassifiedListingTag, type: :liquid_tag do
     )
   end
   let(:org) { create(:organization) }
-  let(:org_user) { create(:user, organization_id: org.id) }
+  let(:org_user) do
+    user = create(:user)
+    create(:organization_membership, user: user, organization: org)
+    user
+  end
   let(:org_listing) do
     create(
       :classified_listing,

--- a/spec/liquid_tags/link_tag_spec.rb
+++ b/spec/liquid_tags/link_tag_spec.rb
@@ -6,7 +6,11 @@ RSpec.describe LinkTag, type: :liquid_tag do
     create(:article, user_id: user.id, title: "test this please", tags: "tag1 tag2 tag3")
   end
   let(:org) { create(:organization) }
-  let(:org_user) { create(:user, organization_id: org.id) }
+  let(:org_user) do
+    user = create(:user)
+    create(:organization_membership, user: user, organization: org)
+    user
+  end
   let(:org_article) do
     create(:article, user_id: org_user.id, title: "test this please", tags: "tag1 tag2 tag3",
                      organization_id: org.id)

--- a/spec/requests/api/v0/followers_spec.rb
+++ b/spec/requests/api/v0/followers_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Api::V0::FollowersController", type: :request do
 
     context "when user is authorized" do
       let(:orgs) { create_list(:organization, 2) }
-      let(:user) { create(:user, organization_id: orgs.first.id) }
+      let(:user) { create(:user) }
 
       before do
         orgs.each { |org| follower.follow(org) }

--- a/spec/requests/articles/articles_update_spec.rb
+++ b/spec/requests/articles/articles_update_spec.rb
@@ -4,7 +4,11 @@ RSpec.describe "ArticlesUpdate", type: :request do
   let(:organization) { create(:organization) }
   let(:organization2) { create(:organization) }
   let(:user) { create(:user, :org_admin) }
-  let(:user2) { create(:user, organization_id: organization2.id) }
+  let(:user2) do
+    user = create(:user)
+    create(:organization_membership, user: user, organization: organization2)
+    user
+  end
   let(:article) { create(:article, user_id: user.id) }
 
   before do
@@ -62,7 +66,7 @@ RSpec.describe "ArticlesUpdate", type: :request do
     put "/articles/#{article.id}", params: {
       article: { post_under_org: true }
     }
-    expect(article.reload.organization_id).to eq user2.organization_id
+    expect(article.reload.organization_id).to be_in(user2.organization_ids)
   end
 
   it "allows an org admin to assign an org article to another user" do

--- a/spec/support/api_analytics_shared_examples.rb
+++ b/spec/support/api_analytics_shared_examples.rb
@@ -58,7 +58,8 @@ RSpec.shared_examples "GET /api/analytics/:endpoint authorization examples" do |
 
   context "when attempting to view organization analytics and being a member of the organization" do
     before do
-      get "/api/analytics/#{endpoint}?organization_id=#{pro_org_member.organization_id}#{params}", headers: { "api-key" => org_member_token.secret }
+      path = "/api/analytics/#{endpoint}?organization_id=#{pro_org_member.organization_ids.first}#{params}"
+      get path, headers: { "api-key" => org_member_token.secret }
     end
 
     it "renders JSON as the content type" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

As we stopped using `User.organization_id` in #6079 and nothing broke, we can now do step 1 of 2 of removing the `organization_id` column.

Step 1 is to tell AR to ignore the column
Step 2 will be to actually remove it from the DB with:

```ruby
class RemoveUserOrganizationId < ActiveRecord::Migration[5.2]
  def change
    safety_assured { remove_column :users, :organization_id, :integer }
  end
end
```

Thanks to [strong-migrations](https://github.com/ankane/strong_migrations#removing-a-column) which helps in these cases :)
