### PR TITLE
Implement home page feed article ranking in Ruby

### DIFF
--- a/app/controllers/stories/feeds_controller.rb
+++ b/app/controllers/stories/feeds_controller.rb
@@ -8,7 +8,7 @@ class Stories::FeedsController < ApplicationController
   private
 
   def assign_feed_stories
-    feed = Articles::Feed.new(page: @page, tag: params[:tag])
+    feed = Articles::Feed.new(user: current_user, page: @page, tag: params[:tag])
     stories = if params[:timeframe].in?(Timeframer::FILTER_TIMEFRAMES)
                 feed.top_articles_by_timeframe(timeframe: params[:timeframe])
               elsif params[:timeframe] == Timeframer::LATEST_TIMEFRAME

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -220,7 +220,7 @@ class StoriesController < ApplicationController
   end
 
   def assign_feed_stories
-    feed = Articles::Feed.new(page: @page, tag: params[:tag])
+    feed = Articles::Feed.new(user: current_user, page: @page, tag: params[:tag])
     if params[:timeframe].in?(Timeframer::FILTER_TIMEFRAMES)
       @stories = feed.top_articles_by_timeframe(timeframe: params[:timeframe])
     elsif params[:timeframe] == Timeframer::LATEST_TIMEFRAME

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -220,7 +220,7 @@ class StoriesController < ApplicationController
   end
 
   def assign_feed_stories
-    feed = Articles::Feed.new(user: current_user, page: @page, tag: params[:tag])
+    feed = Articles::Feed.new(page: @page, tag: params[:tag])
     if params[:timeframe].in?(Timeframer::FILTER_TIMEFRAMES)
       @stories = feed.top_articles_by_timeframe(timeframe: params[:timeframe])
     elsif params[:timeframe] == Timeframer::LATEST_TIMEFRAME

--- a/app/services/articles/feed.rb
+++ b/app/services/articles/feed.rb
@@ -39,7 +39,7 @@ module Articles
           limited_column_select.order("published_at DESC").limit(rand(15..80))
         hot_stories = hot_stories.to_a + new_stories.to_a
       end
-      hot_stories = rank_articles(hot_stories)
+      hot_stories = rank_articles(hot_stories) if @user
       [featured_story, hot_stories]
     end
 
@@ -68,7 +68,7 @@ module Articles
 
     def score_followed_tags(article)
       @user.decorate.cached_followed_tags.select do |tag|
-        article.tag_list.include?(tag.name)
+        article.decorate.cached_tag_list_array.include?(tag.name)
       end.sum(&:points)
     end
 

--- a/app/services/articles/feed.rb
+++ b/app/services/articles/feed.rb
@@ -1,7 +1,5 @@
 module Articles
   class Feed
-    RankedArticle = Struct.new(:article, :score)
-
     def initialize(user: nil, number_of_articles: 35, page: 1, tag: nil)
       @user = user
       @number_of_articles = number_of_articles

--- a/app/services/articles/feed.rb
+++ b/app/services/articles/feed.rb
@@ -67,9 +67,10 @@ module Articles
     end
 
     def score_followed_tags(article)
-      @user.decorate.cached_followed_tags.select do |tag|
-        article.decorate.cached_tag_list_array.include?(tag.name)
-      end.sum(&:points)
+      article_tags = article.decorate.cached_tag_list_array
+      @user.decorate.cached_followed_tags.sum do |tag|
+        article_tags.include?(tag.name) ? tag.points : 0
+      end
     end
 
     def score_followed_organization(article)

--- a/spec/services/articles/feed_spec.rb
+++ b/spec/services/articles/feed_spec.rb
@@ -1,8 +1,13 @@
 require "rails_helper"
 
 RSpec.describe Articles::Feed, type: :service do
-  let!(:feed) { described_class.new(number_of_articles: 100, page: 1) }
+  let(:user) { create(:user) }
+  let!(:feed) { described_class.new(user: user, number_of_articles: 100, page: 1) }
   let!(:article) { create(:article) }
+  let!(:hot_story) { create(:article, hotness_score: 1000, score: 1000, published_at: 3.hours.ago) }
+  let!(:old_story) { create(:article, published_at: 3.days.ago) }
+  let!(:low_scoring_article) { create(:article, score: -1000) }
+  let!(:month_old_story) { create(:article, published_at: 1.month.ago) }
 
   describe "#published_articles_by_tag" do
     let(:unpublished_article) { create(:article, published: false) }
@@ -10,51 +15,45 @@ RSpec.describe Articles::Feed, type: :service do
     let(:tagged_article) { create(:article, tags: [tag]) }
 
     it "returns published articles" do
-      expect(described_class.new(number_of_articles: 1, page: 1).published_articles_by_tag).to eq [article]
+      expect(described_class.new(number_of_articles: 1, page: 1).published_articles_by_tag).to include article
+      expect(described_class.new(number_of_articles: 1, page: 1).published_articles_by_tag).not_to include unpublished_article
     end
 
     context "with tag" do
       it "returns articles with the specified tag" do
-        expect(described_class.new(number_of_articles: 1, page: 1, tag: tag).published_articles_by_tag).to eq [tagged_article]
+        expect(described_class.new(number_of_articles: 1, page: 1, tag: tag).published_articles_by_tag).to include tagged_article
       end
     end
   end
 
   describe "#top_articles_by_timeframe" do
-    let!(:high_scoring_article) { create(:article, score: 100) }
+    let!(:moderately_high_scoring_article) { create(:article, score: 20) }
+    let(:result) { feed.top_articles_by_timeframe(timeframe: "week").to_a }
 
     it "returns articles ordered by score" do
