### PR TITLE
Adds administrate gem CSS & JS assets to Sprockets Manifest

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -4,3 +4,5 @@
 //= link_directory ../stylesheets .css
 //= link internal/layout.css
 //= link s3_direct_upload.js
+// = link administrate/application.css
+// = link administrate/application.js

--- a/spec/system/admin/admin_dashboard_presented_spec.rb
+++ b/spec/system/admin/admin_dashboard_presented_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe "Admin dashboard is presented", type: :system do
+  let(:admin) { create(:user, :super_admin) }
+  let(:user) { create(:user) }
+
+  before { Bullet.raise = false }
+  after { Bullet.raise = true }
+
+  it "loads the admin dashboard view" do
+    sign_in admin
+    visit "/admin"
+    expect(page).to have_content("Articles")
+
+    visit "/admin/podcasts"
+    expect(page).to have_content("Podcast Episodes")
+  end
+
+  it "fails to load admin view for unauthorized users" do
+    expect { visit "/admin" }.to raise_error(Pundit::NotAuthorizedError)
+    expect { visit "/admin/podcasts" }.to raise_error(Pundit::NotAuthorizedError)
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Local development was showing an error caused by Sprockets (4.0) not finding the `Administrate` gem assets. This happened when trying to browse `/admin` and its nested dashboards. 

This PR adds the files to the manifest & includes a simple test to avoid regressions that might break the `Administrate` dashboards

## Related Tickets & Documents

From the Administrate repo's [README (**Getting Started**)](https://github.com/thoughtbot/administrate#getting-started) you'll find the fix they suggest, which is added by this PR.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

N/A

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

N/A

## [optional] What gif best describes this PR or how it makes you feel?

![TEST: you can do it](https://media.giphy.com/media/8FNlmNPDTo2wE/giphy.gif)
