### PR TITLE
Add Worker and callback For Removing Elasticsearch docs

### DIFF
--- a/app/models/chat_channel_membership.rb
+++ b/app/models/chat_channel_membership.rb
@@ -15,7 +15,8 @@ class ChatChannelMembership < ApplicationRecord
   validates :role, inclusion: { in: %w[member mod] }
   validate  :permission
 
-  after_commit :index_to_elasticsearch
+  after_commit :index_to_elasticsearch, on: %i[create update]
+  after_commit :remove_from_elasticsearch, on: [:destroy]
 
   algoliasearch index_name: "SecuredChatChannelMembership_#{Rails.env}", auto_index: false do
     attribute :id, :status, :viewable_by, :chat_channel_id, :last_opened_at,

--- a/app/models/classified_listing.rb
+++ b/app/models/classified_listing.rb
@@ -27,7 +27,8 @@ class ClassifiedListing < ApplicationRecord
   before_save :evaluate_markdown
   before_create :create_slug
   before_validation :modify_inputs
-  after_commit :index_to_elasticsearch
+  after_commit :index_to_elasticsearch, on: %i[create update]
+  after_commit :remove_from_elasticsearch, on: [:destroy]
   acts_as_taggable_on :tags
   has_many :credits, as: :purchase, inverse_of: :purchase, dependent: :nullify
 

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -7,6 +7,10 @@ module Searchable
     self.class::SEARCH_CLASS.index(id, serialized_search_hash)
   end
 
+  def remove_from_elasticsearch
+    Search::RemoveFromElasticsearchIndexWorker.perform_async(self.class::SEARCH_CLASS.to_s, id)
+  end
+
   def serialized_search_hash
     self.class::SEARCH_SERIALIZER.new(self).serializable_hash.dig(:data, :attributes)
   end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -25,7 +25,9 @@ class Tag < ActsAsTaggableOn::Tag
   before_validation :evaluate_markdown
   before_validation :pound_it
   before_save :calculate_hotness_score
-  after_commit :bust_cache, :index_to_elasticsearch
+  after_commit :bust_cache
+  after_commit :index_to_elasticsearch, on: %i[create update]
+  after_commit :remove_from_elasticsearch, on: [:destroy]
   before_save :mark_as_updated
 
   include Searchable

--- a/app/services/search/base.rb
+++ b/app/services/search/base.rb
@@ -13,6 +13,10 @@ module Search
         SearchClient.get(id: doc_id, index: self::INDEX_ALIAS)
       end
 
+      def delete_document(doc_id)
+        SearchClient.delete(id: doc_id, index: self::INDEX_ALIAS)
+      end
+
       def create_index(index_name: self::INDEX_NAME)
         SearchClient.indices.create(index: index_name, body: settings)
       end

--- a/app/workers/search/remove_from_elasticsearch_index_worker.rb
+++ b/app/workers/search/remove_from_elasticsearch_index_worker.rb
@@ -1,0 +1,11 @@
+module Search
+  class RemoveFromElasticsearchIndexWorker
+    include Sidekiq::Worker
+
+    sidekiq_options queue: :medium_priority
+
+    def perform(search_class, id)
+      search_class.safe_constantize.delete_document(id)
+    end
+  end
+end

--- a/spec/models/concerns/searchable_spec.rb
+++ b/spec/models/concerns/searchable_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+class SearchableModel
+  include Searchable
+  SEARCH_CLASS = Search::Tag
+
+  def id
+    1
+  end
+end
+
+RSpec.describe Searchable do
+  describe "#remove_from_elasticsearch" do
+    it "enqueues job to delete model document from elasticsearch" do
+      model = SearchableModel.new
+      sidekiq_assert_enqueued_with(job: Search::RemoveFromElasticsearchIndexWorker, args: [SearchableModel::SEARCH_CLASS.to_s, model.id]) do
+        model.remove_from_elasticsearch
+      end
+    end
+  end
+end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Tag, type: :model do
 
   describe "#index_to_elasticsearch" do
     it "enqueues job to index tag to elasticsearch" do
-      sidekiq_assert_enqueued_with(job: Search::TagEsIndexWorker, args: [tag.id]) do
+      sidekiq_assert_enqueued_with(job: described_class::SEARCH_INDEX_WORKER, args: [tag.id]) do
         tag.index_to_elasticsearch
       end
     end
