### PR TITLE
Replace peform_enqueued_jobs with sidekiq_perform_enqueued_jobs in specs

### DIFF
--- a/spec/models/follow_spec.rb
+++ b/spec/models/follow_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Follow, type: :model do
 
     it "doesn't create a channel when a followable is an org" do
       expect do
-        perform_enqueued_jobs do
+        sidekiq_perform_enqueued_jobs do
           described_class.create!(follower: user, followable: create(:organization))
         end
       end.not_to change(ChatChannel, :count)
@@ -48,7 +48,7 @@ RSpec.describe Follow, type: :model do
 
     it "doesn't create a chat channel when users don't follow mutually" do
       expect do
-        perform_enqueued_jobs do
+        sidekiq_perform_enqueued_jobs do
           described_class.create!(follower: user, followable: user_2)
         end
       end.not_to change(ChatChannel, :count)

--- a/spec/models/reaction_spec.rb
+++ b/spec/models/reaction_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe Reaction, type: :model do
     end
 
     it "updates updated_at if the reactable is a comment" do
-      perform_enqueued_jobs do
+      sidkiq_perform_enqueued_jobs do
         updated_at = 1.day.ago
         comment = create(:comment, commentable: article, updated_at: updated_at)
         reaction.update(reactable: comment)
@@ -152,7 +152,7 @@ RSpec.describe Reaction, type: :model do
     end
 
     it "updates updated_at for the user" do
-      perform_enqueued_jobs do
+      sidekiq_perform_enqueued_jobs do
         updated_at = user.updated_at
         Timecop.travel(1.day.from_now) do
           reaction.save

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -439,7 +439,7 @@ RSpec.describe User, type: :model do
       end
 
       it "sets correct language_settings by default after the jobs are processed" do
-        perform_enqueued_jobs do
+        sidekiq_perform_enqueued_jobs do
           expect(user.language_settings).to eq("preferred_languages" => %w[en])
         end
       end

--- a/spec/requests/articles/articles_create_spec.rb
+++ b/spec/requests/articles/articles_create_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe "ArticlesCreate", type: :request do
 
     it "doesn't fail when executing jobs" do
       stub_request(:post, url).to_return(status: 200)
-      perform_enqueued_jobs do
+      sidekiq_perform_enqueued_jobs do
         post "/articles", params: article_params
       end
     end

--- a/spec/requests/html_variant_successes_spec.rb
+++ b/spec/requests/html_variant_successes_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "HtmlVariantSuccesses", type: :request do
 
   describe "POST /html_variant_successes" do
     it "rejects non-permissioned user" do
-      perform_enqueued_jobs do
+      sidekiq_perform_enqueued_jobs do
         post "/html_variant_successes", params: {
           article_id: article.id,
           html_variant_id: html_variant.id

--- a/spec/requests/html_variant_trials_spec.rb
+++ b/spec/requests/html_variant_trials_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "HtmlVariantTrials", type: :request do
 
   describe "POST /html_variant_trials" do
     it "rejects non-permissioned user" do
-      perform_enqueued_jobs do
+      sidekiq_perform_enqueued_jobs do
         post "/html_variant_trials", params: {
           article_id: article.id,
           html_variant_id: html_variant.id

--- a/spec/requests/internal/moderator_logs_spec.rb
+++ b/spec/requests/internal/moderator_logs_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "/internal/tags", type: :request do
     it "creates entry for #update action" do
       allow(AssignTagModerator).to receive(:add_tag_moderators)
 
-      perform_enqueued_jobs do
+      sidekiq_perform_enqueued_jobs do
         put "/internal/tags/#{tag.id}", params: update_params(tag_moderator.id.to_s)
         log = AuditLog.where(user_id: super_admin.id, slug: :update)
         expected = update_params(tag_moderator.id.to_s)[:tag]

--- a/spec/requests/internal/users_banish_spec.rb
+++ b/spec/requests/internal/users_banish_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Internal::Users", type: :request do
     create(:reaction, reactable: comment2, reactable_type: "Comment", user: user2)
     # create user3 reaction to offending article
     create(:reaction, reactable: article, reactable_type: "Article", user: user3, category: "like")
-    perform_enqueued_jobs do
+    sidekiq_perform_enqueued_jobs do
       Mention.create_all(comment2)
     end
   end
@@ -167,7 +167,7 @@ RSpec.describe "Internal::Users", type: :request do
         user_id: user2.id,
         commentable: article2,
       )
-      perform_enqueued_jobs do
+      sidekiq_perform_enqueued_jobs do
         Mention.create_all(comment)
       end
     end

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -560,7 +560,7 @@ RSpec.describe "NotificationsIndex", type: :request do
         user.add_role :trusted
         user.update(mod_roundrobin_notifications: false)
         sign_in user
-        perform_enqueued_jobs do
+        sidekiq_perform_enqueued_jobs do
           Notification.send_moderation_notification(comment)
         end
         get "/notifications"

--- a/spec/requests/oauth/tokens_spec.rb
+++ b/spec/requests/oauth/tokens_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe "Oauth::Tokens", type: :request do
     end
 
     it "doesn't destroy webhooks" do
-      perform_enqueued_jobs do
+      sidekiq_perform_enqueued_jobs do
         post oauth_revoke_path, params: { token: access_token.token }
       end
       expect(user_webhook.reload).to be_persisted

--- a/spec/requests/user/user_settings_spec.rb
+++ b/spec/requests/user/user_settings_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe "UserSettings", type: :request do
       end
 
       it "does not send an email if there was no request" do
-        perform_enqueued_jobs do
+        sidekiq_perform_enqueued_jobs do
           expect { send_request(false) }.not_to(change { ActionMailer::Base.deliveries.count })
         end
       end

--- a/spec/services/podcasts/get_episode_spec.rb
+++ b/spec/services/podcasts/get_episode_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Podcasts::GetEpisode, type: :service do
     end
 
     it "doesn't create invalid episodes" do
-      perform_enqueued_jobs do
+      sidekiq_perform_enqueued_jobs do
         expect do
           described_class.new(podcast).call(item: item)
         end.not_to change(PodcastEpisode, :count)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
There are a handful of specs that use `perform_enqueued_jobs` in place of `sidekiq_perform_enqueued_jobs` (and at times both within the same spec). So, this PR:

- [x] Replaces all instances of `peform_enqueued_jobs` with `sidekiq_perform_enqueued_jobs` within the specs
- [x] Alleviates confusion and establishes a convention going forward

## Related Tickets & Documents
Further context can be found here: [#6221 (comment)](https://github.com/thepracticaldev/dev.to/pull/6221#discussion_r387646723)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![dog_on_roomba](https://media.giphy.com/media/AZmaf9BRi56Ao/giphy.gif)
