### PR TITLE
Fix 404 page css

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -48,13 +48,13 @@
       font-weight: 500;
     }
 
-    .not-found-page img {
+    .tv__inner--special, .tv__inner {
       max-width: 85%;
       width: 300px;
       border: 25px solid rgb(54, 55, 124);
       border-radius: 36px;
     }
-    .not-found-page p {
+    .tv__inner--text {
       text-align: center;
       max-width: 90%;
     }

--- a/public/404.html
+++ b/public/404.html
@@ -48,13 +48,13 @@
       font-weight: 500;
     }
 
-    img {
+    .not-found-page img {
       max-width: 85%;
       width: 300px;
       border: 25px solid rgb(54, 55, 124);
       border-radius: 36px;
     }
-    p {
+    .not-found-page p {
       text-align: center;
       max-width: 90%;
     }
@@ -96,7 +96,7 @@
           <br>
           <p class="tv__inner--text">This page does not exist <br><br> <a href="https://dev.to/">Return to Home Page</a></p>
         </div>
-      </div>      
+      </div>
   </div>
 </body>
 </html>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The /public/404.html file has local styles for img and p tags. 
Later, 404.html is incorporated in a general dev.to "template" (how ?)
=> All images from this general page conform to the specific css defined in 404.html

I customized the styles defined in the 404.html head to limit their scope.

I think the styles defined locally in 422.html, 500.html and 503.html should also be reviewed. But I don't really understand how they are handled.

## Related Tickets & Documents

Closes #6373 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

