### PR TITLE
Make localstorage draft respect newer saved draft

### DIFF
--- a/app/javascript/article-form/__tests__/articleForm.test.jsx
+++ b/app/javascript/article-form/__tests__/articleForm.test.jsx
@@ -5,12 +5,11 @@ import { JSDOM } from 'jsdom';
 import ArticleForm from '../articleForm';
 import algoliasearch from '../elements/__mocks__/algoliasearch';
 
+const dummyArticleUpdatedAt = new Date();
 const getArticleForm = () => (
   <ArticleForm
     version="v2"
-    article={
-      '{ "id": null, "body_markdown": null, "cached_tag_list": null, "main_image": null, "published": false, "title": null }'
-    }
+    article={`{ "id": null, "body_markdown": null, "cached_tag_list": null, "main_image": null, "published": false, "title": null, "updated_at": "${dummyArticleUpdatedAt}"}`}
   />
 );
 
@@ -59,10 +58,23 @@ describe('<ArticleForm />', () => {
   it('loads text from sessionstorage when available', () => {
     localStorage.setItem(
       'editor-v2-http://localhost/',
-      JSON.stringify({ bodyMarkdown: 'hello, world' }),
+      JSON.stringify({ bodyMarkdown: 'hello, world', updatedAt: new Date() }),
     );
     const form = shallow(getArticleForm());
     expect(form.state().bodyMarkdown).toBe('hello, world');
+  });
+
+  it('do not loads text from sessionstorage if article.updated_at is newer', () => {
+    const localStorageDate = new Date(dummyArticleUpdatedAt.getDate() - 1);
+    localStorage.setItem(
+      'editor-v2-http://localhost/',
+      JSON.stringify({
+        bodyMarkdown: 'hello, world',
+        updatedAt: localStorageDate,
+      }),
+    );
+    const form = shallow(getArticleForm());
+    expect(form.state().bodyMarkdown).toBe('');
   });
 
   it('resets the post on reset press', () => {

--- a/app/javascript/article-form/articleForm.jsx
+++ b/app/javascript/article-form/articleForm.jsx
@@ -116,9 +116,10 @@ export default class ArticleForm extends Component {
 
   componentDidMount() {
     const { version, updatedAt } = this.state;
-    const previousContent = JSON.parse(
-      localStorage.getItem(`editor-${version}-${window.location.href}`),
-    );
+    const previousContent =
+      JSON.parse(
+        localStorage.getItem(`editor-${version}-${window.location.href}`),
+      ) || {};
     const isLocalstorageNewer =
       new Date(previousContent.updatedAt) > new Date(updatedAt);
 

--- a/app/javascript/article-form/articleForm.jsx
+++ b/app/javascript/article-form/articleForm.jsx
@@ -109,16 +109,20 @@ export default class ArticleForm extends Component {
       organizationId: this.article.organization_id,
       errors: null,
       edited: false,
+      updatedAt: this.article.updated_at,
       version,
     };
   }
 
   componentDidMount() {
-    const { version } = this.state;
+    const { version, updatedAt } = this.state;
     const previousContent = JSON.parse(
       localStorage.getItem(`editor-${version}-${window.location.href}`),
     );
-    if (previousContent && this.checkContentChanges(previousContent)) {
+    const isLocalstorageNewer =
+      new Date(previousContent.updatedAt) > new Date(updatedAt);
+
+    if (previousContent && isLocalstorageNewer) {
       this.setState({
         title: previousContent.title || '',
         tagList: previousContent.tagList || '',
@@ -139,18 +143,9 @@ export default class ArticleForm extends Component {
     }
   }
 
-  checkContentChanges = previousContent => {
-    const { bodyMarkdown, title, mainImage, tagList } = this.state;
-    return (
-      bodyMarkdown !== previousContent.bodyMarkdown ||
-      title !== previousContent.title ||
-      mainImage !== previousContent.mainImage ||
-      tagList !== previousContent.tagList
-    );
-  };
-
   localStoreContent = () => {
     const { version, title, tagList, mainImage, bodyMarkdown } = this.state;
+    const updatedAt = new Date();
     localStorage.setItem(
       `editor-${version}-${this.url}`,
       JSON.stringify({
@@ -158,6 +153,7 @@ export default class ArticleForm extends Component {
         tagList,
         mainImage,
         bodyMarkdown,
+        updatedAt,
       }),
     );
   };

--- a/app/views/articles/_v2_form.html.erb
+++ b/app/views/articles/_v2_form.html.erb
@@ -3,7 +3,7 @@
 <div class="articleformcontainer">
   <div class="articleform"
        id="article-form"
-       data-article="<%= article.to_json(only: %i[id title cached_tag_list published body_markdown main_image organization_id canonical_url], methods: %i[series all_series]) %>"
+       data-article="<%= article.to_json(only: %i[id title cached_tag_list published body_markdown main_image organization_id canonical_url updated_at], methods: %i[series all_series]) %>"
        data-organizations="<%= organizations&.to_json(only: %i[id name bg_color_hex text_color_hex], methods: [:profile_image_90]) %>"
        data-version="<%= version %>">
     <form class="articleform__form articleform__form--<%= version %>">


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature
- [x] Bug Fix

## Description
[what the bug currently looks like](https://youtu.be/vlbflkoaRgo)

Our frontend app will now check if the locally cached draft's timestamp is newer or older than the draft provided by the backend before attempting to overwrite it. This is fixed by also caching the timestamp of when localstorage draft is created, then the timestamp is compared to decide if the override should occur.





## Related Tickets & Documents
Resolves https://github.com/thepracticaldev/dev.to/issues/3670
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
TBD
## Added tests?
- [x] yes

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a
