### PR TITLE
Notify slack when release phase fails

### DIFF
--- a/Envfile
+++ b/Envfile
@@ -139,6 +139,7 @@ variable :RECAPTCHA_SITE, :String, default: "Optional"
 # Slack for customer alerts
 # (https://api.slack.com/)
 variable :SLACK_CHANNEL, :String, default: ""
+variable :SLACK_DEPLOY_CHANNEL, :String, default: ""
 variable :SLACK_WEBHOOK_URL, :String, default: ""
 
 # Stripe for payment system

--- a/app/lib/release_phase_notifier.rb
+++ b/app/lib/release_phase_notifier.rb
@@ -3,7 +3,7 @@ class ReleasePhaseNotifier
     client = Slack::Notifier.new(
       ApplicationConfig["SLACK_WEBHOOK_URL"],
       channel: ApplicationConfig["SLACK_DEPLOY_CHANNEL"],
-      username: "heroku",
+      username: "Heroku",
     )
 
     client.ping("Release Phase Failed: #{ENV['FAILED_COMMAND']}")

--- a/app/lib/release_phase_notifier.rb
+++ b/app/lib/release_phase_notifier.rb
@@ -1,0 +1,11 @@
+class ReleasePhaseNotifier
+  def self.ping_slack
+    client = Slack::Notifier.new(
+      ApplicationConfig["SLACK_WEBHOOK_URL"],
+      channel: ApplicationConfig["SLACK_DEPLOY_CHANNEL"],
+      username: "heroku",
+    )
+
+    client.ping("Release Phase Failed: #{ENV['FAILED_COMMAND']}")
+  end
+end

--- a/app/lib/release_phase_notifier.rb
+++ b/app/lib/release_phase_notifier.rb
@@ -1,5 +1,7 @@
 class ReleasePhaseNotifier
   def self.ping_slack
+    return unless ApplicationConfig["SLACK_WEBHOOK_URL"].present? && ApplicationConfig["SLACK_DEPLOY_CHANNEL"].present?
+
     client = Slack::Notifier.new(
       ApplicationConfig["SLACK_WEBHOOK_URL"],
       channel: ApplicationConfig["SLACK_DEPLOY_CHANNEL"],
@@ -7,5 +9,7 @@ class ReleasePhaseNotifier
     )
 
     client.ping("Release Phase Failed: #{ENV['FAILED_COMMAND']}")
+  rescue Slack::Notifier::APIError => e
+    Rails.logger.info("Slack API error occured: #{e.message}")
   end
 end

--- a/release-tasks.sh
+++ b/release-tasks.sh
@@ -2,7 +2,7 @@
 
 notify () {
   FAILED_COMMAND="$(caller): ${BASH_COMMAND}" \
-    bundle exec bin/rails runner "ReleasePhaseNotifier.ping_slack"
+    bundle exec rails runner "ReleasePhaseNotifier.ping_slack"
 }
 
 trap notify ERR

