### PR TITLE
Remove sent attribute from broadcasts table

### DIFF
--- a/db/migrate/20200227214321_remove_sent_from_broadcasts.rb
+++ b/db/migrate/20200227214321_remove_sent_from_broadcasts.rb
@@ -1,0 +1,5 @@
+class RemoveSentFromBroadcasts < ActiveRecord::Migration[5.2]
+  def change
+    safety_assured { remove_column :broadcasts, :sent, :boolean }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_26_192145) do
+ActiveRecord::Schema.define(version: 2020_02_27_214321) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -227,7 +227,6 @@ ActiveRecord::Schema.define(version: 2020_02_26_192145) do
     t.boolean "active", default: false
     t.text "body_markdown"
     t.text "processed_html"
-    t.boolean "sent", default: false
     t.string "title"
     t.string "type_of"
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Now that #6318 and #6319 have been merged, we no longer need the `sent` attribute on the Broadcast model.

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/7#card-32965274

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
N/A

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## Are there any post deployment tasks we need to perform?

Nope! The data in the `sent` column has been migrate to the `active` column on Broadcasts, so we should be good to go! 🚀 
