### PR TITLE
Add nav_image and dark_nav_image fields to org settings form

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -50,6 +50,8 @@ class OrganizationsController < ApplicationController
       url
       proof
       profile_image
+      nav_image
+      dark_nav_image
       location
       company_size
       tech_stack

--- a/app/views/users/_org_admin.html.erb
+++ b/app/views/users/_org_admin.html.erb
@@ -94,6 +94,28 @@
       <%= f.file_field :profile_image %>
     <% end %>
   </div>
+  <%= f.label :nav_image, "Image for the light theme" %>
+  <div class="field">
+    <% if @organization.nav_image_url.present? %>
+      <span class="image-present">
+        <img alt="<%= @organization.name %> profile image" src="<%= cloudinary(@organization.nav_image_url, 50) %>" />
+        <%= f.file_field :nav_image %>
+      </span>
+    <% else %>
+      <%= f.file_field :nav_image %>
+    <% end %>
+  </div>
+  <%= f.label :dark_nav_image, "Image for the dark theme" %>
+  <div class="field">
+    <% if @organization.dark_nav_image_url.present? %>
+      <span class="image-present">
+        <img alt="<%= @organization.name %> profile image" src="<%= cloudinary(@organization.dark_nav_image_url, 50) %>" />
+        <%= f.file_field :dark_nav_image %>
+      </span>
+    <% else %>
+      <%= f.file_field :dark_nav_image %>
+    <% end %>
+  </div>
   <div class="field">
     <%= f.label :twitter_username, "Twitter Username" %>
     <%= f.text_field :twitter_username %>

--- a/spec/requests/organizations_update_spec.rb
+++ b/spec/requests/organizations_update_spec.rb
@@ -31,6 +31,11 @@ RSpec.describe "OrganizationsUpdate", type: :request do
     expect(Organization.last.profile_updated_at).to be > 2.minutes.ago
   end
 
+  it "updates nav_image" do
+    put "/organizations/#{org_id}", params: { organization: { id: org_id, nav_image: fixture_file_upload("files/podcast.png", "image/png") } }
+    expect(Organization.find(org_id).nav_image_url).to be_present
+  end
+
   it "returns not_found if organization is missing" do
     invalid_id = org_id + 100
     expect do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
Added `nav_image` and `dark_nav_imag`e fields to org settings form.
Organizations will be able to set up these images by themselves so that the admins won't need to set these while setting up the sponsorships.

## Related Tickets & Documents
 #6016

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![изображение](https://user-images.githubusercontent.com/30115/75455169-5df5c180-5989-11ea-93c5-97216a30c107.png)