### PR TITLE
Don't Repeatedly Hit the Cache for User Data

### DIFF
--- a/app/services/articles/feed.rb
+++ b/app/services/articles/feed.rb
@@ -83,20 +83,20 @@ module Articles
     end
 
     def score_followed_user(article)
-      @user&.cached_following_users_ids&.include?(article.user_id) ? 1 : 0
+      user_following_users_ids.include?(article.user_id) ? 1 : 0
     end
 
     def score_followed_tags(article)
       return 0 unless @user
 
       article_tags = article.decorate.cached_tag_list_array
-      @user.decorate.cached_followed_tags.sum do |tag|
+      user_followed_tags.sum do |tag|
         article_tags.include?(tag.name) ? tag.points * @tag_weight : 0
       end
     end
 
     def score_followed_organization(article)
-      @user&.cached_following_organizations_ids&.include?(article.organization_id) ? 1 : 0
+      user_following_org_ids.include?(article.organization_id) ? 1 : 0
     end
 
     def score_randomness
@@ -129,6 +129,20 @@ module Articles
         end
         [featured_story, hot_stories.to_a]
       end
+    end
+
+    private
+
+    def user_followed_tags
+      @user_followed_tags ||= (@user&.decorate&.cached_followed_tags || [])
+    end
+
+    def user_following_org_ids
+      @user_following_org_ids ||= (@user&.cached_following_organizations_ids || [])
+    end
+
+    def user_following_users_ids
+      @user_following_users_ids ||= (@user&.cached_following_users_ids || [])
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
Every time we [score an article](https://github.com/thepracticaldev/dev.to/blob/master/app/services/articles/feed.rb#L74) an article we hit these three methods each of which hit Redis. 
```ruby
article_points += score_followed_user(article)
article_points += score_followed_organization(article)
article_points += score_followed_tags(article)
```
Since we know the data likely is not going to change while we process the articles, rather than hitting Redis for every single article,  we should memoize the results and use those instead. Something, something, Cache(LOCAL!) is King! 

This will remove almost all of these requests
![repeat-requests](https://user-images.githubusercontent.com/1813380/75813777-9406bd00-5d5e-11ea-90d5-2d4323ce1a78.png)

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media.giphy.com/media/fQoIDlLW6A6BAhyev8/giphy.gif)
