### PR TITLE
Change sponsorClickHandler to standard function declaration

### DIFF
--- a/app/assets/javascripts/initializers/initializeSponsorshipVisibility.js
+++ b/app/assets/javascripts/initializers/initializeSponsorshipVisibility.js
@@ -1,6 +1,4 @@
-'use strict';
-
-const sponsorClickHandler = event => {
+function sponsorClickHandler(event) {
   if (event.target.classList.contains('follow-action-button')) {
     handleOptimisticButtRender(event.target);
     handleFollowButtPress(event.target);
@@ -13,7 +11,7 @@ const sponsorClickHandler = event => {
     event.target.dataset.details,
     null,
   );
-};
+}
 
 function listenForSponsorClick() {
   setTimeout(() => {

--- a/app/assets/javascripts/initializers/initializeSponsorshipVisibility.js
+++ b/app/assets/javascripts/initializers/initializeSponsorshipVisibility.js
@@ -1,3 +1,7 @@
+/*
+ * kept as a stand function so it can be loaded again without issue
+ * see: https://github.com/thepracticaldev/dev.to/issues/6468
+ */
 function sponsorClickHandler(event) {
   if (event.target.classList.contains('follow-action-button')) {
     handleOptimisticButtRender(event.target);


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
My assumption to the cause of bug report #6468 is that the service worker is trying to load our JS asset twice, causing `SyntaxError: redeclaration of const sponsorClickHandler` and break certain portion of the webpage. This is bandaid solution to avoid that particular error.

## Related Tickets & Documents
Hopefully resolves #6468 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
n/a

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed
