### PR TITLE
Add leading: true to Avoid Debounce Interrupting Typing

### DIFF
--- a/app/javascript/shared/components/tags.jsx
+++ b/app/javascript/shared/components/tags.jsx
@@ -30,7 +30,9 @@ class Tags extends Component {
   constructor(props) {
     super(props);
 
-    this.debouncedTagSearch = debounce(this.handleInput.bind(this), 150);
+    this.debouncedTagSearch = debounce(this.handleInput.bind(this), 150, {
+      leading: true,
+    });
 
     this.state = {
       selectedIndex: -1,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
We [were seeing some weird behavior](https://github.com/thepracticaldev/dev.to/pull/6327#issuecomment-592428676) after I lowered the wait time for debounce causing it to interrupt the user typing. I added leading true so that the time starts after the first keystroke instead of the last. Seems to have fixed the issue for me locally.  

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media3.giphy.com/media/3o6EhFuJ4yjvHFrflm/source.gif)
