### PR TITLE
Linter update: update max line limit to 15 for RSpec files

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,7 @@ RSpec/DescribeClass:
     - spec/system/**/*
 
 RSpec/ExampleLength:
-  Max: 10
+  Max: 15
 
 #############################
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
This PR is upping the max line limit from 10 to 15 for RSpec files. Especially when it comes to Elasticsearch, we've been bumping up against this limit a lot lately which forces us to make the code less readable (i.e. putting Hashes all on one line). The desired code is still concise and necessary in the Elasticsearch example, there are just more steps involved (mock responses, indexing, etc.). This update will help to accommodate that and keep things readable.

## Related Tickets & Documents

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

![bigger_is_better_gif](https://media.giphy.com/media/Q8Zf8nybTQA7W1bIXB/giphy.gif)
