### PR TITLE
Remove Algolia from Comments

### DIFF
--- a/app/javascript/article-form/elements/__mocks__/algoliasearch.js
+++ b/app/javascript/article-form/elements/__mocks__/algoliasearch.js
@@ -45,7 +45,7 @@ const mockIndex = {
             exhaustiveNbHits: true,
             query: 'gi',
             params:
-              'query=gi&hitsPerPage=10&filters=supported%3Atrue&restrictIndices=searchables_development%2CTag_development%2Cordered_articles_development%2Cordered_articles_by_published_at_development%2Cordered_articles_by_positive_reactions_count_development%2Cordered_comments_development',
+              'query=gi&hitsPerPage=10&filters=supported%3Atrue&restrictIndices=searchables_development%2CTag_development%2Cordered_articles_development%2Cordered_articles_by_published_at_development%2Cordered_articles_by_positive_reactions_count_development',
           },
         };
 

--- a/app/javascript/chat/__mocks__/algoliasearchUsers.js
+++ b/app/javascript/chat/__mocks__/algoliasearchUsers.js
@@ -25,7 +25,7 @@ const mockIndex = {
             exhaustiveNbHits: true,
             query: 'ma',
             params:
-              'query=ma&hitsPerPage=10&filters=supported%3Atrue&restrictIndices=searchables_development%2CTag_development%2Cordered_articles_development%2Cordered_articles_by_published_at_development%2Cordered_articles_by_positive_reactions_count_development%2Cordered_comments_development',
+              'query=ma&hitsPerPage=10&filters=supported%3Atrue&restrictIndices=searchables_development%2CTag_development%2Cordered_articles_development%2Cordered_articles_by_published_at_development%2Cordered_articles_by_positive_reactions_count_development',
           },
         };
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,7 +1,6 @@
 class Comment < ApplicationRecord
   has_ancestry
   resourcify
-  include AlgoliaSearch
   include Reactable
   belongs_to :commentable, polymorphic: true, optional: true
   counter_culture :commentable
@@ -40,83 +39,8 @@ class Comment < ApplicationRecord
 
   alias touch_by_reaction save
 
-  algoliasearch per_environment: true, enqueue: :trigger_index do
-    attribute :id
-    add_index "ordered_comments",
-              id: :index_id,
-              per_environment: true,
-              enqueue: :trigger_index do
-      attributes :id, :user_id, :commentable_id, :commentable_type, :id_code_generated, :path,
-                 :id_code, :readable_publish_date, :parent_id, :positive_reactions_count, :created_at
-      attribute :body_html do
-        HTML_Truncator.truncate(processed_html,
-                                500, ellipsis: '<a class="comment-read-more" href="' + path + '">... Read Entire Comment</a>')
-      end
-      attribute :url do
-        path
-      end
-      attribute :css do
-        custom_css
-      end
-      attribute :tag_list do
-        commentable&.tag_list
-      end
-      attribute :root_path do
-        root&.path
-      end
-      attribute :parent_path do
-        parent&.path
-      end
-      attribute :heart_ids do
-        reactions.where(category: "like").pluck(:user_id)
-      end
-      attribute :user do
-        {
-          username: user.username,
-          name: user.name,
-          id: user.id,
-          profile_pic: ProfileImage.new(user).get(width: 90),
-          profile_image_90: ProfileImage.new(user).get(width: 90),
-          github_username: user.github_username,
-          twitter_username: user.twitter_username
-        }
-      end
-      attribute :commentable do
-        {
-          path: commentable&.path,
-          title: commentable&.title,
-          tag_list: commentable&.tag_list,
-          id: commentable&.id
-        }
-      end
-      tags do
-        [commentable&.tag_list,
-         "user_#{user_id}",
-         "commentable_#{commentable_type}_#{commentable_id}"].flatten.compact
-      end
-      ranking ["desc(created_at)"]
-    end
-  end
-
   def self.tree_for(commentable, limit = 0)
     commentable.comments.includes(:user).arrange(order: "score DESC").to_a[0..limit - 1].to_h
-  end
-
-  def self.trigger_index(record, remove)
-    # record is removed from index synchronously in before_destroy_actions
-    return if remove
-
-    if record.deleted == false
-      Search::IndexWorker.perform_async("Comment", record.id)
-    else
-      Search::RemoveFromIndexWorker.perform_async(Comment.algolia_index_name, record.index_id)
-    end
-  end
-
-  # this should remain public because it's called by AlgoliaSearch::AlgoliaJob in .trigger_index
-  def remove_algolia_index
-    remove_from_index!
-    Search::RemoveFromIndexWorker.new.perform("ordered_comments_#{Rails.env}", index_id)
   end
 
   def path
@@ -174,11 +98,6 @@ class Comment < ApplicationRecord
 
   def remove_notifications
     Notification.remove_all_without_delay(notifiable_ids: id, notifiable_type: "Comment")
-  end
-
-  # public because it's used in the algolia indexing methods
-  def index_id
-    "comments-#{id}"
   end
 
   def safe_processed_html
@@ -267,7 +186,6 @@ class Comment < ApplicationRecord
     commentable.touch(:last_comment_at) if commentable.respond_to?(:last_comment_at)
     ancestors.update_all(updated_at: Time.current)
     Comments::BustCacheWorker.new.perform(id)
-    remove_algolia_index
   end
 
   def bust_cache

--- a/app/workers/search/index_worker.rb
+++ b/app/workers/search/index_worker.rb
@@ -4,7 +4,7 @@ module Search
 
     sidekiq_options queue: :medium_priority, retry: 10
 
-    VALID_RECORD_TYPES = %w[Comment Article User].freeze
+    VALID_RECORD_TYPES = %w[Article User].freeze
 
     def perform(record_type, record_id)
       unless VALID_RECORD_TYPES.include?(record_type)

--- a/config/initializers/algoliasearch.rb
+++ b/config/initializers/algoliasearch.rb
@@ -14,7 +14,6 @@ else
       "ClassifiedListing_#{Rails.env}",
       "ordered_articles_by_published_at_#{Rails.env}",
       "ordered_articles_by_positive_reactions_count_#{Rails.env}",
-      "ordered_comments_#{Rails.env}",
     ].join(",")
   }
   secured_algolia_key = Algolia.generate_secured_api_key(

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -121,8 +121,6 @@ num_comments = 30 * SEEDS_MULTIPLIER
 
 Rails.logger.info "5. Creating #{num_comments} Comments"
 
-Comment.clear_index!
-
 num_comments.times do
   attributes = {
     body_markdown: Faker::Hipster.paragraph(sentence_count: 1),

--- a/spec/workers/search/index_worker_spec.rb
+++ b/spec/workers/search/index_worker_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Search::IndexWorker, type: :worker do
   end
 
   it "doesn't fail if a record is not found" do
-    expect { worker.perform("Comment", -1) }.not_to raise_error
+    expect { worker.perform("User", -1) }.not_to raise_error
   end
 
   it "indexes a record if everything is fine" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
I was in the process of moving Comments from Algolia to Elasticsearch when I realized we are not using that index so this PR 🔪 Algolia from comments. Ben confirmed in Algolia that the index has never been queried before.

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-34096238

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

![james_corden_sliding_out_gif](https://media.giphy.com/media/20HLbBD2vXGu1q5qqw/giphy.gif)