### PR TITLE
Excludes styles from (future) erb lintings

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -29,3 +29,5 @@ linters:
         Enabled: false
       Rails/OutputSafety:
         Enabled: false
+        Exclude:
+          - '**/app/views/layouts/_styles.html.erb'


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR is a part of a work to get rid of calls of html_safe in views. 

Though it is not the case in this very PR.

But the styles file has 55+ warnings when linted. A special case as this file includes assets and make a heavy use of html_safe. And I think it deserves a PR on its own to explain why I chose to exclude the file from linting rather than use an alternate solution.
If the css files are escaped, some css syntax like `table < body `
will be escaped like: `table &gt; body`.
Which is not what we are looking for.
The magic comment frozen_string_literals does not work, applying freeze to:
Rails.application.assets["scaffolds.css"] does not prevents Rails to escape some characters.
raw Rails.application raise the same warning as html_safe.

I think that since the styles are compiled in a erb file, there will be escaping. And the only way to escape that is with html_safe.
Since there is no user input here, I think there is no threat and that we can leave the html_safe and try to tackle the warnings in other files. 


## Related Tickets & Documents
#5914 
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [ ] yes
- [X] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
