### PR TITLE
Started moving sponsorships to /internal

### DIFF
--- a/app/controllers/internal/sponsorships_controller.rb
+++ b/app/controllers/internal/sponsorships_controller.rb
@@ -5,11 +5,22 @@ class Internal::SponsorshipsController < Internal::ApplicationController
     @sponsorships = Sponsorship.includes(:organization, :user).order("created_at desc").page(params[:page]).per(50)
   end
 
-  def new
-    @sponsorship = Sponsorship.new
+  def edit
+    @sponsorship = Sponsorship.find(params[:id])
   end
 
-  def create
-    @sponsorship = Sponsorship.new
+  def update
+    @sponsorship = Sponsorship.find(params[:id])
+    if @sponsorship.update(sponsorship_params)
+      redirect_to internal_sponsorships_path
+    else
+      render action: :edit
+    end
+  end
+
+  private
+
+  def sponsorship_params
+    params.require(:sponsorship).permit(%i[status expired_at])
   end
 end

--- a/app/controllers/internal/sponsorships_controller.rb
+++ b/app/controllers/internal/sponsorships_controller.rb
@@ -1,0 +1,15 @@
+class Internal::SponsorshipsController < Internal::ApplicationController
+  layout "internal"
+
+  def index
+    @sponsorships = Sponsorship.includes(:organization, :user).order("created_at desc").page(params[:page]).per(50)
+  end
+
+  def new
+    @sponsorship = Sponsorship.new
+  end
+
+  def create
+    @sponsorship = Sponsorship.new
+  end
+end

--- a/app/controllers/internal/sponsorships_controller.rb
+++ b/app/controllers/internal/sponsorships_controller.rb
@@ -20,6 +20,16 @@ class Internal::SponsorshipsController < Internal::ApplicationController
     end
   end
 
+  def destroy
+    @sponsorship = Sponsorship.find(params[:id])
+    if @sponsorship.destroy
+      flash[:notice] = "Sponsorship was successfully destroyed"
+    else
+      flash[:danger] = "Sponsorship was not destroyed"
+    end
+    redirect_to internal_sponsorships_path
+  end
+
   private
 
   def sponsorship_params

--- a/app/controllers/internal/sponsorships_controller.rb
+++ b/app/controllers/internal/sponsorships_controller.rb
@@ -12,8 +12,10 @@ class Internal::SponsorshipsController < Internal::ApplicationController
   def update
     @sponsorship = Sponsorship.find(params[:id])
     if @sponsorship.update(sponsorship_params)
+      flash[:notice] = "Sponsorship was successfully updated"
       redirect_to internal_sponsorships_path
     else
+      flash[:danger] = @sponsorship.errors.full_messages.join(", ")
       render action: :edit
     end
   end
@@ -21,6 +23,6 @@ class Internal::SponsorshipsController < Internal::ApplicationController
   private
 
   def sponsorship_params
-    params.require(:sponsorship).permit(%i[status expired_at])
+    params.require(:sponsorship).permit(%i[status expires_at tagline url blurb_html featured_number instructions instructions_updated_at])
   end
 end

--- a/app/views/internal/shared/_navbar.html.erb
+++ b/app/views/internal/shared/_navbar.html.erb
@@ -1,6 +1,5 @@
-<% menu_items = %w[comments articles users tags welcome broadcasts reports pages tools chat_channels permissions growth mods config events badges organizations].each_with_object({}) { |v, h| h[v] = v } %>
+<% menu_items = %w[comments articles users tags welcome broadcasts reports pages tools chat_channels permissions growth mods config events badges organizations sponsorships podcasts].each_with_object({}) { |v, h| h[v] = v } %>
 <% menu_items[:listings] = "classified_listings" %>
-<% menu_items[:podcasts] = "podcasts" %>
 <% menu_items[:webhooks] = "webhook_endpoints" %>
 
 <div class="navbar-nav justify-content-center">

--- a/app/views/internal/sponsorships/edit.html.erb
+++ b/app/views/internal/sponsorships/edit.html.erb
@@ -1,7 +1,7 @@
 <h3><%= "Edit Sponsorship ##{@sponsorship.id}" %></h3>
 <%= form_for [:internal, @sponsorship] do |f| %>
   <div class="form-group">
-    User: <%= link_to "@#{@sponsorship.user.username}", "/#{@sponsorship.user.username}" %>
+    Creator: <%= link_to "@#{@sponsorship.user.username}", "/#{@sponsorship.user.username}" %>
   </div>
   <div class="form-group">
     Organization: <%= link_to "@#{@sponsorship.organization.username}", "/#{@sponsorship.organization.username}" %>

