### PR TITLE
Add .present? check

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -546,12 +546,12 @@ class Article < ApplicationRecord
 
   def remove_tag_adjustments_from_tag_list
     tags_to_remove = TagAdjustment.where(article_id: id, adjustment_type: "removal", status: "committed").pluck(:tag_name)
-    tag_list.remove(tags_to_remove, parser: ActsAsTaggableOn::TagParser) if tags_to_remove
+    tag_list.remove(tags_to_remove, parser: ActsAsTaggableOn::TagParser) if tags_to_remove.present?
   end
 
   def add_tag_adjustments_to_tag_list
     tags_to_add = TagAdjustment.where(article_id: id, adjustment_type: "addition", status: "committed").pluck(:tag_name)
-    tag_list.add(tags_to_add, parser: ActsAsTaggableOn::TagParser) if tags_to_add
+    tag_list.add(tags_to_add, parser: ActsAsTaggableOn::TagParser) if tags_to_add.present?
   end
 
   def validate_video

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -31,7 +31,9 @@ RSpec.describe Article, type: :model do
 
     context "when published" do
       before do
-        allow(article).to receive(:published?).and_return(true)
+        # rubocop:disable RSpec/NamedSubject
+        allow(subject).to receive(:published?).and_return(true)
+        # rubocop:enable RSpec/NamedSubject
       end
 
       it { is_expected.to validate_presence_of(:slug) }

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Article, type: :model do
 
     context "when published" do
       before do
-        allow(subject).to receive(:published?).and_return(true) # rubocop:disable RSpec/NamedSubject
+        allow(article).to receive(:published?).and_return(true)
       end
 
       it { is_expected.to validate_presence_of(:slug) }
@@ -115,6 +115,24 @@ RSpec.describe Article, type: :model do
           expect(article).to be_valid
         end
       end
+    end
+
+    describe "tag validation" do
+      let(:article) { build(:article, user: user) }
+
+      # See https://github.com/thepracticaldev/dev.to/pull/6302
+      # rubocop:disable RSpec/VerifiedDoubles
+      it "does not modify the tag list if there are no adjustments" do
+        allow(TagAdjustment).to receive(:where).and_return(TagAdjustment.none)
+        allow(article).to receive(:tag_list).and_return(spy("tag_list"))
+
+        article.save
+
+        # We expect this to happen once in #evaluate_front_matter
+        expect(article.tag_list).to have_received(:add).once
+        expect(article.tag_list).not_to have_received(:remove)
+      end
+      # rubocop:enable RSpec/VerifiedDoubles
     end
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

As discussed with @rhymes on Slack, the other day while reading the `Article` model I noticed two places where empty arrays were used as falsy values. This doesn't work in Ruby, so I added `.present?` checks.

## Related Tickets & Documents

n/a

## Added tests?

- [X] no, because they aren't needed

Let me know if you disagree and actually want to see a test for this.

## Added to documentation?

- [X] no documentation needed
