### PR TITLE
Implement Search for Chat Channels with Elasticsearch

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -9,4 +9,28 @@ class SearchController < ApplicationController
     DatadogStatsClient.increment("elasticsearch.errors", tags: ["error:BadRequest"])
     render json: { result: [] }
   end
+
+  def chat_channels
+    ccm_docs = Search::ChatChannelMembership.search_documents(
+      params: chat_channel_params.to_h, user_id: current_user.id,
+    )
+
+    render json: { result: ccm_docs }
+  end
+
+  private
+
+  def chat_channel_params
+    accessible = %i[
+      per_page
+      page
+      channel_text
+      channel_type
+      channel_status
+      status
+    ]
+    params[:page] = params[:page].to_i if params[:page].present?
+    params[:per_page] = params[:per_page].to_i if params[:per_page].present?
+    params.permit(accessible)
+  end
 end

--- a/app/models/chat_channel_membership.rb
+++ b/app/models/chat_channel_membership.rb
@@ -38,7 +38,8 @@ class ChatChannelMembership < ApplicationRecord
   end
 
   def channel_text
-    "#{chat_channel.channel_name} #{chat_channel.slug} #{chat_channel.channel_human_names}"
+    parsed_channel_name = chat_channel.channel_name&.gsub("chat between", "")&.gsub("and", "")
+    "#{parsed_channel_name} #{chat_channel.slug} #{chat_channel.channel_human_names.join(' ')}"
   end
 
   def channel_name

--- a/app/services/search/chat_channel_membership.rb
+++ b/app/services/search/chat_channel_membership.rb
@@ -3,18 +3,36 @@ module Search
     INDEX_NAME = "chat_channel_memberships_#{Rails.env}".freeze
     INDEX_ALIAS = "chat_channel_memberships_#{Rails.env}_alias".freeze
     MAPPINGS = JSON.parse(File.read("config/elasticsearch/mappings/chat_channel_memberships.json"), symbolize_names: true).freeze
+    DEFAULT_PAGE = 0
+    DEFAULT_PER_PAGE = 30
 
     class << self
       def search_documents(params:, user_id:)
+        set_query_size(params)
         query_hash = Search::QueryBuilders::ChatChannelMembership.new(params, user_id).as_hash
+
         results = search(body: query_hash)
-        results.dig("hits", "hits").map { |ccm_doc| ccm_doc.dig("_source") }
+        hits = results.dig("hits", "hits").map { |ccm_doc| ccm_doc.dig("_source") }
+        paginate_hits(hits, params)
       end
 
       private
 
       def search(body:)
         SearchClient.search(index: INDEX_ALIAS, body: body)
+      end
+
+      def set_query_size(params)
+        params[:page] ||= DEFAULT_PAGE
+        params[:per_page] ||= DEFAULT_PER_PAGE
+
+        # pages start at 0
+        params[:size] = params[:per_page].to_i * (params[:page].to_i + 1)
+      end
+
+      def paginate_hits(hits, params)
+        start = (params[:per_page] + 1) * params[:page]
+        hits[start, params[:per_page]]
       end
 
       def index_settings

--- a/app/services/search/query_builders/chat_channel_membership.rb
+++ b/app/services/search/query_builders/chat_channel_membership.rb
@@ -42,7 +42,7 @@ module Search
       def build_queries
         @body[:query] = {}
         @body[:query][:bool] = { filter: filter_conditions }
-        @body[:query][:bool] = { must: query_conditions } if query_keys_present?
+        @body[:query][:bool][:must] = query_conditions if query_keys_present?
       end
 
       def add_sort

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -216,6 +216,7 @@ Rails.application.routes.draw do
   resolve("ProMembership") { [:pro_membership] } # see https://guides.rubyonrails.org/routing.html#using-resolve
 
   get "/search/tags" => "search#tags"
+  get "/search/chat_channels" => "search#chat_channels"
   get "/chat_channel_memberships/find_by_chat_channel_id" => "chat_channel_memberships#find_by_chat_channel_id"
   get "/listings/dashboard" => "classified_listings#dashboard"
   get "/listings/:category" => "classified_listings#index"

--- a/spec/models/chat_channel_membership_spec.rb
+++ b/spec/models/chat_channel_membership_spec.rb
@@ -3,6 +3,15 @@ require "rails_helper"
 RSpec.describe ChatChannelMembership, type: :model do
   let(:chat_channel_membership) { FactoryBot.create(:chat_channel_membership) }
 
+  describe "#channel_text" do
+    it "sets channel text using name, slig, and human names" do
+      chat_channel = chat_channel_membership.chat_channel
+      parsed_channel_name = chat_channel_membership.channel_name&.gsub("chat between", "")&.gsub("and", "")
+      expected_text = "#{parsed_channel_name} #{chat_channel.slug} #{chat_channel.channel_human_names.join(' ')}"
+      expect(chat_channel_membership.channel_text).to eq(expected_text)
+    end
+  end
+
   describe "#index_to_elasticsearch" do
     it "enqueues job to index tag to elasticsearch" do
       sidekiq_assert_enqueued_with(job: described_class::SEARCH_INDEX_WORKER, args: [chat_channel_membership.id]) do

--- a/spec/requests/search_spec.rb
+++ b/spec/requests/search_spec.rb
@@ -23,4 +23,20 @@ RSpec.describe "Search", type: :request, proper_status: true do
       expect(response.parsed_body).to eq("result" => [])
     end
   end
