### PR TITLE
Bump min version of PostgreSQL from 9.4 to 9.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ A more complete overview of our stack is available in
   the badge.
 - [Yarn](https://yarnpkg.com/) 1.x: please refer to their
   [installation guide](https://classic.yarnpkg.com/en/docs/install).
-- [PostgreSQL](https://www.postgresql.org/) 9.4 or higher.
+- [PostgreSQL](https://www.postgresql.org/) 9.5 or higher.
 - [ImageMagick](https://imagemagick.org/): please refer to ImageMagick's
   [installation instructions](https://imagemagick.org/script/download.php).
 - [Redis](https://redis.io/) 4 or higher.

--- a/docs/installation/linux.md
+++ b/docs/installation/linux.md
@@ -36,6 +36,8 @@ There are two ways to install Yarn.
 
 ### PostgreSQL
 
+DEV requires PostgreSQL version 9.5 or higher.
+
 1. Run
    `sudo apt update && sudo apt install postgresql postgresql-contrib libpq-dev`.
 1. To test the installation you can run `sudo -u postgres psql` which should
@@ -45,8 +47,7 @@ There are two ways to install Yarn.
 
 There are more than one ways to setup PostgreSQL. For additional configuration,
 check out our [PostgreSQL setup guide](/installation/postgresql) or the official
-[PostgreSQL](https://www.postgresql.org/) site for further information. DEV
-requires PostgreSQL version 9.4 or higher.
+[PostgreSQL](https://www.postgresql.org/) site for further information.
 
 ### ImageMagick
 

--- a/docs/installation/mac.md
+++ b/docs/installation/mac.md
@@ -20,10 +20,11 @@ Please refer to their [installation guide](https://yarnpkg.com/en/docs/install).
 
 ### PostgreSQL
 
-DEV requires PostgreSQL version 9.4 or higher. The easiest way to get started is
-to use [Postgres.app](https://postgresapp.com/). Alternatively, check out the
-official [PostgreSQL](https://www.postgresql.org/) site for more installation
-options.
+DEV requires PostgreSQL version 9.5 or higher.
+
+The easiest way to get started is to use
+[Postgres.app](https://postgresapp.com/). Alternatively, check out the official
+[PostgreSQL](https://www.postgresql.org/) site for more installation options.
 
 For additional configuration options, check our
 [PostgreSQL setup guide](/installation/postgresql).

--- a/docs/installation/windows.md
+++ b/docs/installation/windows.md
@@ -110,9 +110,11 @@ Make sure that Yarn is installed with `yarn -v`
 
 ### PostgreSQL
 
+DEV requires PostgreSQL version 9.5 or higher.
+
 If you don't have PostgreSQL installed on your Windows system, you can do so
 right now. WSL is able to connect to a PostgreSQL instance on your Windows
-machine. DEV requires PostgreSQL version 9.4 or higher.
+machine.
 
 Download [PostgreSQL for Windows](https://www.postgresql.org/download/windows/)
 and install it.


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

PostgreSQL is [officially unsupported as of February 13, 2020](https://www.postgresql.org/support/versioning/):

![Screenshot_2020-03-04 PostgreSQL Versioning Policy](https://user-images.githubusercontent.com/146201/75884398-0641d500-5e25-11ea-8985-e3d7f520dce5.png)

I've updated the minimum required version in the docs. 

AFAIK (or can check) we still don't use any features that are available only on newer versions.

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [x] docs.dev.to
- [x] readme
- [ ] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
