### PR TITLE
Add explicit note about `cd`ing into Elasticsearch before starting

### DIFF
--- a/docs/installation/mac.md
+++ b/docs/installation/mac.md
@@ -81,10 +81,15 @@ wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-7.5.
 wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-7.5.2-darwin-x86_64.tar.gz.sha512
 shasum -a 512 -c elasticsearch-oss-7.5.2-darwin-x86_64.tar.gz.sha512
 tar -xzf elasticsearch-oss-7.5.2-darwin-x86_64.tar.gz
-cd elasticsearch-7.5.2/
 ```
 
-To start elasticsearch:
+To start elasticsearch, make sure you are in the correct directory:
+
+```shell
+cd elasticsearch-7.5.2
+```
+
+You can then start it by running:
 
 ```shell
 ./bin/elasticsearch


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description
Every time that I have to start ES, I get frustrated that it doesn't work, and then remember that I need to be in the directory for it to work. Seems like this should be documented.

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [x] docs.dev.to
- [ ] readme
- [ ] no documentation needed