### PR TITLE
Fix pagination on Search::ChatChannelMembership

### DIFF
--- a/app/services/search/chat_channel_membership.rb
+++ b/app/services/search/chat_channel_membership.rb
@@ -31,8 +31,8 @@ module Search
       end
 
       def paginate_hits(hits, params)
-        start = (params[:per_page] + 1) * params[:page]
-        hits[start, params[:per_page]]
+        start = params[:per_page] * params[:page]
+        hits[start, params[:per_page]] || []
       end
 
       def index_settings

--- a/spec/models/chat_channel_membership_spec.rb
+++ b/spec/models/chat_channel_membership_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ChatChannelMembership, type: :model do
   let(:chat_channel_membership) { FactoryBot.create(:chat_channel_membership) }
 
   describe "#channel_text" do
-    it "sets channel text using name, slig, and human names" do
+    it "sets channel text using name, slug, and human names" do
       chat_channel = chat_channel_membership.chat_channel
       parsed_channel_name = chat_channel_membership.channel_name&.gsub("chat between", "")&.gsub("and", "")
       expected_text = "#{parsed_channel_name} #{chat_channel.slug} #{chat_channel.channel_human_names.join(' ')}"

--- a/spec/services/search/chat_channel_membership_spec.rb
+++ b/spec/services/search/chat_channel_membership_spec.rb
@@ -219,6 +219,21 @@ RSpec.describe Search::ChatChannelMembership, type: :service, elasticsearch: tru
       expect(chat_channel_membership_docs.count).to eq(1)
     end
 
+    it "paginates the results" do
+      allow(chat_channel_membership1).to receive(:channel_last_message_at).and_return(Time.current)
+      allow(chat_channel_membership2).to receive(:channel_last_message_at).and_return(1.year.ago)
+      index_documents([chat_channel_membership1, chat_channel_membership2])
+      first_page_params = { page: 0, per_page: 1, sort_by: "channel_last_message_at", order: "dsc" }
+
+      chat_channel_membership_docs = described_class.search_documents(params: first_page_params, user_id: user.id)
+      expect(chat_channel_membership_docs.first["id"]).to eq(chat_channel_membership1.id)
+
+      second_page_params = { page: 1, per_page: 1, sort_by: "channel_last_message_at", order: "dsc" }
+
+      chat_channel_membership_docs = described_class.search_documents(params: second_page_params, user_id: user.id)
+      expect(chat_channel_membership_docs.first["id"]).to eq(chat_channel_membership2.id)
+    end
+
     it "returns an empty Array if no results are found" do
       allow(chat_channel_membership1).to receive(:channel_last_message_at).and_return(Time.current)
       allow(chat_channel_membership2).to receive(:channel_last_message_at).and_return(1.year.ago)

--- a/spec/services/search/chat_channel_membership_spec.rb
+++ b/spec/services/search/chat_channel_membership_spec.rb
@@ -218,5 +218,15 @@ RSpec.describe Search::ChatChannelMembership, type: :service, elasticsearch: tru
       chat_channel_membership_docs = described_class.search_documents(params: params, user_id: user.id)
       expect(chat_channel_membership_docs.count).to eq(1)
     end
+
+    it "returns an empty Array if no results are found" do
+      allow(chat_channel_membership1).to receive(:channel_last_message_at).and_return(Time.current)
+      allow(chat_channel_membership2).to receive(:channel_last_message_at).and_return(1.year.ago)
+      index_documents([chat_channel_membership1, chat_channel_membership2])
+      params = { page: 3, per_page: 1 }
+
+      chat_channel_membership_docs = described_class.search_documents(params: params, user_id: user.id)
+      expect(chat_channel_membership_docs.count).to eq(0)
+    end
   end
 end

--- a/spec/services/search/chat_channel_membership_spec.rb
+++ b/spec/services/search/chat_channel_membership_spec.rb
@@ -241,7 +241,7 @@ RSpec.describe Search::ChatChannelMembership, type: :service, elasticsearch: tru
       params = { page: 3, per_page: 1 }
 
       chat_channel_membership_docs = described_class.search_documents(params: params, user_id: user.id)
-      expect(chat_channel_membership_docs.count).to eq(0)
+      expect(chat_channel_membership_docs).to eq([])
     end
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
I noticed the logic for pagination in `Search::ChatChannelMembership` wasn't working as expected.

1. It would return `nil` or `[]`, depending on parameters. This PR fixes that to always return `[]`.
2. The pagination logic was slightly off. This PR fixes that as well.

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-33726279

## Added tests?
- [x] yes

## Added to documentation?
- [x] no documentation needed

![thinking_gif](https://media.giphy.com/media/3o7bu4T3Jcib9vlrvG/giphy.gif)
