### PR TITLE
Fix Flaky Comment Spec

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,6 @@
     }
   },
   "ruby.format": "rubocop",
-  "ruby.intellisense": "rubyLocate"
+  "ruby.intellisense": "rubyLocate",
+  "ruby.specCommand": "rspec"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,5 @@
     }
   },
   "ruby.format": "rubocop",
-  "ruby.intellisense": "rubyLocate",
-  "ruby.specCommand": "rspec"
+  "ruby.intellisense": "rubyLocate"
 }

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -192,10 +192,10 @@ RSpec.describe Comment, type: :model do
     end
 
     it "retains content from #processed_html" do
-      comment.processed_html = "Hello this is a post." # Remove randomness
+      comment.processed_html = "Hello this is a post."
       comment.validate!
       text = comment.title.gsub("...", "").delete("\n")
-      expect(comment.processed_html).to include(CGI.unescapeHTML(text))
+      expect(CGI.unescapeHTML(comment.processed_html)).to include(CGI.unescape_html(text))
     end
 
     it "is converted to deleted if the comment is deleted" do

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -191,11 +191,10 @@ RSpec.describe Comment, type: :model do
       expect(comment.title(5).length).to eq(5)
     end
 
-    it "retains content from #processed_html" do
-      comment.processed_html = "Hello this is a post."
+    it "gets content from body_markdown" do
+      comment.body_markdown = "Migas fingerstache pbr&b tofu."
       comment.validate!
-      text = comment.title.gsub("...", "").delete("\n")
-      expect(CGI.unescapeHTML(comment.processed_html)).to include(CGI.unescape_html(text))
+      expect(comment.title).to eq("Migas fingerstache pbr&b tofu.")
     end
 
     it "is converted to deleted if the comment is deleted" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
Sometimes, the Comment spec named `"retains content from #processed_html"` randomly failed. This was happening only when the Comment model was created with a `body_markdown` that included special characters, e.g. `&` as in: `Migas fingerstache pbr&b tofu.` from `Faker::Hipster` module.

The `expect` part was comparing `&` with `&amp;` which was failing the spec. By unescaping both parts, this flaky is fixed.

Resolves https://github.com/thepracticaldev/dev.to/issues/6251

## Related Tickets & Documents
I'm not sure if there is an existing issue, I couldn't find one.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [ ] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
