### PR TITLE
Refactor debounce usage into debounceAction util

### DIFF
--- a/app/javascript/chat/chat.jsx
+++ b/app/javascript/chat/chat.jsx
@@ -1,6 +1,5 @@
 import { h, Component } from 'preact';
 import PropTypes from 'prop-types';
-import debounce from 'lodash.debounce';
 import ConfigImage from '../../assets/images/three-dots.svg';
 import {
   conductModeration,
@@ -25,6 +24,7 @@ import Video from './video';
 import View from './view';
 
 import setupPusher from '../src/utils/pusher';
+import debounceAction from '../src/utils/debounceAction';
 
 export default class Chat extends Component {
   static propTypes = {
@@ -39,9 +39,8 @@ export default class Chat extends Component {
     const chatChannels = JSON.parse(props.chatChannels);
     const chatOptions = JSON.parse(props.chatOptions);
 
-    this.debouncedChannelFilter = debounce(
+    this.debouncedChannelFilter = debounceAction(
       this.triggerChannelFilter.bind(this),
-      300,
     );
 
     this.state = {

--- a/app/javascript/listings/listings.jsx
+++ b/app/javascript/listings/listings.jsx
@@ -106,7 +106,7 @@ export class Listings extends Component {
 
     t.debouncedClassifiedListingSearch = debounceAction(
       this.handleQuery.bind(this),
-      150,
+      { time: 150, config: { leading: true } },
     );
 
     t.setState({

--- a/app/javascript/listings/listings.jsx
+++ b/app/javascript/listings/listings.jsx
@@ -1,5 +1,5 @@
 import { h, Component } from 'preact';
-import debounce from 'lodash.debounce';
+import debounceAction from '../src/utils/debounceAction';
 import { fetchSearch } from '../src/utils/search';
 import SingleListing from './singleListing';
 
@@ -84,28 +84,29 @@ export class Listings extends Component {
     const category = container.dataset.category || '';
     const allCategories = JSON.parse(container.dataset.allcategories || []);
     let tags = [];
+    let openedListing = null;
+    let slug = null;
+    let listings = [];
+
     if (params.t) {
       tags = params.t.split(',');
     }
+
     const query = params.q || '';
-    let listings = [];
+
     if (tags.length === 0 && query === '') {
       listings = JSON.parse(container.dataset.listings);
     }
-    let openedListing = null;
-    let slug = null;
+
     if (container.dataset.displayedlisting) {
       openedListing = JSON.parse(container.dataset.displayedlisting);
       ({ slug } = openedListing);
       document.body.classList.add('modal-open');
     }
 
-    t.debouncedClassifiedListingSearch = debounce(
+    t.debouncedClassifiedListingSearch = debounceAction(
       this.handleQuery.bind(this),
       150,
-      {
-        leading: true,
-      },
     );
 
     t.setState({

--- a/app/javascript/readingList/readingList.jsx
+++ b/app/javascript/readingList/readingList.jsx
@@ -39,7 +39,9 @@ export class ReadingList extends Component {
     this.state = defaultState({ availableTags, archiving: false, statusView });
 
     // bind and initialize all shared functions
-    this.onSearchBoxType = debounceAction(onSearchBoxType.bind(this));
+    this.onSearchBoxType = debounceAction(onSearchBoxType.bind(this), {
+      leading: true,
+    });
     this.loadNextPage = loadNextPage.bind(this);
     this.performInitialSearch = performInitialSearch.bind(this);
     this.search = search.bind(this);

--- a/app/javascript/readingList/readingList.jsx
+++ b/app/javascript/readingList/readingList.jsx
@@ -1,6 +1,6 @@
 import { h, Component } from 'preact';
 import { PropTypes } from 'preact-compat';
-import debounce from 'lodash.debounce';
+import debounceAction from '../src/utils/debounceAction';
 
 import {
   defaultState,
@@ -39,9 +39,7 @@ export class ReadingList extends Component {
     this.state = defaultState({ availableTags, archiving: false, statusView });
 
     // bind and initialize all shared functions
-    this.onSearchBoxType = debounce(onSearchBoxType.bind(this), 300, {
-      leading: true,
-    });
+    this.onSearchBoxType = debounceAction(onSearchBoxType.bind(this));
     this.loadNextPage = loadNextPage.bind(this);
     this.performInitialSearch = performInitialSearch.bind(this);
     this.search = search.bind(this);

--- a/app/javascript/shared/components/tags.jsx
+++ b/app/javascript/shared/components/tags.jsx
@@ -34,7 +34,9 @@ class Tags extends Component {
     // 250ms without invoking the function at the leading edge of the timeout
     // NOTE: this seems the best combination of wait time and options to avoid
     // flickering and text replacement during autocomplete
-    this.debouncedTagSearch = debounceAction(this.handleInput.bind(this), 250);
+    this.debouncedTagSearch = debounceAction(this.handleInput.bind(this), {
+      time: 250,
+    });
 
     this.state = {
       selectedIndex: -1,

--- a/app/javascript/shared/components/tags.jsx
+++ b/app/javascript/shared/components/tags.jsx
@@ -1,6 +1,6 @@
 import { h, Component } from 'preact';
 import PropTypes from 'prop-types';
-import debounce from 'lodash.debounce';
+import debounceAction from '../../src/utils/debounceAction';
 import { fetchSearch } from '../../src/utils/search';
 
 const KEYS = {
@@ -34,7 +34,7 @@ class Tags extends Component {
     // 250ms without invoking the function at the leading edge of the timeout
     // NOTE: this seems the best combination of wait time and options to avoid
     // flickering and text replacement during autocomplete
-    this.debouncedTagSearch = debounce(this.handleInput.bind(this), 250);
+    this.debouncedTagSearch = debounceAction(this.handleInput.bind(this), 250);
 
     this.state = {
       selectedIndex: -1,

--- a/app/javascript/src/utils/debounceAction.js
+++ b/app/javascript/src/utils/debounceAction.js
@@ -1,24 +1,23 @@
 import debounce from 'lodash.debounce';
 
 /**
- * A util function to wrap any action with `debounce`.
+ * A util function to wrap any action with lodash's `debounce` (https://lodash.com/docs/#debounce).
  * To use this util, wrap it in the util like so: debounceAction(onSearchBoxType.bind(this));
  *
- * By default, this util uses a default time of 300ms, and includes a config of `{ leading: true }`,
- * which will pass the first received value to debounced function. These values can be overridden:
- * debounceAction(this.onSearchBoxType.bind(this), 150);
+ * By default, this util uses a default time of 300ms, and includes a default config of `{ leading: false }`.
+ * These values can be overridden: debounceAction(this.onSearchBoxType.bind(this), { time: 100, config: { leading: true }});
  *
  *
  * @param {Function} action - The function that should be wrapped with `debounce`.
- * @param {Number} [debounceTime=300] - The number of milliseconds to wait.
- * @param {Object} [debounceConfig={ leading: true }] - Any configuration for the debounce function.
+ * @param {Number} [time=300] - The number of milliseconds to wait.
+ * @param {Object} [config={ leading: false }] - Any configuration for the debounce function.
  *
  * @returns {Function} A function wrapped in `debounce`.
  */
 export default function debounceAction(
   action,
-  debounceTime = 300,
-  debounceConfig = { leading: true },
+  { time = 300, config = { leading: false } } = {},
 ) {
-  return debounce(action, debounceTime, debounceConfig);
+  const configs = { ...config };
+  return debounce(action, time, configs);
 }

--- a/app/javascript/src/utils/debounceAction.js
+++ b/app/javascript/src/utils/debounceAction.js
@@ -1,0 +1,24 @@
+import debounce from 'lodash.debounce';
+
+/**
+ * A util function to wrap any action with `debounce`.
+ * To use this util, wrap it in the util like so: debounceAction(onSearchBoxType.bind(this));
+ *
+ * By default, this util uses a default time of 300ms, and includes a config of `{ leading: true }`,
+ * which will pass the first received value to debounced function. These values can be overridden:
+ * debounceAction(this.onSearchBoxType.bind(this), 150);
+ *
+ *
+ * @param {Function} action - The function that should be wrapped with `debounce`.
+ * @param {Number} [debounceTime=300] - The number of milliseconds to wait.
+ * @param {Object} [debounceConfig={ leading: true }] - Any configuration for the debounce function.
+ *
+ * @returns {Function} A function wrapped in `debounce`.
+ */
+export default function debounceAction(
+  action,
+  debounceTime = 300,
+  debounceConfig = { leading: true },
+) {
+  return debounce(action, debounceTime, debounceConfig);
+}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

We [have been increasingly adding](https://github.com/thepracticaldev/dev.to/pull/6358#discussion_r385807411) `debounce` to various inputs in our app that send search queries to the ES backend. This has resulted in a lot of duplicated code with slightly different variations.

This PR abstracts out the core `debounce` concept into a util function that can be reused across our app whenever we find ourselves having to do this.

As the documentation explains, to use this function, you simply need to call it like so:
```javascript
debounceAction(this.myFunctionToDeounce.bind(this))
```

The default values for this function include a default wait time of `300`ms, and a default config that includes `{ leading: true }`. Both of these can be overridden like so:
```javascript
debounceAction(this.myFunctionToDeounceFast.bind(this), 100, { leading: false } )
```

I also did some various cleanup inside of `app/javascript/listings/listings.jsx` since I was in the code 😄!

## Related Tickets & Documents

Additional context in [this PR discussion](https://github.com/thepracticaldev/dev.to/pull/6358#discussion_r385807411).

## Added tests?

- [ ] yes
- [ ] no, because they aren't needed
- [x] no, because I need help **NOTE: I could use some help from reviewers to QA that this actually works as expected! I couldn't figure out how to get ES to work correctly on the backend and ran into a bunch of errors, so additional QA would be appreciated!**

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed **Although I have added docs to the function 😉!!**