### PR TITLE
Cloudify article main images in feed

### DIFF
--- a/app/views/stories/feeds/show.json.jbuilder
+++ b/app/views/stories/feeds/show.json.jbuilder
@@ -1,7 +1,7 @@
 article_attributes_to_include = %i[
   title path id user_id comments_count positive_reactions_count organization_id
   reading_time video_thumbnail_url video video_duration_in_minutes language
-  experience_level_rating experience_level_rating_distribution main_image
+  experience_level_rating experience_level_rating_distribution
 ]
 article_methods_to_include = %i[
   readable_publish_date flare_tag class_name
@@ -16,6 +16,14 @@ json.array!(@stories) do |article|
   if article.cached_organization?
     json.organization article.cached_organization.as_json["table"]
   end
+
+  if article.main_image?
+    json.main_image cloud_cover_url(article.main_image)
+  else
+    json.main_image nil
+  end
+
+  # article.main_image? ? cloud_cover_url(article.main_image) : nil
 
   json.tag_list article.cached_tag_list_array
   json.extract! article, *article_methods_to_include

--- a/app/views/stories/feeds/show.json.jbuilder
+++ b/app/views/stories/feeds/show.json.jbuilder
@@ -23,8 +23,6 @@ json.array!(@stories) do |article|
     json.main_image nil
   end
 
-  # article.main_image? ? cloud_cover_url(article.main_image) : nil
-
   json.tag_list article.cached_tag_list_array
   json.extract! article, *article_methods_to_include
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [X] Optimization
- [ ] Documentation Update

## Description

This PR "cloudifies" article main image URLs that are rendered in the new home page feed JSON. This transformation was previously done on the client side: we're doing it server side in our continuing effort to centralize feed logic on the backend.

## Related Tickets & Documents

Related conversation: https://github.com/thepracticaldev/dev.to/pull/6164#discussion_r382371573

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![cloud](https://media.giphy.com/media/XiWnUrN67q75e/giphy.gif)
