### PR TITLE
Add JS confirm to confirmation of user vomits

### DIFF
--- a/app/views/internal/feedback_messages/index.html.erb
+++ b/app/views/internal/feedback_messages/index.html.erb
@@ -91,9 +91,16 @@
             </span>
             <span>
               <% if params[:status] == "Open" || params[:status].blank? %>
-                <%= form_for [:internal, reaction], html: { class: "d-inline" } do |f| %>
-                  <%= f.hidden_field :status, value: "confirmed" %>
-                  <%= f.submit "CONFIRMED", class: "btn btn-success btn-sm" %>
+                <% if reaction.reactable_type == "User" %>
+                  <%= form_for [:internal, reaction], html: { class: "d-inline" } do |f| %>
+                    <%= f.hidden_field :status, value: "confirmed" %>
+                    <%= f.submit "CONFIRMED", class: "btn btn-success btn-sm", data: { confirm: "Are you sure?" } %>
+                  <% end %>
+                <% else %>
+                  <%= form_for [:internal, reaction], html: { class: "d-inline" } do |f| %>
+                    <%= f.hidden_field :status, value: "confirmed" %>
+                    <%= f.submit "CONFIRMED", class: "btn btn-success btn-sm" %>
+                  <% end %>
                 <% end %>
                 <%= form_for [:internal, reaction], html: { class: "d-inline" } do |f| %>
                   <%= f.hidden_field :status, value: "invalid" %>
@@ -117,14 +124,12 @@
   <%= f.label :reporter_username_cont, "Reporter", class: "sr-only" %>
   <%= f.search_field :reporter_username_cont, placeholder: "Reporter", class: "form-control mx-3" %>
 
-  <%= f.select :status_eq,
-    options_for_select([
-      ["Open"],
-      ["Invalid"],
-      ["Resolved"],
-    ], @q.status_eq),
-    {},
-    class: "custom-select mx-3" %>
+  <%= f.select(
+        :status_eq,
+        options_for_select([["Open"], ["Invalid"], ["Resolved"]], @q.status_eq),
+        {},
+        class: "custom-select mx-3",
+      ) %>
 
   <%= f.submit "Search", class: "btn btn-secondary" %>
 <% end %>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Because confirming a User vomit is a particularly destructive task, we
want to make it a bit more intentional. Ben recommended adding a confirm
dialog for these reports.

This commit also satisfies erblint's complaints regarding the select
element in the ransack search form.

## Related Tickets & Documents

Ben mentioned this in Slack.
![Screenshot from 2020-02-20 09-56-58](https://user-images.githubusercontent.com/11466782/74953533-5fdae600-53c7-11ea-81ee-440a5e0d6aa8.png)

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![external-content duckduckgo com](https://user-images.githubusercontent.com/11466782/74953623-7e40e180-53c7-11ea-820c-2d1410f6ee04.gif)
