### PR TITLE
Fixes html_safe issues from comment domain

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -23,6 +23,8 @@ linters:
         Enabled: false
       Layout/LineLength:
         Max: 289
+        Exclude:
+          - '**/app/views/comments/_comment_proper.html.erb'
       Layout/TrailingEmptyLines:
         Enabled: false
       Lint/UselessAssignment:

--- a/app/liquid_tags/liquid_tag_base.rb
+++ b/app/liquid_tags/liquid_tag_base.rb
@@ -1,6 +1,6 @@
 class LiquidTagBase < Liquid::Tag
   def self.script
-    ""
+    "".html_safe
   end
 
   def finalize_html(input)

--- a/app/liquid_tags/podcast_tag.rb
+++ b/app/liquid_tags/podcast_tag.rb
@@ -33,7 +33,7 @@ class PodcastTag < LiquidTagBase
   end
 
   def self.script
-    <<~JAVASCRIPT
+    "".html_safe + <<~JAVASCRIPT
       var waitingOnPodcast = setInterval(function(){
         if (typeof initializePodcastPlayback !== 'undefined') {
           initializePodcastPlayback();

--- a/app/liquid_tags/tweet_tag.rb
+++ b/app/liquid_tags/tweet_tag.rb
@@ -22,26 +22,27 @@ class TweetTag < LiquidTagBase
   end
 
   def self.script
-    'var videoPreviews = document.getElementsByClassName("ltag__twitter-tweet__media__video-wrapper");
-      [].forEach.call(videoPreviews, function(el){
-        el.onclick= function(e){
-          var divHeight = el.offsetHeight;
-          el.style.maxHeight = divHeight + "px";
-          el.getElementsByClassName("ltag__twitter-tweet__media--video-preview")[0].style.display = "none";
-          el.getElementsByClassName("ltag__twitter-tweet__video")[0].style.display = "block";
-          el.getElementsByTagName("video")[0].play();
-        }
-      })
-      var tweets = document.getElementsByClassName("ltag__twitter-tweet__main");
-      [].forEach.call(tweets, function(tweet){
-        tweet.onclick= function(e){
-          if (e.target.nodeName == "A" || e.target.parentElement.nodeName == "A"){
-            return;
+    "".html_safe +
+      'var videoPreviews = document.getElementsByClassName("ltag__twitter-tweet__media__video-wrapper");
+        [].forEach.call(videoPreviews, function(el){
+          el.onclick= function(e){
+            var divHeight = el.offsetHeight;
+            el.style.maxHeight = divHeight + "px";
+            el.getElementsByClassName("ltag__twitter-tweet__media--video-preview")[0].style.display = "none";
+            el.getElementsByClassName("ltag__twitter-tweet__video")[0].style.display = "block";
+            el.getElementsByTagName("video")[0].play();
           }
-          window.open(tweet.dataset.url,"_blank");
-        }
-      });
-      '
+        })
+        var tweets = document.getElementsByClassName("ltag__twitter-tweet__main");
+        [].forEach.call(tweets, function(tweet){
+          tweet.onclick= function(e){
+            if (e.target.nodeName == "A" || e.target.parentElement.nodeName == "A"){
+              return;
+            }
+            window.open(tweet.dataset.url,"_blank");
+          }
+        });
+        '
   end
 
   private

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -180,6 +180,10 @@ class Comment < ApplicationRecord
     "comments-#{id}"
   end
 
+  def safe_processed_html
+    processed_html.html_safe
+  end
+
   private
 
   def update_notifications

--- a/app/views/comments/_comment_proper.html.erb
+++ b/app/views/comments/_comment_proper.html.erb
@@ -78,7 +78,7 @@
         </div>
       </div>
       <div class="body <%= "low-quality-comment" if decorated_comment.low_quality %>">
-        <%= comment.processed_html.html_safe %>
+        <%= comment.safe_processed_html %>
         <button class="reaction-button" id="button-for-comment-<%= comment.id %>" data-comment-id="<%= comment.id %>" title="heart">
           <%= image_tag("favorite-heart-outline-button.svg", alt: "Favorite heart outline button") %>
           <img class="voted-heart" src="<%= asset_path("emoji/emoji-one-heart.png") %>" alt="Favorite heart button" />

--- a/app/views/comments/_liquid.html.erb
+++ b/app/views/comments/_liquid.html.erb
@@ -19,6 +19,6 @@
     <%= render "comments/comment_date", decorated_comment: comment.decorate %>
   </div>
   <div class="body">
-    <%= comment.processed_html.html_safe %>
+    <%= comment.safe_processed_html %>
   </div>
 </div>

--- a/app/views/comments/delete_confirm.html.erb
+++ b/app/views/comments/delete_confirm.html.erb
@@ -1,6 +1,6 @@
 <div class="container delete-confirm">
 
-  <h4><%= truncate(strip_tags(@comment.processed_html.html_safe), length: 80) %></h4>
+  <h4><%= truncate(sanitize(@comment.processed_html, tags: []), length: 80) %></h4>
   <h1>Are you sure you want to delete this comment?</h1>
   <h2>You cannot undo this action, perhaps you just want to
     <a data-no-instant href="<%= @comment.path %>/edit">EDIT</a> instead?</h2>

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -59,7 +59,7 @@
         </div>
       <% else %>
         <div class="body">
-          <%= truncate(strip_tags(@commentable.processed_html), length: 150).html_safe %>
+          <%= truncate(sanitize(@commentable.processed_html, tags: []), length: 150) %>
           <a href="<%= @commentable.path %>"><span class="read-more">[Read Full]</span></a>
         </div>
       <% end %>
@@ -122,8 +122,8 @@
 <% end %>
 
 <script async>
-  <%= TweetTag.script.html_safe %>
-  <%= YoutubeTag.script.html_safe %>
-  <%= PodcastTag.script.html_safe %>
-  <%= GistTag.script.html_safe %>
+  <%= TweetTag.script %>
+  <%= YoutubeTag.script %>
+  <%= PodcastTag.script %>
+  <%= GistTag.script %>
 </script>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Use of html_safe method is replaced or being switched to other areas (models).
This is for comment model. 
Around 12 warnings less when erb-linting.
Approximately 45 warnings left.
## Related Tickets & Documents
#5914 
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [ ] yes
- [X] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
