### PR TITLE
Optionally log to stdout

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -24,10 +24,13 @@ default: &default
   checkout_timeout: 2
   variables:
       statement_timeout: <%= ENV['STATEMENT_TIMEOUT'] || 2500 %>
+
 development:
   <<: *default
   url: <%= ENV.fetch('DATABASE_URL', '') %>
   database: PracticalDeveloper_development
+  variables:
+      statement_timeout: <%= ENV['STATEMENT_TIMEOUT'] || 10_000 %>
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -96,6 +96,12 @@ Rails.application.configure do
   # Debug is the default log_level, but can be changed per environment.
   config.log_level = :debug
 
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
+    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger.formatter = config.log_formatter
+    config.logger    = ActiveSupport::TaggedLogging.new(logger)
+  end
+
   config.after_initialize do
     # See <https://github.com/flyerhzm/bullet#configuration> for other Bullet config options
     Bullet.enable = true
@@ -108,8 +114,7 @@ Rails.application.configure do
     # acts-as-taggable-on has super weird eager loading problems: <https://github.com/mbleigh/acts-as-taggable-on/issues/91>
     Bullet.add_whitelist(type: :n_plus_one_query, class_name: "ActsAsTaggableOn::Tagging", association: :tag)
 
-    DATA_UPDATE_CHECK_COMMANDS = %w[c console s server].freeze
-    if DATA_UPDATE_CHECK_COMMANDS.include?(ENV["COMMAND"])
+    if %w[c console runner s server].include?(ENV["COMMAND"])
       script_ids = DataUpdateScript.load_script_ids
       scripts_to_run = DataUpdateScript.where(id: script_ids).select(&:enqueued?)
       if scripts_to_run.any?

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -30,3 +30,15 @@ sudo -u postgres createdb ec2-user
 The first command creates the user **ec2-user** and the second one creates the
 database for this user because every user needs its database. Even if the first
 command fails, run the second command to create the missing database.
+
+## How do I enable logging to standard output in development?
+
+By default Rails logs to `log.development.log`.
+
+If, instead, you wish to log to `STDOUT` you can add the variable:
+
+```yaml
+RAILS_LOG_TO_STDOUT: true
+```
+
+to your own `config/application.yml` file.


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

By default Rails to `log/development.log`, but this way we kind of lose the ability to log to STDOUT for who prefers that, and if one doesn't remember they won't see any output when running scripts (both the seed file which use to log in STDOUT and all the new data update scripts).

I'm `RAILS_LOG_TO_STDOUT` which is the default env var that's also enabled in `production.rb`.

If a person wants to log to STDOUT all they need to do is to add that variable to their `application.yml`
