### PR TITLE
Switch from cookies to localstorage for hero banner

### DIFF
--- a/app/assets/javascripts/initializers/initializeHeroBannerClose.js
+++ b/app/assets/javascripts/initializers/initializeHeroBannerClose.js
@@ -1,21 +1,12 @@
 'use strict';
 
-function setExpiryForCookie() {
-  // in the future we probably want to set the expiry value dynamically from the campaign config
-  // based on how long the campaign is running for.
-  const date = new Date();
-  const daysUntilExpiry = 5;
-  date.setDate(date.getDate() + daysUntilExpiry);
-  return date.toGMTString();
-}
-
 function initializeHeroBannerClose() {
   let banner = document.getElementById('js-hero-banner');
   let closeIcon = document.getElementById('js-hero-banner__x');
 
   if (banner && closeIcon) {
     closeIcon.addEventListener('click', () => {
-      document.cookie = `heroBanner=false; expires=${setExpiryForCookie()};`;
+      localStorage.setItem('exited_hero', 'shecoded'); // Hardcoded. TODO: generalize.
       banner.style.display = 'none';
     });
   }

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -56,7 +56,7 @@ class StoriesController < ApplicationController
   private
 
   def assign_hero_html
-    return if SiteConfig.campaign_hero_html_variant_name.blank? || cookies[:heroBanner] == "false"
+    return if SiteConfig.campaign_hero_html_variant_name.blank?
 
     @hero_html = HtmlVariant.relevant.select(:html).
       find_by(group: "campaign", name: SiteConfig.campaign_hero_html_variant_name)&.html

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,7 +8,15 @@
   <% end %>
   <div id="page-content-inner">
     <% if @hero_html %>
-      <%= @hero_html.html_safe %>
+      <div id="hero-html-wrapper">
+        <script>
+          console.log(localStorage.getItem('exited_hero'))
+          if (localStorage.getItem('exited_hero') === 'shecoded') {
+            document.getElementById('hero-html-wrapper').style.display = 'none';
+          }
+        </script>
+        <%= @hero_html.html_safe %>
+      </div>
     <% end %>
     <%= yield %>
   </div>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We used cookies in a path where we will share a cached version of the page across user cohorts, so the server logic isn't going to be useful. This takes the same approximate pattern but moves to `localStorage`