### PR TITLE
Run Elasticsearch update before DataUpdateScripts

### DIFF
--- a/bin/update
+++ b/bin/update
@@ -23,11 +23,11 @@ chdir APP_ROOT do
   puts "\n== Updating database =="
   system! 'bin/rails db:migrate'
 
-  puts "\n== Update Data =="
-  system! 'bin/rails data_updates:run'
-
   puts "\n== Update Elasticsearch =="
   system! 'bin/rails search:setup'
+
+  puts "\n== Update Data =="
+  system! 'bin/rails data_updates:run'
 
   puts "\n== Removing old logs and tempfiles =="
   system! 'bin/rails log:clear tmp:clear'


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description
We should be running the Elasticsearch setup before we run the DataUpdateScripts since often the DataUpdateScripts are doing things with new Elasticsearch settings or indexes. We have not run into a problem yet bc we have spaced out the index creation and indexing PRs but I could see this being an issue if not fixed. 

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media3.giphy.com/media/l2JefhuLRZWPnxF1m/giphy.gif)
