### PR TITLE
Fixes some html_safe in Articles

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -33,7 +33,6 @@ linters:
       Rails/OutputSafety:
         Enabled: false
         Exclude:
-          - '**/app/views/articles/_block.html.erb'
           - '**/app/views/feedback_messages/index.html.erb'
           - '**/app/views/layouts/_styles.html.erb'
           - '**/app/views/liquid_embeds/show.html.erb'

--- a/app/views/articles/_block.html.erb
+++ b/app/views/articles/_block.html.erb
@@ -1,23 +1,19 @@
 <div class="block" id="block-index-<%= i %>">
   <% if show_published %>
     <script async>
-      <%= block.published_javascript.html_safe %>
+      <%== block.published_javascript %>
     </script>
-    <style>
-      <%= block.published_css.html_safe %>
-    </style>
+    <%= tag.style block.published_css, escape_attributes: false %>
     <div class="block-wrapper-<%= block.id %>">
-      <%= block.published_html.html_safe %>
+      <%= sanitize block.published_html %>
     </div>
   <% else %>
     <script async>
-      <%= block.processed_javascript.html_safe %>
+      <%== block.processed_javascript %>
     </script>
-    <style>
-      <%= block.processed_css.html_safe %>
-    </style>
+    <%= tag.style block.processed_css, escape_attributes: false %>
     <div class="block-wrapper-<%= block.id %>">
-      <%= block.processed_html.html_safe %>
+      <%= sanitize block.processed_html %>
     </div>
   <% end %>
 </div>

--- a/app/views/articles/_single_sponsor.html.erb
+++ b/app/views/articles/_single_sponsor.html.erb
@@ -4,5 +4,5 @@
     <img src="<%= cloudinary(organization.nav_image_url) %>" alt="<%= organization.name %> logo" loading="lazy" class="partner-image-light-mode" />
     <img src="<%= cloudinary(organization.dark_nav_image_url || organization.nav_image_url) %>" alt="<%= organization.name %> logo" loading="lazy" class="partner-image-dark-mode" />
   </a>
-  <p class="fs-s"><%= sponsorship.sponsorable_type == "ActsAsTaggableOn::Tag" ? sponsorship.blurb_html.html_safe : sponsorship.tagline %></p>
+  <p class="fs-s"><%= sponsorship.sponsorable_type == "ActsAsTaggableOn::Tag" ? sanitize(sponsorship.blurb_html) : sponsorship.tagline %></p>
 </div>

--- a/app/views/articles/_sticky_nav.html.erb
+++ b/app/views/articles/_sticky_nav.html.erb
@@ -62,7 +62,7 @@
       <%= render "articles/user_metadata", context: "sidebar" %>
     <% elsif @actor.class.name == "Organization" && @actor.approved_and_filled_out_cta? %>
       <div class="primary-sticky-nav-org-summary">
-        <%= @actor.cta_processed_html.html_safe %>
+        <%= sanitize_rendered_markdown(@actor.cta_processed_html) %>
         <div class="primary-sticky-nav-org-cta-link-wrapper">
           <% if @actor.cta_button_text.present? && @actor.cta_button_url.present? %>
             <a href="<%= @actor.cta_button_url || "LEARN MORE" %>" class="primary-sticky-nav-org-cta-link">

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -227,9 +227,9 @@
 <% cache("article-show-scripts", expires_in: 8.hours) do %>
   <script async>
     <%# we consider these scripts safe for embedding as they come from our code %>
-    <%= PodcastTag.script.html_safe %>
-    <%= PollTag.script.html_safe %>
-    <%= RunkitTag.script.html_safe %>
-    <%= TweetTag.script.html_safe %>
+    <%== PodcastTag.script %>
+    <%== PollTag.script %>
+    <%== RunkitTag.script %>
+    <%== TweetTag.script %>
   </script>
 <% end %>

--- a/app/views/articles/tags/_sidebar.html.erb
+++ b/app/views/articles/tags/_sidebar.html.erb
@@ -8,7 +8,7 @@
             <h4>#<%= @tag %> 👋</h4>
           </header>
           <div class="widget-body">
-            <%= @tag_model.short_summary.html_safe %>
+            <%= sanitize @tag_model.short_summary %>
           </div>
         </div>
       <% end %>
@@ -18,7 +18,7 @@
             <h4>submission guidelines</h4>
           </header>
           <div class="widget-body">
-            <%= @tag_model.rules_html.html_safe %>
+            <%= sanitize @tag_model.rules_html %>
             <a class="cta cta-button" href="/new/<%= @tag %>">
               WRITE A POST
             </a>
@@ -31,7 +31,7 @@
             <h4>about #<%= @tag %></h4>
           </header>
           <div class="widget-body">
-            <%= @tag_model.wiki_body_html.html_safe %>
+            <%= sanitize @tag_model.wiki_body_html %>
           </div>
         </div>
       <% end %>

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -124,8 +124,8 @@
 <% end %>
 
 <script async>
-  <%= TweetTag.script %>
-  <%= YoutubeTag.script %>
-  <%= PodcastTag.script %>
-  <%= GistTag.script %>
+  <%== TweetTag.script %>
+  <%== YoutubeTag.script %>
+  <%== PodcastTag.script %>
+  <%== GistTag.script %>
 </script>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
 - protected css + javascript content by not escaping them (with `<%==` for js and a tag for css.
 - replaced html_safe with sanitization where possible
 
Warnings fellt from around 45 to 31 (but I also fount out there is another rubocop file that was excluding some files, so total of warning might be a little above).
## Related Tickets & Documents
#5914 
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [ ] yes
- [X] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
