### PR TITLE
Add possible spam users to mod interface

### DIFF
--- a/app/assets/stylesheets/moderators.scss
+++ b/app/assets/stylesheets/moderators.scss
@@ -78,6 +78,10 @@
   }
 }
 
+.mod-index-title {
+  padding-left: 20px;
+}
+
 .mod-index-list {
   margin: 5px auto;
   width: 96%;
@@ -114,6 +118,15 @@
       color: $black;
       vertical-align: 0.2em;
     }
+    .mod-index-potential-spam-user-name {
+        padding: 3px 8px;
+        border-radius: 3px;
+        color: $black;
+        display: inline;
+    }
+    .mod-index-spam-user-link {
+        display: block;
+    }
     .mod-index-actions-and-details {
       img {
         height: 1.4em;
@@ -128,7 +141,7 @@
         @include themeable(color, theme-secondary-color, $medium-gray);
       }
     }
-    .quick-mod-button {
+    .quick-mod-button, .spam-user-button {
       font-size: 0.95em;
       padding: 5px 18px;
       border-radius: 100px;
@@ -138,6 +151,13 @@
       margin-right: 5px;
       background: transparent;
       @include themeable(color, theme-color, $black);
+    }
+    .reacted {
+        @include themeable(
+            background,
+            theme-container-accent-background,
+            $light-green
+        );
     }
     .mod-index-row-iframes {
       padding: 5px 0px;

--- a/app/controllers/concerns/potential_spam_user.rb
+++ b/app/controllers/concerns/potential_spam_user.rb
@@ -1,0 +1,21 @@
+# This module is the source of truth for what we consider a potential spam user.
+module PotentialSpamUser
+  extend ActiveSupport::Concern
+
+  # I think these should exist in constants even though they are evaluated once
+  # it makes it easier to tweak these variables consistently.
+  # rubocop:disable Rails/RelativeDateConstant
+  AUTH_ACCOUNT_AGE = 50.hours.ago
+  ACCOUNT_NAME_CHARACTER_LENGTH = 30
+  ACCOUNT_AGE = 48.hours.ago
+  LIMIT = 150
+  # rubocop:enable Rails/RelativeDateConstant
+
+  def potential_spam_users
+    User.where("github_created_at > ? OR twitter_created_at > ? OR length(name) > ?", ACCOUNT_AGE, ACCOUNT_AGE, ACCOUNT_NAME_CHARACTER_LENGTH).
+      where("created_at > ?", ACCOUNT_AGE).
+      order("created_at DESC").
+      where.not("username LIKE ?", "%spam_%").
+      limit(LIMIT)
+  end
+end

--- a/app/controllers/moderations_controller.rb
+++ b/app/controllers/moderations_controller.rb
@@ -1,4 +1,5 @@
 class ModerationsController < ApplicationController
+  include PotentialSpamUser
   after_action :verify_authorized
 
   def index
@@ -12,6 +13,7 @@ class ModerationsController < ApplicationController
     @articles = @articles.where("nth_published_by_author > 0 AND nth_published_by_author < 4 AND published_at > ?", 7.days.ago) if params[:state] == "new-authors"
     @articles = @articles.decorate
     @tag = Tag.find_by(name: params[:tag]) || not_found if params[:tag].present?
+    @potential_spam_users = potential_spam_users
   end
 
   def article

--- a/app/views/internal/feedback_messages/index.html.erb
+++ b/app/views/internal/feedback_messages/index.html.erb
@@ -39,7 +39,7 @@
     </div>
     <div id="possibleSpamUsersBodyContainer" class="collapse hide" aria-labelledby="possibleSpamUsersHeader" data-parent="#possibleSpamUsers">
       <div class="card-body" style="overflow: scroll; max-height: 500px;">
-        <% @possible_spam_users.each do |user| %>
+        <% @potential_spam_users.each do |user| %>
           <a href="<%= user.path %>">@<%= user.username %></a> - <%= user.name %>
           <span class="float-right">
             <a href="/internal/users/<%= user.id %>" class="btn btn-secondary btn-sm">Internal User</a>

--- a/app/views/moderations/index.html.erb
+++ b/app/views/moderations/index.html.erb
@@ -74,6 +74,25 @@
       </div>
     <% end %>
   </div>
+  <h2 class="mod-index-title">Potential Spam Users</h2>
+  <div class="mod-index-list">
+    <% @potential_spam_users.each do |user| %>
+      <div class="mod-index-row">
+        <div class="mod-index-actions-and-details">
+          <a href="/<%= user.username %>" class="mod-index-spam-user-link"><img src="<%= ProfileImage.new(user).get(width: 90) %>" /><h2 class="mod-index-potential-spam-user-name"><%= user.username %></h2></a>
+          <button class="spam-user-button reaction-button cta <%= Reaction.cached_any_reactions_for?(user, current_user, "vomit") ? "reacted" : "" %>"
+                  data-reactable-id="<%= user.id %>"
+                  data-category="vomit"
+                  data-reactable-type="<%= user.class.name %>">
+            Flag as Spam
+          </button>
+          created <%= time_ago_in_words(user.created_at) %> ago
+          ・ <%= user.articles_count %> Posts
+          ・ <%= user.comments_count %> Comments
+        </div>
+      </div>
+    <% end %>
+  </div>
   <div class="mod-index-footer">
     <a href="/community-moderation" class="mod-link">Community Moderation Guide</a>
     <% if current_user.moderator_for_tags.any? %>
@@ -106,4 +125,39 @@
       }
     }
   }
