### PR TITLE
Invert the text color for social icons in case of dark themes

### DIFF
--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -132,7 +132,8 @@ body.ten-x-hacker-theme {
   .dev-badge,
   .chatchannels__config img,
   .external-link-img,
-  .group-img {
+  .group-img,
+  .user-profile-header .social a {
     -webkit-filter: invert(95%);
     filter: invert(95%);
   }


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
Social Icons on the profile page with night theme currently have a very low contrast which makes them difficult to see. This PR fixes the contrast by applying invert filter in case of dark themes.

## Related Tickets & Documents
Closes #6310

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
**Before**:
![image](https://user-images.githubusercontent.com/8535863/75793647-acde9500-5d95-11ea-97cf-1b00d627aa83.png)

**After**:
![image](https://user-images.githubusercontent.com/8535863/75793705-c253bf00-5d95-11ea-81c8-ffe78abddb49.png)


## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
