### PR TITLE
Delete classified listings when deleting user

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,7 +46,7 @@ class User < ApplicationRecord
   has_many :html_variants, dependent: :destroy
   has_many :page_views, dependent: :destroy
   has_many :credits, dependent: :destroy
-  has_many :classified_listings
+  has_many :classified_listings, dependent: :destroy
   has_many :poll_votes, dependent: :destroy
   has_many :poll_skips, dependent: :destroy
   has_many :backup_data, foreign_key: "instance_user_id", inverse_of: :instance_user, class_name: "BackupData", dependent: :delete_all

--- a/app/services/users/delete_activity.rb
+++ b/app/services/users/delete_activity.rb
@@ -35,6 +35,7 @@ module Users
       user.profile_pins.delete_all
       user.rating_votes.delete_all
       user.tweets.delete_all
+      user.classified_listings.delete_all
 
       handle_feedback_messages(user)
     end

--- a/spec/requests/internal/users_banish_spec.rb
+++ b/spec/requests/internal/users_banish_spec.rb
@@ -236,6 +236,12 @@ RSpec.describe "Internal::Users", type: :request do
       expect(user.follows.count).to eq(0)
     end
 
+    it "removes a user's classified listings" do
+      create(:classified_listing, user: user)
+      banish_user
+      expect(user.classified_listings.count).to eq(0)
+    end
+
     it "creates an entry in the BanishedUsers table" do
       expect do
         banish_user

--- a/spec/services/users/delete_spec.rb
+++ b/spec/services/users/delete_spec.rb
@@ -29,6 +29,12 @@ RSpec.describe Users::Delete, type: :service do
     expect(Article.find_by(id: article.id)).to be_nil
   end
 
+  it "deletes user's classified listings" do
+    listing = create(:classified_listing, user: user)
+    described_class.call(user)
+    expect(ClassifiedListing.find_by(id: listing.id)).to be_nil
+  end
+
   it "deletes the destroy token" do
     allow(Rails.cache).to receive(:delete).and_call_original
     described_class.call(user)

--- a/spec/services/users/delete_spec.rb
+++ b/spec/services/users/delete_spec.rb
@@ -29,12 +29,6 @@ RSpec.describe Users::Delete, type: :service do
     expect(Article.find_by(id: article.id)).to be_nil
   end
 
-  it "deletes user's classified listings" do
-    listing = create(:classified_listing, user: user)
-    described_class.call(user)
-    expect(ClassifiedListing.find_by(id: listing.id)).to be_nil
-  end
-
   it "deletes the destroy token" do
     allow(Rails.cache).to receive(:delete).and_call_original
     described_class.call(user)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Description

We didn't clean up classified listings when removing users, which sometimes led to issues. This PR follows the pattern previously established by Anna and adds classified listings to it.

## Related Tickets & Documents

Closes https://github.com/thepracticaldev/tech-private/issues/379

## Added tests?

- [X] yes

## Added to documentation?

- [X] no documentation needed