+</script>
+
+<script defer>
+  setTimeout(function () {
+    var butts = document.getElementsByClassName('reaction-button');
+    for (var i = 0; i < butts.length; i++) {
+      var butt = butts[i];
+      butt.onclick = function (event) {
+        event.preventDefault();
+        var thisButt = this;
+        thisButt.classList.add('reacted');
+
+        function successCb(response) {
+          if (response.result === 'create') {
+            thisButt.classList.add('reacted');
+          } else {
+            thisButt.classList.remove('reacted');
+          }
+        }
+
+        var formData = new FormData();
+        formData.append('reactable_type', thisButt.dataset.reactableType);
+        formData.append('category', thisButt.dataset.category);
+        formData.append('reactable_id', thisButt.dataset.reactableId);
+
+        getCsrfToken()
+          .then(sendFetch('reaction-creation', formData))
+          .then(function (response) {
+            if (response.status === 200) {
+              response.json().then(successCb);
+            }
+          });
+      };
+    }
+  }, 200)
 </script>

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -80,6 +80,10 @@ FactoryBot.define do
       after(:build) { |user| user.add_role :pro }
     end
 
+    trait :potential_spam_user do
+      after(:build) { |user| user.github_created_at = Time.zone.now }
+    end
+
     trait :org_member do
       after(:create) do |user|
         org = create(:organization)

--- a/spec/requests/internal/feedback_messages_spec.rb
+++ b/spec/requests/internal/feedback_messages_spec.rb
@@ -1,96 +1,110 @@
 require "rails_helper"
 
 RSpec.describe "/internal/reports", type: :request do
-  let(:feedback_message)  { create(:feedback_message, :abuse_report) }
-  let(:feedback_message2) { create(:feedback_message, :abuse_report) }
-  let(:feedback_message3) { create(:feedback_message, :abuse_report) }
-  let(:user)              { create(:user) }
-  let(:admin)             { create(:user, :super_admin) }
+  let(:feedback_message)     { create(:feedback_message, :abuse_report) }
+  let(:feedback_message2)    { create(:feedback_message, :abuse_report) }
+  let(:feedback_message3)    { create(:feedback_message, :abuse_report) }
+  let(:user)                 { create(:user) }
+  let(:admin)                { create(:user, :super_admin) }
+  let!(:potential_spam_user) { create(:user, :potential_spam_user) }
 
-  describe "POST /save_status" do
-    context "when a valid request is made" do
-      before do
-        sign_in admin
-        valid_save_status_params = { status: "Resolved" }
-        valid_save_status_params[:id] = feedback_message.id
-        post "/internal/reports/save_status", params:
-          valid_save_status_params
-      end
+  context "when user is an admin" do
+    before do
+      sign_in admin
+    end
 
-      it "returns a JSON with an outcome key and Success value" do
-        expect(JSON.parse(response.body)).to eq("outcome" => "Success")
-      end
-
-      it "updates the status of the feedback message" do
-        expect(FeedbackMessage.last.status).to eq("Resolved")
+    describe "GET /internal/reports" do
+      it "lists potential spam users" do
+        get "/internal/reports"
+        expect(response.body).to include(potential_spam_user.username)
       end
     end
-  end
 
-  describe "POST /send_email" do
-    context "when a valid request is made" do
-      valid_send_email_params = {
-        "feedback_message_id" => 1,
-        "email_subject" => "Thank you for your report",
-        "email_body" => "Thanks for your report and being an awesome member!",
-        "email_type" => "reporter"
-      }
+    describe "POST /save_status" do
+      # rubocop:disable RSpec/NestedGroups
+      context "when a valid request is made" do
+        before do
+          valid_save_status_params = { status: "Resolved" }
+          valid_save_status_params[:id] = feedback_message.id
+          post "/internal/reports/save_status", params:
+                                                  valid_save_status_params
+        end
 
