### PR TITLE
Fix Sponsorship validations to take expiration date into an account

### DIFF
--- a/app/models/sponsorship.rb
+++ b/app/models/sponsorship.rb
@@ -19,18 +19,8 @@ class Sponsorship < ApplicationRecord
   validates :level, inclusion: { in: LEVELS }
   validates :status, inclusion: { in: STATUSES }
   validates :url, url: { allow_blank: true, no_local: true, schemes: %w[http https] }
-  validates :level,
-            uniqueness: {
-              scope: :organization,
-              message: "You can have only one sponsorship of #{LEVELS_WITH_EXPIRATION}"
-            },
-            if: proc { LEVELS_WITH_EXPIRATION.include?(level) }
-  validates :level,
-            uniqueness: {
-              scope: [:sponsorable],
-              message: proc { "The tag is already sponsored" }
-            },
-            if: proc { level.to_s == "tag" }
+  validate :validate_tag_uniqueness, if: proc { level.to_s == "tag" }
+  validate :validate_level_uniqueness, if: proc { LEVELS_WITH_EXPIRATION.include?(level) }
 
   scope :gold, -> { where(level: :gold) }
   scope :silver, -> { where(level: :silver) }
@@ -41,4 +31,20 @@ class Sponsorship < ApplicationRecord
 
   scope :live, -> { where(status: :live) }
   scope :pending, -> { where(status: :pending) }
+
+  private
+
+  def validate_tag_uniqueness
+    return unless self.class.where(sponsorable: sponsorable, level: :tag).
+      where("expires_at > ? AND id != ?", Time.current, id.to_i).exists?
+
+    errors.add(:level, "The tag is already sponsored")
+  end
+
+  def validate_level_uniqueness
+    return unless self.class.where(organization: organization).
+      where("level IN (?) AND expires_at > ? AND id != ?", LEVELS_WITH_EXPIRATION, Time.current, id.to_i).exists?
+
+    errors.add(:level, "You can have only one sponsorship of #{LEVELS_WITH_EXPIRATION.join(', ')}")
+  end
 end

--- a/spec/models/sponsorship_spec.rb
+++ b/spec/models/sponsorship_spec.rb
@@ -49,34 +49,59 @@ RSpec.describe Sponsorship, type: :model do
   end
 
   describe "validations" do
-    let(:org) { build(:organization) }
+    let(:user) { create(:user, :org_member) }
+    let(:org) { user.organizations.first }
 
-    it "forbids an org to have multiple 'expiring' sponsorships" do
-      create(:sponsorship, level: :gold, organization: org)
-      bronze_sponsorship = build(:sponsorship, level: :gold, organization: org)
+    it "forbids an org to have multiple 'expiring' (bronze-silver-gold) sponsorships" do
+      create(:sponsorship, level: :gold, organization: org, expires_at: Time.current + 2.days)
+      bronze_sponsorship = build(:sponsorship, level: :bronze, organization: org)
       expect(bronze_sponsorship).not_to be_valid
+      expect(bronze_sponsorship.errors[:level]).to be_present
+    end
+
+    it "allows to create a new sponsorship for the same org if the previous one is expired" do
+      create(:sponsorship, expires_at: Time.current - 1.day, user: user, organization: org, level: :bronze)
+      bronze_sponsorship = build(:sponsorship, level: :bronze, user: user, organization: org)
+      expect(bronze_sponsorship).to be_valid
+    end
+
+    it "allows to create a new sponsorship for the same level for another org" do
+      create(:sponsorship, level: :gold, organization: org, expires_at: Time.current + 2.days)
+      other_org = create(:organization)
+      gold_sponsorship = build(:sponsorship, level: :gold, organization: other_org)
+      expect(gold_sponsorship).to be_valid
     end
 
     context "when tag sponsorships" do
+      let(:python) { create(:tag, name: "python") }
+      let(:ruby) { create(:tag, name: "ruby") }
+
       it "allows an org to have multiple tag sponsorships on different tags" do
-        create(:sponsorship, level: :tag, organization: org, sponsorable: create(:tag, name: "python"))
-        tag_sponsorship = build(:sponsorship, level: :tag, organization: org, sponsorable: create(:tag, name: "ruby"))
+        create(:sponsorship, level: :tag, organization: org, expires_at: Time.current + 2.days, sponsorable: python)
+        tag_sponsorship = build(:sponsorship, level: :tag, organization: org, sponsorable: ruby)
         expect(tag_sponsorship).to be_valid
       end
 
-      it "forbids an org to have multiple tag sponsorships on the same tag" do
-        tag = create(:tag, name: "python")
-        create(:sponsorship, level: :tag, organization: org, sponsorable: tag)
-        tag_sponsorship = build(:sponsorship, level: :tag, organization: org, sponsorable: tag)
-        expect(tag_sponsorship).not_to be_valid
+      it "allows to create a new tag sponsorship if the previous one is expired" do
+        create(:sponsorship, user: user, organization: org, expires_at: Time.current - 1.day, level: :tag, sponsorable: ruby)
+        ruby_sponsorship = build(:sponsorship, user: user, organization: org, level: :tag, sponsorable: ruby)
+        expect(ruby_sponsorship).to be_valid
       end
 
-      it "forbids different orgs to have a sponsorship on the same tag" do
+      it "forbids an org to have multiple active tag sponsorships on the same tag" do
         tag = create(:tag, name: "python")
