### PR TITLE
Refactor logic to index to Elasticsearch

### DIFF
--- a/app/models/chat_channel_membership.rb
+++ b/app/models/chat_channel_membership.rb
@@ -2,7 +2,6 @@ class ChatChannelMembership < ApplicationRecord
   include AlgoliaSearch
 
   include Searchable
-  SEARCH_INDEX_WORKER = Search::ChatChannelMembershipEsIndexWorker
   SEARCH_SERIALIZER = Search::ChatChannelMembershipSerializer
   SEARCH_CLASS = Search::ChatChannelMembership
 

--- a/app/models/classified_listing.rb
+++ b/app/models/classified_listing.rb
@@ -2,7 +2,6 @@ class ClassifiedListing < ApplicationRecord
   include AlgoliaSearch
   include Searchable
 
-  SEARCH_INDEX_WORKER = Search::ClassifiedListingEsIndexWorker
   SEARCH_SERIALIZER = Search::ClassifiedListingSerializer
   SEARCH_CLASS = Search::ClassifiedListing
 

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -1,6 +1,6 @@
 module Searchable
   def index_to_elasticsearch
-    self.class::SEARCH_INDEX_WORKER.perform_async(id)
+    Search::IndexToElasticsearchWorker.perform_async(self.class.name, id)
   end
 
   def index_to_elasticsearch_inline

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -31,7 +31,6 @@ class Tag < ActsAsTaggableOn::Tag
   before_save :mark_as_updated
 
   include Searchable
-  SEARCH_INDEX_WORKER = Search::TagEsIndexWorker
   SEARCH_SERIALIZER = Search::TagSerializer
   SEARCH_CLASS = Search::Tag
 

--- a/app/workers/search/index_to_elasticsearch_worker.rb
+++ b/app/workers/search/index_to_elasticsearch_worker.rb
@@ -1,0 +1,12 @@
+module Search
+  class IndexToElasticsearchWorker
+    include Sidekiq::Worker
+
+    sidekiq_options queue: :high_priority
+
+    def perform(search_class, id)
+      object = search_class.safe_constantize.find(id)
+      object.index_to_elasticsearch_inline
+    end
+  end
+end

--- a/app/workers/search/index_to_elasticsearch_worker.rb
+++ b/app/workers/search/index_to_elasticsearch_worker.rb
@@ -5,7 +5,7 @@ module Search
     sidekiq_options queue: :high_priority
 
     def perform(object_class, id)
-      object = object_class.safe_constantize.find(id)
+      object = object_class.constantize.find(id)
       object.index_to_elasticsearch_inline
     end
   end

--- a/app/workers/search/index_to_elasticsearch_worker.rb
+++ b/app/workers/search/index_to_elasticsearch_worker.rb
@@ -4,8 +4,8 @@ module Search
 
     sidekiq_options queue: :high_priority
 
-    def perform(search_class, id)
-      object = search_class.safe_constantize.find(id)
+    def perform(object_class, id)
+      object = object_class.safe_constantize.find(id)
       object.index_to_elasticsearch_inline
     end
   end

--- a/spec/models/chat_channel_membership_spec.rb
+++ b/spec/models/chat_channel_membership_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ChatChannelMembership, type: :model do
 
   describe "#index_to_elasticsearch" do
     it "enqueues job to index tag to elasticsearch" do
-      sidekiq_assert_enqueued_with(job: described_class::SEARCH_INDEX_WORKER, args: [chat_channel_membership.id]) do
+      sidekiq_assert_enqueued_with(job: Search::IndexToElasticsearchWorker, args: [described_class.to_s, chat_channel_membership.id]) do
         chat_channel_membership.index_to_elasticsearch
       end
     end
@@ -22,7 +22,7 @@ RSpec.describe ChatChannelMembership, type: :model do
   describe "#after_commit" do
     it "on update enqueues job to index chat_channel_membership to elasticsearch" do
       chat_channel_membership.save
