### PR TITLE
Remove Shipping Fields from Users

### DIFF
--- a/app/labor/mailchimp_bot.rb
+++ b/app/labor/mailchimp_bot.rb
@@ -32,10 +32,7 @@ class MailchimpBot
             ARTICLES: user.articles.size,
             COMMENTS: user.comments.size,
             ONBOARD_PK: user.onboarding_package_requested.to_s,
-            EXPERIENCE: user.experience_level || 666,
-            COUNTRY: user.shipping_country.to_s,
-            STATE: user.shipping_state.to_s,
-            POSTAL_ZIP: user.shipping_postal_code.to_s
+            EXPERIENCE: user.experience_level || 666
           }
         },
       )

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -138,9 +138,6 @@ class User < ApplicationRecord
   validates :config_navbar,
             inclusion: { in: %w[default static],
                          message: "%<value>s is not a valid navbar value" }
-  validates :shipping_country,
-            length: { in: 2..2 },
-            allow_blank: true
   validates :website_url, :employer_name, :employer_url,
             length: { maximum: 100 }
   validates :employment_title, :education, :location,

--- a/db/migrate/20200304220534_remove_user_shipping_fields.rb
+++ b/db/migrate/20200304220534_remove_user_shipping_fields.rb
@@ -1,0 +1,14 @@
+class RemoveUserShippingFields < ActiveRecord::Migration[5.2]
+  def change
+    safety_assured {
+      remove_column :users, :shipping_name, :string
+      remove_column :users, :shipping_company, :string
+      remove_column :users, :shipping_address, :string
+      remove_column :users, :shipping_address_line_2, :string
+      remove_column :users, :shipping_city, :string
+      remove_column :users, :shipping_state, :string
+      remove_column :users, :shipping_country, :string
+      remove_column :users, :shipping_postal_code, :string
+    }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_04_164719) do
+ActiveRecord::Schema.define(version: 2020_03_04_220534) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1223,14 +1223,6 @@ ActiveRecord::Schema.define(version: 2020_03_04_164719) do
     t.boolean "saw_onboarding", default: true
     t.integer "score", default: 0
     t.string "secret"
-    t.string "shipping_address"
-    t.string "shipping_address_line_2"
-    t.string "shipping_city"
-    t.string "shipping_company"
-    t.string "shipping_country"
-    t.string "shipping_name"
-    t.string "shipping_postal_code"
-    t.string "shipping_state"
     t.boolean "shipping_validated", default: false
     t.datetime "shipping_validated_at"
     t.string "shirt_gender"

--- a/spec/labor/mailchimp_bot_spec.rb
+++ b/spec/labor/mailchimp_bot_spec.rb
@@ -47,10 +47,7 @@ RSpec.describe MailchimpBot, type: :labor do
           ARTICLES: user.articles.size,
           COMMENTS: user.comments.size,
           ONBOARD_PK: user.onboarding_package_requested.to_s,
-          EXPERIENCE: user.experience_level || 666,
-          COUNTRY: user.shipping_country.to_s,
-          STATE: user.shipping_state.to_s,
-          POSTAL_ZIP: user.shipping_postal_code.to_s
+          EXPERIENCE: user.experience_level || 666
         }
       }
     }


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
Per [discussion on](https://github.com/thepracticaldev/dev.to/pull/6461#discussion_r387957319) #6461, we have some sensitive information columns that we are no longer using. Rather than trying to shield them via a second schema, let's just remove them altogether. 
 
## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media.giphy.com/media/1qaUQO7L5YkxEiyZna/giphy.gif)
