### PR TITLE
Prevent deadlocks with article-collection updates.

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -17,7 +17,7 @@ class Article < ApplicationRecord
   belongs_to :user
   belongs_to :job_opportunity, optional: true
   belongs_to :organization, optional: true
-  belongs_to :collection, optional: true, touch: true
+  belongs_to :collection, optional: true
 
   counter_culture :user
   counter_culture :organization
@@ -71,6 +71,7 @@ class Article < ApplicationRecord
   after_save        :detect_human_language
   before_save       :update_cached_user
   before_destroy    :before_destroy_actions, prepend: true
+  after_commit      :touch_collection
 
   serialize :ids_for_suggested_articles
   serialize :cached_user
@@ -676,5 +677,9 @@ class Article < ApplicationRecord
 
   def async_bust
     Articles::BustCacheWorker.perform_async(id)
+  end
+
+  def touch_collection
+    collection.touch if collection && previous_changes.present?
   end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -17,6 +17,8 @@ class Article < ApplicationRecord
   belongs_to :user
   belongs_to :job_opportunity, optional: true
   belongs_to :organization, optional: true
+  # touch: true was removed because when an article is updated, the associated collection
+  # is touched along with all its articles(including this one). This causes eventually a deadlock.
   belongs_to :collection, optional: true
 
   counter_culture :user

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Article, type: :model do
     it { is_expected.to validate_length_of(:cached_tag_list).is_at_most(126) }
     it { is_expected.to belong_to(:user) }
     it { is_expected.to belong_to(:organization).optional }
-    it { is_expected.to belong_to(:collection).optional.touch(true) }
+    it { is_expected.to belong_to(:collection).optional }
     it { is_expected.to have_many(:comments) }
     it { is_expected.to have_many(:reactions).dependent(:destroy) }
     it { is_expected.to have_many(:notifications).dependent(:delete_all) }


### PR DESCRIPTION
When an article is updated the associated collection is touched along with all its articles. This creates a deadlock where two transaction(nested) lock the article that was updated.
With this commit the collection will be touched after the article updates transaction has been committed. Doing so we have two sequential transactions.

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)
Fixes ##5964

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
