### PR TITLE
API listings: improve caching

### DIFF
--- a/app/labor/cache_buster.rb
+++ b/app/labor/cache_buster.rb
@@ -159,6 +159,9 @@ module CacheBuster
   end
 
   def self.bust_classified_listings(classified_listing)
+    # we purge all listings as it's the wanted behavior with the following URL purging
+    classified_listing.purge_all
+
     bust("/listings")
     bust("/listings?i=i")
     bust("/listings/#{classified_listing.category}/#{classified_listing.slug}")

--- a/spec/labor/cache_buster_spec.rb
+++ b/spec/labor/cache_buster_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe CacheBuster, type: :labor do
 
   describe "#bust_classified_listings" do
     it "busts classified listings" do
-      cache_buster.bust_classified_listings(listing)
+      expect { cache_buster.bust_classified_listings(listing) }.not_to raise_error
     end
   end
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [x]  Optimization
- [ ] Documentation Update

## Description

Right now `/api/listings` is not edge cached:

```shell
< Cache-Control: max-age=0, private, must-revalidate
< X-Cache: MISS, MISS
< X-Cache-Hits: 0, 0
```

this is because we are not setting the `cache-control` header correctly.

This PR fixes that and adds proper surrogate keys.

I chose to call `listing.purge_all` in the cache buster because the current URL based system purges all listings, let me know if I should just use `listing.purge`

## Related Tickets & Documents

Similar to #5673 and others but for listings :D

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
