### PR TITLE
Add page and article limit options to feed service

### DIFF
--- a/spec/services/articles/feed_spec.rb
+++ b/spec/services/articles/feed_spec.rb
@@ -287,4 +287,27 @@ RSpec.describe Articles::Feed, type: :service do
       end
     end
   end
+
+  describe "#rank_and_sort_articles" do
+    let(:article1) { create(:article) }
+    let(:article2) { create(:article) }
+    let(:article3) { create(:article) }
+    let(:articles) { [article1, article2, article3] }
+
+    context "when number of articles specified" do
+      let(:feed) { described_class.new(number_of_articles: 1) }
+
+      it "only returns the requested number of articles" do
+        expect(feed.rank_and_sort_articles(articles).size).to eq 1
+      end
+    end
+
+    it "returns articles in scored order" do
+      allow(feed).to receive(:score_single_article).with(article1).and_return(1)
+      allow(feed).to receive(:score_single_article).with(article2).and_return(2)
+      allow(feed).to receive(:score_single_article).with(article3).and_return(3)
+
+      expect(feed.rank_and_sort_articles(articles)).to eq [article3, article2, article1]
+    end
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

@benhalpern rightly pointed out that not all endpoints in the `Articles::Feed` service are respecting the `page` and `number_of_articles` options. This PR makes the endpoints that use a simple ActiveRecord look respect those options. Note that the `default_home-feed` and `default_home_feed_and_featured_story` endpoints will only respect `number_of_articles`: since these methods are doing ranking of stories, I fear that trying to page the results would be tricky (as I can't just rely upon the Kaminari gem to do it for me).

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [ ] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![no limits](https://media.giphy.com/media/7JvlHfd7C2GDr7zfZF/giphy.gif)
