### PR TITLE
Remove Strong Migration safety_assured From Migration

### DIFF
--- a/db/migrate/20200221170905_remove_user_organization_id.rb
+++ b/db/migrate/20200221170905_remove_user_organization_id.rb
@@ -1,5 +1,5 @@
 class RemoveUserOrganizationId < ActiveRecord::Migration[5.2]
   def change
-    safety_assured { remove_column :users, :organization_id, :integer }
+    remove_column :users, :organization_id, :integer
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Strong migrations only runs in dev and test so when we try to run this in prod we get this error
```
undefined method `safety_assured' for #<RemoveUserOrganizationId:0x000000000c64f760>
```
## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

![alt_text](https://media.tenor.com/images/78df280a9d12c78cf258ad37e72df7e7/tenor.gif)
