### PR TITLE
Allow different casings to be specified for syntax highlighting

### DIFF
--- a/app/lib/redcarpet/render/html_rouge.rb
+++ b/app/lib/redcarpet/render/html_rouge.rb
@@ -5,6 +5,13 @@ module Redcarpet
     class HTMLRouge < HTML
       include Rouge::Plugins::Redcarpet
 
+      # Rouge requires the hint language to be lower case, by overriding this
+      # method we can allow the hint language to be specified with other casings
+      # eg. `Ada` instead of `ada`
+      def block_code(code, language)
+        super(code, language.to_s.downcase)
+      end
+
       def link(link, _title, content)
         # Probably not the best fix but it does it's job of preventing
         # a nested links.

--- a/spec/labor/markdown_parser_spec.rb
+++ b/spec/labor/markdown_parser_spec.rb
@@ -314,4 +314,21 @@ RSpec.describe MarkdownParser, type: :labor do
       expect(generate_and_parse_markdown(code_block)).to include("word_<em>italic</em>_")
     end
   end
+
+  context "when adding syntax highlighting" do
+    it "defaults to plaintext" do
+      code_block = "```\ntext\n````"
+      expect(generate_and_parse_markdown(code_block)).to include("highlight plaintext")
+    end
+
+    it "adds correct syntax highlighting to codeblocks when the hint is not lowercase" do
+      code_block = "```Ada\nwith Ada.Directories;\n````"
+      expect(generate_and_parse_markdown(code_block)).to include("highlight ada")
+    end
+
+    it "adds correct syntax highlighting to codeblocks when the hint is lowercase" do
+      code_block = "```ada\nwith Ada.Directories;\n````"
+      expect(generate_and_parse_markdown(code_block)).to include("highlight ada")
+    end
+  end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Our syntax highlighter, [rouge](https://github.com/rouge-ruby/rouge) requires the hint language in code blocks to be always lowercase:

```ruby
[7] pry(main)> Rouge::Lexer.find("python")
=> Rouge::Lexers::Python
[8] pry(main)> Rouge::Lexer.find("Python")
=> nil
```

It might be neat to allow users to specify whatever casing they prefer. For example the following is specified as `RuBy` and it works:

```RuBy
puts "hello world"
```

Closes https://github.com/thepracticaldev/dev.to/issues/6352


## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
