### PR TITLE
Use debounce to limit Chat Channel Searches

### DIFF
--- a/app/javascript/chat/chat.jsx
+++ b/app/javascript/chat/chat.jsx
@@ -1,5 +1,6 @@
 import { h, Component } from 'preact';
 import PropTypes from 'prop-types';
+import debounce from 'lodash.debounce';
 import ConfigImage from '../../assets/images/three-dots.svg';
 import {
   conductModeration,
@@ -902,7 +903,7 @@ export default class Chat extends Component {
                 <b>must</b>
               </em>
               {' '}
-              abide by the 
+              abide by the
               {' '}
               <a href="/code-of-conduct">code of conduct</a>
 .
@@ -914,7 +915,7 @@ export default class Chat extends Component {
         return (
           <div className="chatmessage" style={{ color: 'grey' }}>
             <div className="chatmessage__body">
-              You have joined 
+              You have joined
               {' '}
               {activeChannel.channel_name}
 ! All interactions
@@ -923,7 +924,7 @@ export default class Chat extends Component {
                 <b>must</b>
               </em>
               {' '}
-              abide by the 
+              abide by the
               {' '}
               <a href="/code-of-conduct">code of conduct</a>
 .
@@ -1028,7 +1029,7 @@ export default class Chat extends Component {
             >
               {'<'}
             </button>
-            <input placeholder="Filter" onKeyUp={this.triggerChannelFilter} />
+            <input placeholder="Filter" onKeyUp={debounce(this.triggerChannelFilter, 500)} />
             {invitesButton}
             <div className="chat__channeltypefilter">
               {this.renderChannelFilterButton(

--- a/app/javascript/chat/chat.jsx
+++ b/app/javascript/chat/chat.jsx
@@ -39,6 +39,11 @@ export default class Chat extends Component {
     const chatChannels = JSON.parse(props.chatChannels);
     const chatOptions = JSON.parse(props.chatOptions);
 
+    this.debouncedChannelFilter = debounce(
+      this.triggerChannelFilter.bind(this),
+      300,
+    );
+
     this.state = {
       messages: [],
       scrolled: false,
@@ -903,10 +908,10 @@ export default class Chat extends Component {
                 <b>must</b>
               </em>
               {' '}
-              abide by the
+              abide by the 
               {' '}
               <a href="/code-of-conduct">code of conduct</a>
-.
+              .
             </div>
           </div>
         );
@@ -915,19 +920,19 @@ export default class Chat extends Component {
         return (
           <div className="chatmessage" style={{ color: 'grey' }}>
             <div className="chatmessage__body">
-              You have joined
+              You have joined 
               {' '}
               {activeChannel.channel_name}
-! All interactions
+              ! All interactions
               {' '}
               <em>
                 <b>must</b>
               </em>
               {' '}
-              abide by the
+              abide by the 
               {' '}
               <a href="/code-of-conduct">code of conduct</a>
-.
+              .
             </div>
           </div>
         );
@@ -1029,7 +1034,7 @@ export default class Chat extends Component {
             >
               {'<'}
             </button>
-            <input placeholder="Filter" onKeyUp={debounce(this.triggerChannelFilter, 500)} />
+            <input placeholder="Filter" onKeyUp={this.debouncedChannelFilter} />
             {invitesButton}
             <div className="chat__channeltypefilter">
               {this.renderChannelFilterButton(

--- a/app/views/chat_channels/index.html.erb
+++ b/app/views/chat_channels/index.html.erb
@@ -22,7 +22,7 @@
         <div class="chat__channels chat__channels--expanded chat__channels--placeholder">
           <button class="chat__channelstogglebutt" onClick={this.toggleExpand}>&lt;</button>
           <button class="chat__channelstogglebutt chat__channelstogglebutt--placeholderunexpanded">&gt;</button>
-          <input placeholder='Filter' onKeyUp={debounce(this.triggerChannelFilter, 500)} />
+          <input placeholder='Filter' onKeyUp={this.debouncedChannelFilter} />
         </div>
         <div class="chat__activechat">
           <div class="activechatchannel">

--- a/app/views/chat_channels/index.html.erb
+++ b/app/views/chat_channels/index.html.erb
@@ -22,7 +22,7 @@
         <div class="chat__channels chat__channels--expanded chat__channels--placeholder">
           <button class="chat__channelstogglebutt" onClick={this.toggleExpand}>&lt;</button>
           <button class="chat__channelstogglebutt chat__channelstogglebutt--placeholderunexpanded">&gt;</button>
-          <input placeholder='Filter' onKeyUp={this.triggerChannelFilter} />
+          <input placeholder='Filter' onKeyUp={debounce(this.triggerChannelFilter, 500)} />
         </div>
         <div class="chat__activechat">
           <div class="activechatchannel">


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
Per the recommendation of @rhymes, I added debounce to our ChatChannel searching to prevent a search request from being sent after every single letter is typed by a person. I thought 500 ms seemed like a good wait time but I am open to suggestions if those more versed frontend folks have a better suggestion. 

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-33706458

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media.giphy.com/media/3ohhwpK4LhEBitGT6M/giphy.gif)
