### PR TITLE
Add indexes to PodcastEpisode title and website_url

### DIFF
--- a/db/migrate/20200224153122_add_title_website_url_indexes_to_podcast_episodes.rb
+++ b/db/migrate/20200224153122_add_title_website_url_indexes_to_podcast_episodes.rb
@@ -1,0 +1,8 @@
+class AddTitleWebsiteUrlIndexesToPodcastEpisodes < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :podcast_episodes, :title, algorithm: :concurrently
+    add_index :podcast_episodes, :website_url, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_21_170905) do
-
+ActiveRecord::Schema.define(version: 2020_02_24_153122) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -751,6 +750,8 @@ ActiveRecord::Schema.define(version: 2020_02_21_170905) do
     t.index ["guid"], name: "index_podcast_episodes_on_guid", unique: true
     t.index ["media_url"], name: "index_podcast_episodes_on_media_url", unique: true
     t.index ["podcast_id"], name: "index_podcast_episodes_on_podcast_id"
+    t.index ["title"], name: "index_podcast_episodes_on_title"
+    t.index ["website_url"], name: "index_podcast_episodes_on_website_url"
   end
 
   create_table "podcasts", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Everytime `Podcasts::GetEpisodesWorker` is called we call `Podcast#get_episode` which executes both or only the first one of these queries:

```sql
SELECT podcast_episodes.* 
FROM podcast_episodes 
WHERE ( ( podcast_episodes.media_url = ? OR podcast_episodes.title = ? ) OR podcast_episodes.guid = ? )
```

```sql
SELECT podcast_episodes.* 
FROM podcast_episodes 
WHERE podcast_episodes.website_url IS NULL -- or = 'link'
```

Although `guid` and `media_url` have indexes, `title` and `website_url` don't.

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
