### PR TITLE
Bug Fix 2: Use safety operator for commentable in tags tag_list

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -89,7 +89,7 @@ class Comment < ApplicationRecord
         }
       end
       tags do
-        [commentable.tag_list,
+        [commentable&.tag_list,
          "user_#{user_id}",
          "commentable_#{commentable_type}_#{commentable_id}"].flatten.compact
       end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Missed a commentable in the indexing. Fixes: https://app.honeybadger.io/fault/66984/7ca4f1fff0893a0e28c7a09c391bb565
```
NoMethodError: undefined method `tag_list' for nil:NilClass
 comment.rb  92 block (3 levels) in <class:Comment>(...)
[PROJECT_ROOT]/app/models/comment.rb:92:in `block (3 levels) in <class:Comment>'
90       end
91       tags do
92         [commentable.tag_list,
93          "user_#{user_id}",
94          "commentable_#{commentable_type}_#{commentable_id}"].flatten.compact
```

## Added tests?
- [x] no, because they aren't needed
I would if we were keeping this but it will be moving to Elasticsearch soon so I skipped it

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media.giphy.com/media/xVIkfXYGTJeZKilg3p/giphy.gif)
