### PR TITLE
Add active attribute to Broadcasts

### DIFF
--- a/db/migrate/20200226192145_add_active_to_broadcasts.rb
+++ b/db/migrate/20200226192145_add_active_to_broadcasts.rb
@@ -1,0 +1,5 @@
+class AddActiveToBroadcasts < ActiveRecord::Migration[5.2]
+  def change
+    add_column :broadcasts, :active, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_24_153122) do
+ActiveRecord::Schema.define(version: 2020_02_26_192145) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -224,6 +224,7 @@ ActiveRecord::Schema.define(version: 2020_02_24_153122) do
   end
 
   create_table "broadcasts", id: :serial, force: :cascade do |t|
+    t.boolean "active", default: false
     t.text "body_markdown"
     t.text "processed_html"
     t.boolean "sent", default: false

--- a/lib/data_update_scripts/20200226193303_backfill_column_for_broadcasts.rb
+++ b/lib/data_update_scripts/20200226193303_backfill_column_for_broadcasts.rb
@@ -1,0 +1,7 @@
+module DataUpdateScripts
+  class BackfillColumnForBroadcasts
+    def run
+      Broadcast.find_each { |broadcast| broadcast.update!(active: broadcast.sent) }
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

The content of welcome notifications will be sent to users in the form of Broadcasts, which can be added by admins via the `/internal/broadcasts`. We currently have an unused attribute `sent` on Broadcasts.

I propose that we should rename this attribute to `active`, and then make the necessary requirements in the code so that we actually _only_ send a Broadcast if it has explicitly been marked as `active` or not!

This will be super useful for @thepracticaldev/delightful's work on welcome notifications because it will allow admins to begin adding welcome notifications into production without them being sent out (since they can remain "inactive" until we're ready to ship the feature).

I will do the work of _using_ this new attribute and removing the old `sent` attribute in a separate PR. This PR just focuses on adding the column, and then backfilling its values using the value of `sent` on each `Broadcast` instance.

## Related Tickets & Documents

https://github.com/thepracticaldev/dev.to/projects/7#card-32965274

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
None!

## Added tests?

- [ ] yes
- [x] no, because they aren't needed **Note: I tested the update script locally, and it works!**
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## Are there any post deployment tasks we need to perform?

I believe that the update script will run on its own, and we don't need to do anything. One question for I have for @mstruve is whether it is okay for the script to be deployed at the same time as the migration? If not, I can split them into separate PRs.