### PR TITLE
Add `accept` attribute to the video upload

### DIFF
--- a/app/controllers/email_subscriptions_controller.rb
+++ b/app/controllers/email_subscriptions_controller.rb
@@ -15,7 +15,7 @@ class EmailSubscriptionsController < ApplicationController
     if verified_params[:expires_at] > Time.current
       user = User.find(verified_params[:user_id])
       user.update(verified_params[:email_type] => false)
-      @email_type = PREFERRED_EMAIL_NAME[verified_params[:email_type]]
+      @email_type = PREFERRED_EMAIL_NAME.fetch(verified_params[:email_type], "this list")
     else
       render "invalid_token"
     end

--- a/app/views/videos/new.html.erb
+++ b/app/views/videos/new.html.erb
@@ -22,7 +22,7 @@
                        id: "s3-uploader",
                        class: "upload-form",
                        data: { key: :val } do %>
-    <%= file_field_tag :file %>
+    <%= file_field_tag :file, accept: "video/mp4,video/x-m4v,video/*" %>
     <script id="template-upload" type="text/x-tmpl">
     <div id="file-{%=o.unique_id%}" class="upload">
       {%=o.name%}


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [x] Feature

## Description
Add the `accept` attribute to the video upload. Adding `video/*` alone isn't enough because safari will ignore MP4. The other change is a safe fallback for `PREFERRED_EMAIL_NAME`

ref: https://stackoverflow.com/questions/19107685/safari-input-type-file-accept-video-ignores-mp4-files
## Related Tickets & Documents
n/a
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [x] no, because they aren't needed

## Added to documentation?

- [x] no documentation needed
