### PR TITLE
Removed misleading information about sponsorships renewal

### DIFF
--- a/app/views/partnerships/_form.html.erb
+++ b/app/views/partnerships/_form.html.erb
@@ -61,11 +61,6 @@
               <h4>Sponsorship message/brand instructions:</h4>
               <%= text_area_tag(:instructions, nil, placeholder: "Include brand guideline links and detailed instructions about the message you are trying to get across. DEV editors will use these guidelines contextually depending on sponsorship.") %>
               <button>Subscribe for <%= Sponsorship::CREDITS[level] %> credits</button>
-              <p style="font-size: 0.88em;">
-                <em>
-                  This subscription will renew every month with credits in your account. If there are no credits, 50 credits will be purchased at the appropriate price. You can cancel this automatic sponsorship subscription at any time.
-                </em>
-              </p>
             <% end %>
           <% end %>
         <% elsif level == "tag" %>
@@ -89,11 +84,6 @@
             <% tag_names = Tag.where(supported: true).where.not(name: sponsored_tags).pluck(:name) %>
             <%= select_tag "tag_name", options_for_select(tag_names) %>
             <button>Sponsor Tag for <%= Sponsorship::CREDITS[:tag] %> credits</button>
-            <p style="font-size: 0.88em;">
-              <em>
-                This subscription will renew every month with credits in your account. If there are no credits, 50 credits will be purchased at the appropriate price. You can cancel this automatic sponsorship subscription at any time.
-              </em>
-            </p>
           <% end %>
         <%# NOTE: this currently can't be reached %>
         <% elsif level == "media" %>
@@ -122,11 +112,6 @@
             <button>Sign Up for DevRel Consulting</button>
             <p style="font-size: 1.1em;">
               You will be contacted by the DEV team within one day of signing up for this service.
-            </p>
-            <p style="font-size: 0.88em;">
-              <em>
-                This subscription will renew every month with credits in your account. If there are no credits, 50 credits will be purchased at the appropriate price. You can cancel this automatic sponsorship subscription at any time.
-              </em>
             </p>
           <% end %>
         <% end %>

--- a/spec/requests/partnerships_spec.rb
+++ b/spec/requests/partnerships_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "Partnerships", type: :request do
         OrganizationMembership.create(user_id: user.id, organization_id: organization.id, type_of_user: "admin")
         Credit.add_to_org(organization, 100)
         get "/partnerships/bronze-sponsor"
-        expect(response.body).to include("This subscription will renew every month")
+        expect(response.body).to include("Subscribe for #{Sponsorship::CREDITS[:bronze]} credits")
       end
     end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Removed the information about sponsorships renewal.
Auto-renewal is not implemented, so information about it is misleading.