### PR TITLE
Create Feed Content index for Articles and Podcast Episodes and User Index

### DIFF
--- a/app/services/search/cluster.rb
+++ b/app/services/search/cluster.rb
@@ -3,6 +3,7 @@ module Search
     SEARCH_CLASSES = [
       Search::ChatChannelMembership,
       Search::ClassifiedListing,
+      Search::FeedContent,
       Search::Tag,
     ].freeze
 

--- a/app/services/search/cluster.rb
+++ b/app/services/search/cluster.rb
@@ -5,6 +5,7 @@ module Search
       Search::ClassifiedListing,
       Search::FeedContent,
       Search::Tag,
+      Search::User,
     ].freeze
 
     class << self

--- a/app/services/search/feed_content.rb
+++ b/app/services/search/feed_content.rb
@@ -1,0 +1,25 @@
+module Search
+  class FeedContent < Base
+    INDEX_NAME = "feed_content_#{Rails.env}".freeze
+    INDEX_ALIAS = "feed_content_#{Rails.env}_alias".freeze
+    MAPPINGS = JSON.parse(File.read("config/elasticsearch/mappings/feed_content.json"), symbolize_names: true).freeze
+
+    class << self
+      private
+
+      def index_settings
+        if Rails.env.production?
+          {
+            number_of_shards: 10,
+            number_of_replicas: 1
+          }
+        else
+          {
+            number_of_shards: 1,
+            number_of_replicas: 0
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/services/search/user.rb
+++ b/app/services/search/user.rb
@@ -1,0 +1,25 @@
+module Search
+  class User < Base
+    INDEX_NAME = "users_#{Rails.env}".freeze
+    INDEX_ALIAS = "users_#{Rails.env}_alias".freeze
+    MAPPINGS = JSON.parse(File.read("config/elasticsearch/mappings/users.json"), symbolize_names: true).freeze
+
+    class << self
+      private
+
+      def index_settings
+        if Rails.env.production?
+          {
+            number_of_shards: 10,
+            number_of_replicas: 1
+          }
+        else
+          {
+            number_of_shards: 1,
+            number_of_replicas: 0
+          }
+        end
+      end
+    end
+  end
+end

--- a/config/elasticsearch/mappings/feed_content.json
+++ b/config/elasticsearch/mappings/feed_content.json
@@ -1,0 +1,166 @@
+{
+  "dynamic": "strict",
+  "properties": {
+    "id": {
+      "type": "keyword"
+    },
+    "approved": {
+      "type": "boolean"
+    },
+    "body_text": {
+      "type": "text",
+      "copy_to": "search_fields"
+    },
+    "class_name": {
+      "type": "keyword"
+    },
+    "cloudinary_video_url": {
+      "type": "keyword"
+    },
+    "comments_count": {
+      "type": "integer"
+    },
+    "experience_level_rating": {
+      "type": "integer"
+    },
+    "experience_level_rating_distribution": {
+      "type": "integer"
+    },
+    "featured": {
+      "type": "boolean"
+    },
+    "featured_number": {
+      "type": "integer"
+    },
+    "flare_tag": {
+      "type": "keyword"
+    },
+    "hotness_score": {
+      "type": "integer"
+    },
+    "language": {
+      "type": "keyword"
+    },
+    "main_image": {
+      "type": "keyword"
+    },
+    "organization": {
+      "dynamic": "strict",
+      "properties": {
+        "slug": {
+          "type": "keyword"
+        },
+        "name": {
+          "type": "text",
+          "copy_to": "search_fields",
+          "fields": {
+            "raw": {
+              "type": "keyword"
+            }
+          }
+        },
+        "id": {
+          "type": "keyword"
+        },
+        "profile_image_90": {
+          "type": "keyword"
+        }
+      }
+    },
+    "path": {
+      "type": "keyword"
+    },
+    "positive_reactions_count": {
+      "type": "integer"
+    },
+    "published": {
+      "type": "boolean"
+    },
+    "published_at": {
+      "type": "date"
+    },
+    "quote": {
+      "type": "text"
+    },
+    "reactions_count": {
+      "type": "integer"
+    },
+
+    "readable_publish_date": {
+      "type": "date"
+    },
+    "reading_time": {
+      "type": "integer"
+    },
+    "score": {
+      "type": "integer"
+    },
+    "search_fields": {
+      "type": "text"
+    },
+    "search_score": {
+      "type": "integer"
+    },
+    "subtitle": {
+      "type": "text"
+    },
+    "summary": {
+      "type": "text"
+    },
+    "tags": {
+      "dynamic": "strict",
+      "properties": {
+        "name": {
+          "type": "keyword",
+          "copy_to": "search_fields"
+        },
+        "keywords_for_search": {
+          "type": "keyword",
+          "copy_to": "search_fields"
+        }
+      }
+    },
+    "title": {
+      "type": "text",
+      "copy_to": "search_fields",
+      "fields": {
+        "raw": {
+          "type": "keyword"
+        }
+      }
+    },
+    "user": {
+      "dynamic": "strict",
+      "properties": {
+        "username": {
+          "type": "keyword",
+          "copy_to": "search_fields"
+        },
+        "name": {
+          "type": "text",
+          "copy_to": "search_fields",
+          "fields": {
+            "raw": {
+              "type": "keyword"
+            }
+          }
+        },
+        "id": {
+          "type": "keyword"
+        },
+        "profile_image_90": {
+          "type": "keyword"
+        },
+        "pro": {
+          "type": "boolean"
+        }
+      }
+    },
+    "video_duration_in_minutes": {
+      "type": "integer"
+    },
+    "website_url": {
+      "type": "keyword"
+    }
+  }
+}

--- a/config/elasticsearch/mappings/feed_content.json
+++ b/config/elasticsearch/mappings/feed_content.json
@@ -85,7 +85,6 @@
     "reactions_count": {
       "type": "integer"
     },
-
     "readable_publish_date": {
       "type": "date"
     },

--- a/config/elasticsearch/mappings/users.json
+++ b/config/elasticsearch/mappings/users.json
@@ -1,0 +1,42 @@
+{
+  "dynamic": "strict",
+  "properties": {
+    "id": {
+      "type": "keyword"
+    },
+    "availabe_for": {
+      "type": "keyword",
+      "copy_to": "search_fields"
+    },
+    "comments_count": {
+      "type": "integer"
+    },
+    "employer_name": {
+      "type": "keyword",
+      "copy_to": "search_fields"
+    },
+    "hotness_score": {
+      "type": "integer"
+    },
+    "mostly_work_with": {
+      "type": "keyword",
+      "copy_to": "search_fields"
+    },
+    "name": {
+      "type": "text",
+      "copy_to": "search_fields"
+    },
+    "path": {
+      "type": "keyword"
+    },
+    "positive_reactions_count": {
+      "type": "integer"
+    },
+    "reactions_count": {
+      "type": "integer"
+    },
+    "username": {
+      "type": "keyword"
+    }
+  }
+}

--- a/spec/services/search/base_spec.rb
+++ b/spec/services/search/base_spec.rb
@@ -1,0 +1,101 @@
+require "rails_helper"
+
+RSpec.describe Search::Base, type: :service, elasticsearch: true do
+  let(:document_id) { 123 }
+
+  before do
+    # Need to use an existing index name to ensure proper data cleanup
+    stub_const("#{described_class}::INDEX_NAME", "tags_#{Rails.env}")
+    stub_const("#{described_class}::INDEX_ALIAS", "tags_#{Rails.env}_alias")
+    stub_const("#{described_class}::MAPPINGS", Search::Tag::MAPPINGS)
+    allow(described_class).to receive(:index_settings).and_return({})
+  end
+
+  describe "::index" do
+    it "indexes a document to elasticsearch" do
+      expect { described_class.find_document(document_id) }.to raise_error(Search::Errors::Transport::NotFound)
+      described_class.index(document_id, id: document_id)
+      expect(described_class.find_document(document_id)).not_to be_nil
+    end
+  end
+
+  describe "::find_document" do
+    it "fetches a document for a given ID from elasticsearch" do
+      described_class.index(document_id, id: document_id)
+      expect { described_class.find_document(document_id) }.not_to raise_error
+    end
+  end
+
+  describe "::delete_document" do
+    it "deletes a document for a given ID from elasticsearch" do
+      described_class.index(document_id, id: document_id)
+      expect { described_class.find_document(document_id) }.not_to raise_error
+      described_class.delete_document(document_id)
+      expect { described_class.find_document(document_id) }.to raise_error(Search::Errors::Transport::NotFound)
+    end
+  end
+
+  describe "::create_index" do
+    it "creates an elasticsearch index with INDEX_NAME" do
+      described_class.delete_index
+      expect(Search::Client.indices.exists(index: described_class::INDEX_NAME)).to eq(false)
+      described_class.create_index
+      expect(Search::Client.indices.exists(index: described_class::INDEX_NAME)).to eq(true)
+    end
+
+    it "creates an elasticsearch index with name argument" do
+      other_name = "random"
+      expect(Search::Client.indices.exists(index: other_name)).to eq(false)
+      described_class.create_index(index_name: other_name)
+      expect(Search::Client.indices.exists(index: other_name)).to eq(true)
+
+      # Have to cleanup index since it wont automatically be handled by our cluster class bc of the unexpected name
+      described_class.delete_index(index_name: other_name)
+    end
+  end
+
+  describe "::delete_index" do
+    it "deletes an elasticsearch index with INDEX_NAME" do
+      expect(Search::Client.indices.exists(index: described_class::INDEX_NAME)).to eq(true)
+      described_class.delete_index
+      expect(Search::Client.indices.exists(index: described_class::INDEX_NAME)).to eq(false)
+    end
+
+    it "deletes an elasticsearch index with name argument" do
+      other_name = "random"
+      described_class.create_index(index_name: other_name)
+      expect(Search::Client.indices.exists(index: other_name)).to eq(true)
+
+      described_class.delete_index(index_name: other_name)
+      expect(Search::Client.indices.exists(index: other_name)).to eq(false)
+    end
+  end
+
+  describe "::add_alias" do
+    it "adds alias INDEX_ALIAS to elasticsearch index with INDEX_NAME" do
+      Search::Client.indices.delete_alias(index: described_class::INDEX_NAME, name: described_class::INDEX_ALIAS)
+      expect(Search::Client.indices.exists(index: described_class::INDEX_ALIAS)).to eq(false)
+      described_class.add_alias
+      expect(Search::Client.indices.exists(index: described_class::INDEX_ALIAS)).to eq(true)
+    end
+
+    it "adds custom alias to elasticsearch index with INDEX_NAME" do
+      other_alias = "random"
+      expect(Search::Client.indices.exists(index: other_alias)).to eq(false)
+      described_class.add_alias(index_name: described_class::INDEX_NAME, index_alias: other_alias)
+      expect(Search::Client.indices.exists(index: other_alias)).to eq(true)
+    end
+  end
+
+  describe "::update_mappings" do
+    it "updates index mappings" do
+      other_name = "index_name"
+      allow(Search::Client.indices).to receive(:put_mapping)
+
+      described_class.update_mappings(index_alias: other_name)
+      expect(Search::Client.indices).to have_received(:put_mapping).with(
+        index: other_name, body: described_class::MAPPINGS,
+      )
+    end
+  end
+end

--- a/spec/services/search/feed_content_spec.rb
+++ b/spec/services/search/feed_content_spec.rb
@@ -1,0 +1,99 @@
+require "rails_helper"
+
+RSpec.describe Search::FeedContent, type: :service, elasticsearch: true do
+  let(:feed_content_id) { 123 }
+
+  describe "::index" do
+    it "indexes a feed content to elasticsearch" do
+      expect { described_class.find_document(feed_content_id) }.to raise_error(Search::Errors::Transport::NotFound)
+      described_class.index(feed_content_id, id: feed_content_id)
+      expect(described_class.find_document(feed_content_id)).not_to be_nil
+    end
+  end
+
+  describe "::find_document" do
+    it "fetches a document for a given ID from elasticsearch" do
+      described_class.index(feed_content_id, id: feed_content_id)
+      expect { described_class.find_document(feed_content_id) }.not_to raise_error
+    end
+  end
+
+  describe "::delete_document" do
+    it "deletes a document for a given ID from elasticsearch" do
+      described_class.index(feed_content_id, id: feed_content_id)
+      expect { described_class.find_document(feed_content_id) }.not_to raise_error
+      described_class.delete_document(feed_content_id)
+      expect { described_class.find_document(feed_content_id) }.to raise_error(Search::Errors::Transport::NotFound)
+    end
+  end
+
+  describe "::create_index" do
+    it "creates an elasticsearch index with INDEX_NAME" do
+      described_class.delete_index
+      expect(Search::Client.indices.exists(index: described_class::INDEX_NAME)).to eq(false)
+      described_class.create_index
+      expect(Search::Client.indices.exists(index: described_class::INDEX_NAME)).to eq(true)
+    end
+
+    it "creates an elasticsearch index with name argument" do
+      other_name = "random"
+      expect(Search::Client.indices.exists(index: other_name)).to eq(false)
+      described_class.create_index(index_name: other_name)
+      expect(Search::Client.indices.exists(index: other_name)).to eq(true)
+
+      # Have to cleanup index since it wont automatically be handled by our cluster class bc of the unexpected name
+      described_class.delete_index(index_name: other_name)
+    end
+  end
+
+  describe "::delete_index" do
+    it "deletes an elasticsearch index with INDEX_NAME" do
+      expect(Search::Client.indices.exists(index: described_class::INDEX_NAME)).to eq(true)
+      described_class.delete_index
+      expect(Search::Client.indices.exists(index: described_class::INDEX_NAME)).to eq(false)
+    end
+
+    it "deletes an elasticsearch index with name argument" do
+      other_name = "random"
+      described_class.create_index(index_name: other_name)
+      expect(Search::Client.indices.exists(index: other_name)).to eq(true)
+
+      described_class.delete_index(index_name: other_name)
+      expect(Search::Client.indices.exists(index: other_name)).to eq(false)
+    end
+  end
+
+  describe "::add_alias" do
+    it "adds alias INDEX_ALIAS to elasticsearch index with INDEX_NAME" do
+      Search::Client.indices.delete_alias(index: described_class::INDEX_NAME, name: described_class::INDEX_ALIAS)
+      expect(Search::Client.indices.exists(index: described_class::INDEX_ALIAS)).to eq(false)
+      described_class.add_alias
+      expect(Search::Client.indices.exists(index: described_class::INDEX_ALIAS)).to eq(true)
+    end
+
+    it "adds custom alias to elasticsearch index with INDEX_NAME" do
+      other_alias = "random"
+      expect(Search::Client.indices.exists(index: other_alias)).to eq(false)
+      described_class.add_alias(index_name: described_class::INDEX_NAME, index_alias: other_alias)
+      expect(Search::Client.indices.exists(index: other_alias)).to eq(true)
+    end
+  end
+
+  describe "::update_mappings" do
+    it "updates index mappings for feed content index", :aggregate_failures do
+      other_name = "random"
+      described_class.create_index(index_name: other_name)
+      initial_mapping = Search::Client.indices.get_mapping(index: other_name).dig(other_name, "mappings")
+      expect(initial_mapping).to be_empty
+
+      described_class.update_mappings(index_alias: other_name)
+      es_mapping_keys = Search::Client.indices.get_mapping(index: other_name).dig(other_name, "mappings", "properties").symbolize_keys.keys
+      mapping_keys = described_class::MAPPINGS.dig(:properties).keys
+
+      expect(mapping_keys).to match_array(es_mapping_keys)
+
+      # Cleanup index since it wont automatically be handled by our cluster class bc of the unexpected name
+      described_class.delete_index(index_name: other_name)
+    end
+  end
+end

--- a/spec/services/search/user_spec.rb
+++ b/spec/services/search/user_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Search::FeedContent, type: :service do
+RSpec.describe Search::User, type: :service do
   it "defines INDEX_NAME, INDEX_ALIAS, and MAPPINGS", :aggregate_failures do
     expect(described_class::INDEX_NAME).not_to be_nil
     expect(described_class::INDEX_ALIAS).not_to be_nil


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Feature

## Description
Currently, in Algolia, Articles, Podcast Episodes, and Users are all in the same "searchables" index. Podcast Eps and Articles actually share a lot of the same fields when we index them so having them on the same index makes sense. However, users do not. This creates an index for Articles and Podcast Eps and a separate index for Users. 

Eventually, all of these should have their own separate dedicated search areas, but for now we can issue a search to multiple indexes from the Feed page or we can issue 2 searches if no class_name filter is present. I will be playing around to see what makes the most sense. 

I also took the time to make a base_spec class to handle testing the base search class functionality making the additional two search class specs easier to write. Eventually we should refactor the rest of the search model specs. 

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-32289326
https://github.com/thepracticaldev/dev.to/projects/6#card-33956385

## Added tests?
- [x] yes

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media1.giphy.com/media/GnCc88zZhSVUc/giphy.gif)
