### PR TITLE
Ignore referer on /report-abuse if it's SW.js

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -44,7 +44,8 @@ class PagesController < ApplicationController
   end
 
   def report_abuse
-    reported_url = params[:reported_url] || params[:url] || request.referer
+    referer = URI(request.referer).path == "/serviceworker.js" ? nil : request.referer
+    reported_url = params[:reported_url] || params[:url] || referer
     @feedback_message = FeedbackMessage.new(
       reported_url: reported_url&.chomp("?i=i"),
     )

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -44,7 +44,7 @@ class PagesController < ApplicationController
   end
 
   def report_abuse
-    referer = URI(request.referer).path == "/serviceworker.js" ? nil : request.referer
+    referer = URI(request.referer || "").path == "/serviceworker.js" ? nil : request.referer
     reported_url = params[:reported_url] || params[:url] || referer
     @feedback_message = FeedbackMessage.new(
       reported_url: reported_url&.chomp("?i=i"),

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -121,4 +121,28 @@ RSpec.describe "Pages", type: :request do
       expect(response.body).to include("Sitemap: https://#{ApplicationConfig['AWS_BUCKET_NAME']}.s3.amazonaws.com/sitemaps/sitemap.xml.gz")
     end
   end
+
+  describe "GET /report-abuse" do
+    context "when provided the referer" do
+      it "prefills with the provided url" do
+        url = Faker::Internet.url
+        get "/report-abuse", headers: { referer: url }
+        expect(response.body).to include(url)
+      end
+
+      it "does not prefill if the provide url is /serviceworker.js" do
+        url = "https://dev.to/serviceworker.js"
+        get "/report-abuse", headers: { referer: url }
+        expect(response.body).not_to include(url)
+      end
+    end
+
+    context "when provided the params" do
+      it "prefills with the provided param url" do
+        url = "https://dev.to/serviceworker.js"
+        get "/report-abuse", params: { url: url }
+        expect(response.body).to include(url)
+      end
+    end
+  end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Going to https://dev.to/report-abuse directly would fill the report URL link with `https://dev.to/serviceworker.js`. This PR makes sure that the form will stay empty.
## Related Tickets & Documents
Resolves https://github.com/thepracticaldev/tech-private/issues/366
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?

- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a
