### PR TITLE
Show hidden comments on article mod page

### DIFF
--- a/app/controllers/moderations_controller.rb
+++ b/app/controllers/moderations_controller.rb
@@ -23,6 +23,7 @@ class ModerationsController < ApplicationController
     @adjustments = TagAdjustment.where(article_id: @moderatable.id)
     @already_adjusted_tags = @adjustments.map(&:tag_name).join(", ")
     @allowed_to_adjust = @moderatable.class.name == "Article" && (current_user.has_role?(:super_admin) || @tag_moderator_tags.any?)
+    @hidden_comments = @moderatable.comments.where(hidden_by_commentable_user: true)
     render template: "moderations/mod"
   end
 

--- a/app/views/moderations/mod.html.erb
+++ b/app/views/moderations/mod.html.erb
@@ -54,6 +54,20 @@
       This is the equivalent of vomiting on <b>all</b> of this user's articles.
     </p>
   </div>
+  <% if @hidden_comments.present? %>
+    <div class="tag-mod-form">
+      <h2>Hidden Comments</h2>
+      <form>
+        <ul id="hidden-comments">
+        <% @hidden_comments.each do |comment| %>
+          <li>
+            <a href="<%= comment.path %>">Comment by <%= comment.user.username %></a>
+          </li>
+        <% end %>
+        </ul>
+      </form>
+    </div>
+  <% end %>
   <% if @allowed_to_adjust %>
     <div class="tag-mod-form">
       <h2>Tag Adjustments</h2>

--- a/spec/system/articles/moderator_moderates_an_article.rb
+++ b/spec/system/articles/moderator_moderates_an_article.rb
@@ -24,4 +24,12 @@ RSpec.describe "Views an article", type: :system do
     expect(page).to have_selector('button[data-category="vomit"][data-reactable-type="User"]')
     expect(page).to have_selector("button.level-rating-button")
   end
+
+  it "shows hidden comments on /mod" do
+    commentor = create(:user)
+    create(:comment, commentable: article, user: commentor, hidden_by_commentable_user: true)
+    visit "/#{user.username}/#{article.slug}/mod"
+    expect(page).to have_content("Hidden Comments")
+    expect(page).to have_selector("ul#hidden-comments")
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Feature

## Description

This PR adds a list of hidden comments on an article's `/mod` page.

## Related Tickets & Documents

https://github.com/thepracticaldev/tech-private/issues/351

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

<img width="843" alt="Screen Shot 2020-03-06 at 11 11 31" src="https://user-images.githubusercontent.com/47985/76051525-ad497c80-5f9d-11ea-8d72-241ac5988923.png">

## Added tests?

- [X] yes

## Added to documentation?

- [X] no documentation needed
