### PR TITLE
Fix logger in Mailchimp bot

### DIFF
--- a/app/labor/mailchimp_bot.rb
+++ b/app/labor/mailchimp_bot.rb
@@ -162,7 +162,7 @@ class MailchimpBot
   end
 
   def report_error(exception)
-    logger.error(exception)
+    Rails.logger.error(exception)
     DataDogStatsClient.increment("mailchimp.errors", tags: [action: "failed", user_id: user.id, source: "gibbon-gem"])
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Fixes https://app.honeybadger.io/fault/66984/0ea3a11ef6835ae5098cb4a92ddf3e08
```
NameError: undefined local variable or method `logger' for #<MailchimpBot:0x00007f43438b34f8>
 mailchimp_bot.rb  165 report_error(...)
[PROJECT_ROOT]/app/labor/mailchimp_bot.rb:165:in `report_error'
163 
164   def report_error(exception)
165     logger.error(exception)
166     DataDogStatsClient.increment("mailchimp.errors", tags: [action: "failed", user_id: user.id, source: "gibbon-gem"])
167   end
```

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media.giphy.com/media/dWgHhLGd2cPTHLMgdt/giphy-downsized.gif)
