### PR TITLE
Add welcome thread welcome notification

### DIFF
--- a/app/services/broadcasts/welcome_notification/generator.rb
+++ b/app/services/broadcasts/welcome_notification/generator.rb
@@ -21,7 +21,7 @@ module Broadcasts
       end
 
       def commented_on_welcome_thread?
-        welcome_thread = Article.where("title LIKE 'Welcome Thread - %'").order(created_at: :desc).first
+        welcome_thread = latest_published_thread("welcome")
         Comment.where(commentable: welcome_thread, user: user).any?
       end
 
@@ -29,6 +29,12 @@ module Broadcasts
 
       def welcome_broadcast
         @welcome_broadcast ||= Broadcast.find_by(title: "Welcome Notification: welcome_thread")
+      end
+
+      def latest_published_thread(tag_name)
+        Article.published.
+          order("published_at ASC").
+          cached_tagged_with(tag_name).last
       end
 
       attr_reader :user

--- a/app/services/broadcasts/welcome_notification/generator.rb
+++ b/app/services/broadcasts/welcome_notification/generator.rb
@@ -19,24 +19,24 @@ module Broadcasts
         # Once it has the appropriate Broadcast to be sent, it should send a notification for it:
         # `Notification.send_welcome_notification(receiver_id, welcome_broadcast.id)`
         # welcome_broadcast = # Rubocop will NOT leave me alone and keeps throwing errors in this entire method, so this will have to stay like this for now
-        return unless !has_commented_on_welcome_thread? && receiver_id == user.id # I feel like a check for the User's id is necessary here...
+        return if has_commented_on_welcome_thread?
 
-        # return unless !has_commented_on_welcome_thread? # I CANNOT believe I forgot to eveluate this statement before... :facepalm:
-
-        Broadcast.find_by(title: "Welcome: welcome_thread") # Find the correct, welcome_thread in this case, Broadcast
-        Notification.send_welcome_notification(receiver_id, welcome_broadcast.id) # send the welcome_notification once the appropriate Broadcast has been found...still working on this
-        # end
+        welcome_broadcast = Broadcast.find_by(title: "Welcome Notification")
+        # Find the correct, welcome_thread in this case, Broadcast
+        Notification.send_welcome_notification(receiver_id, welcome_broadcast.id)
+        # Send the welcome_notification once the appropriate Broadcast has been found
       end
 
       def has_commented_on_welcome_thread?
-        # byebug # My BFF again
-        # articles.comments.commentable.where("title LIKE 'Welcome Thread - %'") && user.comments_count > 1
-        articles.comments.commentable.where(["title = ?", "Welcome Thread"]) && user.comments_count > 1 # Still trying to figure out what to do here, but due to spec failures, I am having a hard time hitting byebug/pry to inspect these values and their returns
+        welcome_threads = Article.where("slug LIKE 'welcome-thread%'")
+        # Find all Articles containing the Welcome Thread slug
+        Comment.where(commentable: welcome_threads, user_id: receiver_id).any?
+        # Check to see if there are any comments on the Welcome Thread Articles by the User
       end
 
       private
 
-      attr_reader :receiver_id # Convention is good :)
+      attr_reader :receiver_id
     end
   end
 end

--- a/app/services/broadcasts/welcome_notification/generator.rb
+++ b/app/services/broadcasts/welcome_notification/generator.rb
@@ -13,7 +13,7 @@ module Broadcasts
       def call
         return if commented_on_welcome_thread? || received_notification?
 
-        Notification.send_welcome_notification(receiver_id, welcome_broadcast.id)
+        Notification.send_welcome_notification(user.id, welcome_broadcast.id)
       end
 
       def received_notification?

--- a/app/services/broadcasts/welcome_notification/generator.rb
+++ b/app/services/broadcasts/welcome_notification/generator.rb
@@ -21,8 +21,8 @@ module Broadcasts
       end
 
       def commented_on_welcome_thread?
-        welcome_threads = Article.where("title LIKE 'Welcome Thread - %'").order(created_at: :desc).first
-        Comment.where(commentable: welcome_threads, user: user).any?
+        welcome_thread = Article.where("title LIKE 'Welcome Thread - %'").order(created_at: :desc).first
+        Comment.where(commentable: welcome_thread, user: user).any?
       end
 
       private

--- a/app/services/broadcasts/welcome_notification/generator.rb
+++ b/app/services/broadcasts/welcome_notification/generator.rb
@@ -3,7 +3,7 @@ module Broadcasts
   module WelcomeNotification
     class Generator
       def initialize(receiver_id)
-        @receiver_id = receiver_id
+        @user = User.find(receiver_id)
       end
 
       def self.call(*args)
@@ -13,36 +13,25 @@ module Broadcasts
       def call
         return if commented_on_welcome_thread? || received_notification?
 
