### PR TITLE
Set an HtmlVariant for a campaign tag header container

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -132,6 +132,11 @@ class StoriesController < ApplicationController
     @stories = stories_by_timeframe
     @stories = @stories.decorate
 
+    if SiteConfig.campaign_featured_tags.include?(@tag)
+      @header_container_html = HtmlVariant.relevant.select(:html).
+        find_by(group: "campaign", name: "header_container_#{@tag}")&.html
+    end
+
     set_surrogate_key_header "articles-#{@tag}"
     response.headers["Surrogate-Control"] = "max-age=600, stale-while-revalidate=30, stale-if-error=86400"
     render template: "articles/tag_index"

--- a/app/views/articles/tag_index.html.erb
+++ b/app/views/articles/tag_index.html.erb
@@ -10,25 +10,29 @@
       box-shadow: 5px 6px 0px<%= HexComparer.new([@tag_model.bg_color_hex || "#0000000", @tag_model.text_color_hex || "#ffffff"]).brightness(0.88) %>;
     }
   </style>
-  <div class="user-profile-header tag-header">
-    <div class="tag-or-query-header-container">
-      <h1>
-        <% if @tag_model.badge_id && @tag_model.badge %>
-            <img src="<%= cloudinary @tag_model.badge.badge_image_url, 180 %>" style="transform: rotate(<%= -25 + (@tag_model.id.digits.first * 5) %>deg" />
-        <% end %>
-        <% if @tag_model && @tag_model.pretty_name.present? %>
-          <%= @tag_model.pretty_name %>
-        <% else %>
-          <%= @tag %>
-        <% end %>
-        <% if @tag_model %>
-            <span class="user-profile-follow-button-wrapper">
-              <button id="user-follow-butt" class="cta follow-action-button user-profile-follow-button" style="color:<%= @tag_model.text_color_hex %>;background-color:<%= @tag_model.bg_color_hex %>" data-info='{"id":<%= @tag_model.id %>,"className":"Tag"}'>&nbsp;</button>
-            </span>
-        <% end %>
-      </h1>
+  <% if @header_container_html %>
+    <%= @header_container_html.html_safe %>
+  <% else %>
+    <div class="user-profile-header tag-header">
+      <div class="tag-or-query-header-container">
+        <h1>
+          <% if @tag_model.badge_id && @tag_model.badge %>
+              <img src="<%= cloudinary @tag_model.badge.badge_image_url, 180 %>" style="transform: rotate(<%= -25 + (@tag_model.id.digits.first * 5) %>deg" />
+          <% end %>
+          <% if @tag_model && @tag_model.pretty_name.present? %>
+            <%= @tag_model.pretty_name %>
+          <% else %>
+            <%= @tag %>
+          <% end %>
+          <% if @tag_model %>
+              <span class="user-profile-follow-button-wrapper">
+                <button id="user-follow-butt" class="cta follow-action-button user-profile-follow-button" style="color:<%= @tag_model.text_color_hex %>;background-color:<%= @tag_model.bg_color_hex %>" data-info='{"id":<%= @tag_model.id %>,"className":"Tag"}'>&nbsp;</button>
+              </span>
+          <% end %>
+        </h1>
+      </div>
     </div>
-  </div>
+  <% end %>
   <div class="home sub-home" id="index-container"
       data-params="<%= params.to_json(only: %i[tag username q]) %>" data-which=""
       data-algolia-tag="<%= @tag %>"


### PR DESCRIPTION
# What type of PR is this? (check all applicable)
- [x] Feature

## Description
Implemented a hacky way to set a header for the campaign tag page. A header will be displayed instead of the default box with the tag name and follow/following button.
To do that you will need to create an `HtmlVariant` in a `campaign` group with a name `header_container_#{tag.name}`. The tag should be one of the `SiteConfig.campaign_featured_tags`

I haven't made `html` and styling for an `HtmlVariant`! 

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
How should it look like according to the design:
![изображение](https://user-images.githubusercontent.com/30115/75547206-78887300-5a3b-11ea-875d-f20b904db840.png)



## Added tests?
- [ ] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
