### PR TITLE
Extra padding on tags

### DIFF
--- a/app/assets/stylesheets/articles.scss
+++ b/app/assets/stylesheets/articles.scss
@@ -648,7 +648,7 @@
         display: inline-block;
       }
       .tag {
-        margin-right: 3px;
+        margin-right: 8px;
         &:hover {
           text-decoration: underline;
         }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
This adds extra padding between tags in feed. Following very good suggestion from @rhymes.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![image](https://user-images.githubusercontent.com/108287/75666975-14ea8980-5c77-11ea-923e-8b7ac254bf23.png)

## Added tests?

- [x] no, because they aren't needed

## Added to documentation?

- [x] no documentation needed