-        other_org = create(:organization)
-        create(:sponsorship, level: :tag, organization: org, sponsorable: tag)
-        tag_sponsorship = build(:sponsorship, level: :tag, organization: other_org, sponsorable: tag)
+        create(:sponsorship, level: :tag, organization: org, sponsorable: tag, expires_at: Time.current + 2.days)
+        tag_sponsorship = build(:sponsorship, level: :tag, organization: org, sponsorable: tag)
         expect(tag_sponsorship).not_to be_valid
+        expect(tag_sponsorship.errors[:level]).to be_present
+      end
+
+      it "forbids different orgs to have active sponsorships on the same tag" do
+        other_org = create(:organization)
+        create(:sponsorship, level: :tag, organization: org, sponsorable: python, expires_at: Time.current + 2.days)
+        tag_sponsorship = build(:sponsorship, level: :tag, organization: other_org, sponsorable: python)
+        expect(tag_sponsorship).not_to be_valid
+        expect(tag_sponsorship.errors[:level]).to be_present
       end
     end
   end

--- a/spec/models/sponsorship_spec.rb
+++ b/spec/models/sponsorship_spec.rb
@@ -53,20 +53,20 @@ RSpec.describe Sponsorship, type: :model do
     let(:org) { user.organizations.first }
 
     it "forbids an org to have multiple 'expiring' (bronze-silver-gold) sponsorships" do
-      create(:sponsorship, level: :gold, organization: org, expires_at: Time.current + 2.days)
+      create(:sponsorship, level: :gold, organization: org, expires_at: 2.days.from_now)
       bronze_sponsorship = build(:sponsorship, level: :bronze, organization: org)
       expect(bronze_sponsorship).not_to be_valid
       expect(bronze_sponsorship.errors[:level]).to be_present
     end
 
     it "allows to create a new sponsorship for the same org if the previous one is expired" do
-      create(:sponsorship, expires_at: Time.current - 1.day, user: user, organization: org, level: :bronze)
+      create(:sponsorship, expires_at: 1.day.ago, user: user, organization: org, level: :bronze)
       bronze_sponsorship = build(:sponsorship, level: :bronze, user: user, organization: org)
       expect(bronze_sponsorship).to be_valid
     end
 
     it "allows to create a new sponsorship for the same level for another org" do
-      create(:sponsorship, level: :gold, organization: org, expires_at: Time.current + 2.days)
+      create(:sponsorship, level: :gold, organization: org, expires_at: 2.days.from_now)
       other_org = create(:organization)
       gold_sponsorship = build(:sponsorship, level: :gold, organization: other_org)
       expect(gold_sponsorship).to be_valid
@@ -77,20 +77,20 @@ RSpec.describe Sponsorship, type: :model do
       let(:ruby) { create(:tag, name: "ruby") }
 
       it "allows an org to have multiple tag sponsorships on different tags" do
-        create(:sponsorship, level: :tag, organization: org, expires_at: Time.current + 2.days, sponsorable: python)
+        create(:sponsorship, level: :tag, organization: org, expires_at: 2.days.from_now, sponsorable: python)
         tag_sponsorship = build(:sponsorship, level: :tag, organization: org, sponsorable: ruby)
         expect(tag_sponsorship).to be_valid
       end
 
       it "allows to create a new tag sponsorship if the previous one is expired" do
-        create(:sponsorship, user: user, organization: org, expires_at: Time.current - 1.day, level: :tag, sponsorable: ruby)
+        create(:sponsorship, user: user, organization: org, expires_at: 1.day.ago, level: :tag, sponsorable: ruby)
         ruby_sponsorship = build(:sponsorship, user: user, organization: org, level: :tag, sponsorable: ruby)
         expect(ruby_sponsorship).to be_valid
       end
 
       it "forbids an org to have multiple active tag sponsorships on the same tag" do
         tag = create(:tag, name: "python")
-        create(:sponsorship, level: :tag, organization: org, sponsorable: tag, expires_at: Time.current + 2.days)
+        create(:sponsorship, level: :tag, organization: org, sponsorable: tag, expires_at: 2.days.from_now)
         tag_sponsorship = build(:sponsorship, level: :tag, organization: org, sponsorable: tag)
         expect(tag_sponsorship).not_to be_valid
         expect(tag_sponsorship.errors[:level]).to be_present
@@ -98,7 +98,7 @@ RSpec.describe Sponsorship, type: :model do
 
       it "forbids different orgs to have active sponsorships on the same tag" do
         other_org = create(:organization)
-        create(:sponsorship, level: :tag, organization: org, sponsorable: python, expires_at: Time.current + 2.days)
+        create(:sponsorship, level: :tag, organization: org, sponsorable: python, expires_at: 2.days.from_now)
         tag_sponsorship = build(:sponsorship, level: :tag, organization: other_org, sponsorable: python)
         expect(tag_sponsorship).not_to be_valid
         expect(tag_sponsorship.errors[:level]).to be_present


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Fixed Sponsorship validations so that they would take `expires_at` into an account:
When a sponsorship has expired we should allow creating another sponsorship for this tag, or another sponsorship of gold, silver or bronze levels for a particular organization.

## Related Tickets & Documents
#6017 

## Added tests?
- [x] yes