@@ -93,10 +93,17 @@ RSpec.describe Tag, type: :model do
   end
 
   describe "#after_commit" do
-    it "enqueues job to index tag to elasticsearch" do
+    it "on update enqueues job to index tag to elasticsearch" do
       tag.save
-      sidekiq_assert_enqueued_with(job: Search::TagEsIndexWorker, args: [tag.id]) do
+      sidekiq_assert_enqueued_with(job: described_class::SEARCH_INDEX_WORKER, args: [tag.id]) do
         tag.save
+      end
+    end
+
+    it "on destroy enqueues job to delete tag from elasticsearch" do
+      tag.save
+      sidekiq_assert_enqueued_with(job: Search::RemoveFromElasticsearchIndexWorker, args: [described_class::SEARCH_CLASS.to_s, tag.id]) do
+        tag.destroy
       end
     end
   end

--- a/spec/services/search/chat_channel_membership_spec.rb
+++ b/spec/services/search/chat_channel_membership_spec.rb
@@ -18,6 +18,16 @@ RSpec.describe Search::ChatChannelMembership, type: :service, elasticsearch: tru
     end
   end
 
+  describe "::delete_document" do
+    it "deletes a document for a given ID from elasticsearch" do
+      chat_channel_membership = FactoryBot.create(:chat_channel_membership)
+      chat_channel_membership.index_to_elasticsearch_inline
+      expect { described_class.find_document(chat_channel_membership.id) }.not_to raise_error
+      described_class.delete_document(chat_channel_membership.id)
+      expect { described_class.find_document(chat_channel_membership.id) }.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound)
+    end
+  end
+
   describe "::create_index" do
     it "creates an elasticsearch index with INDEX_NAME" do
       described_class.delete_index

--- a/spec/services/search/classified_listing_spec.rb
+++ b/spec/services/search/classified_listing_spec.rb
@@ -18,6 +18,16 @@ RSpec.describe Search::ClassifiedListing, type: :service, elasticsearch: true do
     end
   end
 
+  describe "::delete_document" do
+    it "deletes a document for a given ID from elasticsearch" do
+      classified_listing = FactoryBot.create(:classified_listing)
+      classified_listing.index_to_elasticsearch_inline
+      expect { described_class.find_document(classified_listing.id) }.not_to raise_error
+      described_class.delete_document(classified_listing.id)
+      expect { described_class.find_document(classified_listing.id) }.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound)
+    end
+  end
+
   describe "::create_index" do
     it "creates an elasticsearch index with INDEX_NAME" do
       described_class.delete_index

--- a/spec/services/search/tag_spec.rb
+++ b/spec/services/search/tag_spec.rb
@@ -67,6 +67,16 @@ RSpec.describe Search::Tag, type: :service, elasticsearch: true do
     end
   end
 
+  describe "::delete_document" do
+    it "deletes a document for a given ID from elasticsearch" do
+      tag = FactoryBot.create(:tag)
+      tag.index_to_elasticsearch_inline
+      expect { described_class.find_document(tag.id) }.not_to raise_error
+      described_class.delete_document(tag.id)
+      expect { described_class.find_document(tag.id) }.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound)
+    end
+  end
+
   describe "::create_index" do
     it "creates an elasticsearch index with INDEX_NAME" do
       described_class.delete_index

--- a/spec/workers/search/remove_from_elasticsearch_index_worker_spec.rb
+++ b/spec/workers/search/remove_from_elasticsearch_index_worker_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe Search::RemoveFromElasticsearchIndexWorker, type: :worker do
+  let(:worker) { subject }
+
+  include_examples "#enqueues_on_correct_queue", "medium_priority", ["SearchClass", 1]
+
+  it "deletes document for given search class" do
+    search_class = Search::Tag
+    allow(search_class).to receive(:delete_document)
+    described_class.new.perform(search_class.to_s, 1)
+    expect(search_class).to have_received(:delete_document).with(1)
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
In addition to the ability to index documents we also need the ability to remove them from Elasticsearch when a document is deleted. This PR adds a new method to our `Search::Base` class for deleting documents in Elasticsearch. It also adds a SINGLE 🎉  new worker to handle removing them.  

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-33385085

## Added tests?
- [x] yes

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media2.giphy.com/media/QynS05YmkmPjGQK690/giphy.gif)
