### PR TITLE
Remove Algolia from ChatChannelMemberships

### DIFF
--- a/app/controllers/chat_channel_memberships_controller.rb
+++ b/app/controllers/chat_channel_memberships_controller.rb
@@ -26,7 +26,6 @@ class ChatChannelMembershipsController < ApplicationController
     authorize @chat_channel_membership
     if permitted_params[:user_action] == "accept"
       @chat_channel_membership.update(status: "active")
-      @chat_channel_membership.index!
     else
       @chat_channel_membership.update(status: "rejected")
     end
@@ -42,7 +41,6 @@ class ChatChannelMembershipsController < ApplicationController
       chat_channel_memberships.where(user_id: current_user.id).first
     authorize @chat_channel_membership
     @chat_channel_membership.update(status: "left_channel")
-    @chat_channel_membership.remove_from_index!
     @chat_channels_memberships = []
     render json: { result: "left channel" }, status: :created
   end

--- a/app/models/chat_channel.rb
+++ b/app/models/chat_channel.rb
@@ -77,7 +77,6 @@ class ChatChannel < ApplicationRecord
         status: "active",
       )
       channel.add_users(users)
-      channel.chat_channel_memberships.map(&:index!)
     end
     channel
   end

--- a/app/models/chat_channel_membership.rb
+++ b/app/models/chat_channel_membership.rb
@@ -1,6 +1,4 @@
 class ChatChannelMembership < ApplicationRecord
-  include AlgoliaSearch
-
   include Searchable
   SEARCH_SERIALIZER = Search::ChatChannelMembershipSerializer
   SEARCH_CLASS = Search::ChatChannelMembership
@@ -16,15 +14,6 @@ class ChatChannelMembership < ApplicationRecord
 
   after_commit :index_to_elasticsearch, on: %i[create update]
   after_commit :remove_from_elasticsearch, on: [:destroy]
-
-  algoliasearch index_name: "SecuredChatChannelMembership_#{Rails.env}", auto_index: false do
-    attribute :id, :status, :viewable_by, :chat_channel_id, :last_opened_at,
-              :channel_text, :channel_last_message_at, :channel_status, :channel_type, :channel_username,
-              :channel_name, :channel_image, :channel_modified_slug, :channel_messages_count
-    searchableAttributes %i[channel_text]
-    attributesForFaceting ["filterOnly(viewable_by)", "filterOnly(status)", "filterOnly(channel_status)", "filterOnly(channel_type)"]
-    ranking ["desc(channel_last_message_at)"]
-  end
 
   delegate :channel_type, to: :chat_channel
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -27,7 +27,7 @@ class Message < ApplicationRecord
 
   def update_chat_channel_last_message_at
     chat_channel.touch(:last_message_at)
-    chat_channel.chat_channel_memberships.reindex!
+    chat_channel.chat_channel_memberships.each(&:index_to_elasticsearch)
   end
 
   def update_all_has_unopened_messages_statuses

--- a/app/services/user_blocks/channel_handler.rb
+++ b/app/services/user_blocks/channel_handler.rb
@@ -20,7 +20,6 @@ module UserBlocks
       chat_channel.update(status: "blocked")
       chat_channel.chat_channel_memberships.includes([:user]).each do |membership|
         membership.update(status: "left_channel")
-        membership.remove_from_index!
       end
     end
 
@@ -31,7 +30,6 @@ module UserBlocks
       chat_channel.update(status: "active")
       chat_channel.chat_channel_memberships.includes([:user]).each do |membership|
         membership.update(status: "active")
-        membership.index!
       end
     end
   end

--- a/app/services/users/cleanup_chat_channels.rb
+++ b/app/services/users/cleanup_chat_channels.rb
@@ -13,10 +13,7 @@ module Users
     end
 
     def self.cleanup_memberships(chat_channel_memberships)
-      chat_channel_memberships.each do |ccm|
-        ccm.remove_from_index!
-        ccm.destroy!
-      end
+      chat_channel_memberships.each(&:destroy!)
     end
     private_class_method :cleanup_memberships
   end

--- a/app/views/chat_channels/index.html.erb
+++ b/app/views/chat_channels/index.html.erb
@@ -12,9 +12,6 @@
       id="chat"
       class="live-chat"
       data-pusher-key="<%= ApplicationConfig["PUSHER_KEY"] %>"
-      data-algolia-id="<%= ApplicationConfig["ALGOLIASEARCH_APPLICATION_ID"] %>"
-      data-algolia-key="<%= @secured_algolia_key %>"
-      data-algolia-index="<%= "SecuredChatChannelMembership_#{Rails.env}" %>"
       data-github-token="<%= @github_token %>"
       data-chat-channels="<%= [] %>"
       data-chat-options="<%= { showChannelsList: true, showTimestamp: true, activeChannelId: @active_channel&.id, currentUserId: current_user.id }.to_json %>">


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
Now that we are no longer using Algolia for searching Chat Channel Memberships we can remove it from the model!

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-32955031

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media.giphy.com/media/1xnNdG7kMqAYqCbNdT/200w_d.gif)