--- a/app/views/internal/sponsorships/edit.html.erb
+++ b/app/views/internal/sponsorships/edit.html.erb
@@ -1,5 +1,4 @@
 <h3><%= "Edit Sponsorship ##{@sponsorship.id}" %></h3>
-
 <%= form_for [:internal, @sponsorship] do |f| %>
   <div class="form-group">
     User: <%= link_to "@#{@sponsorship.user.username}", "/#{@sponsorship.user.username}" %>
@@ -50,5 +49,7 @@
     <%= f.label :instructions_updated_at %>
     <%= f.datetime_select :instructions_updated_at, required: true, start_year: Time.current.year, end_year: Time.current.year + 2, class: "form-control" %> UTC Time
   </div>
-  <%= f.submit "Update Sponsorship", class: "btn btn-primary float-right" %>
+  <%= f.submit "Update Sponsorship", class: "btn btn-primary" %>
+  <%= link_to "Destroy Sponsorship", url_for(action: :destroy, id: @sponsorship.id), method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-danger float-right" %>
 <% end %>
+<hr />

--- a/app/views/internal/sponsorships/edit.html.erb
+++ b/app/views/internal/sponsorships/edit.html.erb
@@ -1,0 +1,27 @@
+<h3><%= "Edit Sponsorship ##{@sponsorship.id}" %></h3>
+
+<%= form_for [:internal, @sponsorship] do |form| %>
+  <div class="form-group">
+    User: <%= link_to "@#{@sponsorship.user.username}", "/#{@sponsorship.user.username}" %>
+  </div>
+  <div class="form-group">
+    Organization: <%= link_to "@#{@sponsorship.organization.username}", "/#{@sponsorship.organization.username}" %>
+  </div>
+  <div class="form-group">
+    Level: <%= @sponsorship.level %>
+  </div>
+  <div class="form-group">
+    <% if @sponsorship.sponsorable.is_a?(ActsAsTaggableOn::Tag) %>
+      Sponsorable: <%= link_to @sponsorship.sponsorable.name, "/t/#{@sponsorship.sponsorable.name}" %>
+    <% end %>
+  </div>
+  <div class="form-group">
+    <%= form.label :status %>
+    <%= form.select :status, Sponsorship::STATUSES %>
+  </div>
+  <div class="form-group">
+    <%= form.label :expires_at %>
+    <%= form.text_field :expires_at, "data-type" => "datetime" %>
+  </div>
+  <%= form.submit "Update Sponsorship", class: "btn btn-primary float-right" %>
+<% end %>

--- a/app/views/internal/sponsorships/edit.html.erb
+++ b/app/views/internal/sponsorships/edit.html.erb
@@ -1,11 +1,14 @@
 <h3><%= "Edit Sponsorship ##{@sponsorship.id}" %></h3>
 
-<%= form_for [:internal, @sponsorship] do |form| %>
+<%= form_for [:internal, @sponsorship] do |f| %>
   <div class="form-group">
     User: <%= link_to "@#{@sponsorship.user.username}", "/#{@sponsorship.user.username}" %>
   </div>
   <div class="form-group">
     Organization: <%= link_to "@#{@sponsorship.organization.username}", "/#{@sponsorship.organization.username}" %>
+  </div>
+  <div class="form-group">
+    Created at: <%= f.object.created_at.strftime("%d %B %Y %H:%M UTC") %>
   </div>
   <div class="form-group">
     Level: <%= @sponsorship.level %>
@@ -16,12 +19,36 @@
     <% end %>
   </div>
   <div class="form-group">
-    <%= form.label :status %>
-    <%= form.select :status, Sponsorship::STATUSES %>
+    <%= f.label :status %>
+    <%= f.select :status, Sponsorship::STATUSES %>
   </div>
   <div class="form-group">
-    <%= form.label :expires_at %>
-    <%= form.text_field :expires_at, "data-type" => "datetime" %>
+    <%= f.label :expires_at %>
+    <%= f.datetime_select :expires_at, required: true, start_year: Time.current.year, end_year: Time.current.year + 2, class: "form-control" %> UTC Time
   </div>
-  <%= form.submit "Update Sponsorship", class: "btn btn-primary float-right" %>
+  <div class="form-group">
+    <%= f.label :tagline %>
+    <%= f.text_field :tagline, class: "form-control" %>
+  </div>
+  <div class="form-group">
+    <%= f.label :url %>
+    <%= f.text_field :url, class: "form-control" %>
+  </div>
+  <div class="form-group">
+    <%= f.label :blurb_html %>
+    <%= f.text_area :blurb_html, class: "form-control" %>
+  </div>
+  <div class="form-group">
+    <%= f.label :featured_number %>
+    <%= f.text_field :featured_number, class: "form-control" %>
+  </div>
+  <div class="form-group">
+    <%= f.label :instructions %>
+    <%= f.text_field :instructions, class: "form-control" %>
+  </div>
+  <div class="form-group">
+    <%= f.label :instructions_updated_at %>
+    <%= f.datetime_select :instructions_updated_at, required: true, start_year: Time.current.year, end_year: Time.current.year + 2, class: "form-control" %> UTC Time
+  </div>
+  <%= f.submit "Update Sponsorship", class: "btn btn-primary float-right" %>
 <% end %>