-        welcome_broadcast = Broadcast.find_by(title: "Welcome Notification: welcome_thread")
         Notification.send_welcome_notification(receiver_id, welcome_broadcast.id)
       end
 
       def received_notification?
-        welcome_broadcast = Broadcast.find_by(title: "Welcome Notification: welcome_thread")
-        # Find a Notification by its Broadcast, e.g. Notification.notifiable
-        # Check whether a Notification exists where a Broadcast is the Broadcast
-        # Notification where Notifiable is welcome_broadcast and User is the receiver_id - this must return true
-        # notification = Notification.find_by(notifiable_id: welcome_broadcast.id, user_id: receiver_id)
-        Notification.find_by(notifiable_id: welcome_broadcast.id, user_id: receiver_id)
-      # rescue ActiveRecord::RecordInvalid # attempt to rescue error - this may need to be changed a bit
-      #   # raise StandardError, "Invalid User: User is already associated with this notification."
-      #   raise "Invalid User: User is already associated with this notification.", if notification.true?
-      #                                                                             end
-      # rescue StandardError => e
-      rescue ActiveRecord::RecordInvalid
-        # raise StandardError.new("User is already associated with this notification: #{e}")
-        raise StandardError, "User is already associated with this notification."
+        Notification.exists?(notifiable: welcome_broadcast, user: user)
       end
 
       def commented_on_welcome_thread?
-        welcome_threads = Article.where("slug LIKE 'welcome-thread%'")
-        user = User.find_by(id: receiver_id)
-        Comment.where(commentable: welcome_threads, user_id: receiver_id).any? && user.created_at + 3.hours <= Time.zone.now
+        welcome_threads = Article.where("title LIKE 'Welcome Thread - %'").order(created_at: :desc).first
+        Comment.where(commentable: welcome_threads, user: user).any?
       end
 
       private
 
-      attr_reader :receiver_id
+      def welcome_broadcast
+        @welcome_broadcast ||= Broadcast.find_by(title: "Welcome Notification: welcome_thread")
+      end
+
+      attr_reader :user
     end
   end
 end

--- a/app/services/broadcasts/welcome_notification/generator.rb
+++ b/app/services/broadcasts/welcome_notification/generator.rb
@@ -18,11 +18,25 @@ module Broadcasts
 
         # Once it has the appropriate Broadcast to be sent, it should send a notification for it:
         # `Notification.send_welcome_notification(receiver_id, welcome_broadcast.id)`
+        # welcome_broadcast = # Rubocop will NOT leave me alone and keeps throwing errors in this entire method, so this will have to stay like this for now
+        return unless !has_commented_on_welcome_thread? && receiver_id == user.id # I feel like a check for the User's id is necessary here...
+
+        # return unless !has_commented_on_welcome_thread? # I CANNOT believe I forgot to eveluate this statement before... :facepalm:
+
+        Broadcast.find_by(title: "Welcome: welcome_thread") # Find the correct, welcome_thread in this case, Broadcast
+        Notification.send_welcome_notification(receiver_id, welcome_broadcast.id) # send the welcome_notification once the appropriate Broadcast has been found...still working on this
+        # end
+      end
+
+      def has_commented_on_welcome_thread?
+        # byebug # My BFF again
+        # articles.comments.commentable.where("title LIKE 'Welcome Thread - %'") && user.comments_count > 1
+        articles.comments.commentable.where(["title = ?", "Welcome Thread"]) && user.comments_count > 1 # Still trying to figure out what to do here, but due to spec failures, I am having a hard time hitting byebug/pry to inspect these values and their returns
       end
 
       private
 
-      attr_reader :receiver_id
+      attr_reader :receiver_id # Convention is good :)
     end
   end
 end

--- a/spec/factories/broadcasts.rb
+++ b/spec/factories/broadcasts.rb
@@ -1,12 +1,19 @@
 FactoryBot.define do
   factory :broadcast do
     active { false }
-  end
 
-  trait :onboarding do
-    title { "Onboarding Notification" }
-    type_of { "Onboarding" }
-    processed_html { "Welcome! Introduce yourself in our <a href='/welcome'>welcome thread!</a>" }
+    factory :welcome_broadcast do
+      title { "Welcome Notification: welcome_thread" }
+      type_of { "Welcome" }
+      processed_html { "Sloan here again! 👋 DEV is a friendly community. Why not introduce yourself by leaving a comment in <a href='/welcome'>the welcome thread</a>!" }
+    end
+
+    # TODO: [@thepracticaldev/delightful] Remove onboarding factory once welcome notifications are live.
+    factory :onboarding_broadcast do
+      title { "Welcome Notification" }
+      type_of { "Onboarding" }
+      processed_html { "Welcome! Introduce yourself in our <a href='/welcome'>welcome thread!</a>" }
+    end
   end
 
   trait :active do

