### PR TITLE
Fix podcasts internal page

### DIFF
--- a/app/controllers/internal/podcasts_controller.rb
+++ b/app/controllers/internal/podcasts_controller.rb
@@ -5,8 +5,8 @@ class Internal::PodcastsController < Internal::ApplicationController
   before_action :find_user, only: %i[remove_admin add_admin]
 
   def index
-    @podcasts = Podcast.joins(:podcast_episodes).
-      select("podcasts.*, count(podcast_episodes) as count").
+    @podcasts = Podcast.left_outer_joins(:podcast_episodes).
+      select("podcasts.*, count(podcast_episodes) as episodes_count").
       group("podcasts.id").order("podcasts.created_at DESC").
       page(params[:page]).per(50)
     @podcasts = @podcasts.where("podcasts.title ILIKE :search", search: "%#{params[:search]}%") if params[:search].present?

--- a/app/views/internal/podcasts/index.html.erb
+++ b/app/views/internal/podcasts/index.html.erb
@@ -32,7 +32,7 @@
       <td><%= podcast.id %></td>
       <td><%= link_to podcast.title, edit_internal_podcast_path(podcast) %></td>
       <td><%= link_to podcast.feed_url, podcast.feed_url %></td>
-      <td><%= podcast.podcast_episode.size %></td>
+      <td><%= podcast.episodes_count %></td>
       <td><%= podcast.reachable %></td>
       <td><%= podcast.published %></td>
       <td><%= podcast.status_notice %></td>

--- a/spec/requests/internal/podcasts_spec.rb
+++ b/spec/requests/internal/podcasts_spec.rb
@@ -10,14 +10,22 @@ RSpec.describe "/internal/podcasts", type: :request do
   end
 
   describe "GET /internal/podcasts" do
+    let!(:no_eps_podcast) { create(:podcast, title: Faker::Book.title) }
+
     before do
-      create_list(:podcast, 3)
+      create(:podcast_episode, podcast: podcast)
       user.add_role(:podcast_admin, Podcast.order(Arel.sql("RANDOM()")).first)
     end
 
     it "renders success" do
       get internal_podcasts_path
       expect(response).to be_successful
+    end
+
+    it "displays podcasts with and without episodes" do
+      get internal_podcasts_path
+      expect(response.body).to include(CGI.escapeHTML(no_eps_podcast.title))
+      expect(response.body).to include(CGI.escapeHTML(podcast.title))
     end
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
I found out that the `/internal/podcasts` page was broken because of referring to `podcast.podcast_episode.size` instead of `podcast.podcast_episodes.size`, and the test was not failing because we were selecting only podcasts with episodes for the internal.
So, in this pr I:
- fixed the `/internal/podcasts` page by referring to `podcast.episodes_count` because the episodes count was already selected in the controller
- replaced `join` with `left_outer_join` so that the page would display podcasts without episodes