### PR TITLE
Mailchimp resubscribe

### DIFF
--- a/app/labor/mailchimp_bot.rb
+++ b/app/labor/mailchimp_bot.rb
@@ -39,6 +39,24 @@ class MailchimpBot
           }
         },
       )
+
+      success = true
+    rescue Gibbon::MailChimpError => e
+      # If user was previously subscribed, set their status to "pending"
+      return resubscribe_to_newsletter if previously_subcribed?(e)
+
+      report_error(e)
+    end
+    success
+  end
+
+  def resubscribe_to_newsletter
+    success = false
+
+    begin
+      gibbon.lists(SiteConfig.mailchimp_newsletter_id).members(target_md5_email).upsert(
+        body: { status: "pending" },
+      )
       success = true
     rescue Gibbon::MailChimpError => e
       report_error(e)
@@ -169,5 +187,9 @@ class MailchimpBot
   def target_md5_email
     email = saved_changes["unconfirmed_email"] ? saved_changes["email"][0] : user.email
     md5_email(email)
+  end
+
+  def previously_subcribed?(error)
+    error.title.match?(/Member In Compliance State/)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -417,7 +417,7 @@ class User < ApplicationRecord
   def subscribe_to_mailchimp_newsletter
     return unless email.present? && email.include?("@")
     return if saved_changes["unconfirmed_email"] && saved_changes["confirmation_sent_at"]
-    return if saved_changes.key?(:user_email) || saved_changes.key?(:email_newsletter)
+    return unless saved_changes.key?(:email) || saved_changes.key?(:email_newsletter)
 
     Users::SubscribeToMailchimpNewsletterWorker.perform_async(id)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -172,9 +172,9 @@ class User < ApplicationRecord
   }
 
   after_create_commit :send_welcome_notification
-  after_save  :bust_cache
-  after_save  :subscribe_to_mailchimp_newsletter
-  after_save  :conditionally_resave_articles
+  after_save :bust_cache
+  after_save :subscribe_to_mailchimp_newsletter
+  after_save :conditionally_resave_articles
   after_create_commit :estimate_default_language
   before_create :set_default_language
   before_validation :set_username
@@ -417,6 +417,7 @@ class User < ApplicationRecord
   def subscribe_to_mailchimp_newsletter
     return unless email.present? && email.include?("@")
     return if saved_changes["unconfirmed_email"] && saved_changes["confirmation_sent_at"]
+    return if saved_changes.key?(:user_email) || saved_changes.key?(:email_newsletter)
 
     Users::SubscribeToMailchimpNewsletterWorker.perform_async(id)
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -69,7 +69,7 @@ FactoryBot.define do
       after(:build) { |user| user.created_at = 3.weeks.ago }
     end
 
-    trait :ignore_after_callback do
+    trait :ignore_mailchimp_subscribe_callback do
       after(:build) do |user|
         user.define_singleton_method(:subscribe_to_mailchimp_newsletter) {}
         # user.class.skip_callback(:validates, :after_create)

--- a/spec/labor/mailchimp_bot_spec.rb
+++ b/spec/labor/mailchimp_bot_spec.rb
@@ -91,6 +91,19 @@ RSpec.describe MailchimpBot, type: :labor do
       expect(my_gibbon_client).to have_received(:upsert).
         with(hash_including(body: hash_including(email_address: user.email)))
     end
+
+    it "tries to resubscribe the user if the user has previously been subscribed" do
+      user.update(email_newsletter: false)
+      mailchimp_bot = described_class.new(user)
+      mc_error =
+        Gibbon::MailChimpError.new("Error", status_code: 400, title: "Member In Compliance State")
+      allow(mailchimp_bot.gibbon).to receive(:upsert).and_raise(mc_error)
+      allow(mailchimp_bot).to receive(:resubscribe_to_newsletter)
+
+      mailchimp_bot.upsert_to_newsletter
+
+      expect(mailchimp_bot).to have_received(:resubscribe_to_newsletter)
+    end
   end
 
   describe "manage community moderator list" do

--- a/spec/labor/mailchimp_bot_spec.rb
+++ b/spec/labor/mailchimp_bot_spec.rb
@@ -19,7 +19,7 @@ class FakeGibbonRequest < Gibbon::Request
 end
 
 RSpec.describe MailchimpBot, type: :labor do
-  let(:user) { create(:user, :ignore_after_callback) }
+  let(:user) { create(:user, :ignore_mailchimp_subscribe_callback) }
   let(:article) { create(:article, user_id: user.id) }
   let(:my_gibbon_client) { instance_double(FakeGibbonRequest) }
   let(:tag) { create(:tag, name: "tagname", bg_color_hex: Faker::Color.hex_color, text_color_hex: Faker::Color.hex_color, supported: true) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -527,7 +527,7 @@ RSpec.describe User, type: :model do
       end
 
       it "does not enqueue when the email address or subscription status has not changed" do
-        user = create(:user, :ignore_after_callback)
+        user = create(:user, :ignore_mailchimp_subscribe_callback)
 
         sidekiq_assert_no_enqueued_jobs(only: Users::SubscribeToMailchimpNewsletterWorker) do
           user.update(website_url: "http://example.com")

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -525,6 +525,14 @@ RSpec.describe User, type: :model do
           user.update(unconfirmed_email: "bob@bob.com", confirmation_sent_at: Time.current)
         end
       end
+
+      it "does not enqueue when the email address or subscription status has not changed" do
+        user = create(:user, :ignore_after_callback)
+
+        sidekiq_assert_no_enqueued_jobs(only: Users::SubscribeToMailchimpNewsletterWorker) do
+          user.update(website_url: "http://example.com")
+        end
+      end
     end
 
     describe "#conditionally_resave_articles" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -527,7 +527,8 @@ RSpec.describe User, type: :model do
       end
 
       it "does not enqueue when the email address or subscription status has not changed" do
-        user = create(:user, :ignore_mailchimp_subscribe_callback)
+        # The trait replaces the method with a dummy, but we need the actual method for this test.
+        user = described_class.find(create(:user, :ignore_mailchimp_subscribe_callback).id)
 
         sidekiq_assert_no_enqueued_jobs(only: Users::SubscribeToMailchimpNewsletterWorker) do
           user.update(website_url: "http://example.com")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Feature

## Description

If user's who previously subscribed to our newsletter try to resubscribe, it won't work without them explicitly opting in again. Setting their user status to 'pending' should™ trigger a confirmation email and this PR implements this.

There are several things that could be improved once we get the basics working, I'll leave some comments inline/below.

## Related Tickets & Documents

https://github.com/thepracticaldev/tech-private/issues/398

## Added tests?

- [X] yes

## Added to documentation?

- [X] no documentation needed

![complicated](https://media.giphy.com/media/cnuQwZ8IFLDZFwreWF/giphy.gif)