+
+  describe "GET /search/chat_channels" do
+    let(:authorized_user) { create(:user) }
+    let(:mock_documents) do
+      [{ "channel_name" => "channel1" }]
+    end
+
+    it "returns json" do
+      sign_in authorized_user
+      allow(Search::ChatChannelMembership).to receive(:search_documents).and_return(
+        mock_documents,
+      )
+      get "/search/chat_channels"
+      expect(response.parsed_body).to eq("result" => mock_documents)
+    end
+  end
 end

--- a/spec/services/search/chat_channel_membership_spec.rb
+++ b/spec/services/search/chat_channel_membership_spec.rb
@@ -194,5 +194,13 @@ RSpec.describe Search::ChatChannelMembership, type: :service, elasticsearch: tru
       expect(chat_channel_membership_docs.first["id"]).to eq(chat_channel_membership1.id)
       expect(chat_channel_membership_docs.last["id"]).to eq(chat_channel_membership2.id)
     end
+
+    it "will return a set number of docs based on pagination params" do
+      index_documents([chat_channel_membership1, chat_channel_membership2])
+      params = { page: 0, per_page: 1 }
+
+      chat_channel_membership_docs = described_class.search_documents(params: params, user_id: user.id)
+      expect(chat_channel_membership_docs.count).to eq(1)
+    end
   end
 end

--- a/spec/services/search/chat_channel_membership_spec.rb
+++ b/spec/services/search/chat_channel_membership_spec.rb
@@ -171,6 +171,22 @@ RSpec.describe Search::ChatChannelMembership, type: :service, elasticsearch: tru
       end
     end
 
+    context "with a query and filter" do
+      it "searches by channel_text and status" do
+        allow(chat_channel_membership1).to receive(:channel_text).and_return("a name")
+        allow(chat_channel_membership2).to receive(:channel_text).and_return("another name")
+        chat_channel_membership1.update(status: "active")
+        chat_channel_membership2.update(status: "inactive")
+        index_documents([chat_channel_membership1, chat_channel_membership2])
+        name_params = { size: 5, channel_text: "name", status: "active" }
+
+        chat_channel_membership_docs = described_class.search_documents(params: name_params, user_id: user.id)
+        expect(chat_channel_membership_docs.count).to eq(1)
+        doc_ids = chat_channel_membership_docs.map { |t| t.dig("id") }
+        expect(doc_ids).to include(chat_channel_membership1.id)
+      end
+    end
+
     it "sorts documents for given field" do
       chat_channel_membership1.update(status: "inactive")
       chat_channel_membership2.update(status: "active")

--- a/spec/services/search/query_builders/chat_channel_membership_spec.rb
+++ b/spec/services/search/query_builders/chat_channel_membership_spec.rb
@@ -30,10 +30,12 @@ RSpec.describe Search::QueryBuilders::ChatChannelMembership, type: :service do
     it "applies QUERY_KEYS from params" do
       params = { channel_text: "a_name" }
       query = described_class.new(params, 1)
-      expected_musts = [
-        { "match" => { "channel_text" => { "query" => "a_name" } } },
-      ]
-      expect(query.as_hash.dig("query", "bool", "must")).to match_array(expected_musts)
+      expected_query = [{
+        "simple_query_string" => {
+          "query" => "a_name*", "fields" => [:channel_text], "lenient" => true, "analyze_wildcard" => true
+        }
+      }]
+      expect(query.as_hash.dig("query", "bool", "must")).to match_array(expected_query)
     end
 
     it "ignores params we dont support" do

--- a/spec/services/search/query_builders/chat_channel_membership_spec.rb
+++ b/spec/services/search/query_builders/chat_channel_membership_spec.rb
@@ -38,6 +38,19 @@ RSpec.describe Search::QueryBuilders::ChatChannelMembership, type: :service do
       expect(query.as_hash.dig("query", "bool", "must")).to match_array(expected_query)
     end
 
+    it "applies QUERY_KEYS and FILTER_KEYS from params" do
+      params = { channel_text: "a_name", channel_status: "active" }
+      query = described_class.new(params, 1)
+      expected_query = [{
+        "simple_query_string" => {
+          "query" => "a_name*", "fields" => [:channel_text], "lenient" => true, "analyze_wildcard" => true
+        }
+      }]
+      expected_filters = [{ "term" => { "channel_status" => "active" } }, { "term" => { "viewable_by" => 1 } }]
+      expect(query.as_hash.dig("query", "bool", "must")).to match_array(expected_query)
+      expect(query.as_hash.dig("query", "bool", "filter")).to match_array(expected_filters)
+    end
+
     it "ignores params we dont support" do
       params = { not_supported: "direct", status: "closed" }
       filter = described_class.new(params, 1)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
This PR moves the searching of chat channels from Algolia to Elasticsearch. Couple things to note.
1) **Pagination:** The backend and js support the ability to pass paging params, however, I did not see any buttons or links on the chat channel pages that implemented those features. Talked with @sarthology briefly and he confirmed he does not think its implemented. Well the backend is in place for when we do. 
2) **Improved Searching:** I updated what we store in the `channel_text` field by removing some common words. These can cause searches to return unwanted results. For example, say you want to search for your friend "Andy" If you type in "And" you will get back every single direct channel bc "and" is in all of the channel texts. With the common words removed typing in "And" will return only those channels with someone who has a name or username that starts with "and".

~TODO: Update the allowed params in Fastly~

## Card
https://github.com/thepracticaldev/dev.to/projects/6#card-33478501

## Added tests?
- [x] yes

## Added to documentation?
- [x] no documentation needed

Once again, Molly has touched frontend code...
![alt_text](https://media.giphy.com/media/5zovVQf2qvX1Pil0Um/giphy.gif)
