### PR TITLE
Ensure seeds.rb does not fail validation

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -33,7 +33,7 @@ User.clear_index!
 roles = %i[trusted chatroom_beta_tester workshop_pass]
 
 num_users.times do |i|
-  name = "#{Faker::Name.name} #{Faker::Lorem.word.titleize}"
+  name = "#{Faker::Name.name} #{Faker::Lorem.word.titleize}"[0..29]
 
   user = User.create!(
     name: name,
@@ -43,7 +43,7 @@ num_users.times do |i|
     twitter_username: Faker::Internet.username(specifier: name),
     email_comment_notifications: false,
     email_follower_notifications: false,
-    email: Faker::Internet.email(name: name, separators: "+"),
+    email: Faker::Internet.email(name: name, separators: "+")[-49..-1], # Emails limited to 50 characters
     confirmed_at: Time.current,
     password: "password",
   )

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -43,7 +43,7 @@ num_users.times do |i|
     twitter_username: Faker::Internet.username(specifier: name),
     email_comment_notifications: false,
     email_follower_notifications: false,
-    email: Faker::Internet.email(name: name, separators: "+")[-49..-1], # Emails limited to 50 characters
+    email: Faker::Internet.email(name: name, separators: "+", domain: Faker::Internet.domain_word.first(20)), # Emails limited to 50 characters
     confirmed_at: Time.current,
     password: "password",
   )

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -33,7 +33,7 @@ User.clear_index!
 roles = %i[trusted chatroom_beta_tester workshop_pass]
 
 num_users.times do |i|
-  name = "#{Faker::Name.name} #{Faker::Lorem.word.titleize}"[0..29]
+  name = Faker::Name.unique.name
 
   user = User.create!(
     name: name,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Currently, we have limitations on usernames to be 30 characters and emails to be 50 characters.

However, we rely on the Faker gem to generate mock data in our `seeds.rb`, which can at times produce larger values and fail the build.

This commit ensures username and email length do not fail on generation.

(To test this yourself, you can run on a clean database `SEEDS_MULTIPLIER=10 rails db:setup` and see it break before finishing)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/13p77tfexyLtx6/giphy.gif)
