### PR TITLE
Hide information about expired sponsorships from "partnerships" pages

### DIFF
--- a/app/models/sponsorship.rb
+++ b/app/models/sponsorship.rb
@@ -32,6 +32,8 @@ class Sponsorship < ApplicationRecord
   scope :live, -> { where(status: :live) }
   scope :pending, -> { where(status: :pending) }
 
+  scope :unexpired, -> { where("expires_at > ?", Time.current) }
+
   private
 
   def validate_tag_uniqueness

--- a/app/views/partnerships/_form.html.erb
+++ b/app/views/partnerships/_form.html.erb
@@ -37,7 +37,7 @@
         <% if Sponsorship::LEVELS_WITH_EXPIRATION.include?(level) %>
           <h3><img src="<%= ProfileImage.new(org).get(width: 90) %>" />@<%= org.slug %></h3>
           <div style="font-size: 0.88em;"><em>This organization account has <%= org.credits.unspent.size %> credits available</em></div>
-          <% sponsorships = org.sponsorships.where(level: Sponsorship::LEVELS_WITH_EXPIRATION) %>
+          <% sponsorships = org.sponsorships.unexpired.where(level: Sponsorship::LEVELS_WITH_EXPIRATION) %>
           <% level_sponsorship = sponsorships.where(level: level).take %>
           <% if level_sponsorship %>
             <div class="partner-explainer-notice">
@@ -77,15 +77,16 @@
             <%= hidden_field_tag(:level, level) %>
             <h4>Sponsorship message/brand instructions:</h4>
             <%= text_area_tag(:instructions, nil, placeholder: "Include brand guideline links and detailed instructions about the message you are trying to get across. DEV editors will use these guidelines contextually depending on sponsorship.") %>
-            <% org.sponsorships.where(level: :tag).find_each do |sponsorship| %>
+            <% tag_sponsorships = org.sponsorships.unexpired.where(level: :tag) %>
+            <% tag_sponsorships.find_each do |sponsorship| %>
               <div class="partner-explainer-notice">
                 🎉 You are Subscribed as the sponsor of #<%= sponsorship.sponsorable.name %>.
               </div>
             <% end %>
-            <% if org.sponsorships.where(level: :tag).any? %>
+            <% if tag_sponsorships.any? %>
               <h4>Sponsor another tag:</h4>
             <% end %>
-            <% sponsored_tags = org.sponsorships.includes(:sponsorable).where(level: :tag).map { |sp| sp.sponsorable.name } %>
+            <% sponsored_tags = org.sponsorships.unexpired.includes(:sponsorable).where(level: :tag).map { |sp| sp.sponsorable.name } %>
             <% tag_names = Tag.where(supported: true).where.not(name: sponsored_tags).pluck(:name) %>
             <%= select_tag "tag_name", options_for_select(tag_names) %>
             <button>Sponsor Tag for <%= Sponsorship::CREDITS[:tag] %> credits</button>

--- a/spec/requests/partnerships_spec.rb
+++ b/spec/requests/partnerships_spec.rb
@@ -68,8 +68,7 @@ RSpec.describe "Partnerships", type: :request do
           sign_in user
         end
 
-        describe "level sponsorshi[s" do
-          # should pass
+        describe "level sponsorships" do
           it "displays info about an existing sponsorship" do
             create(:sponsorship, level: :bronze, organization: org, user: user, expires_at: 3.days.from_now)
             get "/partnerships/bronze-sponsor"
@@ -77,21 +76,18 @@ RSpec.describe "Partnerships", type: :request do
             expect(response.body).to include("You are Subscribed as a Bronze Sponsor")
           end
 
-          # should pass
           it "displayes already sponsored for other level" do
             create(:sponsorship, level: :bronze, organization: org, user: user, expires_at: 3.days.from_now)
             get "/partnerships/silver-sponsor"
             expect(response.body).to include("You are already subscribed as a bronze sponsor")
           end
 
