### PR TITLE
Comments API: hide deleted and hidden comments (plus docs)

### DIFF
--- a/app/controllers/api/v0/comments_controller.rb
+++ b/app/controllers/api/v0/comments_controller.rb
@@ -27,7 +27,9 @@ module Api
         set_surrogate_key_header Comment.table_key, edge_cache_keys(tree_with_root_comment)
       end
 
-      ATTRIBUTES_FOR_SERIALIZATION = %i[id processed_html user_id ancestry].freeze
+      ATTRIBUTES_FOR_SERIALIZATION = %i[
+        id processed_html user_id ancestry deleted hidden_by_commentable_user
+      ].freeze
       private_constant :ATTRIBUTES_FOR_SERIALIZATION
 
       private

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,8 +1,12 @@
 class Comment < ApplicationRecord
+  TITLE_DELETED = "[deleted]".freeze
+  TITLE_HIDDEN = "[hidden by post author]".freeze
+
   has_ancestry
   resourcify
   include AlgoliaSearch
   include Reactable
+
   belongs_to :commentable, polymorphic: true, optional: true
   counter_culture :commentable
   belongs_to :user
@@ -152,8 +156,8 @@ class Comment < ApplicationRecord
   end
 
   def title(length = 80)
-    return "[deleted]" if deleted
-    return "[hidden by post author]" if hidden_by_commentable_user
+    return TITLE_DELETED if deleted
+    return TITLE_HIDDEN if hidden_by_commentable_user
 
     text = ActionController::Base.helpers.strip_tags(processed_html).strip
     truncated_text = ActionController::Base.helpers.truncate(text, length: length).gsub("&#39;", "'").gsub("&amp;", "&")

--- a/app/views/api/v0/comments/_comment.json.jbuilder
+++ b/app/views/api/v0/comments/_comment.json.jbuilder
@@ -1,6 +1,13 @@
-json.type_of    "comment"
+json.type_of "comment"
+json.id_code comment.id_code_generated
 
-json.id_code    comment.id_code_generated
-json.body_html  comment.processed_html
-
-json.partial! "api/v0/shared/user", user: comment.user
+if comment.deleted?
+  json.body_html "<p>[deleted]</p>"
+  json.set! :user, {}
+elsif comment.hidden_by_commentable_user?
+  json.body_html "<p>[hidden by post author]</p>"
+  json.set! :user, {}
+else
+  json.body_html comment.processed_html
+  json.partial! "api/v0/shared/user", user: comment.user
+end

--- a/app/views/api/v0/comments/_comment.json.jbuilder
+++ b/app/views/api/v0/comments/_comment.json.jbuilder
@@ -2,10 +2,10 @@ json.type_of "comment"
 json.id_code comment.id_code_generated
 
 if comment.deleted?
-  json.body_html "<p>[deleted]</p>"
+  json.body_html "<p>#{Comment::TITLE_DELETED}</p>"
   json.set! :user, {}
 elsif comment.hidden_by_commentable_user?
-  json.body_html "<p>[hidden by post author]</p>"
+  json.body_html "<p>#{Comment::TITLE_HIDDEN}</p>"
   json.set! :user, {}
 else
   json.body_html comment.processed_html

--- a/docs/api_v0.yml
+++ b/docs/api_v0.yml
@@ -485,6 +485,29 @@ components:
           description: Text color (hexadecimal)
           type: string
 
+    Comment:
+      type: object
+      required:
+        - type_of
+        - id_code
+        - body_html
+        - user
+        - children
+      properties:
+        type_of:
+          type: string
+        id_code:
+          type: string
+        body_html:
+          description: HTML formatted comment
+          type: string
+        user:
+          $ref: "#/components/schemas/SharedUser"
+        children:
+          type: array
+          items:
+            $ref: "#/components/schemas/Comment"
+
     Listing:
       type: object
       required:
@@ -588,6 +611,7 @@ components:
               description: Set it to "draft" to create an unpublished listing
               type: string
               enum: [draft]
+
     ListingUpdate:
       type: object
       properties:
@@ -641,7 +665,6 @@ components:
                 It will take priority on any other param in the payload.
               type: string
               enum: [bump, publish, unpublish]
-
 
     SharedUser:
       description: The resource creator
@@ -707,6 +730,30 @@ components:
               items:
                 type: string
 
+    WebhookIndex:
+      description: Webhook
+      type: object
+      properties:
+        type_of:
+          type: string
+        id:
+          type: integer
+          format: int64
+        source:
+          description: The name of the requester, eg. "DEV"
+          type: string
+        target_url:
+          type: string
+          format: url
+        events:
+          description: An array of events identifiers
+          type: array
+          items:
+            type: string
+        created_at:
+          type: string
+          format: date-time
+
     WebhookShow:
       description: Webhook
       type: object
