### PR TITLE
Bump reverse_markdown to 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,7 +79,7 @@ gem "recaptcha", "~> 5.3", require: "recaptcha/rails" # Helpers for the reCAPTCH
 gem "redcarpet", "~> 3.5" # A fast, safe and extensible Markdown to (X)HTML parser
 gem "redis", "~> 4.1.3" # Redis ruby client
 gem "redis-rails", "~> 5.0.2" # Redis for Ruby on Rails
-gem "reverse_markdown", "~> 1.4" # Map simple html back into markdown
+gem "reverse_markdown", "~> 2.0" # Map simple html back into markdown
 gem "rolify", "~> 5.2" # Very simple Roles library
 gem "rouge", "~> 3.16" # A pure-ruby code highlighter
 gem "rubyzip", "~> 2.1" # Rubyzip is a ruby library for reading and writing zip files

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -634,7 +634,7 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     retriable (3.1.2)
-    reverse_markdown (1.4.0)
+    reverse_markdown (2.0.0)
       nokogiri
     rolify (5.2.0)
     rouge (3.16.0)
@@ -942,7 +942,7 @@ DEPENDENCIES
   redcarpet (~> 3.5)
   redis (~> 4.1.3)
   redis-rails (~> 5.0.2)
-  reverse_markdown (~> 1.4)
+  reverse_markdown (~> 2.0)
   rolify (~> 5.2)
   rouge (~> 3.16)
   rspec-rails (~> 3.9)


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Bump [reverse_markdown](https://github.com/xijo/reverse_markdown) to 2.0

The changelog is the following:

```markdown
-    BREAKING: Dropped support for ruby 1.9.3
-    Add support for details and summary tags, see #85
```

## Added tests?

- [ ] yes
- [ ] no, because they aren't needed
- [x] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
