### PR TITLE
Use DataUpdateScript.scripts_to_run? in development

### DIFF
--- a/app/models/data_update_script.rb
+++ b/app/models/data_update_script.rb
@@ -28,7 +28,7 @@ class DataUpdateScript < ApplicationRecord
 
     # true if there are any new files on disk or any scripts to run, false otherwise
     def scripts_to_run?
-      db_scripts = DataUpdateScript.pluck(:file_name, :status).to_a.to_h
+      db_scripts = DataUpdateScript.pluck(:file_name, :status).to_h
 
       return true unless filenames.to_set == db_scripts.keys.to_set
       return true if db_scripts.values.any? { |s| s.to_sym == :enqueued }

--- a/app/models/data_update_script.rb
+++ b/app/models/data_update_script.rb
@@ -25,6 +25,16 @@ class DataUpdateScript < ApplicationRecord
     def scripts_to_run
       DataUpdateScript.where(id: load_script_ids).select(&:enqueued?)
     end
+
+    # true if there are any new files on disk or any scripts to run, false otherwise
+    def scripts_to_run?
+      db_scripts = DataUpdateScript.pluck(:file_name, :status).to_a.to_h
+
+      return true unless filenames.to_set == db_scripts.keys.to_set
+      return true if db_scripts.values.any? { |s| s.to_sym == :enqueued }
+
+      false
+    end
   end
 
   def mark_as_run!

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -116,11 +116,8 @@ Rails.application.configure do
 
     # Check if there are any data update scripts to run during startup
     if %w[c console runner s server].include?(ENV["COMMAND"])
-      if DataUpdateScript.scripts_to_run.any?
-        message = <<~ERROR
-          Data update scripts need to be run before you can start the application. Please run "rails data_updates:run"
-        ERROR
-        raise message
+      if DataUpdateScript.scripts_to_run?
+        raise "Data update scripts need to be run before you can start the application. Please run 'rails data_updates:run'"
       end
     end
   end

--- a/spec/models/data_update_script_spec.rb
+++ b/spec/models/data_update_script_spec.rb
@@ -63,6 +63,41 @@ RSpec.describe DataUpdateScript do
     end
   end
 
+  describe ".scripts_to_run?" do
+    let(:test_directory) { Rails.root.join("spec/support/fixtures/data_update_scripts") }
+
+    before { stub_const "#{described_class}::DIRECTORY", test_directory }
+
+    it "returns true for a new set of files" do
+      expect(described_class.scripts_to_run?).to be(true)
+    end
+
+    it "returns true if there is a script on disk but not in the DB" do
+      create(:data_update_script, file_name: "not_the_one_on_disk")
+      expect(described_class.scripts_to_run?).to be(true)
+    end
+
+    it "returns true if there is an enqueued script" do
+      create(:data_update_script, status: :enqueued)
+      expect(described_class.scripts_to_run?).to be(true)
+    end
+
+    it "returns false if there are only working scripts" do
+      create(:data_update_script, status: :working)
+      expect(described_class.scripts_to_run?).to be(false)
+    end
+
+    it "returns false if there are only succeeded scripts" do
+      create(:data_update_script, status: :succeeded)
+      expect(described_class.scripts_to_run?).to be(false)
+    end
+
+    it "returns false if there are only failed scripts" do
+      create(:data_update_script, status: :failed)
+      expect(described_class.scripts_to_run?).to be(false)
+    end
+  end
+
   describe "#mark_as_finished!" do
     it "marks data update script as finished" do
       test_script = create(:data_update_script)


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Right now, everytime we call `rails server` or `rails console` we check if there are scripts to be run, this though has two side effects:

- it issues as many SQL queries as there are scripts (currently 4 but potentially many more in the future) plus one to check existence
- it loads scripts in memory and in the DB, which might be an issue if I'm testing a branch and I generate a script that I then decide to delete

This slows down a little the feedback cycle for developers.

I decided to change to issue only 1 query and check the following:

- if there are more scripts on disk than in the DB (intentional or not), exit
- if there are scripts in the DB that are in the enqueued status, exit

The `DataUpdateWorker` already loads scripts in the DB before running them, so there's no need to have it done as a side effect

This makes using the development tools a little bit faster

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
