### PR TITLE
Check presence of auth_data_dump

### DIFF
--- a/app/views/internal/users/edit.html.erb
+++ b/app/views/internal/users/edit.html.erb
@@ -72,7 +72,7 @@
       <% @user.identities.each do |identity| %>
         <%= form_for(@user, url: remove_identity_internal_user_path(@user), html: { method: :delete, onsubmit: "return confirm('Are you sure? This should only be done as a solution for the listed example(s).)" }) do |f| %>
           <%= f.hidden_field :identity_id, value: identity.id %>
-          <p><b><%= identity.provider.capitalize %> UID: <%= identity.uid %> - Username: <%= identity.auth_data_dump["info"]["nickname"] %></b></p>
+          <p><b><%= identity.provider.capitalize %> UID: <%= identity.uid %> - Username: <%= identity.auth_data_dump.present? ? identity.auth_data_dump["info"]["nickname"] : "no auth data dump available! 😞" %></b></p>
           <%= f.submit "Delete #{identity.provider.capitalize} Identity", class: "btn btn-danger" %>
         <% end %>
       <% end %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Some users' identities have an `auth_data_dump = nil` for some reason. Based on this issue https://github.com/omniauth/omniauth/issues/767, I believe the reason was because we (a long time ago) used to use `env["omniauth.auth"]` which would sometimes return `nil`. We've been using `request.env["omniauth.auth"]` long enough where we don't see this issue anymore.

Long story short, this code solves an edge case for those users who have this edge case.

Honeybadger error: https://app.honeybadger.io/projects/66984/faults/58419984/23a3dd40-5a7a-11ea-9e54-fe85e1e0f780?page=0

Resolves https://github.com/thepracticaldev/tech-private/issues/405

## Added tests?
- [x] no, because they aren't needed (ancient edge case)

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
No