### PR TITLE
Fix tags autocomplete deleting input with fast typing

### DIFF
--- a/app/javascript/shared/components/tags.jsx
+++ b/app/javascript/shared/components/tags.jsx
@@ -31,9 +31,10 @@ class Tags extends Component {
   constructor(props) {
     super(props);
 
-    this.debouncedTagSearch = debounce(this.handleInput.bind(this), 150, {
-      leading: true,
-    });
+    // 250ms without invoking the function at the leading edge of the timeout
+    // NOTE: this seems the best combination of wait time and options to avoid
+    // flickering and text replacement during autocomplete
+    this.debouncedTagSearch = debounce(this.handleInput.bind(this), 250);
 
     this.state = {
       selectedIndex: -1,


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

After a bit of fiddling and testing I think I found the right combination between wait time and options to not incur in deleting characters during autocomplete.

This is how it would look in the editor:

![250ms](https://user-images.githubusercontent.com/146201/75895808-7147d780-5e36-11ea-9173-2412cdae1f70.gif)

This is how it would look in the listing form:

![listing](https://user-images.githubusercontent.com/146201/75895937-9b00fe80-5e36-11ea-9501-65570afa7060.gif)

I recorded a few examples of other combinations to show what wasn't working:

**150ms with leading aka production right now**

![](https://user-images.githubusercontent.com/146201/75891708-76a22380-5e30-11ea-8814-549ea62de1bf.gif)

as you can see it deletes characters

**200ms with no leading**

![200ms](https://user-images.githubusercontent.com/146201/75895553-1dd58980-5e36-11ea-941b-3bd22808f994.gif)

losing the `y`

**200ms with leading**

![200ms-leading](https://user-images.githubusercontent.com/146201/75895676-42c9fc80-5e36-11ea-9800-b091ad830651.gif)

The first `a` in Java is often replaced

**250ms with leading**

![250ms-leading](https://user-images.githubusercontent.com/146201/75895980-abb17480-5e36-11ea-8718-aa8d50db9d6e.gif)

even if now the wait time is okay, the initial call is too fast.

## Related Tickets & Documents

Closes https://github.com/thepracticaldev/dev.to/issues/6436

- [Debouncing and Throttling Explained Through Examples](https://css-tricks.com/debouncing-throttling-explained-examples/)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
