### PR TITLE
Disable service worker on /search endpoints

### DIFF
--- a/app/views/service_worker/index.js.erb
+++ b/app/views/service_worker/index.js.erb
@@ -111,7 +111,9 @@
         !url.href.includes('/social_previews') && // Skip for social previews
         !url.href.includes('/users/auth') && // Don't run on authentication.
         !url.href.includes('/enter') && // Don't run on registration.
-        !url.href.includes('/search') && // Don't run on search endpoints.
+
+        // Don't run on search endpoints (trailing slash important not to match the search page itself)
+        !url.href.includes('/search/') &&
 
         caches.match('/shell_top') && // Ensure shell_top is in the cache.
         caches.match('/shell_bottom')) { // Ensure shell_bottom is in the cache.

--- a/app/views/service_worker/index.js.erb
+++ b/app/views/service_worker/index.js.erb
@@ -112,8 +112,9 @@
         !url.href.includes('/users/auth') && // Don't run on authentication.
         !url.href.includes('/enter') && // Don't run on registration.
 
-        // Don't run on search endpoints (trailing slash important not to match the search page itself)
-        !url.href.includes('/search/') &&
+        // Don't run on search endpoints
+        !url.href.includes('/search/tags') &&
+        !url.href.includes('/search/chat_channels') &&
 
         caches.match('/shell_top') && // Ensure shell_top is in the cache.
         caches.match('/shell_bottom')) { // Ensure shell_bottom is in the cache.

--- a/app/views/service_worker/index.js.erb
+++ b/app/views/service_worker/index.js.erb
@@ -111,6 +111,7 @@
         !url.href.includes('/social_previews') && // Skip for social previews
         !url.href.includes('/users/auth') && // Don't run on authentication.
         !url.href.includes('/enter') && // Don't run on registration.
+        !url.href.includes('/search') && // Don't run on search endpoints.
 
         caches.match('/shell_top') && // Ensure shell_top is in the cache.
         caches.match('/shell_bottom')) { // Ensure shell_bottom is in the cache.


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Right now https://dev.to/search/tags and https://dev.to/search/chat_channels are wrapped in the service worker shell. This fixes it by disabling the SW on those endpoints

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

**Before**

![Screenshot_2020-02-29 https dev to(1)](https://user-images.githubusercontent.com/146201/75609714-3f1f3880-5b0b-11ea-8476-3d6dee7394a8.png)


**After**

![Screenshot_2020-02-29 Screenshot](https://user-images.githubusercontent.com/146201/75609695-1e56e300-5b0b-11ea-8644-0b9804eb939d.png)


## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
