### PR TITLE
Create Searchable Specs and Remove Redundant specs from AR models

### DIFF
--- a/spec/models/chat_channel_membership_spec.rb
+++ b/spec/models/chat_channel_membership_spec.rb
@@ -12,22 +12,6 @@ RSpec.describe ChatChannelMembership, type: :model do
     end
   end
 
-  describe "#index_to_elasticsearch" do
-    it "enqueues job to index tag to elasticsearch" do
-      sidekiq_assert_enqueued_with(job: Search::IndexToElasticsearchWorker, args: [described_class.to_s, chat_channel_membership.id]) do
-        chat_channel_membership.index_to_elasticsearch
-      end
-    end
-  end
-
-  describe "#index_to_elasticsearch_inline" do
-    it "indexed chat_channel_membership to elasticsearch inline" do
-      allow(Search::ChatChannelMembership).to receive(:index)
-      chat_channel_membership.index_to_elasticsearch_inline
-      expect(Search::ChatChannelMembership).to have_received(:index).with(chat_channel_membership.id, hash_including(:id, :channel_name))
-    end
-  end
-
   describe "#after_commit" do
     it "on update enqueues job to index chat_channel_membership to elasticsearch" do
       chat_channel_membership.save
@@ -41,21 +25,6 @@ RSpec.describe ChatChannelMembership, type: :model do
       sidekiq_assert_enqueued_with(job: Search::RemoveFromElasticsearchIndexWorker, args: [described_class::SEARCH_CLASS.to_s, chat_channel_membership.id]) do
         chat_channel_membership.destroy
       end
-    end
-  end
-
-  describe "#serialized_search_hash" do
-    it "creates a valid serialized hash to send to elasticsearch" do
-      mapping_keys = Search::ChatChannelMembership::MAPPINGS.dig(:properties).keys
-      expect(chat_channel_membership.serialized_search_hash.symbolize_keys.keys).to eq(mapping_keys)
-    end
-  end
-
-  describe "#elasticsearch_doc" do
-    it "finds document in elasticsearch", elasticsearch: true do
-      allow(Search::ChatChannelMembership).to receive(:find_document)
-      chat_channel_membership.elasticsearch_doc
-      expect(Search::ChatChannelMembership).to have_received(:find_document)
     end
   end
 end

--- a/spec/models/concerns/searchable_spec.rb
+++ b/spec/models/concerns/searchable_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 class SearchableModel
   include Searchable
   SEARCH_CLASS = Search::Tag
+  SEARCH_SERIALIZER = Search::TagSerializer
 
   def id
     1
@@ -10,12 +11,53 @@ class SearchableModel
 end
 
 RSpec.describe Searchable do
+  let(:model_class) { SearchableModel }
+  let(:searchable_model) { model_class.new }
+  let(:serialized_hash) { { data: { attributes: { id: searchable_model.id } } } }
+
+  before do
+    mock_serializer = instance_double("MockSerializer", :serializable_hash)
+    allow(model_class::SEARCH_SERIALIZER).to receive(:new).and_return(mock_serializer)
+    allow(mock_serializer).to receive(:serializable_hash).and_return(
+      serialized_hash,
+    )
+  end
+
   describe "#remove_from_elasticsearch" do
     it "enqueues job to delete model document from elasticsearch" do
-      model = SearchableModel.new
-      sidekiq_assert_enqueued_with(job: Search::RemoveFromElasticsearchIndexWorker, args: [SearchableModel::SEARCH_CLASS.to_s, model.id]) do
-        model.remove_from_elasticsearch
+      sidekiq_assert_enqueued_with(job: Search::RemoveFromElasticsearchIndexWorker, args: [SearchableModel::SEARCH_CLASS.to_s, searchable_model.id]) do
+        searchable_model.remove_from_elasticsearch
       end
+    end
+  end
+
+  describe "#index_to_elasticsearch" do
+    it "enqueues job to index document to elasticsearch" do
+      sidekiq_assert_enqueued_with(job: Search::IndexToElasticsearchWorker, args: ["SearchableModel", searchable_model.id]) do
+        searchable_model.index_to_elasticsearch
+      end
+    end
+  end
+
+  describe "#index_to_elasticsearch_inline" do
+    it "indexes a document to elasticsearch inline" do
+      allow(model_class::SEARCH_CLASS).to receive(:index)
+      searchable_model.index_to_elasticsearch_inline
+      expect(model_class::SEARCH_CLASS).to have_received(:index).with(searchable_model.id, id: searchable_model.id)
+    end
+  end
+
+  describe "#serialized_search_hash" do
+    it "creates a valid serialized hash to send to elasticsearch" do
+      expect(searchable_model.serialized_search_hash.symbolize_keys.keys).to eq([:id])
+    end
+  end
+
+  describe "#elasticsearch_doc" do
+    it "finds document in elasticsearch" do
+      allow(model_class::SEARCH_CLASS).to receive(:find_document)
+      searchable_model.elasticsearch_doc
+      expect(model_class::SEARCH_CLASS).to have_received(:find_document)
     end
   end
 end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -76,22 +76,6 @@ RSpec.describe Tag, type: :model do
     expect(tag.mod_chat_channel).to eq(channel)
   end
 
-  describe "#index_to_elasticsearch" do
-    it "enqueues job to index tag to elasticsearch" do
-      sidekiq_assert_enqueued_with(job: Search::IndexToElasticsearchWorker, args: [described_class.to_s, tag.id]) do
-        tag.index_to_elasticsearch
-      end
-    end
-  end
-
-  describe "#index_to_elasticsearch_inline" do
-    it "indexed tag to elasticsearch inline" do
-      allow(Search::Tag).to receive(:index)
-      tag.index_to_elasticsearch_inline
-      expect(Search::Tag).to have_received(:index).with(tag.id, hash_including(:id, :name))
-    end
-  end
-
   describe "#after_commit" do
     it "on update enqueues job to index tag to elasticsearch" do
       tag.save
@@ -105,21 +89,6 @@ RSpec.describe Tag, type: :model do
       sidekiq_assert_enqueued_with(job: Search::RemoveFromElasticsearchIndexWorker, args: [described_class::SEARCH_CLASS.to_s, tag.id]) do
         tag.destroy
       end
-    end
-  end
-
-  describe "#serialized_search_hash" do
-    it "creates a valid serialized hash to send to elasticsearch" do
-      mapping_keys = Search::Tag::MAPPINGS.dig(:properties).keys
-      expect(tag.serialized_search_hash.symbolize_keys.keys).to eq(mapping_keys)
-    end
-  end
-
-  describe "#elasticsearch_doc" do
-    it "finds document in elasticsearch", elasticsearch: true do
-      allow(Search::Tag).to receive(:find_document)
-      tag.elasticsearch_doc
-      expect(Search::Tag).to have_received(:find_document)
     end
   end
 end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
This creates a new Searchable spec for the Elasticsearch helper module that we use in our AR models. It also removes the redundant specs from each model. 

## Added tests?
- [x] yes

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media.giphy.com/media/9rfYHAHb0CAxSjCR0o/200w_d.gif)
