### PR TITLE
Only Show users their Active Chat Channels

### DIFF
--- a/app/javascript/chat/actions.js
+++ b/app/javascript/chat/actions.js
@@ -110,6 +110,7 @@ export function getChannels(
     dataHash[key] = value;
   }
   dataHash.per_page = 30;
+  dataHash.status = 'active';
   dataHash.page = paginationNumber;
   dataHash.channel_text = query;
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Before when a [user would leave a Chat Channel we would remove the Membership from Algolia](https://github.com/thepracticaldev/dev.to/blob/e159217dcea43a5d706e47b6238e1e680c7294d3/app/controllers/chat_channel_memberships_controller.rb#L45). Now we only remove chat channel memberships when they are destroyed we need to set the default filter to "active" so that all memberships with status such as inactive, blocked, or left_channel are not shown. 

Why not remove them from Elasticsearch? I want to keep all of the memberships in Elasticsearch bc we may want to search for other statuses in the future. It is also easier to stay synced when the general principle is that every membership has a document in Elasticsearch rather than making it a conditional of whether it is or isn't

## Added tests?
- [x] no, because they aren't needed
Ideally we should write some for this but this is a quick bug fix so I am punting for now. 

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media.giphy.com/media/RIq4nU3TgUQztUhYRr/giphy.gif)