-      sidekiq_assert_enqueued_with(job: described_class::SEARCH_INDEX_WORKER, args: [chat_channel_membership.id]) do
+      sidekiq_assert_enqueued_with(job: Search::IndexToElasticsearchWorker, args: [described_class.to_s, chat_channel_membership.id]) do
         chat_channel_membership.save
       end
     end

--- a/spec/models/classified_listing_spec.rb
+++ b/spec/models/classified_listing_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe ClassifiedListing, type: :model do
 
   describe "#index_to_elasticsearch" do
     it "enqueues job to index classified_listing to elasticsearch" do
-      sidekiq_assert_enqueued_with(job: described_class::SEARCH_INDEX_WORKER, args: [classified_listing.id]) do
+      sidekiq_assert_enqueued_with(job: Search::IndexToElasticsearchWorker, args: [described_class.to_s, classified_listing.id]) do
         classified_listing.index_to_elasticsearch
       end
     end
@@ -92,7 +92,7 @@ RSpec.describe ClassifiedListing, type: :model do
     it "on update enqueues worker to index tag to elasticsearch" do
       classified_listing.save
 
-      sidekiq_assert_enqueued_with(job: described_class::SEARCH_INDEX_WORKER, args: [classified_listing.id]) do
+      sidekiq_assert_enqueued_with(job: Search::IndexToElasticsearchWorker, args: [described_class.to_s, classified_listing.id]) do
         classified_listing.save
       end
     end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Tag, type: :model do
 
   describe "#index_to_elasticsearch" do
     it "enqueues job to index tag to elasticsearch" do
-      sidekiq_assert_enqueued_with(job: described_class::SEARCH_INDEX_WORKER, args: [tag.id]) do
+      sidekiq_assert_enqueued_with(job: Search::IndexToElasticsearchWorker, args: [described_class.to_s, tag.id]) do
         tag.index_to_elasticsearch
       end
     end
@@ -95,7 +95,7 @@ RSpec.describe Tag, type: :model do
   describe "#after_commit" do
     it "on update enqueues job to index tag to elasticsearch" do
       tag.save
-      sidekiq_assert_enqueued_with(job: described_class::SEARCH_INDEX_WORKER, args: [tag.id]) do
+      sidekiq_assert_enqueued_with(job: Search::IndexToElasticsearchWorker, args: [described_class.to_s, tag.id]) do
         tag.save
       end
     end

--- a/spec/workers/search/index_to_elasticsearch_worker_spec.rb
+++ b/spec/workers/search/index_to_elasticsearch_worker_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe Search::IndexToElasticsearchWorker, type: :worker, elasticsearch: true do
+  let(:worker) { subject }
+
+  include_examples "#enqueues_on_correct_queue", "high_priority", ["Tag", 1]
+
+  it "raises an error if record is not found" do
+    expect { worker.perform("Tag", 1234) }.to raise_error(ActiveRecord::RecordNotFound)
+  end
+
+  it "indexes document" do
+    tag = FactoryBot.create(:tag)
+    expect { tag.elasticsearch_doc }.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound)
+    worker.perform(tag.class.name, tag.id)
+
+    expect(tag.elasticsearch_doc.dig("_source", "id")).to eql(tag.id)
+  end
+end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
This PR follows an idea from #6213 - it moves the logic for indexing documents to Elasticsearch into a single worker. If we need to batch index in the future, we could always add a 3rd optional argument to this worker or create a new worker for that entirely. Let me know what you think!

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-33598410

## Added tests?
- [x] yes

## Added to documentation?
- [x] no documentation needed

## Are there any post deployment tasks we need to perform?
Monitor the Sidekiq queue just to make sure this new worker isn't failing. I'll open a separate PR to remove the old workers and specs if/when this is merged.

![harley_quinn_sips_tea_gif](https://media.giphy.com/media/Wp0ZtQjgViqR2/giphy.gif)
