### PR TITLE
Add troubleshooting section to docs and restore hidden sections

### DIFF
--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -13,20 +13,3 @@ make ruby-doc
 
 Then open `.static/ruby-doc/index.html` in the `docs` directory and browse the
 Ruby documentation
-
-## How do I fix the Error `role "ec2-user" does not exist` on an AWS instance?
-
-After installing and configuring PostgreSQL on an AWS EC2 (or AWS Cloud9)
-instance and running `bin/setup`, this error could occur.
-
-To fix it, run the following two commands in a terminal (assuming your
-PostgreSQL user is named **postgres**):
-
-```
-sudo -u postgres createuser -s ec2-user
-sudo -u postgres createdb ec2-user
-```
-
-The first command creates the user **ec2-user** and the second one creates the
-database for this user because every user needs its database. Even if the first
-command fails, run the second command to create the missing database.

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -13,3 +13,15 @@ make ruby-doc
 
 Then open `.static/ruby-doc/index.html` in the `docs` directory and browse the
 Ruby documentation
+
+## How do I enable logging to standard output in development?
+
+By default Rails logs to `log.development.log`.
+
+If, instead, you wish to log to `STDOUT` you can add the variable:
+
+```yaml
+RAILS_LOG_TO_STDOUT: true
+```
+
+to your own `config/application.yml` file.

--- a/docs/installation/postgresql.md
+++ b/docs/installation/postgresql.md
@@ -66,13 +66,3 @@ The number of connections to the database (the connection limit) is dependent on
 our
 [Heroku Postgres plan](https://devcenter.heroku.com/articles/heroku-postgres-plans).
 PgBouncer ensures that we do not exceed our plan's connection limit.
-
-## Troubleshooting tests
-
-- While running test cases, if you get an error message
-  `postgresql connection timeout`, please re-run the tests by increasing the
-  statement timeout, for example:
-
-```shell
-STATEMENT_TIMEOUT=10000 bundle exec rspec
-```

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -7,13 +7,14 @@ items:
   - frontend
   - internal
   - design
-  - deployment
+  - deployment.md
   - tests
-  - contributing
-  - contributing_api
-  - faqs
-  - licensing
-  - self-hosting
+  - contributing.md
+  - contributing_api.md
+  - faqs.md
+  - troubleshooting.md
+  - licensing.md
+  - self-hosting.md
   - maintainers
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,82 @@
+---
+title: Troubleshooting
+---
+
+## Tests
+
+### Connection timeout
+
+While running test cases, if you get an error message
+`postgresql connection timeout`, please re-run the tests by increasing the
+statement timeout, for example:
+
+```shell
+STATEMENT_TIMEOUT=10000 bundle exec rspec
+```
+
+## PostgreSQL
+
+### How do I fix the Error `role "ec2-user" does not exist` on an AWS instance?
+
+After installing and configuring PostgreSQL on an AWS EC2 (or AWS Cloud9)
+instance and running `bin/setup`, this error could occur.
+
+To fix it, run the following two commands in a terminal (assuming your
+PostgreSQL user is named **postgres**):
+
+```
+sudo -u postgres createuser -s ec2-user
+sudo -u postgres createdb ec2-user
+```
+
+The first command creates the user **ec2-user** and the second one creates the
+database for this user because every user needs its database. Even if the first
+command fails, run the second command to create the missing database.
+
+## Elasticsearch
+
+### Index read-only error
+
+If you encounter an error similar to the following:
+
+```shell
+{"error":{"root_cause":[{"type":"cluster_block_exception","reason":"index [tags_development] blocked by: [FORBIDDEN/12/index read-only / allow delete (api)];"}],"type":"cluster_block_exception","reason":"index [tags_development] blocked by: [FORBIDDEN/12/index read-only / allow delete (api)];"},"status":403}
+```
+
+it means that Elasticsearch went into read only mode because its disk allocator
+noticed how the disk drive is nearly full:
+
+> Elasticsearch enforces a read-only index block
+> (`index.blocks.read_only_allow_delete`) on every index that has one or more
+> shards allocated on the node that has at least one disk exceeding the flood
+> stage.
+
+This is an indication that you might not have enough space for ES to work
+correctly.
+
+If you want to disable the threshold check on your local machine you can open a
+Rails console (with `rails console`) and issue the following command:
+
+```ruby
+SearchClient.cluster.put_settings(body: {
+  persistent: {
+    "cluster.routing.allocation.disk.threshold_enabled" => false,
+  }
+})
+```
+
+To disable the "read only" mode to allow operations on the Elasticsearch indexes
+you can issue the following command, similary in the Rails console:
+
+```ruby
+SearchClient.indices.get(index: "*").keys.each do |index_name|
+  SearchClient.indices.put_settings(
+    index: index_name,
+    body: { "index.blocks.read_only_allow_delete" => nil }
+  )
+end
+```
+
+If instead you want to tune the Elasticsearch disk allocator's settings, please
+refer to
+[Disk-based shard allocation](https://www.elastic.co/guide/en/elasticsearch/reference/current/disk-allocator.html#disk-allocator).


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

I wrote down some notes about the errors I have been having lately with Elasticsearch (kudos to @mstruve for the assistance!).

I also noticed how some sections are not reachable right now in production:

![Screenshot_2020-02-21 DEV Docs](https://user-images.githubusercontent.com/146201/75046579-aa428c80-54c5-11ea-8ec9-42df98f9db97.png)

should instead be

![Screenshot_2020-02-21 Deployment and CI CD Process · DEV Docs](https://user-images.githubusercontent.com/146201/75046587-af074080-54c5-11ea-8501-c8b58ab34884.png)

Closes https://github.com/thepracticaldev/dev.to/issues/6085 as it's not an error we can control :)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
