### PR TITLE
Add published field to ClassifiedListing Search

### DIFF
--- a/app/serializers/search/classified_listing_serializer.rb
+++ b/app/serializers/search/classified_listing_serializer.rb
@@ -10,6 +10,7 @@ module Search
                :expires_at,
                :location,
                :processed_html,
+               :published,
                :slug,
                :title,
                :user_id

--- a/app/services/search/query_builders/classified_listing.rb
+++ b/app/services/search/query_builders/classified_listing.rb
@@ -52,7 +52,7 @@ module Search
       def build_queries
         @body[:query] = { bool: {} }
         @body[:query][:bool][:filter] = filter_conditions
-        @body[:query][:bool][:must] = query_conditions
+        @body[:query][:bool][:must] = query_conditions if query_keys_present?
       end
 
       def add_sort

--- a/app/services/search/query_builders/classified_listing.rb
+++ b/app/services/search/query_builders/classified_listing.rb
@@ -34,7 +34,7 @@ module Search
         @params = params.deep_symbolize_keys
 
         # For now, we're not allowing searches for ClassifiedListings that are
-        # not published. If we want tochange this in the future we can just do:
+        # not published. If we want to change this in the future we can do:
         # @params[:published] = DEFAULT_PARAMS[:published] unless @params.key?(:published)
         @params[:published] = DEFAULT_PARAMS[:published]
 

--- a/app/services/search/query_builders/classified_listing.rb
+++ b/app/services/search/query_builders/classified_listing.rb
@@ -5,6 +5,7 @@ module Search
         category
         contact_via_connect
         location
+        published
         slug
         tags
         title