@@ -732,30 +779,6 @@ components:
           format: date-time
         user:
           $ref: "#/components/schemas/SharedUser"
-
-    WebhookIndex:
-      description: Webhook
-      type: object
-      properties:
-        type_of:
-          type: string
-        id:
-          type: integer
-          format: int64
-        source:
-          description: The name of the requester, eg. "DEV"
-          type: string
-        target_url:
-          type: string
-          format: url
-        events:
-          description: An array of events identifiers
-          type: array
-          items:
-            type: string
-        created_at:
-          type: string
-          format: date-time
 
   examples:
     ErrorBadRequest:
@@ -909,6 +932,113 @@ components:
           series: Hello series
           canonical_url: https://example.com/blog/hello
           organization_id: 1234
+
+    Comments:
+      value:
+        - type_of: comment
+          id_code: m3m0
+          body_html: |
+            <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+            <html><body>
+            <p>...</p>
+
+            </body></html>
+          user:
+            name: Heriberto Morissette
+            username: heriberto_morissette
+            twitter_username:
+            github_username:
+            website_url:
+            profile_image: https://res.cloudinary.com/...jpeg
+            profile_image_90: https://res.cloudinary.com/...jpeg
+          children: []
+        - type_of: comment
+          id_code: m357
+          body_html: |
+            <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+            <html><body>
+            <p>...</p>
+
+            <p>...</p>
+
+            </body></html>
+          user:
+            name: Dario Waelchi
+            username: dario waelchi
+            twitter_username:
+            github_username:
+            website_url:
+            profile_image: https://res.cloudinary.com/...png
+            profile_image_90: https://res.cloudinary.com/...png
+          children:
+          - type_of: comment
+            id_code: m35m
+            body_html: |
+              <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+              <html><body>
+
+              <p>...</p>
+
+              </body></html>
+            user:
+              name: rhymes
+              username: rhymes
+              twitter_username:
+              github_username:
+              website_url:
+              profile_image: https://res.cloudinary.com/...jpeg
+              profile_image_90: https://res.cloudinary.com/practicaldev/image/fetch/s--SC90PuMi--/c_fill,f_auto,fl_progressive,h_90,q_auto,w_90/https://dev-to-uploads.s3.amazonaws.com/uploads/user/profile_image/2693/146201.jpeg
+            children: []
+    CommentsDeleted:
+      value:
+        - type_of: comment
+          id_code: m357
+          body_html: <p>[deleted]</p>
+          user: {}
+          children:
+          - type_of: comment
+            id_code: m35m
+            body_html: |
+              <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+              <html><body>
+
+              <p>...</p>
+
+              </body></html>
+            user:
+              name: rhymes
+              username: rhymes
+              twitter_username:
+              github_username:
+              website_url:
+              profile_image: https://res.cloudinary.com/...jpeg
+              profile_image_90: https://res.cloudinary.com/practicaldev/image/fetch/s--SC90PuMi--/c_fill,f_auto,fl_progressive,h_90,q_auto,w_90/https://dev-to-uploads.s3.amazonaws.com/uploads/user/profile_image/2693/146201.jpeg
+            children: []
+    CommentsHidden:
+      value:
+        - type_of: comment
+          id_code: m357
+          body_html: <p>[hidden by post author]</p>
+          user: {}
+          children:
+          - type_of: comment
+            id_code: m35m
+            body_html: |
+              <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+              <html><body>
+
+              <p>...</p>
+
+              </body></html>
+            user:
+              name: rhymes
+              username: rhymes
+              twitter_username:
+              github_username:
+              website_url:
+              profile_image: https://res.cloudinary.com/...jpeg
+              profile_image_90: https://res.cloudinary.com/practicaldev/image/fetch/s--SC90PuMi--/c_fill,f_auto,fl_progressive,h_90,q_auto,w_90/https://dev-to-uploads.s3.amazonaws.com/uploads/user/profile_image/2693/146201.jpeg
+            children: []
 
     Listings:
       value:
@@ -1626,10 +1756,14 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/CommentsIndex"
+                  $ref: "#/components/schemas/Comment"
               examples:
