### PR TITLE
Fix flapping test

### DIFF
--- a/spec/services/articles/feed_spec.rb
+++ b/spec/services/articles/feed_spec.rb
@@ -12,16 +12,16 @@ RSpec.describe Articles::Feed, type: :service do
   describe "#published_articles_by_tag" do
     let(:unpublished_article) { create(:article, published: false) }
     let(:tag) { "foo" }
-    let(:tagged_article) { create(:article, tags: [tag]) }
+    let(:tagged_article) { create(:article, tags: tag) }
 
     it "returns published articles" do
-      expect(described_class.new(number_of_articles: 1, page: 1).published_articles_by_tag).to include article
-      expect(described_class.new(number_of_articles: 1, page: 1).published_articles_by_tag).not_to include unpublished_article
+      expect(feed.published_articles_by_tag).to include article
+      expect(feed.published_articles_by_tag).not_to include unpublished_article
     end
 
     context "with tag" do
       it "returns articles with the specified tag" do
-        expect(described_class.new(number_of_articles: 1, page: 1, tag: tag).published_articles_by_tag).to include tagged_article
+        expect(described_class.new(tag: tag).published_articles_by_tag).to include tagged_article
       end
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixes a test for the feed service that was poorly structured: instead of just requesting the first tagged article, we request multiple (35 by default). The order or tagged articles isn't consistent in this testing scenario.

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![Kf0aQy105Ns7DIIaDs](https://user-images.githubusercontent.com/37842/75482312-304d5000-596a-11ea-8990-2d020c3c6de7.gif)

