### PR TITLE
Add HtmlVariantSuccess and HtmlVariantTrial dashboards

### DIFF
--- a/app/controllers/admin/html_variant_successes_controller.rb
+++ b/app/controllers/admin/html_variant_successes_controller.rb
@@ -1,0 +1,34 @@
+module Admin
+  class HtmlVariantSuccessesController < Admin::ApplicationController
+    # Overwrite any of the RESTful controller actions to implement custom behavior
+    # For example, you may want to send an email after a foo is updated.
+    #
+    # def update
+    #   foo = Foo.find(params[:id])
+    #   foo.update(params[:foo])
+    #   send_foo_updated_email
+    # end
+
+    # Override this method to specify custom lookup behavior.
+    # This will be used to set the resource for the `show`, `edit`, and `update`
+    # actions.
+    #
+    # def find_resource(param)
+    #   Foo.find_by!(slug: param)
+    # end
+
+    # Override this if you have certain roles that require a subset
+    # this will be used to set the records shown on the `index` action.
+    #
+    # def scoped_resource
+    #  if current_user.super_admin?
+    #    resource_class
+    #  else
+    #    resource_class.with_less_stuff
+    #  end
+    # end
+
+    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/controllers/admin/html_variant_trials_controller.rb
+++ b/app/controllers/admin/html_variant_trials_controller.rb
@@ -1,0 +1,34 @@
+module Admin
+  class HtmlVariantTrialsController < Admin::ApplicationController
+    # Overwrite any of the RESTful controller actions to implement custom behavior
+    # For example, you may want to send an email after a foo is updated.
+    #
+    # def update
+    #   foo = Foo.find(params[:id])
+    #   foo.update(params[:foo])
+    #   send_foo_updated_email
+    # end
+
+    # Override this method to specify custom lookup behavior.
+    # This will be used to set the resource for the `show`, `edit`, and `update`
+    # actions.
+    #
+    # def find_resource(param)
+    #   Foo.find_by!(slug: param)
+    # end
+
+    # Override this if you have certain roles that require a subset
+    # this will be used to set the records shown on the `index` action.
+    #
+    # def scoped_resource
+    #  if current_user.super_admin?
+    #    resource_class
+    #  else
+    #    resource_class.with_less_stuff
+    #  end
+    # end
+
+    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/dashboards/dashboard_manifest.rb
+++ b/app/dashboards/dashboard_manifest.rb
@@ -26,6 +26,8 @@ class DashboardManifest
     badges
     badge_achievements
     html_variants
+    html_variant_trials
+    html_variant_successes
     sponsorships
     pro_memberships
   ].freeze

--- a/app/dashboards/html_variant_success_dashboard.rb
+++ b/app/dashboards/html_variant_success_dashboard.rb
@@ -1,0 +1,58 @@
+require "administrate/base_dashboard"
+
+class HtmlVariantSuccessDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    html_variant: Field::BelongsTo,
+    article: Field::BelongsTo
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = %i[
+    html_variant
+    article
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = %i[
+    html_variant
+    article
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = %i[
+    html_variant
+    article
+  ].freeze
+
+  # COLLECTION_FILTERS
+  # a hash that defines filters that can be used while searching via the search
+  # field of the dashboard.
+  #
+  # For example to add an option to search for open resources by typing "open:"
+  # in the search field:
+  #
+  #   COLLECTION_FILTERS = {
+  #     open: ->(resources) { where(open: true) }
+  #   }.freeze
+  COLLECTION_FILTERS = {}.freeze
+
+  # Overwrite this method to customize how html variant successes are displayed
+  # across all pages of the admin dashboard.
+  #
+  # def display_resource(html_variant_success)
+  #   "HtmlVariantSuccess ##{html_variant_success.id}"
+  # end
+end

--- a/app/dashboards/html_variant_trial_dashboard.rb
+++ b/app/dashboards/html_variant_trial_dashboard.rb
@@ -1,0 +1,58 @@
+require "administrate/base_dashboard"
+
+class HtmlVariantTrialDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    html_variant: Field::BelongsTo,
+    article: Field::BelongsTo
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = %i[
+    html_variant
+    article
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = %i[
+    html_variant
+    article
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = %i[
+    html_variant
+    article
+  ].freeze
+
+  # COLLECTION_FILTERS
+  # a hash that defines filters that can be used while searching via the search
+  # field of the dashboard.
+  #
+  # For example to add an option to search for open resources by typing "open:"
+  # in the search field:
+  #
+  #   COLLECTION_FILTERS = {
+  #     open: ->(resources) { where(open: true) }
+  #   }.freeze
+  COLLECTION_FILTERS = {}.freeze
+
+  # Overwrite this method to customize how html variant trials are displayed
+  # across all pages of the admin dashboard.
+  #
+  # def display_resource(html_variant_trial)
+  #   "HtmlVariantTrial ##{html_variant_trial.id}"
+  # end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Description

The show page variants on `HtmlVariantDashboard` didn't work. I'm not super familiar with this part of our app, but adding the missing dashboards with `rails generate administrate:dashboard` seemed like the easiest fix. 

## Related Tickets & Documents

Closes #6143 

## Added tests?

- [X] no, because I'm not sure if we need them

## Added to documentation?

- [X] no documentation needed