### PR TITLE
Add attributesForFaceting to ordered_articles

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -203,6 +203,7 @@ class Article < ApplicationRecord
          ("organization_#{organization_id}" if organization)].flatten.compact
       end
       ranking ["desc(hotness_score)"]
+      attributesForFaceting %i[class_name approved]
       add_replica "ordered_articles_by_positive_reactions_count", inherit: true, per_environment: true do
         ranking ["desc(positive_reactions_count)"]
       end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
We had `attributesForFaceting` set for the `searchables` index, but not the `ordered_articles` index.

This is a temporary measure before we replicate this in Elastic.