### PR TITLE
Add a mascot_user_id to SiteConfig

### DIFF
--- a/app/controllers/internal/configs_controller.rb
+++ b/app/controllers/internal/configs_controller.rb
@@ -20,7 +20,7 @@ class Internal::ConfigsController < Internal::ApplicationController
 
   def config_params
     allowed_params = %i[
-      default_site_email social_networks_handle
+      default_site_email social_networks_handle mascot_user_id
       campaign_hero_html_variant_name campaign_background_color
       campaign_text_color campaign_sidebar_enabled campaign_featured_tags
       campaign_sidebar_image

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -13,6 +13,9 @@ class SiteConfig < RailsSettings::Base
   field :default_site_email, type: :string, default: "yo@dev.to"
   field :social_networks_handle, type: :string, default: "thepracticaldev"
 
+  # mascot account
+  field :mascot_user_id, type: :integer, default: 1
+
   # campaign
   field :campaign_hero_html_variant_name, type: :string, default: ""
   field :campaign_background_color, type: :string, default: "FFFFFF"

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -46,6 +46,21 @@
         </div>
 
         <div class="card mt-3">
+          <div class="card-header">Mascot</div>
+          <div class="card-body">
+            <div class="form-group">
+              <%= f.label :mascot_user_id, "Mascot user ID" %>
+              <%= f.text_field :mascot_user_id,
+                               class: "form-control",
+                               value: SiteConfig.mascot_user_id,
+                               min: 1,
+                               placeholder: "1" %>
+              <div class="alert alert-info">User ID of the Mascot account</div>
+            </div>
+          </div>
+        </div>
+
+        <div class="card mt-3">
           <div class="card-header">Campaign</div>
           <div class="card-body">
             <div class="form-group">

--- a/spec/requests/internal/configs_spec.rb
+++ b/spec/requests/internal/configs_spec.rb
@@ -61,6 +61,14 @@ RSpec.describe "/internal/config", type: :request do
         end
       end
 
+      describe "mascot" do
+        it "updates the mascot_user_id" do
+          expected_mascot_user_id = 2
+          post "/internal/config", params: { site_config: { mascot_user_id: expected_mascot_user_id }, confirmation: confirmation_message }
+          expect(SiteConfig.mascot_user_id).to eq(expected_mascot_user_id)
+        end
+      end
+
       describe "images" do
         it "updates main_social_image" do
           expected_image_url = "https://dummyimage.com/300x300"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR extracts work that was already being done in #5419, and adds a `mascot_user_id` to the `SiteConfig`. In a separate PR, we will replaced the WELCOMING_USER_ID, introduced in #6045, with this value from the SiteConfig.

I paired with @juliannatetreault on this!

## Related Tickets & Documents

#5419

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
Adds this to the `/internal/config` page:
<img width="845" alt="Screen Shot 2020-03-05 at 10 12 11 AM" src="https://user-images.githubusercontent.com/6921610/76016809-5b87f000-5ed2-11ea-950b-8f4a727b1ce6.png">


## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## Are there any post deployment tasks we need to perform?

I will need someone with super duper admin privileges to set the `mascot_user_id` to the current `staff_user_id`! Eventually, we'll set the `mascot_user_id` to Sloan's account, but for now, we need to set it to the practicaldev account!
