### PR TITLE
Gracefully Handle Elasticsearch BadRequest Errors for Tags

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -5,5 +5,8 @@ class SearchController < ApplicationController
     tag_docs = Search::Tag.search_documents("name:#{params[:name]}* AND supported:true")
 
     render json: { result: tag_docs }
+  rescue Elasticsearch::Transport::Transport::Errors::BadRequest
+    DataDogStatsClient.increment("elasticsearch.errors", tags: ["error:BadRequest"])
+    render json: { result: [] }
   end
 end

--- a/spec/requests/search_spec.rb
+++ b/spec/requests/search_spec.rb
@@ -15,5 +15,12 @@ RSpec.describe "Search", type: :request, proper_status: true do
       get "/search/tags"
       expect(response.parsed_body).to eq("result" => mock_documents)
     end
+
+    it "returns an empty array when a Elasticsearch Bad Request error is raised" do
+      sign_in authorized_user
+      allow(Search::Tag).to receive(:search_documents).and_raise(Elasticsearch::Transport::Transport::Errors::BadRequest)
+      get "/search/tags"
+      expect(response.parsed_body).to eq("result" => [])
+    end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
When someone enters an invalid tag name into our search box it can cause an Elasticsearch BadRequest error which gets raised to Honeybadger. Since there is nothing we can really do about it we should record the error and instead return an empty dataset. 

I choose to record the error bc if this happens over and over again either our code is broken or we have a bad actor hitting us that we should address.

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-33292262

## Added tests?
- [x] yes

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media0.giphy.com/media/2ceie42EHfAaa9OTMH/giphy.gif)
