### PR TITLE
Bug Fix: Use safety operator when indexing comment tag list

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -58,7 +58,7 @@ class Comment < ApplicationRecord
         custom_css
       end
       attribute :tag_list do
-        commentable.tag_list
+        commentable&.tag_list
       end
       attribute :root_path do
         root&.path


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Fixes: https://app.honeybadger.io/fault/66984/bb9520df544e22526d7ce1e0c15b5cb9
```
NoMethodError: undefined method `tag_list' for nil:NilClass
 comment.rb  61 block (3 levels) in <class:Comment>(...)
[PROJECT_ROOT]/app/models/comment.rb:61:in `block (3 levels) in <class:Comment>'
59       end
60       attribute :tag_list do
61         commentable.tag_list
62       end
63       attribute :root_path do
```
## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media.giphy.com/media/l0Iylo1ru4RCQ4Za0/giphy.gif)
