### PR TITLE
Remove User.organization_id

### DIFF
--- a/db/migrate/20200221170905_remove_user_organization_id.rb
+++ b/db/migrate/20200221170905_remove_user_organization_id.rb
@@ -1,0 +1,5 @@
+class RemoveUserOrganizationId < ActiveRecord::Migration[5.2]
+  def change
+    safety_assured { remove_column :users, :organization_id, :integer }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_13_182938) do
+ActiveRecord::Schema.define(version: 2020_02_21_170905) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1120,7 +1120,6 @@ ActiveRecord::Schema.define(version: 2020_02_13_182938) do
     t.boolean "onboarding_package_requested_again", default: false
     t.string "onboarding_variant_version", default: "0"
     t.boolean "org_admin", default: false
-    t.integer "organization_id"
     t.datetime "organization_info_updated_at"
     t.boolean "permit_adjacent_sponsors", default: true
     t.datetime "personal_data_updated_at"
@@ -1181,7 +1180,6 @@ ActiveRecord::Schema.define(version: 2020_02_13_182938) do
     t.index ["language_settings"], name: "index_users_on_language_settings", using: :gin
     t.index ["old_old_username"], name: "index_users_on_old_old_username"
     t.index ["old_username"], name: "index_users_on_old_username"
-    t.index ["organization_id"], name: "index_users_on_organization_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["twitter_username"], name: "index_users_on_twitter_username", unique: true
     t.index ["username"], name: "index_users_on_username", unique: true


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

With #6079 we stopped using `User.organization_id` in favor of `user.organizations`, with #6203 we told the app to ignore the field and fixed the last remaining specs, with this PR we get rid of the field altogether.

Checkout https://github.com/ankane/strong_migrations#removing-a-column for the meaning of `safety_assured`.

## Related Tickets & Documents

#6079 
#6203 

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