--- a/app/views/internal/sponsorships/index.html.erb
+++ b/app/views/internal/sponsorships/index.html.erb
@@ -20,7 +20,7 @@
         <td><%= link_to sponsorship.id, edit_internal_sponsorship_path(sponsorship) %></td>
         <td><%= sponsorship.level %></td>
         <td><%= sponsorship.status %></td>
-        <td><%= sponsorship.expires_at.strftime("%d %B %Y %H:%M UTC") %></td>
+        <td><%= sponsorship.expires_at&.strftime("%d %B %Y %H:%M UTC") %></td>
         <td>
           <% if sponsorship.sponsorable.is_a?(ActsAsTaggableOn::Tag) %>
             <%= link_to sponsorship.sponsorable.name, "/t/#{sponsorship.sponsorable.name}" %>

--- a/app/views/internal/sponsorships/index.html.erb
+++ b/app/views/internal/sponsorships/index.html.erb
@@ -31,7 +31,9 @@
         <td>
           <%= link_to "@#{sponsorship.organization.username}", "/#{sponsorship.organization.username}" %>
         </td>
-        <td><%= link_to "edit", edit_internal_sponsorship_path(sponsorship) %></td>
+        <td>
+          <%= link_to "edit", edit_internal_sponsorship_path(sponsorship) %>
+        </td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/internal/sponsorships/index.html.erb
+++ b/app/views/internal/sponsorships/index.html.erb
@@ -1,0 +1,40 @@
+<%= paginate @sponsorships %>
+
+<table class="table">
+  <thead>
+    <tr>
+      <th scope="col">ID</th>
+      <th scope="col">Level</th>
+      <th scope="col">Status</th>
+      <th scope="col">Expires At</th>
+      <th scope="col">Sponsorable</th>
+      <th scope="col">Created At</th>
+      <th scope="col">User</th>
+      <th scope="col">Organization</th>
+      <th scope="col">Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @sponsorships.each do |sponsorship| %>
+      <tr>
+        <td><%= link_to sponsorship.id, edit_internal_sponsorship_path(sponsorship) %></td>
+        <td><%= sponsorship.level %></td>
+        <td><%= sponsorship.status %></td>
+        <td><%= sponsorship.expires_at.strftime("%d %B %Y %H:%M UTC") %></td>
+        <td>
+          <% if sponsorship.sponsorable.is_a?(ActsAsTaggableOn::Tag) %>
+            <%= link_to sponsorship.sponsorable.name, "/t/#{sponsorship.sponsorable.name}" %>
+          <% end %>
+        </td>
+        <td><%= sponsorship.created_at.strftime("%d %B %Y %H:%M UTC") %></td>
+        <td><%= link_to "@#{sponsorship.user.username}", "/#{sponsorship.user.username}" %></td>
+        <td>
+          <%= link_to "@#{sponsorship.organization.username}", "/#{sponsorship.organization.username}" %>
+        </td>
+        <td><%= link_to "edit", edit_internal_sponsorship_path(sponsorship) %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<%= paginate @sponsorships %>

--- a/app/views/internal/sponsorships/index.html.erb
+++ b/app/views/internal/sponsorships/index.html.erb
@@ -9,7 +9,7 @@
       <th scope="col">Expires At</th>
       <th scope="col">Sponsorable</th>
       <th scope="col">Created At</th>
-      <th scope="col">User</th>
+      <th scope="col">Creator</th>
       <th scope="col">Organization</th>
       <th scope="col">Actions</th>
     </tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,6 +76,7 @@ Rails.application.routes.draw do
     end
     resources :organization_memberships, only: %i[update destroy create]
     resources :organizations, only: %i[index show]
+    resources :sponsorships
     resources :welcome, only: %i[index create]
     resources :growth, only: %i[index]
     resources :tools, only: %i[index create] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,7 +76,7 @@ Rails.application.routes.draw do
     end
     resources :organization_memberships, only: %i[update destroy create]
     resources :organizations, only: %i[index show]
-    resources :sponsorships, only: %i[index edit update]
+    resources :sponsorships, only: %i[index edit update destroy]
     resources :welcome, only: %i[index create]
     resources :growth, only: %i[index]
     resources :tools, only: %i[index create] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,7 +76,7 @@ Rails.application.routes.draw do
     end
     resources :organization_memberships, only: %i[update destroy create]
     resources :organizations, only: %i[index show]