@@ -21,6 +22,7 @@ module Search
       ].freeze
 
       DEFAULT_PARAMS = {
+        published: true,
         sort_by: "bumped_at",
         sort_direction: "desc",
         size: 0
@@ -30,6 +32,7 @@ module Search
 
       def initialize(params)
         @params = params.deep_symbolize_keys
+        @params[:published] = DEFAULT_PARAMS[:published] unless @params.key?(:published)
         build_body
       end
 
@@ -48,8 +51,8 @@ module Search
 
       def build_queries
         @body[:query] = { bool: {} }
-        @body[:query][:bool][:filter] = filter_conditions if filter_keys_present?
-        @body[:query][:bool][:must] = query_conditions if query_keys_present?
+        @body[:query][:bool][:filter] = filter_conditions
+        @body[:query][:bool][:must] = query_conditions
       end
 
       def add_sort
@@ -67,7 +70,11 @@ module Search
 
       def filter_conditions
         filter_conditions = []
-        filter_conditions.concat term_keys if term_keys_present?
+
+        # term_keys are always present because we are setting a filter of
+        # published: true by default
+        filter_conditions.concat term_keys
+
         filter_conditions.concat range_keys if range_keys_present?
 
         filter_conditions
@@ -87,14 +94,6 @@ module Search
 
           { range: { range_key => @params[range_key] } }
         end.compact
-      end
-
-      def filter_keys_present?
-        term_keys_present? || range_keys_present?
-      end
-
-      def term_keys_present?
-        TERM_KEYS.detect { |key| @params[key].present? }
       end
 
       def range_keys_present?

--- a/app/services/search/query_builders/classified_listing.rb
+++ b/app/services/search/query_builders/classified_listing.rb
@@ -32,7 +32,12 @@ module Search
 
       def initialize(params)
         @params = params.deep_symbolize_keys
-        @params[:published] = DEFAULT_PARAMS[:published] unless @params.key?(:published)
+
+        # For now, we're not allowing searches for ClassifiedListings that are
+        # not published. If we want tochange this in the future we can just do:
+        # @params[:published] = DEFAULT_PARAMS[:published] unless @params.key?(:published)
+        @params[:published] = DEFAULT_PARAMS[:published]
+
         build_body
       end
 

--- a/config/elasticsearch/mappings/classified_listings.json
+++ b/config/elasticsearch/mappings/classified_listings.json
@@ -49,6 +49,9 @@
     "processed_html": {
       "type": "keyword"
     },
+    "published": {
+      "type": "boolean"
+    },
     "slug": {
       "type": "text",
       "copy_to": "classified_listing_search",

--- a/spec/services/search/query_builders/classified_listing_spec.rb
+++ b/spec/services/search/query_builders/classified_listing_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Search::QueryBuilders::ClassifiedListing, type: :service do
         { "term" => { "category" => "cfp" } },
         { "term" => { "tags" => ["beginner"] } },
         { "term" => { "contact_via_connect" => false } },
+        { "term" => { "published" => true } },
       ]
       expect(filter.as_hash.dig("query", "bool", "filter")).to match_array(exepcted_filters)
     end
@@ -33,6 +34,7 @@ RSpec.describe Search::QueryBuilders::ClassifiedListing, type: :service do
         exepcted_filters = [
           { "range" => { "bumped_at" => Time.current } },
           { "range" => { "expires_at" => 1.day.from_now } },
+          { "term" => { "published" => true } },
         ]
         expect(filter.as_hash.dig("query", "bool", "filter")).to match_array(exepcted_filters)
       end
@@ -56,7 +58,11 @@ RSpec.describe Search::QueryBuilders::ClassifiedListing, type: :service do
         exepcted_query = [{
           "simple_query_string" => { "query" => "test*", "fields" => [:classified_listing_search], "lenient" => true, "analyze_wildcard" => true }
         }]
-        exepcted_filters = [{ "range" => { "bumped_at" => Time.current } }, { "term" => { "category" => "cfp" } }]
+        exepcted_filters = [
+          { "range" => { "bumped_at" => Time.current } },
+          { "term" => { "category" => "cfp" } },
+          { "term" => { "published" => true } },
+        ]
         expect(filter.as_hash.dig("query", "bool", "must")).to match_array(exepcted_query)
         expect(filter.as_hash.dig("query", "bool", "filter")).to match_array(exepcted_filters)
       end
@@ -67,21 +73,24 @@ RSpec.describe Search::QueryBuilders::ClassifiedListing, type: :service do
       filter = described_class.new(params)
       exepcted_filters = [
         { "term" => { "category" => "cfp" } },
+        { "term" => { "published" => true } },
       ]
       expect(filter.as_hash.dig("query", "bool", "filter")).to match_array(exepcted_filters)
     end
 
     it "sets default params when not present" do
-      filter = described_class.new({})
-      expect(filter.as_hash.dig("sort")).to eq("bumped_at" => "desc")
-      expect(filter.as_hash.dig("size")).to eq(0)
+      filter = described_class.new({}).as_hash
+      expect(filter.dig("sort")).to eq("bumped_at" => "desc")
+      expect(filter.dig("size")).to eq(0)
+      expect(filter.dig("query", "bool", "filter")).to match_array([{ "term" => { "published" => true } }])
     end
 
     it "allows default params to be overriden" do
-      params = { sort_by: "category", sort_direction: "asc", size: 20 }
-      filter = described_class.new(params)
-      expect(filter.as_hash.dig("sort")).to eq("category" => "asc")
-      expect(filter.as_hash.dig("size")).to eq(20)
+      params = { sort_by: "category", sort_direction: "asc", size: 20, published: false }
+      filter = described_class.new(params).as_hash
+      expect(filter.dig("sort")).to eq("category" => "asc")
+      expect(filter.dig("size")).to eq(20)
+      expect(filter.dig("query", "bool", "filter")).to match_array([{ "term" => { "published" => false } }])
     end
   end
 end

--- a/spec/services/search/query_builders/classified_listing_spec.rb
+++ b/spec/services/search/query_builders/classified_listing_spec.rb
@@ -86,11 +86,10 @@ RSpec.describe Search::QueryBuilders::ClassifiedListing, type: :service do
     end
 
     it "allows default params to be overriden" do
-      params = { sort_by: "category", sort_direction: "asc", size: 20, published: false }
+      params = { sort_by: "category", sort_direction: "asc", size: 20 }
       filter = described_class.new(params).as_hash
       expect(filter.dig("sort")).to eq("category" => "asc")
       expect(filter.dig("size")).to eq(20)
-      expect(filter.dig("query", "bool", "filter")).to match_array([{ "term" => { "published" => false } }])
     end
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
@mstruve [mentioned](https://github.com/thepracticaldev/dev.to/pull/6372#pullrequestreview-367219294) that we need to filter on `published` for `ClassifiedListings` so that, by default, we're only returning `published` `ClassifiedListings`.

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/pull/6372#pullrequestreview-367219294
https://github.com/thepracticaldev/dev.to/projects/6#card-33950122

## Added tests?
- [x] yes

## Added to documentation?
- [x] no documentation needed

## Are there any post deployment tasks we need to perform?
I'll coordinate with @mstruve to manually reindex `ClassifiedListings`.

![need_coffee_gif](https://media.giphy.com/media/l3vR0EfzAm6eAqRFe/giphy.gif)