### PR TITLE
Enable strong-migrations in all environments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,6 +92,7 @@ gem "sprockets", "~> 3.7" # Sprockets is a Rack-based asset packaging system
 gem "staccato", "~> 0.5" # Ruby Google Analytics Measurement
 gem "storext", "~> 3.1" # Add type-casting and other features on top of ActiveRecord::Store.store_accessor
 gem "stripe", "~> 5.15" # Ruby library for the Stripe API
+gem "strong_migrations", "~> 0.6" # Catch unsafe migrations in development
 gem "timber", "~> 3.0" # Great Ruby logging made easy
 gem "timber-rails", "~> 1.0" #  Timber integration for Rails
 gem "twilio-ruby", "~> 5.31" # The official library for communicating with the Twilio REST API
@@ -136,7 +137,6 @@ group :development, :test do
   gem "rubocop-rspec", "~> 1.38", require: false # Code style checking for RSpec files
   gem "spring", "~> 2.1" # Preloads your application so things like console, rake and tests run faster
   gem "spring-commands-rspec", "~> 1.0" # rspec command for spring
-  gem "strong_migrations", "~> 0.6" # Catch unsafe migrations in development
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -92,7 +92,7 @@ gem "sprockets", "~> 3.7" # Sprockets is a Rack-based asset packaging system
 gem "staccato", "~> 0.5" # Ruby Google Analytics Measurement
 gem "storext", "~> 3.1" # Add type-casting and other features on top of ActiveRecord::Store.store_accessor
 gem "stripe", "~> 5.15" # Ruby library for the Stripe API
-gem "strong_migrations", "~> 0.6" # Catch unsafe migrations in development
+gem "strong_migrations", "~> 0.6" # Catch unsafe migrations
 gem "timber", "~> 3.0" # Great Ruby logging made easy
 gem "timber-rails", "~> 1.0" #  Timber integration for Rails
 gem "twilio-ruby", "~> 5.31" # The official library for communicating with the Twilio REST API

--- a/config/initializers/strong_migrations.rb
+++ b/config/initializers/strong_migrations.rb
@@ -1,7 +1,5 @@
-if Rails.env.test? || Rails.env.development?
-  # https://github.com/ankane/strong_migrations#existing-migrations
-  StrongMigrations.start_after = 20_200_106_074_859
+# https://github.com/ankane/strong_migrations#existing-migrations
+StrongMigrations.start_after = 20_200_106_074_859
 
-  # https://github.com/ankane/strong_migrations#target-version
-  StrongMigrations.target_postgresql_version = 11
-end
+# https://github.com/ankane/strong_migrations#target-version
+StrongMigrations.target_postgresql_version = 11

--- a/db/migrate/20200221170905_remove_user_organization_id.rb
+++ b/db/migrate/20200221170905_remove_user_organization_id.rb
@@ -1,5 +1,5 @@
 class RemoveUserOrganizationId < ActiveRecord::Migration[5.2]
   def change
-    remove_column :users, :organization_id, :integer
+    safety_assured { remove_column :users, :organization_id, :integer }
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When we merged #5522 we weren't familiar with the gem and opted to enable it only in development, but to be effective this gem should be enabled in production as well, being able to catch unsafe migrations if they somehow skip our PR review process.

By merging #6242 we broke deploy because the https://github.com/ankane/strong_migrations gem wasn't enabled in production. @mstruve quickly fixed it with #6277

This should fix the underline problem we have triggered

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
