### PR TITLE
Add more tag weight/more random variant

### DIFF
--- a/app/controllers/stories/feeds_controller.rb
+++ b/app/controllers/stories/feeds_controller.rb
@@ -32,6 +32,8 @@ class Stories::FeedsController < ApplicationController
       feed.mix_default_and_more_random
     when "more_tag_weight"
       feed.more_tag_weight
+    when "more_tag_weight_more_random"
+      feed.more_tag_weight_more_random
     else
       feed.default_home_feed(user_signed_in: true)
     end

--- a/app/services/articles/feed.rb
+++ b/app/services/articles/feed.rb
@@ -66,6 +66,13 @@ module Articles
       stories
     end
 
+    def more_tag_weight_more_random
+      @tag_weight = 2
+      @randomness = 7
+      _featured_story, stories = default_home_feed_and_featured_story(user_signed_in: true)
+      stories
+    end
+
     # Test variation: Base half the time, more random other half. Varies on impressions.
     def mix_default_and_more_random
       if rand(2) == 1
@@ -126,7 +133,7 @@ module Articles
 
     def globally_hot_articles(user_signed_in)
       hot_stories = published_articles_by_tag.
-        where("score > ? OR featured = ?", 9, true).
+        where("score > ? OR featured = ?", 8, true).
         order("hotness_score DESC")
       featured_story = hot_stories.where.not(main_image: nil).first
       if user_signed_in

--- a/config/field_test.yml
+++ b/config/field_test.yml
@@ -5,11 +5,13 @@ experiments:
       - more_random
       - more_tag_weight
       - mix_base_more_random
+      - more_tag_weight_more_random
     weights:
-      - 65
+      - 55
       - 10
       - 10
       - 15
+      - 10
     goals:
       - user_creates_comment
       - user_creates_reaction

--- a/spec/services/articles/feed_spec.rb
+++ b/spec/services/articles/feed_spec.rb
@@ -169,6 +169,16 @@ RSpec.describe Articles::Feed, type: :service do
     end
   end
 
+  describe "#more_tag_weight_more_random" do
+    let!(:new_story) { create(:article, published_at: 10.minutes.ago, score: 10) }
+    let(:stories) { feed.more_tag_weight_more_random }
+
+    it "includes stories from between 2 and 6 hours ago" do
+      expect(stories).not_to include(old_story)
+      expect(stories).to include(new_story)
+    end
+  end
+
   describe "#score_followed_user" do
     context "when article is written by a followed user" do
       before { user.follow(article.user) }


### PR DESCRIPTION


## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
It's too early to be sure, but it looks like both `more_random` and `more_tag_weight` are slightly more successful variants than the base.... so why not combine them!

I think throwing more spaghetti at the wall is a good thing to do.

I like the idea of rolling experimentation so we can add new variants in a more adhoc way like this. 

For now we'll have to sort of just account for the normalization issues ourselves of different tests being introduced at different times as we evolve the rules on how we do this stuff and measure it all.