### PR TITLE
Enable caching in Redis in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -22,7 +22,9 @@ Rails.application.configure do
   if Rails.root.join("tmp/caching-dev.txt").exist?
     config.action_controller.perform_caching = true
 
-    config.cache_store = :memory_store
+    DEFAULT_EXPIRATION = 1.hour.to_i.freeze
+    config.cache_store = :redis_cache_store, { url: ENV["REDIS_URL"], expires_in: DEFAULT_EXPIRATION }
+
     config.public_file_server.headers = {
       "Cache-Control" => "public, max-age=#{2.days.to_i}"
     }


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Since we already require Redis in development (for sessions), I think we should use it for caching as well. It's easier to test caching issues if we use the same store we use in production. I only lowered the default expiration.

This is also an attempt to have `development` and `production` a little bit more similar.

Tip: you can toggle caching on and off in development with `rails dev:cache`

## Added tests?

- [ ] yes
- [ ] no, because they aren't needed
- [x] no, because I need help
