### PR TITLE
Don't run the service worker on /enter

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -5,8 +5,8 @@ class RegistrationsController < Devise::RegistrationsController
   def new
     if user_signed_in?
       redirect_to "/dashboard?signed-in-already&t=#{Time.current.to_i}"
-      return
+    else
+      super
     end
-    super
   end
 end

--- a/app/views/service_worker/index.js.erb
+++ b/app/views/service_worker/index.js.erb
@@ -110,6 +110,7 @@
         !url.href.includes('/sidekiq') && // Skip for Sidekiq dashboard
         !url.href.includes('/social_previews') && // Skip for social previews
         !url.href.includes('/users/auth') && // Don't run on authentication.
+        !url.href.includes('/enter') && // Don't run on registration.
 
         caches.match('/shell_top') && // Ensure shell_top is in the cache.
         caches.match('/shell_bottom')) { // Ensure shell_bottom is in the cache.


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The service worker is run on `/enter` but seems to conflict with the automatic redirection to the dashboard and it results on a full page rendered inside the shell (causing the double footer mentioned in the related issue #6347).

You can verify this by going to https://dev.to/enter - you'll not be redirected but still be shown the dashboard, if you scroll down you'll see the double footer

I also noticed it doesn't actually redirects, only shows the dashboard:

![Screenshot 2020-02-28 at 10 10 32 AM](https://user-images.githubusercontent.com/146201/75526733-9db4bb80-5a12-11ea-86f1-132081984243.png)

This should fix this, let me know if I missed something

Closes #6347 

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
