### PR TITLE
Fix index_to_elasticsearch_worker_spec.rb

### DIFF
--- a/spec/workers/search/index_to_elasticsearch_worker_spec.rb
+++ b/spec/workers/search/index_to_elasticsearch_worker_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Search::IndexToElasticsearchWorker, type: :worker, elasticsearch:
 
   it "indexes document" do
     tag = FactoryBot.create(:tag)
-    expect { tag.elasticsearch_doc }.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound)
+    expect { tag.elasticsearch_doc }.to raise_error(Search::Errors::Transport::NotFound)
     worker.perform(tag.class.name, tag.id)
 
     expect(tag.elasticsearch_doc.dig("_source", "id")).to eql(tag.id)


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Rhymes had a PR #6227 that was merged just before my PR #6286 and I didn't have his changes incorporated so my specs failed. This PR fixes the spec with the changes from #6227.

## Related Tickets & Documents
#6227 
#6286
[Failed build](https://travis-ci.com/thepracticaldev/dev.to/builds/150531125)

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

![sonic_dancing_gif](https://media.giphy.com/media/LMQgs60HFzAfdZYKtn/giphy.gif)
