### PR TITLE
Hide banished users vomit confirmations and delete vomit reactions on banish

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -406,6 +406,10 @@ class User < ApplicationRecord
     errors.add(:username, "has been banished.") if BanishedUser.exists?(username: username)
   end
 
+  def banished?
+    username.starts_with?("spam_")
+  end
+
   def subscribe_to_mailchimp_newsletter
     return unless email.present? && email.include?("@")
     return if saved_changes["unconfirmed_email"] && saved_changes["confirmation_sent_at"]

--- a/app/services/moderator/banish_user.rb
+++ b/app/services/moderator/banish_user.rb
@@ -22,6 +22,7 @@ module Moderator
       Users::CleanupChatChannels.call(user)
       user.remove_from_algolia_index
       reassign_and_bust_username
+      delete_vomit_reactions
     end
 
     private
@@ -48,6 +49,10 @@ module Moderator
       )
 
       user.update_columns(profile_image: "https://thepracticaldev.s3.amazonaws.com/i/99mvlsfu5tfj9m7ku25d.png")
+    end
+
+    def delete_vomit_reactions
+      Reaction.where(reactable: user, category: "vomit").delete_all
     end
   end
 end

--- a/app/views/internal/feedback_messages/index.html.erb
+++ b/app/views/internal/feedback_messages/index.html.erb
@@ -80,7 +80,7 @@
     <div id="vomitReactionsBodyContainer" class="collapse hide" aria-labelledby="vomitReactionsHeader" data-parent="#vomitReactions">
       <div class="card-body" style="overflow: scroll; max-height: 500px;">
         <% @vomits.each do |reaction| %>
-          <% next if (reaction.reactable_type == "Article" && !reaction.reactable.published) || (reaction.reactable_type == "User" && reaction.reactable.banned) %>
+          <% next if (reaction.reactable_type == "Article" && !reaction.reactable.published) || (reaction.reactable_type == "User" && reaction.reactable.username.starts_with?("spam_")) %>
           <div class="d-flex justify-content-between">
             <span>
               🤢 <a href="<%= reaction.user.path %>">@<%= reaction.user.username %></a>

--- a/app/views/internal/feedback_messages/index.html.erb
+++ b/app/views/internal/feedback_messages/index.html.erb
@@ -80,7 +80,7 @@
     <div id="vomitReactionsBodyContainer" class="collapse hide" aria-labelledby="vomitReactionsHeader" data-parent="#vomitReactions">
       <div class="card-body" style="overflow: scroll; max-height: 500px;">
         <% @vomits.each do |reaction| %>
-          <% next if (reaction.reactable_type == "Article" && !reaction.reactable.published) || (reaction.reactable_type == "User" && reaction.reactable.username.starts_with?("spam_")) %>
+          <% next if (reaction.reactable_type == "Article" && !reaction.reactable.published) || (reaction.reactable_type == "User" && reaction.reactable&.banished?) %>
           <div class="d-flex justify-content-between">
             <span>
               🤢 <a href="<%= reaction.user.path %>">@<%= reaction.user.username %></a>

--- a/spec/services/moderator/banish_user_spec.rb
+++ b/spec/services/moderator/banish_user_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe Moderator::BanishUser, type: :service do
+  let(:user) { create(:user) }
+  let(:moderator) { create(:user, :trusted) }
+  let(:admin) { create(:user, :super_admin) }
+
+  it "updates the user's username" do
+    sidekiq_perform_enqueued_jobs do
+      described_class.call(user: user, admin: admin)
+    end
+    expect(user.username).to include "spam_"
+  end
+
+  it "removes all their articles" do
+    create(:article, user: user, published: true)
+    sidekiq_perform_enqueued_jobs do
+      described_class.call(user: user, admin: admin)
+    end
+    expect(user.articles.count).to eq 0
+  end
+
+  it "removes all their comments" do
+    article = create(:article, user: user, published: true)
+    create(:comment, user: user, commentable: article)
+    sidekiq_perform_enqueued_jobs do
+      described_class.call(user: user, admin: admin)
+    end
+    expect(user.comments.count).to eq 0
+  end
+
+  it "creates a BanishedUser record with their original username" do
+    original_username = user.username
+    sidekiq_perform_enqueued_jobs do
+      described_class.call(user: user, admin: admin)
+    end
+    expect(BanishedUser.exists?(username: original_username)).to be true
+  end
+
+  it "deletes existing vomit reactions on the banished user" do
+    create(:reaction, category: "vomit", reactable: user, user: moderator)
+    sidekiq_perform_enqueued_jobs do
+      described_class.call(user: user, admin: admin)
+    end
+    expect(Reaction.where(reactable: user).count).to eq 0
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
This updates the vomit confirmation section to hide only vomits on banished users.

**Update: removes any associated vomit reactions on banished users.**

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed