### PR TITLE
Do not render or link to empty rss feeds

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -19,9 +19,8 @@ class ArticlesController < ApplicationController
                   @articles.where(featured: true).includes(:user)
                 end
 
-    unless @articles
-      render body: nil
-      return
+    unless @articles&.any?
+      not_found
     end
 
     set_surrogate_key_header "feed"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -154,4 +154,8 @@ module ApplicationHelper
 
     "#{path}-#{heroku_slug_commit}"
   end
+
+  def app_protocol_and_domain
+    "#{ApplicationConfig["APP_PROTOCOL"]}#{ApplicationConfig["APP_DOMAIN"]}"
+  end
 end

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -5,12 +5,12 @@
        content_for: true,
      ) %>
 
-  <link rel="canonical" href="https://dev.to<%= request.path %>" />
+  <link rel="canonical" href="<%= app_protocol_and_domain %><%= request.path %>" />
   <meta name="description" content="Where programmers share ideas and help each other grow.">
   <meta name="keywords" content="software development,engineering,rails,javascript,ruby">
 
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://dev.to<%= request.path %>" />
+  <meta property="og:url" content="<%= app_protocol_and_domain %><%= request.path %>" />
   <meta property="og:title" content="<%= title_with_timeframe(page_title: community_qualified_name, timeframe: params[:timeframe]) %>" />
   <meta property="og:image" content="<%= SiteConfig.main_social_image %>">
   <meta property="og:description" content="Where programmers share ideas and help each other grow." />
@@ -21,7 +21,7 @@
   <meta name="twitter:description" content="Where programmers share ideas, experiences, and help each other grow.">
   <meta name="twitter:image:src" content="<%= SiteConfig.main_social_image %>">
   <meta name="twitter:card" content="summary_large_image">
-  <%= auto_discovery_link_tag(:rss, "https://dev.to/feed", title: "#{ApplicationConfig['COMMUNITY_NAME']} RSS Feed") %>
+  <%= auto_discovery_link_tag(:rss, "#{app_protocol_and_domain}/feed", title: "#{ApplicationConfig['COMMUNITY_NAME']} RSS Feed") %>
 <% end %>
 <%= javascript_pack_tag "homePage", defer: true %>
 

--- a/app/views/users/_meta.html.erb
+++ b/app/views/users/_meta.html.erb
@@ -1,9 +1,9 @@
-<link rel="canonical" href="https://dev.to/<%= @user.username %>" />
+<link rel="canonical" href="<%= app_protocol_and_domain %>/<%= @user.username %>" />
 <meta name="description" content="<%= @user.summary %>">
 <meta name="keywords" content="software development,engineering,rails,javascript,ruby">
 
 <meta property="og:type" content="website" />
-<meta property="og:url" content="https://dev.to/<%= @user.username %>" />
+<meta property="og:url" content="<%= app_protocol_and_domain %>/<%= @user.username %>" />
 <meta property="og:title" content="<%= @user.name %> — DEV Profile" />
 <meta property="og:image" content="<%= user_social_image_url(@user) %>">
 <meta property="og:description" content="<%= @user.summary %>" />
@@ -15,7 +15,9 @@
 <meta name="twitter:title" content="<%= @user.name %> — DEV Profile">
 <meta name="twitter:description" content="<%= @user.summary %>">
 <meta name="twitter:image:src" content="<%= user_social_image_url(@user) %>">
-<%= auto_discovery_link_tag(:rss, "https://dev.to/feed/#{@user.username}", title: "The Practical Dev RSS Feed") %>
+<% if @stories.any? %>
+  <%= auto_discovery_link_tag(:rss, "#{app_protocol_and_domain}/feed/#{@user.username}", title: "The Practical Dev RSS Feed") %>
+<% end %>
 
 <% if @user.banned %>
   <meta name="googlebot" content="noindex">

--- a/spec/requests/articles/articles_spec.rb
+++ b/spec/requests/articles/articles_spec.rb
@@ -6,9 +6,16 @@ RSpec.describe "Articles", type: :request do
 
   describe "GET /feed" do
     it "returns rss+xml content" do