-                articles-success:
-                  $ref: "#/components/examples/CommentsIndex"
+                comments-success:
+                  $ref: "#/components/examples/Comments"
+                comments-success-deleted:
+                  $ref: "#/components/examples/CommentsDeleted"
+                comments-success-hidden:
+                  $ref: "#/components/examples/CommentsHidden"
       x-code-samples: # https://github.com/Redocly/redoc/blob/master/docs/redoc-vendor-extensions.md#x-code-samples
         - lang: Shell
           label: curl (all comments of an article)

--- a/docs/api_v0.yml
+++ b/docs/api_v0.yml
@@ -1039,6 +1039,95 @@ components:
               profile_image: https://res.cloudinary.com/...jpeg
               profile_image_90: https://res.cloudinary.com/practicaldev/image/fetch/s--SC90PuMi--/c_fill,f_auto,fl_progressive,h_90,q_auto,w_90/https://dev-to-uploads.s3.amazonaws.com/uploads/user/profile_image/2693/146201.jpeg
             children: []
+    Comment:
+      value:
+        type_of: comment
+        id_code: m357
+        body_html: |
+          <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+          <html><body>
+          <p>...</p>
+
+          <p>...</p>
+
+          </body></html>
+        user:
+          name: Dario Waelchi
+          username: dario waelchi
+          twitter_username:
+          github_username:
+          website_url:
+          profile_image: https://res.cloudinary.com/...png
+          profile_image_90: https://res.cloudinary.com/...png
+        children:
+        - type_of: comment
+          id_code: m35m
+          body_html: |
+            <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+            <html><body>
+
+            <p>...</p>
+
+            </body></html>
+          user:
+            name: rhymes
+            username: rhymes
+            twitter_username:
+            github_username:
+            website_url:
+            profile_image: https://res.cloudinary.com/...jpeg
+            profile_image_90: https://res.cloudinary.com/....jpeg
+          children: []
+    CommentDeleted:
+      value:
+        type_of: comment
+        id_code: m357
+        body_html: <p>[deleted]</p>
+        user: {}
+        children:
+        - type_of: comment
+          id_code: m35m
+          body_html: |
+            <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+            <html><body>
+
+            <p>...</p>
+
+            </body></html>
+          user:
+            name: rhymes
+            username: rhymes
+            twitter_username:
+            github_username:
+            website_url:
+            profile_image: https://res.cloudinary.com/...jpeg
+            profile_image_90: https://res.cloudinary.com/...jpeg
+          children: []
+    CommentHidden:
+      value:
+        type_of: comment
+        id_code: m357
+        body_html: <p>[hidden by post author]</p>
+        user: {}
+        children:
+        - type_of: comment
+          id_code: m35m
+          body_html: |
+            <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+            <html><body>
+
+            <p>...</p>
+
+            </body></html>
+          user:
+            name: rhymes
+            username: rhymes
+            twitter_username:
+            github_username:
+            website_url:
+            profile_image: https://res.cloudinary.com/...jpeg
+            profile_image_90: https://res.cloudinary.com/...jpeg
+          children: []
 
     Listings:
       value:
@@ -1730,7 +1819,7 @@ paths:
 
   /comments:
     get:
-      operationId: getComments
+      operationId: getCommentsByArticleId
       summary: Comments
       description: |
         This endpoint allows the client to retrieve all comments belonging to an
@@ -1764,12 +1853,71 @@ paths:
                   $ref: "#/components/examples/CommentsDeleted"
                 comments-success-hidden:
                   $ref: "#/components/examples/CommentsHidden"
+        404:
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/APIError"
+              examples:
+                article-not-found:
+                  $ref: "#/components/examples/ErrorNotFound"
       x-code-samples: # https://github.com/Redocly/redoc/blob/master/docs/redoc-vendor-extensions.md#x-code-samples
         - lang: Shell
           label: curl (all comments of an article)
           source: |
             curl https://dev.to/api/comments?a_id=270180
 
+  /comments/{id}:
+    get:
+      operationId: getCommentById
+      summary: Comment
+      description: |
+        This endpoint allows the client to retrieve a comment as well as his
+        descendants comments.
+
+        It will return the required comment (the root) with its nested
+        descendants as a thread.
+
+        See the format specification for further details.
+      tags:
+        - comments
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Comment identifier.
+          schema:
+            type: string
+          example: m35m
+      responses:
+        200:
+          description: A comment and its descendants
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Comment"
+              examples:
+                comment-success:
+                  $ref: "#/components/examples/Comment"
+                comments-success-deleted:
+                  $ref: "#/components/examples/CommentDeleted"
+                comments-success-hidden:
+                  $ref: "#/components/examples/CommentHidden"
+        404:
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/APIError"
+              examples:
+                article-not-found:
+                  $ref: "#/components/examples/ErrorNotFound"
+      x-code-samples: # https://github.com/Redocly/redoc/blob/master/docs/redoc-vendor-extensions.md#x-code-samples
+        - lang: Shell
+          label: curl (a comment and its descendants)
+          source: |
+            curl https://dev.to/api/comments/m51e
 
   /listings:
     get:

