### PR TITLE
Disable service worker on social previews

### DIFF
--- a/app/views/service_worker/index.js.erb
+++ b/app/views/service_worker/index.js.erb
@@ -89,24 +89,28 @@
       if (event.clientId === "" && // Not fetched via AJAX after page load.
         event.request.method == "GET" && // Don't fetch on POST, DELETE, etc.
         !event.request.referrer.includes('/signout_confirm') && // If this is the referrer, we instead want to flush.
+
         !url.href.includes('i=i') && // Parameter representing "internal" navigation.
-        !url.href.includes('?signin') && // Don't run on sign in.
-        !url.href.includes('.js') && // Don't run on JS.
         !url.href.includes('.css') && // Don't run on CSS.
-        !url.href.includes('/onboarding') && // Don't run on onboarding.
-        !url.href.includes('/api/') && // Don't run on API endpoints.
-        !url.href.includes('/users/auth') && // Don't run on authentication.
-        !url.href.includes('/shell_') && // Don't fetch for shell.
-        !url.href.includes('/embed/') && // Don't fetch for embeded content.
-        !url.href.includes('/admin') && // Don't fetch for administrate dashboard.
-        !url.href.includes('/internal') && // Don't fetch for internal dashboard.
-        !url.href.includes('/future') && // Skip for /future.
+        !url.href.includes('.js') && // Don't run on JS.
         !url.href.includes('?preview=') && // Skip for preview pages.
-        !url.href.includes('/sidekiq') && // Skip for Sidekiq dashboard
-        !url.href.includes('/oauth/') && // Skip oauth apps
-        !url.href.includes('/robots.txt') && // Skip robots for web crawlers
-        !url.href.includes('/rails/mailers') && // Skip for mailers previews in development mode
+        !url.href.includes('?signin') && // Don't run on sign in.
+
+        !url.href.includes('/admin') && // Don't fetch for administrate dashboard.
+        !url.href.includes('/api/') && // Don't run on API endpoints.
+        !url.href.includes('/embed/') && // Don't fetch for embeded content.
         !url.href.includes('/feed') && // Skip the RSS feed
+        !url.href.includes('/future') && // Skip for /future.
+        !url.href.includes('/internal') && // Don't fetch for internal dashboard.
+        !url.href.includes('/oauth/') && // Skip oauth apps
+        !url.href.includes('/onboarding') && // Don't run on onboarding.
+        !url.href.includes('/rails/mailers') && // Skip for mailers previews in development mode
+        !url.href.includes('/robots.txt') && // Skip robots for web crawlers
+        !url.href.includes('/shell_') && // Don't fetch for shell.
+        !url.href.includes('/sidekiq') && // Skip for Sidekiq dashboard
+        !url.href.includes('/social_previews') && // Skip for social previews
+        !url.href.includes('/users/auth') && // Don't run on authentication.
+
         caches.match('/shell_top') && // Ensure shell_top is in the cache.
         caches.match('/shell_bottom')) { // Ensure shell_bottom is in the cache.
         event.respondWith(createPageStream(event.request)); // Respond with the stream


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Now the service worker intercepts social previews:

![Screenshot 2020-02-20 at 3 37 25 PM](https://user-images.githubusercontent.com/146201/74944850-f4107180-53f6-11ea-9fa2-cbfac718699e.png)

It shouldn't :D 

