### PR TITLE
Getting rid of min-height on saved articles contianer

### DIFF
--- a/app/assets/stylesheets/item-list.scss
+++ b/app/assets/stylesheets/item-list.scss
@@ -91,7 +91,6 @@
     .results {
       @include dev-card;
       border-radius: 3px;
-      min-height: 350px;
       display: none;
       text-align: left;
       font-size: 14px;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description
As title says: this PR is about getting rid of min-height value from container with "saved articles". It was causing a weird gap if there was one article only.

## Added tests?

- [x] no, because they aren't needed

## Added to documentation?

- [x] no documentation needed
