### PR TITLE
Add field test variant info to Honeycomb

### DIFF
--- a/app/controllers/stories/feeds_controller.rb
+++ b/app/controllers/stories/feeds_controller.rb
@@ -23,6 +23,7 @@ class Stories::FeedsController < ApplicationController
 
   def ab_test_user_signed_in_feed(feed)
     test_variant = field_test(:user_home_feed, participant: current_user)
+    Honeycomb.add_field("field_test_user_home_feed", test_variant) # Monitoring different variants
     case test_variant
     when "base"
       feed.default_home_feed(user_signed_in: true)


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

I'm not sure this is correct or appropriate, and we might want to prefer this kind of line in a wrapper class so we can send this kind of data to several places, but all in all it seems useful to have these alternate paths segmentable in Honeycomb.