--- a/docs/api_v0.yml
+++ b/docs/api_v0.yml
@@ -8,7 +8,7 @@ info:
 
     Dates and date times, unless otherwise specified, must be in
     the [RFC 3339](https://tools.ietf.org/html/rfc3339) format.
-  version: "0.6.2"
+  version: "0.6.3"
   termsOfService: https://dev.to/terms
   contact:
     name: DEV Team
@@ -62,6 +62,7 @@ components:
           tokenUrl: https://dev.to/oauth/token
           refreshUrl: https://dev.to/oauth/token
           scopes: {}
+
   schemas:
     APIError:
       type: object
@@ -1026,6 +1027,8 @@ components:
 tags:
   - name: articles
     description: Articles are all the posts users create on DEV
+  - name: comments
+    description: Users can leave comments to articles and podcasts episodes
   - name: listings
     description: Listings are classified ads
   - name: users
@@ -1594,6 +1597,45 @@ paths:
           label: curl
           source: |
             curl -H "api-key: API_KEY" https://dev.to/api/articles/me/all
+
+  /comments:
+    get:
+      operationId: getComments
+      summary: Comments
+      description: |
+        This endpoint allows the client to retrieve all comments belonging to an
+        article as threaded conversations.
+
+        It will return the all top level comments with their nested comments as
+        threads. See the format specification for further details.
+      tags:
+        - comments
+      parameters:
+        - name: a_id
+          in: query
+          description: Article identifier.
+          schema:
+            type: integer
+            format: int32
+          example: 270180
+      responses:
+        200:
+          description: A list of threads of comments
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/CommentsIndex"
+              examples:
+                articles-success:
+                  $ref: "#/components/examples/CommentsIndex"
+      x-code-samples: # https://github.com/Redocly/redoc/blob/master/docs/redoc-vendor-extensions.md#x-code-samples
+        - lang: Shell
+          label: curl (all comments of an article)
+          source: |
+            curl https://dev.to/api/comments?a_id=270180
+
 
   /listings:
     get:

--- a/spec/requests/api/v0/comments_spec.rb
+++ b/spec/requests/api/v0/comments_spec.rb
@@ -1,10 +1,6 @@
 require "rails_helper"
 
 RSpec.describe "Api::V0::Comments", type: :request do
-  def json_response
-    JSON.parse(response.body)
-  end
-
   let_it_be(:article) { create(:article) }
   let_it_be(:root_comment) { create(:comment, commentable: article) }
   let_it_be(:child_comment) { create(:comment, commentable: article, parent: root_comment) }
@@ -13,38 +9,43 @@ RSpec.describe "Api::V0::Comments", type: :request do
 
   describe "GET /api/comments" do
     it "returns not found if wrong article id" do
-      get "/api/comments?a_id=gobbledygook"
+      get api_comments_path(a_id: "gobbledygook")
+
       expect(response).to have_http_status(:not_found)
     end
 
     it "returns comments for article" do
-      get "/api/comments?a_id=#{article.id}"
-      expect(json_response.size).to eq(1)
+      get api_comments_path(a_id: article.id)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body.size).to eq(1)
     end
 
     it "does not include children comments in the root list" do
-      get "/api/comments?a_id=#{article.id}"
+      get api_comments_path(a_id: article.id)
+
       expected_ids = article.comments.roots.map(&:id_code_generated)
-      expect(json_response.map { |cm| cm["id_code"] }).to match_array(expected_ids)
+      expect(response.parsed_body.map { |cm| cm["id_code"] }).to match_array(expected_ids)
     end
 
     it "includes children comments in the children list" do
-      get "/api/comments?a_id=#{article.id}"
-      comment_with_children = json_response.detect { |cm| cm["id_code"] == root_comment.id_code_generated }
+      get api_comments_path(a_id: article.id)
+
+      comment_with_children = response.parsed_body.detect { |cm| cm["id_code"] == root_comment.id_code_generated }
       expect(comment_with_children["children"][0]["id_code"]).to eq(child_comment.id_code_generated)
     end
 
     it "includes grandchildren comments in the children-children list" do
-      get "/api/comments?a_id=#{article.id}"
+      get api_comments_path(a_id: article.id)
 
