### PR TITLE
Add shell synchronization script to page

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,8 @@
 module ApplicationHelper
+  def shell_version
+    0
+  end
+
   def user_logged_in_status
     user_signed_in? ? "logged-in" : "logged-out"
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,13 @@
 <%= render "shell/top" %>
-<style>.app-shell-loader {display: none;}</style>
+<% if internal_navigation? %>
+  <style>.app-shell-loader {display: none;}</style>
+  <script async>
+    var shellData = document.getElementById('shell-data')
+    if (shellData && parseInt(shellData.dataset.version) < <%= shell_version %>) {
+      window.location.reload()
+    }
+  </script>
+<% end %>
 <div id="page-content" class="universal-page-content-wrapper <%= view_class %>" data-current-page="<%= current_page %>">
   <% if flash[:global_notice] %>
     <div class="global-notice">

--- a/app/views/shell/_top.html.erb
+++ b/app/views/shell/_top.html.erb
@@ -61,5 +61,6 @@
       <div class="app-shell-loader">
         loading...
       </div>
+      <div id="shell-data" data-version="<%= shell_version %>">
     <!-- End Top Shell -->
   <% end %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -37,4 +37,10 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(helper.cache_key_heroku_slug("cache-me")).to eq("cache-me-abc123")
     end
   end
+
+  describe "#shell_version" do
+    it "is an integer" do
+      expect(helper.shell_version).to be_a(Integer)
+    end
+  end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Since we use store the "shell" of our page right in the browser via serviceworkers, it's possible for the shell and the streamed page content to get out of sync with styles/JS/etc.

We have the functionality in place to refetch a new shell in the background any time a user visits the site after we have deployed new code, but sometimes a change to the shell can truly effect the user experience in a way where we do not want to wait for the user to reload the browser.

This PR implements a `window.location.reload()` if the shell is behind the loaded page. Since we don't want to do this unless we need to, we should reserve this for when we do, but make sure to increment it as part of any PRs which affect this.

PRs like this one: #6274 are in need of this functionality.

This should be pretty quick and not super noticeable for the end user, but it's kind of hard to tell. It will sometimes be imperceptible, and sometimes result in a flicker.