-      expect(feed.top_articles_by_timeframe(timeframe: "week")).to eq [high_scoring_article, article]
+      expect(result.slice(0, 2)).to eq [hot_story, moderately_high_scoring_article]
+      expect(result.last).to eq low_scoring_article
     end
 
     context "with week article timeframe specified" do
-      let!(:month_old_article) { create(:article, published_at: 1.month.ago) }
-
       it "only returns articles from this week" do
-        expect(feed.top_articles_by_timeframe(timeframe: "week")).not_to include(month_old_article)
+        expect(feed.top_articles_by_timeframe(timeframe: "week")).not_to include(month_old_story)
       end
     end
   end
 
   describe "#latest_feed" do
-    let!(:low_scoring_article) { create(:article, score: -1000) }
-    let!(:new_article) { create(:article) }
-
-    before { article.update(published_at: 1.week.ago) }
-
     it "only returns articles with scores above -40" do
       expect(feed.latest_feed).not_to include(low_scoring_article)
     end
 
     it "returns articles ordered by publishing date descending" do
-      expect(feed.latest_feed).to eq [new_article, article]
+      expect(feed.latest_feed.last).to eq month_old_story
     end
   end
 
   describe "#default_home_feed_and_featured_story" do
-    let!(:hot_story) { create(:article, hotness_score: 100, score: 100, published_at: 1.day.ago) }
-    let!(:new_story) { create(:article, published_at: 1.minute.ago) }
-    let!(:low_scoring_article) { create(:article, score: -1000) }
+    # let!(:new_story) { create(:article, published_at: 1.minute.ago) }
 
     let(:featured_story) { feed.default_home_feed_and_featured_story.first }
     let(:stories) { feed.default_home_feed_and_featured_story.second }
@@ -63,7 +62,8 @@ RSpec.describe Articles::Feed, type: :service do
 
     it "returns a featured article and array of other articles" do
       expect(featured_story).to be_a(Article)
-      expect(stories).to be_a(ActiveRecord::Relation)
+      expect(stories).to be_a(Array)
+      expect(stories.first).to be_a(Article)
     end
 
     it "chooses a featured story with a main image" do
@@ -77,35 +77,81 @@ RSpec.describe Articles::Feed, type: :service do
     context "when user logged in" do
       let(:stories) { feed.default_home_feed_and_featured_story(user_signed_in: true).second }
 
-      it "only includes stories from more than 6 hours ago" do
+      it "only includes stories from less than 6 hours ago" do
+        expect(stories).not_to include(old_story)
+        expect(stories).to include(hot_story)
         expect(stories).not_to include(article)
-        expect(stories).to include(new_story)
       end
     end
   end
 
   describe "#default_home_feed" do
-    let!(:new_story) { create(:article, published_at: 1.minute.ago) }
-    let!(:low_scoring_article) { create(:article, score: -1000) }
+    let!(:new_story) { create(:article, published_at: 10.minutes.ago, score: 10) }
 
-    let(:stories) { feed.default_home_feed }
+    context "when user is not logged in" do
+      let(:stories) { feed.default_home_feed(user_signed_in: false) }
 
-    before { article.update(published_at: 1.week.ago) }
+      before { article.update(published_at: 1.week.ago) }
 
-    it "returns array of articles" do
-      expect(stories).to be_a(ActiveRecord::Relation)
-    end
+      it "returns array of articles" do
+        expect(stories).to be_a(Array)
+        expect(stories.first).to be_a(Article)
+      end
 
-    it "doesn't include low scoring stories" do
-      expect(stories).not_to include(low_scoring_article)
+      it "doesn't include low scoring stories" do
+        expect(stories).not_to include(low_scoring_article)
+      end
     end
 
     context "when user logged in" do
       let(:stories) { feed.default_home_feed(user_signed_in: true) }
 
-      it "only includes stories from more than 6 hours ago" do
-        expect(stories).not_to include(article)
+      it "includes stories from between 2 and 6 hours ago" do
+        expect(stories).not_to include(old_story)
         expect(stories).to include(new_story)
+      end
+    end
+  end
+
+  describe "#score_followed_user" do
+    context "when article is written by a followed user" do
+      before { user.follow(article.user) }
+
+      it "returns a score of 1" do
+        expect(feed.score_followed_user(article)).to eq 1
+      end
+    end
+
+    context "when article is not written by a followed user" do
+      it "returns a score of 0" do
+        expect(feed.score_followed_user(article)).to eq 0
+      end
+    end
+  end
+
+  describe "#score_followed_organization" do
+    let(:organization) { create(:organization) }
+    let(:article) { create(:article, organization: organization) }
+
+    context "when article is from a followed organization" do
+      before { user.follow(organization) }
+
+      it "returns a score of 1" do
+        expect(feed.score_followed_organization(article)).to eq 1
+      end
+    end
+
+    context "when article is not from a followed organization" do
+      it "returns a score of 0" do
+        expect(feed.score_followed_organization(article)).to eq 0
+      end
+    end
+
+    context "when article has no organization" do
+      let(:article) { create(:article) }
+
+      it "returns a score of 0" do
+        expect(feed.score_followed_organization(article)).to eq 0
       end
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
On the Preact version of the home page, we want all logic related to selecting and ordering articles for the feed to happen on the server side. This logic current happens in the browser/client side/Javascript. 

This PR takes the article ranking logic in `app/assets/javascripts/initializers/initializeFetchFollowedArticles.js.erb` and duplicates it in `app/services/articles/feed.rb`. The client side code has been left in place for now for backwards compatibility.

Please note: we're trying to replicate current logic as closely as we can. Please no feedback on how effect that ranking criteria might be 😄 

## Related Tickets & Documents

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [ ] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![5](https://media.giphy.com/media/CwwD92OpB5y3S/giphy.gif)