-      comment_with_descendants = json_response.detect { |cm| cm["id_code"] == root_comment.id_code_generated }
+      comment_with_descendants = response.parsed_body.detect { |cm| cm["id_code"] == root_comment.id_code_generated }
       expect(comment_with_descendants["children"][0]["children"][0]["id_code"]).to eq(grandchild_comment.id_code_generated)
     end
 
     it "includes great-grandchildren comments in the children-children-children list" do
-      get "/api/comments?a_id=#{article.id}"
+      get api_comments_path(a_id: article.id)
 
-      comment_with_descendants = json_response.detect { |cm| cm["id_code"] == root_comment.id_code_generated }
+      comment_with_descendants = response.parsed_body.detect { |cm| cm["id_code"] == root_comment.id_code_generated }
       json_great_grandchild_id_code = comment_with_descendants["children"][0]["children"][0]["children"][0]["id_code"]
       expect(json_great_grandchild_id_code).to eq(great_grandchild_comment.id_code_generated)
     end
@@ -52,7 +53,7 @@ RSpec.describe "Api::V0::Comments", type: :request do
     it "sets the correct edge caching surrogate key for all the comments" do
       sibling_root_comment = create(:comment, commentable: article)
 
-      get "/api/comments?a_id=#{article.id}"
+      get api_comments_path(a_id: article.id)
 
       expected_key = [
         article.record_key, "comments", sibling_root_comment.record_key,
@@ -71,27 +72,27 @@ RSpec.describe "Api::V0::Comments", type: :request do
 
     it "returns the comment" do
       get "/api/comments/#{root_comment.id_code_generated}"
-      expect(json_response["id_code"]).to eq(root_comment.id_code_generated)
+      expect(response.parsed_body["id_code"]).to eq(root_comment.id_code_generated)
     end
 
     it "includes children comments in the children list" do
       get "/api/comments/#{root_comment.id_code_generated}"
 
-      comment_with_children = json_response
+      comment_with_children = response.parsed_body
       expect(comment_with_children["children"][0]["id_code"]).to eq(child_comment.id_code_generated)
     end
 
     it "includes grandchildren comments in the children-children list" do
       get "/api/comments/#{root_comment.id_code_generated}"
 
-      comment_with_descendants = json_response
+      comment_with_descendants = response.parsed_body
       expect(comment_with_descendants["children"][0]["children"][0]["id_code"]).to eq(grandchild_comment.id_code_generated)
     end
 
     it "includes great-grandchildren comments in the children-children-children list" do
       get "/api/comments/#{root_comment.id_code_generated}"
 
-      comment_with_descendants = json_response
+      comment_with_descendants = response.parsed_body
       json_great_grandchild_id_code = comment_with_descendants["children"][0]["children"][0]["children"][0]["id_code"]
       expect(json_great_grandchild_id_code).to eq(great_grandchild_comment.id_code_generated)
     end

--- a/spec/requests/api/v0/comments_spec.rb
+++ b/spec/requests/api/v0/comments_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe "Api::V0::Comments", type: :request do
       it "replaces the body_html" do
         get api_comments_path(a_id: article.id)
 
-        expect(find_child_comment(response)["body_html"]).to eq("<p>[deleted]</p>")
+        expect(find_child_comment(response)["body_html"]).to eq("<p>#{Comment::TITLE_DELETED}</p>")
       end
 
       it "does not render the user information" do
@@ -141,7 +141,7 @@ RSpec.describe "Api::V0::Comments", type: :request do
       it "replaces the body_html" do
         get api_comments_path(a_id: article.id)
 
-        expect(find_child_comment(response)["body_html"]).to eq("<p>[hidden by post author]</p>")
+        expect(find_child_comment(response)["body_html"]).to eq("<p>#{Comment::TITLE_HIDDEN}</p>")
       end
 
       it "does not render the user information" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

This PR contains the following two fixes:

- deleted comments will appear like this in the tree of comments

```json
{
    "type_of": "comment",
    "id_code": "16",
    "body_html": "<p>[deleted]</p>",
    "user": {},
    "children": [{}, {}]
 }
```

- hidden comments will appear like this in the tree of comments

```json
{
    "type_of": "comment",
    "id_code": "16",
    "body_html": "<p>[hidden by post author]</p>",
    "user": {},
    "children": [{}, {}]
 }
```

I used the same text we use for the website. Their children comments won't be hidden or deleted, the logic checks each single comment to see if it shouldn't appear in full, like the website does.

I also added the comments API to the documentation.

## Related Tickets & Documents

#4474 at least regarding documentation

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [x] docs.dev.to
- [ ] readme
- [ ] no documentation needed
