### PR TITLE
Fix Spelling for Elasticsearch User Field 

### DIFF
--- a/config/elasticsearch/mappings/users.json
+++ b/config/elasticsearch/mappings/users.json
@@ -4,7 +4,7 @@
     "id": {
       "type": "keyword"
     },
-    "availabe_for": {
+    "available_for": {
       "type": "keyword",
       "copy_to": "search_fields"
     },


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
availabe_for != available_for 🤦‍♀ 

Now I am sure many of you are wondering, but wait! You can't change Elasticsearch mappings so what is going to happen when you call `update_mappings` with this? 
Answer: This will just add a new field to our mappings because we are not trying to change any existing fields. This is what will end up in our index.
```
"properties"=>
      {"availabe_for"=>{"type"=>"keyword", "copy_to"=>["search_fields"]},
       "available_for"=>{"type"=>"keyword", "copy_to"=>["search_fields"]},
```
Besides making my OCD eye twitch having an extra unused single field like this is not a huge deal. There is a teenie tiny amount of overhead at the mapping level bc ES has to track this field but thats it. If you added thousands of unused fields, that is when you can run into problems and what Elasticsearch calls a [mapping explosion](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping.html#mapping-limit-settings). Preventing a mapping explosion is a big reason why we use strict mappings

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media.giphy.com/media/QvLYsJhp5vGr8wl3Ia/giphy.gif)
