### PR TITLE
Use mascot_account in place of welcoming_account

### DIFF
--- a/Envfile
+++ b/Envfile
@@ -165,7 +165,6 @@ variable :STACK_EXCHANGE_APP_KEY, :String, default: ""
 
 # For setting the IDs of the staff and welcoming users
 variable :STAFF_USER_ID, :Integer, default: 1
-variable :WELCOMING_USER_ID, :Integer, default: 1
 
 group :production do
   variable :SECRET_KEY_BASE, :String

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -157,7 +157,7 @@ class User < ApplicationRecord
   alias_attribute :positive_reactions_count, :reactions_count
 
   scope :dev_account, -> { find_by(id: SiteConfig.staff_user_id) }
-  scope :welcoming_account, -> { find_by(id: ApplicationConfig["WELCOMING_USER_ID"]) }
+  scope :mascot_account, -> { find_by(id: SiteConfig.mascot_user_id) }
 
   scope :with_this_week_comments, lambda { |number|
     includes(:counters).joins(:counters).where("(user_counters.data -> 'comments_these_7_days')::int >= ?", number)

--- a/app/services/notifications/welcome_notification/send.rb
+++ b/app/services/notifications/welcome_notification/send.rb
@@ -14,9 +14,9 @@ module Notifications
       end
 
       def call
-        welcoming_account = User.welcoming_account
+        mascot_account = User.mascot_account
         json_data = {
-          user: user_data(welcoming_account),
+          user: user_data(mascot_account),
           broadcast: {
             title: welcome_broadcast.title,
             processed_html: welcome_broadcast.processed_html

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -120,8 +120,6 @@ Rails.application.configure do
     enable_starttls_auto: true
   }
 
-  config.welcoming_user_id = ENV["WELCOMING_USER_ID"]
-
   config.middleware.use Rack::HostRedirect,
                         ENV["HEROKU_APP_URL"] => ENV["APP_DOMAIN"]
 end

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -4,13 +4,13 @@ RSpec.describe "NotificationsIndex", type: :request do
   include ActionView::Helpers::DateHelper
 
   let_it_be_readonly(:dev_account) { create(:user) }
-  let_it_be_readonly(:welcoming_account) { create(:user) }
+  let_it_be_readonly(:mascot_account) { create(:user) }
   let_it_be_changeable(:user) { create(:user) }
   let_it_be_changeable(:organization) { create(:organization) }
 
   before do
     allow(User).to receive(:dev_account).and_return(dev_account)
-    allow(User).to receive(:welcoming_account).and_return(welcoming_account)
+    allow(User).to receive(:mascot_account).and_return(mascot_account)
   end
 
   def has_both_names(response_body)

--- a/spec/services/notifications/welcome_notification/send_spec.rb
+++ b/spec/services/notifications/welcome_notification/send_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Notifications::WelcomeNotification::Send, type: :service do
   describe "::call" do
     before do
-      allow(User).to receive(:welcoming_account).and_return(create(:user))
+      allow(User).to receive(:mascot_account).and_return(create(:user))
     end
 
     it "creates a new welcome notification", :aggregate_failures do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

There is actually only [one relevant commit](https://github.com/thepracticaldev/dev.to/commit/78fde37d122142b5c1fbd4ef596fe61e0d23cf17) in this PR, as it branches off of #6483. 

Once #6483 is merged, and once we want have set the `mascot_user_id` on the SiteConfig, we want to use the mascot_user_id when sending out notifications. We also want to remove `WELCOMING_USER_ID`.

**Note: I will rebase on master once #6483 is merged!**

Paired with @juliannatetreault on this!

## Related Tickets & Documents

Branches off of the work in #6483.
Refactors the concept introduced in #6045.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
N/A

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## Are there any post deployment tasks we need to perform?
**⚠️DO NOT merge this until:**
1)~#6483 has been merged and deployed~ DONE
2) An admin has set the `mascot_user_id` in our internal SiteConfig!