### PR TITLE
Clean up chat channels when deleting users

### DIFF
--- a/app/services/users/delete_activity.rb
+++ b/app/services/users/delete_activity.rb
@@ -8,7 +8,7 @@ module Users
       user.follows.delete_all
       Follow.where(followable_id: user.id, followable_type: "User").delete_all
       user.messages.delete_all
-      user.chat_channel_memberships.delete_all
+      Users::CleanupChatChannels.call(user)
       user.mentions.delete_all
       user.badge_achievements.delete_all
       user.github_repos.delete_all

--- a/spec/services/users/delete_spec.rb
+++ b/spec/services/users/delete_spec.rb
@@ -86,4 +86,20 @@ RSpec.describe Users::Delete, type: :service do
       end
     end
   end
+
+  context "when cleaning up chat channels" do
+    let_it_be(:other_user) { create(:user) }
+
+    it "deletes the user's private chat channels" do
+      chat_channel = ChatChannel.create_with_users([user, other_user])
+      described_class.call(user)
+      expect(ChatChannel.find_by(id: chat_channel.id)).to be_nil
+    end
+
+    it "does not delete the user's open channels" do
+      chat_channel = ChatChannel.create_with_users([user, other_user], "open")
+      described_class.call(user)
+      expect(ChatChannel.find_by(id: chat_channel.id)).not_to be_nil
+    end
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Description

When deleting users we did not properly clean up their private chat channels. I recently did some work of that in the context of banishing users and thought it makes the most sense to use the same service object when deleting users.

## Related Tickets & Documents

Closes #6216 

## Added tests?

- [X] yes

## Added to documentation?

- [X] no documentation needed
