### PR TITLE
ONLY Allow Active ChatChannelMembership Search

### DIFF
--- a/app/javascript/chat/actions.js
+++ b/app/javascript/chat/actions.js
@@ -110,7 +110,6 @@ export function getChannels(
     dataHash[key] = value;
   }
   dataHash.per_page = 30;
-  dataHash.status = 'active';
   dataHash.page = paginationNumber;
   dataHash.channel_text = query;
 

--- a/app/services/search/query_builders/chat_channel_membership.rb
+++ b/app/services/search/query_builders/chat_channel_membership.rb
@@ -23,6 +23,11 @@ module Search
       def initialize(params, user_id)
         @params = params.deep_symbolize_keys
         @params[:viewable_by] = user_id
+
+        # TODO: @mstruve: When we want to allow people like admins to
+        # search ALL memberships this will need to change
+        @params[:status] = "active"
+
         build_body
       end
 

--- a/spec/services/search/chat_channel_membership_spec.rb
+++ b/spec/services/search/chat_channel_membership_spec.rb
@@ -159,11 +159,11 @@ RSpec.describe Search::ChatChannelMembership, type: :service, elasticsearch: tru
         expect(chat_channel_membership_docs.first["id"]).to eq(chat_channel_membership2.id)
       end
 
-      it "searches by status" do
+      it "only returns active status memberships" do
         chat_channel_membership1.update(status: "inactive")
         chat_channel_membership2.update(status: "active")
         index_documents([chat_channel_membership1, chat_channel_membership2])
-        params = { size: 5, status: "active" }
+        params = { size: 5 }
 
         chat_channel_membership_docs = described_class.search_documents(params: params, user_id: user.id)
         expect(chat_channel_membership_docs.count).to eq(1)
@@ -188,10 +188,10 @@ RSpec.describe Search::ChatChannelMembership, type: :service, elasticsearch: tru
     end
 
     it "sorts documents for given field" do
-      chat_channel_membership1.update(status: "inactive")
-      chat_channel_membership2.update(status: "active")
+      allow(chat_channel_membership1).to receive(:channel_type).and_return("not_direct")
+      allow(chat_channel_membership2).to receive(:channel_type).and_return("direct")
       index_documents([chat_channel_membership1, chat_channel_membership2])
-      params = { size: 5, sort_by: "status", sort_direction: "asc" }
+      params = { size: 5, sort_by: "channel_type", sort_direction: "asc" }
 
       chat_channel_membership_docs = described_class.search_documents(params: params, user_id: user.id)
       expect(chat_channel_membership_docs.count).to eq(2)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
#6321 was a hotfix when I discovered we don't remove chat channel memberships when users leave a channel or are blocked(maybe we should revisit this???) While it works, because it is in the params a user could intercept the request and change it allowing them to view chat channel memberships that have other statuses. This PR hard codes the active status into the filter params before we send the query to Elasticsearch, same way we do with the user id. This means users can only ever see their own memberships that are active. 

In the future we may want to allow admins to view those with other statuses, which I noted in a comment, but for now I think this will do just fine. 

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-33722868

## Added tests?
- [x] yes

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media.giphy.com/media/APKJC7CEzmFT0Yez0q/200w_d.gif)
