### PR TITLE
Sanitisation of Ads

### DIFF
--- a/app/models/display_ad.rb
+++ b/app/models/display_ad.rb
@@ -28,7 +28,7 @@ class DisplayAd < ApplicationRecord
     initial_html = markdown.render(body_markdown)
 
     # Temporarily disable the sanitisation in order to launch the SheCoded Campaign.
-    # TODO: find an alternate solution.
+    # TODO: [@thepracticaldev/cool] find an alternate solution.
 
     # stripped_html = ActionController::Base.helpers.sanitize initial_html.html_safe,
     #                                                         tags: %w[a em i b u br img h1 h2 h3 h4 div style],

--- a/app/models/display_ad.rb
+++ b/app/models/display_ad.rb
@@ -26,9 +26,14 @@ class DisplayAd < ApplicationRecord
     renderer = Redcarpet::Render::HTMLRouge.new(hard_wrap: true, filter_html: false)
     markdown = Redcarpet::Markdown.new(renderer)
     initial_html = markdown.render(body_markdown)
-    stripped_html = ActionController::Base.helpers.sanitize initial_html.html_safe,
-                                                            tags: %w[a em i b u br img h1 h2 h3 h4 div],
-                                                            attributes: %w[href target src height width style]
+
+    # Temporarily disable the sanitisation in order to launch the SheCoded Campaign.
+    # TODO: find an alternate solution.
+
+    # stripped_html = ActionController::Base.helpers.sanitize initial_html.html_safe,
+    #                                                         tags: %w[a em i b u br img h1 h2 h3 h4 div style],
+    #                                                         attributes: %w[href target src height width style]
+    stripped_html = initial_html.html_safe
     html = stripped_html.delete("\n")
     self.processed_html = MarkdownParser.new(html).prefix_all_images(html, 350)
   end

--- a/spec/models/display_ad_spec.rb
+++ b/spec/models/display_ad_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe DisplayAd, type: :model do
 
   context "when callbacks are triggered before save" do
     it "generates #processed_html from #body_markdown" do
-      expect(display_ad.processed_html).to eq("Hello <em>hey</em> Hey hey")
+      expect(display_ad.processed_html).to eq("<p>Hello <em>hey</em> Hey hey</p>")
     end
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix (temp)
- [ ] Optimization
- [ ] Documentation Update

## Description
At the moment the display_ads does not allow us to add a css style of background with an image or linear-gradient. Both @lightalloy and I tried to tackle this today without success. For more info, please read this slack conversation https://dev-internal.slack.com/archives/C7GE84DEJ/p1582892484118100. It's currently impeding us from going live with SheCoded. 

After discussion, we figured that it should be safe to not sanitise this temporarily (and fix and reenable) since it’s an internal admin page. 

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/71PLYtZUiPRg4/giphy.gif)
