### PR TITLE
Only send notifications that belong to an active broadcast

### DIFF
--- a/app/controllers/internal/broadcasts_controller.rb
+++ b/app/controllers/internal/broadcasts_controller.rb
@@ -27,7 +27,7 @@ class Internal::BroadcastsController < Internal::ApplicationController
   private
 
   def broadcast_params
-    params.permit(:title, :processed_html, :type_of, :sent)
+    params.permit(:title, :processed_html, :type_of, :active)
   end
 
   def authorize_admin

--- a/app/models/broadcast.rb
+++ b/app/models/broadcast.rb
@@ -7,6 +7,8 @@ class Broadcast < ApplicationRecord
   # TODO: [@thepracticaldev/delightful] Remove Onboarding type once we have launched welcome notifications.
   validates :type_of, inclusion: { in: %w[Announcement Onboarding Welcome] }
 
+  scope :active, -> { where(active: true) }
+
   def get_inner_body(content)
     Nokogiri::HTML(content).at("body").inner_html
   end

--- a/app/views/internal/broadcasts/_form.html.erb
+++ b/app/views/internal/broadcasts/_form.html.erb
@@ -10,7 +10,7 @@
   <%= select_tag "type_of", options_for_select(%w[Onboarding Announcement Welcome]) %>
 </div>
 <div class="form-group">
-  <%= label_tag :sent, "Sent:" %>
-  <%= select_tag :sent, options_for_select([true, false]) %>
+  <%= label_tag :active, "Active:" %>
+  <%= select_tag :active, options_for_select([true, false]) %>
 </div>
 <br>

--- a/app/views/internal/broadcasts/index.html.erb
+++ b/app/views/internal/broadcasts/index.html.erb
@@ -17,8 +17,8 @@
         </p>
         <h3>Status:</h3>
         <h3>
-          <span class="badge badge-<%= broadcast.sent ? "success" : "warning" %>">
-            <%= broadcast.sent ? "Sent" : "Not Sent" %>
+          <span class="badge badge-<%= broadcast.active? ? "success" : "warning" %>">
+            <%= broadcast.active? ? "Active" : "Inactive" %>
           </span>
           <span class="sr-only">Broadcast Status</span>
         </h3>

--- a/app/views/internal/broadcasts/index.html.erb
+++ b/app/views/internal/broadcasts/index.html.erb
@@ -6,6 +6,7 @@
 <hr>
 
 <div class="row">
+  <div class="alert alert-warning"><strong>Note: You must ensure that your Broadcast is active in order for it to be sent to users!<strong></div>
   <div class="list-group-flush w-100">
     <% @broadcasts.each do |broadcast| %>
       <a class="list-group-item list-group-item-action flex-column align-items-start" href="/internal/broadcasts/<%= broadcast.id %>/edit">

--- a/app/workers/notifications/welcome_notification_worker.rb
+++ b/app/workers/notifications/welcome_notification_worker.rb
@@ -4,7 +4,7 @@ module Notifications
     sidekiq_options queue: :low_priority, retry: 10
 
     def perform(receiver_id, broadcast_id)
-      return unless (welcome_broadcast = Broadcast.find_by(id: broadcast_id))
+      return unless (welcome_broadcast = Broadcast.active.find_by(id: broadcast_id))
 
       Notifications::WelcomeNotification::Send.call(receiver_id, welcome_broadcast)
     end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -206,7 +206,7 @@ Broadcast.create!(
   title: "Welcome Notification",
   processed_html: "Welcome to dev.to! Start by introducing yourself in <a href='/welcome' data-no-instant>the welcome thread</a>.",
   type_of: "Onboarding",
-  sent: true,
+  active: true,
 )
 
 broadcast_messages = {
@@ -221,7 +221,7 @@ broadcast_messages.each do |type, message|
     title: "Welcome Notification: #{type}",
     processed_html: message,
     type_of: "Welcome",
-    sent: true,
+    active: true,
   )
 end
 

--- a/spec/factories/broadcasts.rb
+++ b/spec/factories/broadcasts.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :broadcast do
-    sent { false }
+    active { false }
   end
 
   trait :onboarding do
@@ -9,7 +9,7 @@ FactoryBot.define do
     processed_html { "Welcome! Introduce yourself in our <a href='/welcome'>welcome thread!</a>" }
   end
 
-  trait :sent do
-    sent { true }
+  trait :active do
+    active { true }
   end
 end

--- a/spec/workers/notifications/welcome_notification_worker_spec.rb
+++ b/spec/workers/notifications/welcome_notification_worker_spec.rb
@@ -1,7 +1,8 @@
 require "rails_helper"
 RSpec.describe Notifications::WelcomeNotificationWorker, type: :worker do
   describe "#perform" do
-    let!(:broadcast) { create(:broadcast, :onboarding) }
+    let(:broadcast) { create(:broadcast, :onboarding, :active) }
+    let(:inactive_broadcast) { create(:broadcast, :onboarding) }
     let(:user) { create(:user) }
     let(:service) { Notifications::WelcomeNotification::Send }
     let(:worker) { subject }
@@ -10,9 +11,18 @@ RSpec.describe Notifications::WelcomeNotificationWorker, type: :worker do
       allow(service).to receive(:call)
     end
 
-    it "calls a service" do
-      worker.perform(user.id, broadcast.id)
-      expect(service).to have_received(:call).with(user.id, broadcast).once
+    context "with an active broadcast" do
+      it "calls a service" do
+        worker.perform(user.id, broadcast.id)
+        expect(service).to have_received(:call).with(user.id, broadcast).once
+      end
+    end
+
+    context "with an inactive broadcast" do
+      it "does not call a service" do
+        worker.perform(user.id, inactive_broadcast.id)
+        expect(service).not_to have_received(:call)
+      end
     end
 
     context "when there is a non-existent broadcast" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR branches off and builds on the work in #6318 .

**⚠️Please review #6318 first, since it needs to be merged FIRST, before this one!** Once #6318 has been merged, I will rebase this PR against master.

This PR uses the `active` attribute on the `Broadcast` model and ensures that we only ever send a notification if the Broadcast itself is active. I've updated the related specs and added an `active` scope that we can explicitly use whenever we deal with Broadcasts.

## Related Tickets & Documents

https://github.com/thepracticaldev/dev.to/projects/7#card-32965274

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

The only real UI change is that admins can now have active and inactive broadcasts in the `/internal/broadcasts` route:

<img width="1166" alt="Screen Shot 2020-02-26 at 12 36 46 PM" src="https://user-images.githubusercontent.com/6921610/75385499-b5663580-5894-11ea-8d5b-4a8d7131f447.png">

I also added a note about this at the top of the `/internal/broadcasts` route for all admins:
<img width="1189" alt="Screen Shot 2020-02-26 at 12 41 33 PM" src="https://user-images.githubusercontent.com/6921610/75385890-8603f880-5895-11ea-9072-10f1544d4a2a.png">

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## Are there any post deployment tasks we need to perform?

As mentioned above, #6318 needs to be merged before this PR. Then, this PR needs to be rebased against master and deployed.
