### PR TITLE
Add base element to open embed links in parent context

### DIFF
--- a/app/views/liquid_embeds/show.html.erb
+++ b/app/views/liquid_embeds/show.html.erb
@@ -1,3 +1,4 @@
+<base target="_parent">
 <% cache "liquid_tag_styles_#{ApplicationConfig['HEROKU_SLUG_COMMIT']}", expires_in: 8.hours do #TODO: Render specific ltag class instead of everything %>
   <style><%= Rails.application.assets["ltags/LiquidTags.scss"].to_s.html_safe %></style>
 <% end %>

--- a/spec/requests/liquid_embeds_spec.rb
+++ b/spec/requests/liquid_embeds_spec.rb
@@ -17,5 +17,10 @@ RSpec.describe "LiquidEmbeds", type: :request, vcr: vcr_option do
         get "/embed/tweet?args=improper"
       end.to raise_error(ActionView::Template::Error)
     end
+
+    it "contains base target parent" do
+      get "/embed/tweet?args=1018911886862057472"
+      expect(response.body).to include('<base target="_parent">')
+    end
   end
 end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Embeds should open in parent context instead of the iframe itself for expected behavior.

This is accomplished by adding `<base target="_parent">` to the page.