-          # should fail
           it "doesn't display info about an expired sponsorship" do
             create(:sponsorship, level: :bronze, organization: org, user: user, expires_at: 3.days.ago)
             get "/partnerships/bronze-sponsor"
             expect(response.body).not_to include("You are Subscribed as a Bronze Sponsor")
           end
 
-          # should fail
           it "doesn't display 'already sponsored' for the different level if an org has expired sponsorship" do
             create(:sponsorship, level: :bronze, organization: org, user: user, expires_at: 3.days.ago)
             get "/partnerships/silver-sponsor"

--- a/spec/requests/partnerships_spec.rb
+++ b/spec/requests/partnerships_spec.rb
@@ -58,6 +58,63 @@ RSpec.describe "Partnerships", type: :request do
         get "/partnerships/bronze-sponsor"
         expect(response.body).to include("This subscription will renew every month")
       end
+
+      context "when sponsorship exists" do
+        let(:org) { create(:organization) }
+
+        before do
+          create(:organization_membership, user: user, organization: org, type_of_user: "admin")
+          Credit.add_to_org(org, 1000)
+          sign_in user
+        end
+
+        describe "level sponsorshi[s" do
+          # should pass
+          it "displays info about an existing sponsorship" do
+            create(:sponsorship, level: :bronze, organization: org, user: user, expires_at: 3.days.from_now)
+            get "/partnerships/bronze-sponsor"
+            expect(response.body).not_to include("Credits are your wallet for flexibly managing")
+            expect(response.body).to include("You are Subscribed as a Bronze Sponsor")
+          end
+
+          # should pass
+          it "displayes already sponsored for other level" do
+            create(:sponsorship, level: :bronze, organization: org, user: user, expires_at: 3.days.from_now)
+            get "/partnerships/silver-sponsor"
+            expect(response.body).to include("You are already subscribed as a bronze sponsor")
+          end
+
+          # should fail
+          it "doesn't display info about an expired sponsorship" do
+            create(:sponsorship, level: :bronze, organization: org, user: user, expires_at: 3.days.ago)
+            get "/partnerships/bronze-sponsor"
+            expect(response.body).not_to include("You are Subscribed as a Bronze Sponsor")
+          end
+
+          # should fail
+          it "doesn't display 'already sponsored' for the different level if an org has expired sponsorship" do
+            create(:sponsorship, level: :bronze, organization: org, user: user, expires_at: 3.days.ago)
+            get "/partnerships/silver-sponsor"
+            expect(response.body).not_to include("You are already subscribed as a bronze sponsor")
+          end
+        end
+
+        describe "tag sponsorships" do
+          let(:ruby) { create(:tag, name: "ruby") }
+
+          it "displays info about an existing sponsorship" do
+            create(:sponsorship, level: :tag, organization: org, user: user, sponsorable: ruby, expires_at: 3.days.from_now)
+            get "/partnerships/tag-sponsor"
+            expect(response.body).to include("You are Subscribed as the sponsor of #ruby")
+          end
+
+          it "doesn't display info about an expired sponsorship" do
+            create(:sponsorship, level: :tag, organization: org, user: user, sponsorable: ruby, expires_at: 3.days.ago)
+            get "/partnerships/tag-sponsor"
+            expect(response.body).not_to include("You are Subscribed as the sponsor of #ruby")
+          end
+        end
+      end
     end
 
     context "when user is not logged in" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
- removed information about the expired sponsorships from the bronze (`/partnerships/bronze-sponsor`) and silver (`/partnerships/silver-sponsor`) level sponsor pages and tag sponsor page (`/partnerships/tag-sponsor`)
- if an org has an expired sponsorship on a tag, this tag now appears as an option in the tag `select` in the "new sponsorship" form
- added specs for the cases when the info about sponsorships should be shown or not

There are a lot of opportunities for optimizations and refactoring, but I kept them for the future, only fixing bugs and adding basic tests here.

## Related Tickets & Documents
#6018 

## Added tests?
- [x] yes