-    resources :sponsorships
+    resources :sponsorships, only: %i[index edit update]
     resources :welcome, only: %i[index create]
     resources :growth, only: %i[index]
     resources :tools, only: %i[index create] do

--- a/spec/requests/internal/sponsorships_spec.rb
+++ b/spec/requests/internal/sponsorships_spec.rb
@@ -70,4 +70,15 @@ RSpec.describe "/internal/sponsorships", type: :request do
       expect(response.body).to include("Status is not included in the list")
     end
   end
+
+  describe "DELETE /internal/sponsorships/:id" do
+    let!(:sponsorship) { create(:sponsorship, organization: org, level: :silver, status: "live", expires_at: Time.current) }
+
+    it "destroys a sponsorship" do
+      sign_in admin
+      expect do
+        delete internal_sponsorship_path(sponsorship.id)
+      end.to change(Sponsorship, :count).by(-1)
+    end
+  end
 end

--- a/spec/requests/internal/sponsorships_spec.rb
+++ b/spec/requests/internal/sponsorships_spec.rb
@@ -1,0 +1,73 @@
+require "rails_helper"
+
+RSpec.describe "/internal/sponsorships", type: :request do
+  let(:admin) { create(:user, :super_admin) }
+  let(:org) { create(:organization, username: "super-community") }
+
+  describe "GET /internal/sponsorships" do
+    before do
+      sign_in admin
+      create(:sponsorship, organization: org, level: :gold)
+    end
+
+    it "renders successfully" do
+      get "/internal/sponsorships"
+      expect(response).to be_successful
+    end
+
+    it "shows sponsorship" do
+      get "/internal/sponsorships"
+      expect(response.body).to include(org.username)
+      expect(response.body).to include("gold")
+    end
+  end
+
+  describe "GET /internal/sponsorships/:id/edit" do
+    let(:ruby) { create(:tag, name: "ruby") }
+    let!(:sponsorship) { create(:sponsorship, organization: org, level: :tag, sponsorable: ruby, status: "pending", expires_at: Time.current) }
+
+    before do
+      sign_in admin
+    end
+
+    it "renders successfully" do
+      get edit_internal_sponsorship_path(sponsorship.id)
+      expect(response).to be_successful
+    end
+  end
+
+  describe "PUT /internal/sponsorships/:id" do
+    let(:ruby) { create(:tag, name: "ruby") }
+    let!(:sponsorship) { create(:sponsorship, organization: org, level: :tag, sponsorable: ruby, status: "pending", expires_at: Time.current) }
+    let(:valid_attributes) { { status: "live", expires_at: 1.month.from_now, blurb_html: Faker::Book.title } }
+    let(:invalid_attributes) { { status: "super-live", expires_at: 1.month.from_now } }
+
+    before do
+      sign_in admin
+    end
+
+    it "redirects to index" do
+      put "/internal/sponsorships/#{sponsorship.id}", params: { sponsorship: valid_attributes }
+      expect(response).to redirect_to(internal_sponsorships_path)
+    end
+
+    it "updates the sponsorship" do
+      put "/internal/sponsorships/#{sponsorship.id}", params: { sponsorship: valid_attributes }
+      sponsorship.reload
+      expect(sponsorship.status).to eq("live")
+      expect(sponsorship.expires_at).to be > Time.current
+      expect(sponsorship.blurb_html).to eq(valid_attributes[:blurb_html])
+    end
+
+    it "doesn't update when attributes are invalid" do
+      put "/internal/sponsorships/#{sponsorship.id}", params: { sponsorship: invalid_attributes }
+      sponsorship.reload
+      expect(sponsorship.status).to eq("pending")
+    end
+
+    it "shows errors when attributes are invalid" do
+      put "/internal/sponsorships/#{sponsorship.id}", params: { sponsorship: invalid_attributes }
+      expect(response.body).to include("Status is not included in the list")
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
- created `/internal/sponsorships`
- moved part of the functionality from `/admin/sponsorships` to `/internal/sponsorships`
I decided to start with moving displaying, editing and destroying sponsorships to `/internal` to fit the task in this cycle. 
Creating sponsorships from `/internal` should be implemented later in another pr.

## Related Tickets & Documents
 #6015

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![изображение](https://user-images.githubusercontent.com/30115/75546201-17f83680-5a39-11ea-8309-77298d9d17fc.png)

![изображение](https://user-images.githubusercontent.com/30115/75545335-175ea080-5a37-11ea-888d-dbc96c0577c3.png)

## Added tests?
- [x] yes