### PR TITLE
Add index missing check to podcast migration

### DIFF
--- a/app/lib/index_migration_helpers.rb
+++ b/app/lib/index_migration_helpers.rb
@@ -1,0 +1,19 @@
+module IndexMigrationHelpers
+  def add_index_if_missing(table_name, column_name, options = {})
+    columns = Array(column_name)
+    if options.key?(:name) && indexes(table_name).none? { |idx| idx.name == options[:name] }
+      add_index(table_name, column_name, options)
+    elsif indexes(table_name).none? { |idx| idx.columns.map(&:to_sym) == columns }
+      add_index(table_name, column_name, options)
+    end
+  end
+
+  def remove_index_if_exists(table_name, options = {})
+    columns = Array(options[:column])
+    if options.key?(:name) && indexes(table_name).any? { |idx| idx.name == options[:name] }
+      remove_index(table_name, options)
+    elsif indexes(table_name).any? { |idx| idx.columns.map(&:to_sym) == columns }
+      remove_index(table_name, options)
+    end
+  end
+end

--- a/db/migrate/20200224153122_add_title_website_url_indexes_to_podcast_episodes.rb
+++ b/db/migrate/20200224153122_add_title_website_url_indexes_to_podcast_episodes.rb
@@ -2,8 +2,13 @@ class AddTitleWebsiteUrlIndexesToPodcastEpisodes < ActiveRecord::Migration[5.2]
   disable_ddl_transaction!
   include IndexMigrationHelpers
 
-  def change
+  def up
     add_index_if_missing(:podcast_episodes, :title, algorithm: :concurrently)
     add_index_if_missing(:podcast_episodes, :website_url, algorithm: :concurrently)
+  end
+
+  def down
+    remove_index_if_exists(:podcast_episodes, column: :title, algorithm: :concurrently)
+    remove_index_if_exists(:podcast_episodes, column: :website_url, algorithm: :concurrently)
   end
 end

--- a/db/migrate/20200224153122_add_title_website_url_indexes_to_podcast_episodes.rb
+++ b/db/migrate/20200224153122_add_title_website_url_indexes_to_podcast_episodes.rb
@@ -1,8 +1,9 @@
 class AddTitleWebsiteUrlIndexesToPodcastEpisodes < ActiveRecord::Migration[5.2]
   disable_ddl_transaction!
+  include IndexMigrationHelpers
 
   def change
-    add_index :podcast_episodes, :title, algorithm: :concurrently
-    add_index :podcast_episodes, :website_url, algorithm: :concurrently
+    add_index_if_missing(:podcast_episodes, :title, algorithm: :concurrently)
+    add_index_if_missing(:podcast_episodes, :website_url, algorithm: :concurrently)
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2020_02_24_153122) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
When we first ran this migration we got a statement timeout error from Postgres which caused our release phase to fail HOWEVER the index was actually created so when I tried to rerun it we got an Argument Error
```
ArgumentError: Index name 'index_podcast_episodes_on_title' on table 'podcast_episodes' already exists
```
This helper will check if an index already exists before attempting to apply it. I choose to add a full helper bc my guess is as we expand our environments in the future this will not be the last time this happens. We found this helper extremely useful at Kenna dealing with multiple environments. 

I ran the migrations and the extra line got added to the schema file, I'm assuming it accidentally got removed at some point. 

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media1.giphy.com/media/3og0IJgyj4hijAEyk0/giphy.gif)
