### PR TITLE
Re-enable correct operation of liquid tags with scripts in articles

### DIFF
--- a/app/liquid_tags/liquid_tag_base.rb
+++ b/app/liquid_tags/liquid_tag_base.rb
@@ -1,6 +1,6 @@
 class LiquidTagBase < Liquid::Tag
   def self.script
-    "".html_safe
+    ""
   end
 
   def finalize_html(input)

--- a/app/liquid_tags/podcast_tag.rb
+++ b/app/liquid_tags/podcast_tag.rb
@@ -5,6 +5,15 @@ class PodcastTag < LiquidTagBase
   attr_reader :episode, :podcast
   PARTIAL = "podcast_episodes/liquid".freeze
 
+  SCRIPT = <<~JAVASCRIPT.freeze
+    var waitingOnPodcast = setInterval(function() {
+      if (typeof initializePodcastPlayback !== 'undefined') {
+        initializePodcastPlayback();
+        clearInterval(waitingOnPodcast);
+      }
+    }, 1);
+  JAVASCRIPT
+
   IMAGE_LINK = {
     itunes: "https://d.ibtimes.co.uk/en/full/1423047/itunes-12.png",
     overcast: "https://d2uzvmey2c90kn.cloudfront.net/img/logo.svg",
@@ -33,14 +42,7 @@ class PodcastTag < LiquidTagBase
   end
 
   def self.script
-    "".html_safe + <<~JAVASCRIPT
-      var waitingOnPodcast = setInterval(function(){
-        if (typeof initializePodcastPlayback !== 'undefined') {
-          initializePodcastPlayback();
-          clearInterval(waitingOnPodcast);
-        }
-      },1);
-    JAVASCRIPT
+    SCRIPT
   end
 
   private

--- a/app/liquid_tags/poll_tag.rb
+++ b/app/liquid_tags/poll_tag.rb
@@ -1,6 +1,100 @@
 class PollTag < LiquidTagBase
   PARTIAL = "liquids/poll".freeze
 
+  SCRIPT = <<~JAVASCRIPT.freeze
+    if (document.head.querySelector('meta[name="user-signed-in"][content="true"]')) {
+      function displayPollResults(json) {
+        var totalVotes = json.voting_data.votes_count;
+        json.voting_data.votes_distribution.forEach(function(point) {
+          var pollOptionItem = document.getElementById('poll_option_list_item_'+point[0]);
+          var optionText = document.getElementById('poll_option_label_'+point[0]).textContent;
+          if (json.user_vote_poll_option_id === point[0]) {
+            var votedClass = 'optionvotedfor'
+          } else {
+            var votedClass = 'optionnotvotedfor'
+          }
+          if (totalVotes === 0) {
+            var percent = 0;
+          } else {
+            var percent = (point[1]/totalVotes)*100;
+          }
+          var roundedPercent = Math.round( percent * 10 ) / 10
+          var percentFromRight = (100-roundedPercent)
+          var html = '<span><span class="ltag-votepercent ltag-'+votedClass+'" style="right:'+percentFromRight+'%"></span>\
+            <span class="ltag-votepercenttext">'+optionText+' — '+roundedPercent+'%</span></span>';
+          pollOptionItem.innerHTML = html;
+          pollOptionItem.classList.add('already-voted')
+          document.getElementById('showmethemoney-'+json.poll_id).innerHTML = '<span class="ltag-voting-results-count">'+totalVotes+' total votes</span>';
+        })
+      }
+
+      var polls = document.getElementsByClassName('ltag-poll');
+      for (var i = 0; i < polls.length; i += 1) {
+        var poll = polls[i]
+        var pollId = poll.dataset.pollId
+        window.fetch('/poll_votes/'+pollId)
+        .then(function(response){
+          response.json().then(
+            function(json) {
+              if (json.voted) {
+                displayPollResults(json)
+              } else {
+                var els = document.getElementById('poll_'+json.poll_id).getElementsByClassName('ltag-polloption');
+
+                for (i = 0; i < els.length; i += 1) {
+                  els[i].addEventListener('click', function(e) {
+                    var tokenMeta = document.querySelector("meta[name='csrf-token']")
+                    if (!tokenMeta) {
+                      alert('Whoops. There was an error. Your vote was not counted. Try refreshing the page.')
+                      return
+                    }
+                    var csrfToken = tokenMeta.getAttribute('content')
+                    var optionId = e.target.dataset.optionId
+                    window.fetch('/poll_votes', {
+                      method: 'POST',
+                      headers: {
+                        'X-CSRF-Token': csrfToken,
+                        'Content-Type': 'application/json',
+                      },
+                      body: JSON.stringify({poll_vote: { poll_option_id: optionId } }),
+                      credentials: 'same-origin',
+                    }).then(function(response){
+                      response.json().then(function(j){displayPollResults(j)})
+                    })
+                  });
+                }
+
+                document.getElementById('showmethemoney-'+json.poll_id).addEventListener('click', function() {
+                  pollId = this.dataset.pollId
+                  window.fetch('/poll_skips', {
+                    method: 'POST',
+                    headers: {
+                      'X-CSRF-Token': csrfToken,
+                      'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify({poll_skip: {poll_id: pollId }}),
+                    credentials: 'same-origin',
+                  }).then(function(response){
+                    response.json().then(function(j){displayPollResults(j)})
+                  })
+                });
+              }
+            }
+          )
+        })
+      }
+    } else {
+        var els = document.getElementsByClassName('ltag-poll')
+        for (i = 0; i < els.length; i += 1) {
+          els[i].onclick = function(e) {
+            if (typeof showModal !== "undefined") {
+              showModal('poll');
+            }
+          }
+        }
+    }
+  JAVASCRIPT
+
   def initialize(_tag_name, id_code, _tokens)
     @poll = Poll.find(id_code)
   end
@@ -21,100 +115,7 @@ class PollTag < LiquidTagBase
   end
 
   def self.script
-    <<~JAVASCRIPT
-        if (document.head.querySelector(
-          'meta[name="user-signed-in"][content="true"]',
-        )) {
-
-          function displayPollResults(json) {
-            var totalVotes = json.voting_data.votes_count;
-            json.voting_data.votes_distribution.forEach(function(point) {
-              var pollOptionItem = document.getElementById('poll_option_list_item_'+point[0]);
-              var optionText = document.getElementById('poll_option_label_'+point[0]).textContent;
-              if (json.user_vote_poll_option_id === point[0]) {
-                var votedClass = 'optionvotedfor'
-              } else {
-                var votedClass = 'optionnotvotedfor'
-              }
-              if (totalVotes === 0) {
-                var percent = 0;
-              } else {
-                var percent = (point[1]/totalVotes)*100;
-              }
-              var roundedPercent = Math.round( percent * 10 ) / 10
-              var percentFromRight = (100-roundedPercent)
-              var html = '<span><span class="ltag-votepercent ltag-'+votedClass+'" style="right:'+percentFromRight+'%"></span>\
-                <span class="ltag-votepercenttext">'+optionText+' — '+roundedPercent+'%</span></span>';
-              pollOptionItem.innerHTML = html;
-              pollOptionItem.classList.add('already-voted')
-              document.getElementById('showmethemoney-'+json.poll_id).innerHTML = '<span class="ltag-voting-results-count">'+totalVotes+' total votes</span>';
-            })
-          }
-
-          var polls = document.getElementsByClassName('ltag-poll');
-          for (i = 0; i < polls.length; i += 1) {
-            var poll = polls[i]
-            var pollId = poll.dataset.pollId
-            window.fetch('/poll_votes/'+pollId)
-            .then(function(response){
-              response.json().then(
-                function(json){
-                  if (json.voted) {
-                    displayPollResults(json)
-                  } else {
-                    var els = document.getElementById('poll_'+json.poll_id).getElementsByClassName('ltag-polloption')
-                    for (i = 0; i < els.length; i += 1) {
-                      els[i].addEventListener('click', function(e) {
-                        var tokenMeta = document.querySelector("meta[name='csrf-token']")
-                        if (!tokenMeta) {
-                          alert('Whoops. There was an error. Your vote was not counted. Try refreshing the page.')
-                          return
-                        }
-                        var csrfToken = tokenMeta.getAttribute('content')
-                        var optionId = e.target.dataset.optionId
-                        window.fetch('/poll_votes', {
-                          method: 'POST',
-                          headers: {
-                            'X-CSRF-Token': csrfToken,
-                            'Content-Type': 'application/json',
-                          },
-                          body: JSON.stringify({poll_vote: { poll_option_id: optionId } }),
-                          credentials: 'same-origin',
-                        }).then(function(response){
-                          response.json().then(function(j){displayPollResults(j)})
-                        })
-                      });
-                    }
-                    document.getElementById('showmethemoney-'+json.poll_id).addEventListener('click', function(e) {
-                      pollId = this.dataset.pollId
-                      window.fetch('/poll_skips', {
-                        method: 'POST',
-                        headers: {
-                          'X-CSRF-Token': csrfToken,
-                          'Content-Type': 'application/json',
-                        },
-                        body: JSON.stringify({poll_skip: {poll_id: pollId }}),
-                        credentials: 'same-origin',
-                      }).then(function(response){
-                        response.json().then(function(j){displayPollResults(j)})
-                      })
-                    });
-                  }
-                }
-              )
-            })
-          }
-        } else {
-          var els = document.getElementsByClassName('ltag-poll')
-          for (i = 0; i < els.length; i += 1) {
-            els[i].onclick = function(e) {
-              if (typeof showModal !== "undefined") {
-                showModal('poll');
-              }
-            }
-          }
-      }
-    JAVASCRIPT
+    SCRIPT
   end
 end
 

--- a/app/liquid_tags/tweet_tag.rb
+++ b/app/liquid_tags/tweet_tag.rb
@@ -3,6 +3,28 @@ class TweetTag < LiquidTagBase
   PARTIAL = "liquids/tweet".freeze
   ID_REGEXP = /\A\d{10,20}\z/.freeze # id must be all numbers between 10 and 20 chars
 
+  SCRIPT = <<~JAVASCRIPT.freeze
+    var videoPreviews = document.getElementsByClassName("ltag__twitter-tweet__media__video-wrapper");
+    [].forEach.call(videoPreviews, function(el) {
+      el.onclick = function(e) {
+        var divHeight = el.offsetHeight;
+        el.style.maxHeight = divHeight + "px";
+        el.getElementsByClassName("ltag__twitter-tweet__media--video-preview")[0].style.display = "none";
+        el.getElementsByClassName("ltag__twitter-tweet__video")[0].style.display = "block";
+        el.getElementsByTagName("video")[0].play();
+      }
+    });
+    var tweets = document.getElementsByClassName("ltag__twitter-tweet__main");
+    [].forEach.call(tweets, function(tweet){
+      tweet.onclick = function(e) {
+        if (e.target.nodeName == "A" || e.target.parentElement.nodeName == "A") {
+          return;
+        }
+        window.open(tweet.dataset.url,"_blank");
+      }
+    });
+  JAVASCRIPT
+
   def initialize(tag_name, id, tokens)
     super
     @id = parse_id(id)
@@ -22,27 +44,7 @@ class TweetTag < LiquidTagBase
   end
 
   def self.script
-    "".html_safe +
-      'var videoPreviews = document.getElementsByClassName("ltag__twitter-tweet__media__video-wrapper");
-        [].forEach.call(videoPreviews, function(el){
-          el.onclick= function(e){
-            var divHeight = el.offsetHeight;
-            el.style.maxHeight = divHeight + "px";
-            el.getElementsByClassName("ltag__twitter-tweet__media--video-preview")[0].style.display = "none";
-            el.getElementsByClassName("ltag__twitter-tweet__video")[0].style.display = "block";
-            el.getElementsByTagName("video")[0].play();
-          }
-        })
-        var tweets = document.getElementsByClassName("ltag__twitter-tweet__main");
-        [].forEach.call(tweets, function(tweet){
-          tweet.onclick= function(e){
-            if (e.target.nodeName == "A" || e.target.parentElement.nodeName == "A"){
-              return;
-            }
-            window.open(tweet.dataset.url,"_blank");
-          }
-        });
-        '
+    SCRIPT
   end
 
   private

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -220,12 +220,11 @@
 
 <% cache("article-show-scripts", expires_in: 8.hours) do %>
   <script async>
-    <%= TweetTag.script.html_safe %>
-    <%= YoutubeTag.script.html_safe %>
+    <%# we consider these script safe for embedding as they come from our code %>
     <%= PodcastTag.script.html_safe %>
-    <%= GistTag.script.html_safe %>
-    <%= RunkitTag.script.html_safe %>
     <%= PollTag.script.html_safe %>
+    <%= RunkitTag.script.html_safe %>
+    <%= TweetTag.script.html_safe %>
   </script>
 <% end %>
 

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -220,7 +220,7 @@
 
 <% cache("article-show-scripts", expires_in: 8.hours) do %>
   <script async>
-    <%# we consider these script safe for embedding as they come from our code %>
+    <%# we consider these scripts safe for embedding as they come from our code %>
     <%= PodcastTag.script.html_safe %>
     <%= PollTag.script.html_safe %>
     <%= RunkitTag.script.html_safe %>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

With #6422 we accidentally broke some liquid tags rendering in articles, mainly those that have JavaScript to run.

I took the opportunity to put the JS in a frozen constant as well.

## Related Tickets & Documents

Closes https://github.com/thepracticaldev/dev.to/issues/6460
Closes https://github.com/thepracticaldev/dev.to/issues/6485

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

**before**

![Screenshot_2020-03-05 test runkit](https://user-images.githubusercontent.com/146201/75968059-1614f400-5ecd-11ea-92bf-786a3f201278.png)

**after**

![Screenshot_2020-03-05 runkit article - DEV(local) Community 👩‍💻👨‍💻](https://user-images.githubusercontent.com/146201/75968076-1d3c0200-5ecd-11ea-8493-0d4d272f647f.png)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
