### PR TITLE
Update ES docs for min/max versions and macOS brew

### DIFF
--- a/docs/installation/linux.md
+++ b/docs/installation/linux.md
@@ -66,11 +66,18 @@ We recommend following Digital Ocean's extensive
 
 ### Elasticsearch
 
-DEV requires Elasticsearch version 7 or higher.
+DEV requires a version of Elasticsearch between 7.1 and 7.5. Version 7.6 is not
+supported. We recommend version 7.5.2.
 
 We recommend following
 [Elasticsearch's guide for installing on Linux](https://www.elastic.co/guide/en/elasticsearch/reference/7.5/targz.html#install-linux).
-NOTE: Make sure to download the OSS version, `elasticsearch-oss`.
+
+Elasticsearch is also available as as
+[Debian package](https://www.elastic.co/guide/en/elasticsearch/reference/7.5/deb.html)
+or a
+[RPM package](https://www.elastic.co/guide/en/elasticsearch/reference/7.5/rpm.html).
+
+NOTE: Make sure to download **the OSS version**, `elasticsearch-oss`.
 
 ## Installing DEV
 

--- a/docs/installation/mac.md
+++ b/docs/installation/mac.md
@@ -59,7 +59,8 @@ redis-cli ping
 
 ### Elasticsearch
 
-DEV requires Elasticsearch version 7 or higher.
+DEV requires a version of Elasticsearch between 7.1 and 7.5. Version 7.6 is not
+supported. We recommend version 7.5.2.
 
 You have the option of installing Elasticsearch with Homebrew or through an
 archive. We recommend installing from archive on Mac.
@@ -96,17 +97,15 @@ To start elasticsearch as a daemonized process:
 
 ### Installing Elasticsearch with Homebrew
 
-The following directions were
-[taken from the Elasticsearch docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/brew.html).
-
 ```shell
 brew tap elastic/tap
-brew install elastic/tap/elasticsearch-oss
+brew install https://raw.githubusercontent.com/elastic/homebrew-tap/bed8bc6b03213c2c1a7df6e4b9f928e7082fae46/Formula/elasticsearch-oss.rb
+brew pin elasticsearch-oss
 ```
 
 After installation you can manually test if the Elasticsearch server starts by
 issuing the command `elasticsearch` in the shell. You can then start the server
-as a service with `brew services start elastic/tap/elasticsearch-oss`.
+as a service with `brew services start elasticsearch-oss`.
 
 You can find further info on your local Elasticsearch installation by typing
 `brew info elastic/tap/elasticsearch-oss`.
@@ -122,8 +121,8 @@ Exception in thread "main" org.elasticsearch.bootstrap.BootstrapException: java.
 Likely root cause: java.nio.file.FileSystemLoopException: /usr/local/etc/elasticsearch/elasticsearch
 ```
 
-This happens because the installation of Elasticsearch might have a recursive link in the
-configuration directory causing the infinite loop:
+This happens because the installation of Elasticsearch might have a recursive
+link in the configuration directory causing the infinite loop:
 
 ```shell
 > ll /usr/local/etc/elasticsearch
@@ -169,13 +168,13 @@ your local Elasticsearch installation, for example:
   "cluster_name": "elasticsearch_...",
   "cluster_uuid": "...",
   "version": {
-    "number": "7.6.0",
+    "number": "7.5.2",
     "build_flavor": "oss",
     "build_type": "tar",
-    "build_hash": "7f634e9f44834fbc12724506cc1da681b0c3b1e3",
-    "build_date": "2020-02-06T00:09:00.449973Z",
+    "build_hash": "8bec50e1e0ad29dad5653712cf3bb580cd1afcdf",
+    "build_date": "2020-01-15T12:11:52.313576Z",
     "build_snapshot": false,
-    "lucene_version": "8.4.0",
+    "lucene_version": "8.3.0",
     "minimum_wire_compatibility_version": "6.8.0",
     "minimum_index_compatibility_version": "6.0.0-beta1"
   },

--- a/docs/installation/mac.md
+++ b/docs/installation/mac.md
@@ -97,6 +97,10 @@ To start elasticsearch as a daemonized process:
 
 ### Installing Elasticsearch with Homebrew
 
+As the default version of the Homebrew formula points to Elasticsearch 7.6, we
+need to retrieve the correct revision of the formula to make sure we install the
+latest supported version: 7.5.2.
+
 ```shell
 brew tap elastic/tap
 brew install https://raw.githubusercontent.com/elastic/homebrew-tap/bed8bc6b03213c2c1a7df6e4b9f928e7082fae46/Formula/elasticsearch-oss.rb

--- a/docs/installation/windows.md
+++ b/docs/installation/windows.md
@@ -142,12 +142,14 @@ WSL.
 
 ### Elasticsearch
 
-DEV requires Elasticsearch version 7 or higher.
+DEV requires a version of Elasticsearch between 7.1 and 7.5. Version 7.6 is not
+supported. We recommend version 7.5.2.
 
 We recommend following the install guide
 [in Elasticsearch's docs](https://www.elastic.co/guide/en/elasticsearch/reference/7.5/zip-windows.html)
-for installing on Windows machines. NOTE: Make sure to download the OSS version,
-`elasticsearch-oss`.
+for installing on Windows machines.
+
+NOTE: Make sure to download **the OSS version**, `elasticsearch-oss`.
 
 ## Installing DEV
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

Yesterday while testing https://github.com/thepracticaldev/dev.to/pull/6372 with @atsmith813 we found out that our current code does not fully support ES 7.6 which I inadvertently installed thanks to the Homebrew instructions.

This was confirmed by the [release notes of `elasticsearch-ruby`](https://github.com/elastic/elasticsearch-ruby/releases/tag/v7.5.0), which we recently updated:

```md
- Support for Elasticsearch 7.5.
```

Once downgraded to ES 7.5.2 everything worked well as expected.

Since in the documentation we, until now, recommend "ES 7 or higher" I think we should be more specific, lest we incur on bug reports about features not working locally.

I also updated the `Homebrew` instructions for how to install the correct version (which I tested locally twice).

I tested manually our code with the following ES versions:

- 7.1.1
- 7.2.1
- 7.3.2
- 7.4.2
- 7.5.2

and they all work fine.

The code I used for testing was:

```ruby
Search::Client.info
Search::Cluster.setup_indexes
[ChatChannelMembership, ClassifiedListing, Tag].each { |klass| klass.find_each(&:index_to_elasticsearch_inline) }
Search::Tag.search_documents("python")
```

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [x] docs.dev.to
- [ ] readme
- [ ] no documentation needed
