### PR TITLE
Search::Client refactor

### DIFF
--- a/app/services/search/client.rb
+++ b/app/services/search/client.rb
@@ -4,18 +4,25 @@ module Search
     class << self
       # adapted from https://api.rubyonrails.org/classes/Module.html#method-i-delegate_missing_to
       def method_missing(method, *args, &block)
-        if target.respond_to?(method, false)
+        return super unless target.respond_to?(method, false)
+
+        # define for re-use
+        self.class.define_method(method) do |*new_args, &new_block|
           request do
-            target.public_send(method, *args, &block)
+            target.public_send(method, *new_args, &new_block)
           end
-        else
-          super
+        end
+
+        # call the original method, this will only be called the first time
+        # as in subsequent calls, the newly defined method will prevail
+        request do
+          target.public_send(method, *args, &block)
         end
       end
 
       # adapted from https://api.rubyonrails.org/classes/Module.html#method-i-delegate_missing_to
       def respond_to_missing?(method, _include_all = false)
-        target.respond_to?(method, false) || super
+        respond_to?(method, false) || target.respond_to?(method, false) || super
       end
 
       private

--- a/app/services/search/client.rb
+++ b/app/services/search/client.rb
@@ -22,7 +22,7 @@ module Search
 
       # adapted from https://api.rubyonrails.org/classes/Module.html#method-i-delegate_missing_to
       def respond_to_missing?(method, _include_all = false)
-        respond_to?(method, false) || target.respond_to?(method, false) || super
+        target.respond_to?(method, false) || super
       end
 
       private


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

During @rhymes' recent work on `Search::Client` I suggested an improvement in the form of using `define_method` instead of repeatedly going through `method_missing` ([thread](https://github.com/thepracticaldev/dev.to/pull/6307/files#r384902241)). 

## Related Tickets & Documents

n/a

## Added tests?

- [X] no, because this should be covered by other `Search::Client` tests. I also have issues with my local Elasticsearch install/config and decided not to sink more than 30 minutes into trying to resolve them.

## Added to documentation?

- [X] no documentation needed