--- a/spec/factories/broadcasts.rb
+++ b/spec/factories/broadcasts.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   end
 
   trait :onboarding do
-    title { "Welcome Notification" }
+    title { "Onboarding Notification" }
     type_of { "Onboarding" }
     processed_html { "Welcome! Introduce yourself in our <a href='/welcome'>welcome thread!</a>" }
   end

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -593,8 +593,8 @@ RSpec.describe "NotificationsIndex", type: :request do
 
     context "when a user has a new welcome notification" do
       # TODO: [@thepracticaldev/delightful] Only test against type_of Welcome once Onbarding notifications have been removed.
-      let(:active_broadcast) { create(:broadcast, :onboarding, :active) }
-      let(:inactive_broadcast) { create(:broadcast, :onboarding) }
+      let(:active_broadcast) { create(:onboarding_broadcast, :active) }
+      let(:inactive_broadcast) { create(:onboarding_broadcast) }
 
       before { sign_in user }
 

--- a/spec/services/broadcasts/welcome_notification/generator_spec.rb
+++ b/spec/services/broadcasts/welcome_notification/generator_spec.rb
@@ -33,10 +33,8 @@ RSpec.describe Broadcasts::WelcomeNotification::Generator, type: :service do
       end
 
       it "does not send a notification to a user who has commented in a welcome thread", :aggregate_failures do
-        expect(user.comments.count).to eq(1)
-
+        expect(user.notifications.count).to eq(0)
         sidekiq_perform_enqueued_jobs { described_class.call(user.id) }
-
         expect(user.notifications.count).to eq(0)
       end
 

--- a/spec/services/broadcasts/welcome_notification/generator_spec.rb
+++ b/spec/services/broadcasts/welcome_notification/generator_spec.rb
@@ -2,6 +2,14 @@ require "rails_helper"
 
 RSpec.describe Broadcasts::WelcomeNotification::Generator, type: :service do
   describe "::call" do
+    subject(:welcome_notification) { WelcomeNotification.new(user_id(broadcast_id)) }
+
+    let(:user) { create(:user) }
+    let(:broadcast) { create(:broadcast, :welcome_broadcast) } # why does eager loading throw a rubocop error here?
+    let(:article) { create(:article) }
+    let(:not_commented_on) { create(:comment, commentable: article, title: "Welcome Thread") }
+    let(:commented_on) { create(:comment, user: user, commentable: article, title: "Welcome Thread") }
+
     context "when sending a set_up_profile notification" do
       xit "generates the appropriate broadcast to be sent to a user"
       xit "it sends a welcome notification for that broadcast"
@@ -9,11 +17,19 @@ RSpec.describe Broadcasts::WelcomeNotification::Generator, type: :service do
       xit "does not send a notification to a user who has set up their profile"
     end
 
-    context "when sending a welcome_thread notification" do
+    context "when sending a welcome_thread notification", :aggregate_failures do
       xit "generates the appropriate broadcast to be sent to a user"
-      xit "it sends a welcome notification for that broadcast"
-      xit "it does not send duplicate welcome notification for that broadcast"
-      xit "does not send a notification to a user who has commented in a welcome thread"
+      xit "sends a welcome notification for that broadcast" do
+        expect(welcome_notification.call).to be_success
+      end
+
+      xit "does not send duplicate welcome notification for that broadcast" do
+        expect(user).to have_received(:call).with(broadcast).once
+      end
+
+      xit "does not send a notification to a user who has commented in a welcome thread" do
+        # expect(user)
+      end
     end
 
     context "when sending a twitter_connect notification" do

--- a/spec/services/broadcasts/welcome_notification/generator_spec.rb
+++ b/spec/services/broadcasts/welcome_notification/generator_spec.rb
@@ -2,13 +2,13 @@ require "rails_helper"
 
 RSpec.describe Broadcasts::WelcomeNotification::Generator, type: :service do
   describe "::call" do
-    subject(:welcome_notification) { WelcomeNotification.new(user_id(broadcast_id)) }
-
+    let(:receiving_user) { create(:user) }
     let(:user) { create(:user) }
-    let(:broadcast) { create(:broadcast, :welcome_broadcast) } # why does eager loading throw a rubocop error here?
-    let(:article) { create(:article) }
-    let(:not_commented_on) { create(:comment, commentable: article, title: "Welcome Thread") }
-    let(:commented_on) { create(:comment, user: user, commentable: article, title: "Welcome Thread") }
+    let!(:welcome_broadcast) { create(:welcome_broadcast, :active) }
+
+    before do
+      allow(User).to receive(:mascot_account).and_return(create(:user))
+    end
 
     context "when sending a set_up_profile notification" do
       xit "generates the appropriate broadcast to be sent to a user"
