### PR TITLE
Add debounce to Tag Search

### DIFF
--- a/app/javascript/shared/components/tags.jsx
+++ b/app/javascript/shared/components/tags.jsx
@@ -30,7 +30,7 @@ class Tags extends Component {
   constructor(props) {
     super(props);
 
-    this.debouncedTagSearch = debounce(this.handleInput.bind(this), 300);
+    this.debouncedTagSearch = debounce(this.handleInput.bind(this), 150);
 
     this.state = {
       selectedIndex: -1,

--- a/app/javascript/shared/components/tags.jsx
+++ b/app/javascript/shared/components/tags.jsx
@@ -440,7 +440,7 @@ class Tags extends Component {
           placeholder={`${maxTags} tags max, comma separated, no spaces or special characters`}
           autoComplete="off"
           value={defaultValue}
-          onInput={debounce(this.handleInput, 500)}
+          onInput={debounce(this.handleInput, 300)}
           onKeyDown={this.handleKeyDown}
           onBlur={this.handleFocusChange}
           onFocus={this.handleFocusChange}

--- a/app/javascript/shared/components/tags.jsx
+++ b/app/javascript/shared/components/tags.jsx
@@ -29,6 +29,9 @@ const LETTERS_NUMBERS = /[a-z0-9]/i;
 class Tags extends Component {
   constructor(props) {
     super(props);
+
+    this.debouncedTagSearch = debounce(this.handleInput.bind(this), 300);
+
     this.state = {
       selectedIndex: -1,
       searchResults: [],
@@ -440,7 +443,7 @@ class Tags extends Component {
           placeholder={`${maxTags} tags max, comma separated, no spaces or special characters`}
           autoComplete="off"
           value={defaultValue}
-          onInput={debounce(this.handleInput, 300)}
+          onInput={this.debouncedTagSearch}
           onKeyDown={this.handleKeyDown}
           onBlur={this.handleFocusChange}
           onFocus={this.handleFocusChange}

--- a/app/javascript/shared/components/tags.jsx
+++ b/app/javascript/shared/components/tags.jsx
@@ -1,5 +1,6 @@
 import { h, Component } from 'preact';
 import PropTypes from 'prop-types';
+import debounce from 'lodash.debounce';
 
 const KEYS = {
   UP: 'ArrowUp',
@@ -439,7 +440,7 @@ class Tags extends Component {
           placeholder={`${maxTags} tags max, comma separated, no spaces or special characters`}
           autoComplete="off"
           value={defaultValue}
-          onInput={this.handleInput}
+          onInput={debounce(this.handleInput, 500)}
           onKeyDown={this.handleKeyDown}
           onBlur={this.handleFocusChange}
           onFocus={this.handleFocusChange}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
Same as #6322 we don't want to necessarily send a search for every single character that is entered. Here we will only run a search every 300ms when the input in the box has changed. Once again, frontend people let me know if you have a better suggestion for wait time!

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-33725394

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media.giphy.com/media/TIyK8V35lMAFD5guV8/giphy.gif)