-      email_message_attributes = {
-        "feedback_message_id" => 1,
-        "subject" => "Thank you for your report",
-        "utm_campaign" => "reporter"
-      }
+        it "returns a JSON with an outcome key and Success value" do
+          expect(JSON.parse(response.body)).to eq("outcome" => "Success")
+        end
 
-      before do
-        feedback_message
-        sign_in admin
-        valid_send_email_params["email_to"] = user.email
-        post "/internal/reports/send_email", params:
-          valid_send_email_params
-      end
-
-      it "returns a JSON with an outcome key and Success value" do
-        expect(JSON.parse(response.body)).to eq("outcome" => "Success")
-      end
-
-      it "creates a new email message with the same params" do
-        email_message_attributes["to"] = user.email
-        expect(EmailMessage.last.attributes).to include(email_message_attributes)
+        it "updates the status of the feedback message" do
+          expect(FeedbackMessage.last.status).to eq("Resolved")
+        end
       end
     end
-  end
 
-  describe "POST /internal/reports/create_note" do
-    context "when a valid request is made" do
-      note_params = {
-        "content" => "test note",
-        "reason" => "abuse-reports",
-        "noteable_type" => "FeedbackMessage"
-      }
+    describe "POST /send_email" do
+      context "when a valid request is made" do
+        valid_send_email_params = {
+          "feedback_message_id" => 1,
+          "email_subject" => "Thank you for your report",
+          "email_body" => "Thanks for your report and being an awesome member!",
+          "email_type" => "reporter"
+        }
 
-      json_response = {
-        outcome: "Success",
-        content: "test note"
-      }
+        email_message_attributes = {
+          "feedback_message_id" => 1,
+          "subject" => "Thank you for your report",
+          "utm_campaign" => "reporter"
+        }
 
-      before do
-        allow(SlackBot).to receive(:ping).and_return(true)
-        feedback_message
-        sign_in admin
-        note_params["noteable_id"] = feedback_message.id
-        note_params["author_id"] = admin.id
-        post "/internal/reports/create_note", params: note_params
+        before do
+          feedback_message
+          valid_send_email_params["email_to"] = user.email
+          post "/internal/reports/send_email", params:
+                                                 valid_send_email_params
+        end
+
+        it "returns a JSON with an outcome key and Success value" do
+          expect(JSON.parse(response.body)).to eq("outcome" => "Success")
+        end
+
+        it "creates a new email message with the same params" do
+          email_message_attributes["to"] = user.email
+          expect(EmailMessage.last.attributes).to include(email_message_attributes)
+        end
       end
+    end
 
-      it "renders the proper JSON response" do
-        json_response["author_name"] = admin.name
-        expect(response.body).to eq(json_response.to_json)
-      end
+    describe "POST /internal/reports/create_note" do
+      context "when a valid request is made" do
+        note_params = {
+          "content" => "test note",
+          "reason" => "abuse-reports",
+          "noteable_type" => "FeedbackMessage"
+        }
 
-      it "creates a note with the correct params" do
-        expect(Note.last.attributes).to include(note_params)
+        json_response = {
+          outcome: "Success",
+          content: "test note"
+        }
+
+        before do
+          allow(SlackBot).to receive(:ping).and_return(true)
+          feedback_message
+          sign_in admin
+          note_params["noteable_id"] = feedback_message.id
+          note_params["author_id"] = admin.id
+          post "/internal/reports/create_note", params: note_params
+        end
+
+        it "renders the proper JSON response" do
+          json_response["author_name"] = admin.name
+          expect(response.body).to eq(json_response.to_json)
+        end
+
+        it "creates a note with the correct params" do
+          expect(Note.last.attributes).to include(note_params)
+        end
       end
+      # rubocop:enable RSpec/NestedGroups
     end
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adding a list of potential spam users to /mod. I need to determine if we need a new type of reaction or flag for spam users (to be confirmed in internal/reports), or if we should consider these a user vomit.

I'll need @pkfrank and @michael-tharrington to weigh in on this at some point.

I'll update this description once it's ready to review.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

*WIP* screenshot of UI
![image](https://user-images.githubusercontent.com/11466782/75081179-eda3f780-54d3-11ea-8a85-96a1a30848ce.png)


## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [ ] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