@@ -17,18 +17,55 @@ RSpec.describe Broadcasts::WelcomeNotification::Generator, type: :service do
       xit "does not send a notification to a user who has set up their profile"
     end
 
-    context "when sending a welcome_thread notification", :aggregate_failures do
-      xit "generates the appropriate broadcast to be sent to a user"
-      xit "sends a welcome notification for that broadcast" do
-        expect(welcome_notification.call).to be_success
+    context "when sending a welcome_thread notification" do
+      let(:welcome_thread_article) { create(:article, title: "Welcome Thread") }
+      let(:welcome_thread_comment) { create(:comment, commentable: welcome_thread_article, user: user) }
+      let(:article) { create(:article) }
+      let(:comment) { create(:comment, commentable: article, user: receiving_user) }
+
+      it "generates the correct broadcast type and sends the notification to the user", :aggregate_failures do
+        expect(receiving_user.notifications.count).to eq(0)
+
+        sidekiq_perform_enqueued_jobs do
+          described_class.call(receiving_user.id)
+        end
+
+        expect(receiving_user.notifications.count).to eq(1)
+        expect(receiving_user.notifications.first.notifiable).to eq(welcome_broadcast)
       end
 
-      xit "does not send duplicate welcome notification for that broadcast" do
-        expect(user).to have_received(:call).with(broadcast).once
+      it "does not send a notification to a user who has commented in a welcome thread" do
+        sidekiq_perform_enqueued_jobs do
+          described_class.call(receiving_user.id)
+        end
+
+        expect(user.notifications).to be_empty
+      end
+    end
+
+    context "when sending a duplicate notification" do
+      before do
+        sidekiq_perform_enqueued_jobs do
+          described_class.call(receiving_user.id)
+        end
       end
 
-      xit "does not send a notification to a user who has commented in a welcome thread" do
-        # expect(user)
+      it "raises an ActiveRecord error" do
+        # allow(Rails.logger).to receive(:error)
+        # assert_raises ActiveRecord::RecordInvalid do
+        expect do
+          sidekiq_perform_enqueued_jobs do
+            described_class.call(receiving_user.id)
+          end
+        end.to raise_error(StandardError)
+        # end.to not_change(receiving_user.notifications, :count)
+        # end
+        # end.to raise_error(StandardError)
+        # expect(Rails.logger).to have_received(:error)
+        # expect(logger).to have_received(:error).once
+        # expect { described_class }.to raise_error(StandardError)
+        # Test that the correct error is raised after job is run with receiver_id more than once
+        # This is the only failure left - there must be a bug within the received_notification? method still since error is not logging
       end
     end
 

--- a/spec/services/notifications/welcome_notification/send_spec.rb
+++ b/spec/services/notifications/welcome_notification/send_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Notifications::WelcomeNotification::Send, type: :service do
     end
 
     it "creates a new welcome notification", :aggregate_failures do
-      welcome_broadcast = create(:broadcast, :onboarding)
+      welcome_broadcast = create(:onboarding_broadcast)
       welcome_notification = described_class.call(create(:user).id, welcome_broadcast)
 
       expect(welcome_notification).to be_kind_of(Notification)

--- a/spec/workers/notifications/welcome_notification_worker_spec.rb
+++ b/spec/workers/notifications/welcome_notification_worker_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 RSpec.describe Notifications::WelcomeNotificationWorker, type: :worker do
   describe "#perform" do
-    let(:broadcast) { create(:broadcast, :onboarding, :active) }
-    let(:inactive_broadcast) { create(:broadcast, :onboarding) }
+    let(:broadcast) { create(:onboarding_broadcast, :active) }
+    let(:inactive_broadcast) { create(:onboarding_broadcast) }
     let(:user) { create(:user) }
     let(:service) { Notifications::WelcomeNotification::Send }
     let(:worker) { subject }


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
This is the first of many Welcome Notification PRs to come! This PR:
- [x] Adds a new, nested `:welcome_broadcast` factory to the Broadcasts factory in preparation for further Welcome Notification work.
- [x] Adds logic for "Welcome Thread" Notifications to the `Broadcasts::WelcomeNotification::Generator` so that eventually, "Welcome Thread" notifications can be delivered to Users who have not commented on the Welcome Thread after 3 hours of account creation.
- [x] Adds tests around sending "Welcome Thread" Notifications.

## Related Tickets & Documents
Closes #6700.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
N/A

## Added tests?

- [x] yes (for `welcome_thread` Welcome Notifications only)
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![happy_dance](https://media.giphy.com/media/l3V0dy1zzyjbYTQQM/giphy.gif)
