### PR TITLE
Skip vomit reactions on banned users

### DIFF
--- a/app/views/internal/feedback_messages/index.html.erb
+++ b/app/views/internal/feedback_messages/index.html.erb
@@ -80,7 +80,7 @@
     <div id="vomitReactionsBodyContainer" class="collapse hide" aria-labelledby="vomitReactionsHeader" data-parent="#vomitReactions">
       <div class="card-body" style="overflow: scroll; max-height: 500px;">
         <% @vomits.each do |reaction| %>
-          <% next if reaction.reactable_type == "Article" && !reaction.reactable.published %>
+          <% next if (reaction.reactable_type == "Article" && !reaction.reactable.published) || (reaction.reactable_type == "User" && reaction.reactable.banned) %>
           <div class="d-flex justify-content-between">
             <span>
               🤢 <a href="<%= reaction.user.path %>">@<%= reaction.user.username %></a>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Just a quick fix to filter banned users out of the vomit reaction lists,
we are doing essentially the same thing for unpublished articles. It
might worth handling this at the controller level if we experience any
performance issues.

## Related Tickets & Documents

Closes https://github.com/thepracticaldev/tech-private/issues/406

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed