### PR TITLE
Refactor /spec/services/search specs to use index_documents helper

### DIFF
--- a/spec/services/search/chat_channel_membership_spec.rb
+++ b/spec/services/search/chat_channel_membership_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Search::ChatChannelMembership, type: :service, elasticsearch: tru
   describe "::delete_document" do
     it "deletes a document for a given ID from elasticsearch" do
       chat_channel_membership = create(:chat_channel_membership)
-      chat_channel_membership.index_to_elasticsearch_inline
+      index_documents(chat_channel_membership)
       expect { described_class.find_document(chat_channel_membership.id) }.not_to raise_error
       described_class.delete_document(chat_channel_membership.id)
       expect { described_class.find_document(chat_channel_membership.id) }.to raise_error(Search::Errors::Transport::NotFound)
@@ -100,11 +100,6 @@ RSpec.describe Search::ChatChannelMembership, type: :service, elasticsearch: tru
     let(:user) { create(:user) }
     let(:chat_channel_membership1) { create(:chat_channel_membership, user_id: user.id) }
     let(:chat_channel_membership2) { create(:chat_channel_membership, user_id: user.id) }
-
-    def index_documents(resources)
-      resources.each(&:index_to_elasticsearch_inline)
-      described_class.refresh_index
-    end
 
     it "parses chat_channel_membership document hits from search response" do
       mock_search_response = { "hits" => { "hits" => {} } }

--- a/spec/services/search/classified_listing_spec.rb
+++ b/spec/services/search/classified_listing_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Search::ClassifiedListing, type: :service, elasticsearch: true do
   describe "::delete_document" do
     it "deletes a document for a given ID from elasticsearch" do
       classified_listing = FactoryBot.create(:classified_listing)
-      classified_listing.index_to_elasticsearch_inline
+      index_documents(classified_listing)
       expect { described_class.find_document(classified_listing.id) }.not_to raise_error
       described_class.delete_document(classified_listing.id)
       expect { described_class.find_document(classified_listing.id) }.to raise_error(Search::Errors::Transport::NotFound)

--- a/spec/services/search/tag_spec.rb
+++ b/spec/services/search/tag_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Search::Tag, type: :service, elasticsearch: true do
   describe "::delete_document" do
     it "deletes a document for a given ID from elasticsearch" do
       tag = create(:tag)
-      tag.index_to_elasticsearch_inline
+      index_documents(tag)
       expect { described_class.find_document(tag.id) }.not_to raise_error
       described_class.delete_document(tag.id)
       expect { described_class.find_document(tag.id) }.to raise_error(Search::Errors::Transport::NotFound)


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Optimization

## Description
With #6348 we introduced a new spec helper to send documents to Elasticsearch called `index_documents`. This is just a quick (somewhat nitpicky) PR to update existing specs to use the helper to keep everything consistent while we're still implementing Elasticearch.

## Related Tickets & Documents
#6348 
https://github.com/thepracticaldev/dev.to/projects/6#card-33783332

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

![nitpicky_gif](https://media.giphy.com/media/NFRycyvw1kjiE/giphy.gif)