### PR TITLE
Use cache_key_heroku_slug helper more consistently

### DIFF
--- a/app/views/articles/_sidebar.html.erb
+++ b/app/views/articles/_sidebar.html.erb
@@ -1,7 +1,7 @@
 <div id="sidebar-wrapper-left" class="sidebar-wrapper sidebar-wrapper-left">
   <div class="sidebar-bg" id="sidebar-bg-left"></div>
   <div class="side-bar">
-    <% cache("main-sidebar-nav--#{user_signed_in?}-#{ApplicationConfig['HEROKU_SLUG_COMMIT']}", expires_in: 5.days) do %>
+    <% cache(cache_key_heroku_slug("main-sidebar-nav--#{user_signed_in?}"), expires_in: 5.days) do %>
       <%= render "articles/sidebar_nav" %>
       <div class="widget widget-sponsorship <%= "showing" unless user_signed_in? %>" id="sponsorship-widget">
         <header>

--- a/app/views/feedback_messages/index.html.erb
+++ b/app/views/feedback_messages/index.html.erb
@@ -1,5 +1,5 @@
 <% title "Feedback" %>
-<% cache "feedback-messages-lander-styling-#{ApplicationConfig['HEROKU_SLUG_COMMIT']}" do %>
+<% cache(cache_key_heroku_slug("feedback-messages-lander-styling")) do %>
   <style>
     <%= Rails.application.assets["feedback_messages.css"].to_s.html_safe %>
   </style>

--- a/app/views/moderations/mod.html.erb
+++ b/app/views/moderations/mod.html.erb
@@ -1,6 +1,6 @@
 <% title "[Moderate] " + @moderatable.title %>
 
-<% cache "mod-styling-#{ApplicationConfig['HEROKU_SLUG_COMMIT']}" do %>
+<% cache(cache_key_heroku_slug("mod-styling")) do %>
   <style>
     <%= Rails.application.assets["moderators.css"].to_s.html_safe %>
   </style>

--- a/app/views/pages/live.html.erb
+++ b/app/views/pages/live.html.erb
@@ -20,7 +20,7 @@
 <meta name="twitter:image:src" content="https://thepracticaldev.s3.amazonaws.com/i/bqzj1pwho9e0jicqo44s.png">
 
 <style>
-  <% cache "live-page-css-#{ApplicationConfig['HEROKU_SLUG_COMMIT']}", expires_in: 1.hour do %>
+  <% cache(cache_key_heroku_slug("live-page-css"), expires_in: 1.hour) do %>
   <%= Rails.application.assets["live.css"].to_s.html_safe %>
   <% end %>
 </style>

--- a/app/views/pages/onboarding.html.erb
+++ b/app/views/pages/onboarding.html.erb
@@ -1,7 +1,7 @@
 <% title "Welcome to #{ApplicationConfig['COMMUNITY_NAME']}" %>
 
 <style>
-  <% cache "onboarding-css-#{ApplicationConfig['HEROKU_SLUG_COMMIT']}", expires_in: 10.hours do %>
+  <% cache(cache_key_heroku_slug("onboarding-css"), expires_in: 10.hours) do %>
     <%= Rails.application.assets["onboarding.css"].to_s.html_safe %>
     <%= Rails.application.assets["preact/onboarding-modal.css"].to_s.html_safe %>
   <% end %>

--- a/app/views/partnerships/index.html.erb
+++ b/app/views/partnerships/index.html.erb
@@ -1,7 +1,7 @@
 <% title "Partnerships and Sponsors" %>
 
 <style>
-  <% cache "partnership-org-section-credits-#{ApplicationConfig['HEROKU_SLUG_COMMIT']}", expires_in: 10.hours do %>
+  <% cache(cache_key_heroku_slug("partnership-org-section-credits"), expires_in: 10.hours) do %>
     <%= Rails.application.assets["partnerships.css"].to_s.html_safe %>
   <% end %>
 </style>

--- a/app/views/partnerships/show.html.erb
+++ b/app/views/partnerships/show.html.erb
@@ -1,7 +1,7 @@
 <% title "#{params[:option].titleize} Overview" %>
 
 <style>
-  <% cache "partnership-org-section-credits-#{ApplicationConfig['HEROKU_SLUG_COMMIT']}", expires_in: 10.hours do %>
+  <% cache(cache_key_heroku_slug("partnership-org-section-credits"), expires_in: 10.hours) do %>
     <%= Rails.application.assets["partnerships.css"].to_s.html_safe %>
   <% end %>
 </style>

--- a/app/views/pro_memberships/show.html.erb
+++ b/app/views/pro_memberships/show.html.erb
@@ -1,7 +1,7 @@
 <% title "Pro Membership" %>
 
 <style>
-  <% cache "partnership-org-section-credits-#{ApplicationConfig['HEROKU_SLUG_COMMIT']}", expires_in: 10.hours do %>
+  <% cache(cache_key_heroku_slug("partnership-org-section-credits"), expires_in: 10.hours) do %>
     <%= Rails.application.assets["partnerships.css"].to_s.html_safe %>
   <% end %>
 </style>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

In #6190 we introduced a helper named `cache_key_heroku_slug` for generating cache keys which include the `HEROKU_SLUG_COMMIT` environment variable. This refactors the remaining views to use this helper for consistency.

## Related Tickets & Documents

n/a

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [X] no, because they aren't needed

## Added to documentation?

- [X] no documentation needed

## Note

There are a few other places that look like the could use the helper, but they are using different separators between the prefix and `ApplicationConfig['HEROKU_SLUG_COMMIT']`:

```
$  rg -i slug_commit app/views
app/views/shell/_bottom.html.erb
3:  <% cache("footer-and-signup-modal--#{user_signed_in?}--#{ApplicationConfig['HEROKU_SLUG_COMMIT']}", expires_in: 24.hours) do %>

app/views/layouts/_styles.html.erb
1:<% cache "base_inline_styles_#{@story_show}_#{@article_index}_#{@home_page}_#{@article_show}_#{view_class}_#{@notifications_index}_#{@tags_index}_#{@reading_list_items_index}_#{@history_index}_#{ApplicationConfig['HEROKU_SLUG_COMMIT']}_#{user_signed_in?}_#{@shell}", expires_in: 8.hours do %>

app/views/liquid_embeds/show.html.erb
2:<% cache "liquid_tag_styles_#{ApplicationConfig['HEROKU_SLUG_COMMIT']}", expires_in: 8.hours do #TODO: Render specific ltag class instead of everything %>
```

Let me know if we can/want to change them too.