### PR TITLE
Remove parentheses when time ago not present

### DIFF
--- a/app/javascript/articles/Article.jsx
+++ b/app/javascript/articles/Article.jsx
@@ -29,6 +29,11 @@ export const Article = ({
     return <PodcastArticle article={article} />;
   }
 
+  const timeAgoIndicator = timeAgo({
+    oldTimeInSeconds: article.published_at_int,
+    formatter: x => x,
+  })
+
   return (
     <div
       className="single-article single-article-small-pic"
@@ -89,12 +94,7 @@ export const Article = ({
           )}
           {article.published_at_int ? (
             <span className="time-ago-indicator">
-              (
-              {timeAgo({
-                oldTimeInSeconds: article.published_at_int,
-                formatter: x => x,
-              })}
-              )
+              {timeAgoIndicator.length > 0 ? `(${timeAgoIndicator})`: '' }
             </span>
           ) : null}
         </a>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Fixes this issue where we show an empty parentheses instead of nothing on articles over a day old...

<img width="161" alt="Screen Shot 2020-02-29 at 12 57 27 PM" src="https://user-images.githubusercontent.com/3102842/75612595-0a9f8280-5af3-11ea-9d32-97bb606482e3.png">