--- a/release-tasks.sh
+++ b/release-tasks.sh
@@ -8,7 +8,8 @@ notify () {
 trap notify ERR
 
 # enable echo mode (-x) and exit on error (-e)
-set -ex
+# -E ensures that ERR traps get inherited by functions, command substitutions, and subshell environments.
+set -ex -E
 
 # abort release if deploy status equals "blocked"
 [[ $DEPLOY_STATUS = "blocked" ]] && echo "Deploy blocked" && exit 1

--- a/release-tasks.sh
+++ b/release-tasks.sh
@@ -1,29 +1,21 @@
 #!/bin/bash
 
-action () {
-  "$@"
-  local status=$?
-
-  # Test the exit status of the command run
-  # and display an error message on failure
-  if test ${status} -ne 0
-  then
-      FAILED_COMMAND="$@" bundle exec rails runner "ReleasePhaseNotifier.ping_slack"
-      exit 1
-  fi
-
-  return ${status}
+notify () {
+  FAILED_COMMAND="$(caller): ${BASH_COMMAND}" \
+    bundle exec bin/rails runner "ReleasePhaseNotifier.ping_slack"
 }
 
-# enable echo mode
-set -x
+trap notify ERR
+
+# enable echo mode (-x) and exit on error (-e)
+set -ex
 
 # abort release if deploy status equals "blocked"
 [[ $DEPLOY_STATUS = "blocked" ]] && echo "Deploy blocked" && exit 1
 
 # runs migration for Postgres, setups/updates Elasticsearch
 # and boots the app to check there are no errors
-STATEMENT_TIMEOUT=180000 action bundle exec rails db:migrate # && \
-action bundle exec rake search:setup #&& \
-action bundle exec rake data_updates:enqueue_data_update_worker #&& \
-action bundle exec rails runner "puts 'app load success'"
+STATEMENT_TIMEOUT=180000 bundle exec rails db:migrate
+bundle exec rake search:setup
+bundle exec rake data_updates:enqueue_data_update_worker
+bundle exec rails runner "puts 'app load success'"

--- a/release-tasks.sh
+++ b/release-tasks.sh
@@ -9,7 +9,7 @@ trap notify ERR
 
 # enable echo mode (-x) and exit on error (-e)
 # -E ensures that ERR traps get inherited by functions, command substitutions, and subshell environments.
-set -ex -E
+set -Eex
 
 # abort release if deploy status equals "blocked"
 [[ $DEPLOY_STATUS = "blocked" ]] && echo "Deploy blocked" && exit 1

--- a/spec/lib/release_phase_notifier_spec.rb
+++ b/spec/lib/release_phase_notifier_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe ReleasePhaseNotifier, type: :lib do
+  describe ".ping_slack" do
+    it "sends a failure message to slack" do
+      mock_slack = Slack::Notifier.new("url")
+      ENV["FAILED_COMMAND"] = "rake db:migrate"
+      failure_message = "Release Phase Failed: #{ENV['FAILED_COMMAND']}"
+      allow(Slack::Notifier).to receive(:new) { mock_slack }
+      allow(mock_slack).to receive(:ping)
+
+      described_class.ping_slack
+      expect(mock_slack).to have_received(:ping).with(failure_message)
+    end
+  end
+end

--- a/spec/lib/release_phase_notifier_spec.rb
+++ b/spec/lib/release_phase_notifier_spec.rb
@@ -2,6 +2,11 @@ require "rails_helper"
 
 RSpec.describe ReleasePhaseNotifier, type: :lib do
   describe ".ping_slack" do
+    before do
+      allow(ApplicationConfig).to receive(:[]).with("SLACK_WEBHOOK_URL").and_return("url")
+      allow(ApplicationConfig).to receive(:[]).with("SLACK_DEPLOY_CHANNEL").and_return("channel")
+    end
+
     it "sends a failure message to slack" do
       mock_slack = Slack::Notifier.new("url")
       ENV["FAILED_COMMAND"] = "rake db:migrate"
@@ -11,6 +16,19 @@ RSpec.describe ReleasePhaseNotifier, type: :lib do
 
       described_class.ping_slack
       expect(mock_slack).to have_received(:ping).with(failure_message)
+    end
+
+    it "bails when config variables are missing" do
+      allow(ApplicationConfig).to receive(:[]).with("SLACK_WEBHOOK_URL").and_return("")
+      allow(ApplicationConfig).to receive(:[]).with("SLACK_DEPLOY_CHANNEL").and_return("")
+
+      expect { described_class.ping_slack }.not_to raise_error
+    end
+
+    it "rescues any Slack API Errors" do
+      allow(Slack::Notifier).to receive(:new).and_raise(Slack::Notifier::APIError.new)
+
+      expect { described_class.ping_slack }.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
Currently the only way we are notified of release phase failures is via an email from Heroku to the Heroku admins. Unfortunately, that's not helpful to anyone else who is trying to deploy their code. This attempts to hook up a command in our release phase script to catch any errors that occur and notify slack about them for everyone to see. 

I am FAR from an expert in bash and actually [found this script on no other than StackOverflow](https://stackoverflow.com/a/41852435/1438582). There is probably a slicker better way to do this so please let me know what that is! 

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/5#card-33642543

## Added tests?
- [x] yes

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media3.giphy.com/media/l4lRmZ9JXumY3q2zu/giphy.gif)
