### PR TITLE
Only show the ghost option if user has content

### DIFF
--- a/app/views/users/_account.html.erb
+++ b/app/views/users/_account.html.erb
@@ -111,10 +111,12 @@
   <p>Please, <%= link_to "provide an email", "/settings/profile" %> to fully delete your account.</p>
 <% end %>
 
-<p>
-  If you would like to keep your content under the <%= link_to "@ghost", "/ghost" %> account,
-  please <a href="mailto:<%= SiteConfig.default_site_email %>?subject=Request Account Deletion&body=<%= @email_body %>">click here.</a>
-</p>
+<% if current_user.articles_count.positive? || current_user.comments_count.positive? %>
+  <p>
+    If you would like to keep your content under the <%= link_to "@ghost", "/ghost" %> account,
+    please <a href="mailto:<%= SiteConfig.default_site_email %>?subject=Request Account Deletion&body=<%= @email_body %>">click here.</a>
+  </p>
+<% end %>
 
 <p>
   Feel free to contact <a href="mailto:<%= SiteConfig.default_site_email %>"><%= SiteConfig.default_site_email %></a> with any questions.

--- a/spec/requests/user/user_settings_spec.rb
+++ b/spec/requests/user/user_settings_spec.rb
@@ -41,6 +41,20 @@ RSpec.describe "UserSettings", type: :request do
         error_message = "There is an existing account authorized with that social account"
         expect(response.body).to include error_message
       end
+
+      it "does not render the ghost account email option if the user has no content" do
+        ghost_account_message = "If you would like to keep your content under the"
+        get "/settings/account"
+        expect(response.body).not_to include ghost_account_message
+      end
+
+      it "does render the ghost account email option if the user has content" do
+        ghost_account_message = "If you would like to keep your content under the"
+        create(:article, user: user)
+        user.update(articles_count: 1)
+        get "/settings/account"
+        expect(response.body).to include ghost_account_message
+      end
     end
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
We should only show the option to request an account deletion via email if the user has content to begin with.

## Added tests?
- [x] yes

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
No