+      create(:article, featured: true)
       get "/feed"
       expect(response.status).to eq(200)
       expect(response.content_type).to eq("application/rss+xml")
+    end
+
+    it "returns not found if no articles" do
+      expect { get "/feed" }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { get "/feed/#{user.username}" }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { get "/feed/#{tag.name}" }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     context "when :username param is not given" do
@@ -51,14 +58,12 @@ RSpec.describe "Articles", type: :request do
 
     context "when :username param is given but it belongs to nither user nor organization" do
       include_context "when user/organization articles exist"
-      before { get "/feed", params: { username: "unknown" } }
-
-      it("renders empty body") { expect(response.body).to be_empty }
+      it("renders empty body") { expect { get "/feed", params: { username: "unknown" } }.to raise_error(ActiveRecord::RecordNotFound) }
     end
 
     context "when format is invalid" do
       it "returns a 404 response" do
-        expect { get "/feed.zip" }.to raise_error(ActionController::RoutingError)
+        expect { get "/feed.zip" }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
   end
@@ -91,9 +96,8 @@ RSpec.describe "Articles", type: :request do
 
     context "when :tag param is given and tag does not exist" do
       include_context "when tagged articles exist"
-      before { get "/feed/tag/unknown" }
 
-      it("renders empty body") { expect(response.body).to be_empty }
+      it("renders empty body") { expect { get "/feed/tag/unknown" }.to raise_error(ActiveRecord::RecordNotFound) }
     end
   end
 

--- a/spec/requests/rss_feed_spec.rb
+++ b/spec/requests/rss_feed_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe "RssFeed", type: :request do
     end
 
     it "renders organization feed" do
+      create(:article, organization_id: organization.id)
       get "/feed/#{organization.slug}"
       expect(response.body).to include("<link>https://dev.to/#{organization.slug}</link>")
     end

--- a/spec/requests/user/user_profile_spec.rb
+++ b/spec/requests/user/user_profile_spec.rb
@@ -57,6 +57,18 @@ RSpec.describe "UserProfiles", type: :request do
       expect(response.body).not_to include("<meta name=\"googlebot\" content=\"noindex\">")
     end
 
+    it "renders rss feed link if any stories" do
+      create(:article, user_id: user.id)
+
+      get "/#{user.username}"
+      expect(response.body).to include("/feed/#{user.username}")
+    end
+
+    it "does not render feed link if any stories" do
+      get "/#{user.username}"
+      expect(response.body).not_to include("/feed/#{user.username}")
+    end
+
     context "when organization" do
       it "renders organization page if org" do
         get organization.path

--- a/spec/requests/user/user_profile_spec.rb
+++ b/spec/requests/user/user_profile_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe "UserProfiles", type: :request do
       expect(response.body).to include("/feed/#{user.username}")
     end
 
-    it "does not render feed link if any stories" do
+    it "does not render feed link if no stories" do
       get "/#{user.username}"
       expect(response.body).not_to include("/feed/#{user.username}")
     end
@@ -114,6 +114,17 @@ RSpec.describe "UserProfiles", type: :request do
         organization.update(location: "123, ave dev & < ' \" &quot; to")
         get organization.path
         expect(response.body).to include(ActionController::Base.helpers.sanitize(organization.location))
+      end
+
+      it "renders rss feed link if any stories" do
+        create(:article, organization_id: organization.id)
+        get organization.path
+        expect(response.body).to include("/feed/#{organization.slug}")
+      end
+
+      it "does not render feed link if no stories" do
+        get organization.path
+        expect(response.body).not_to include("/feed/#{organization.slug}")
       end
     end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We had been linking to empty RSS feeds on user profiles without published articles and rendering `body: nil` for empty RSS feeds.

This PR switches to `not_found` for empty feeds and takes away the reference to RSS feeds for users who have not published articles yet.

This is to help waste less robot time when they crawl our site.

While I was here I switched out a few instances of hardcoded `https://dev.to`.