### PR TITLE
Run BackfillColumnForBroadcasts script only if the column actually exists

### DIFF
--- a/lib/data_update_scripts/20200226193303_backfill_column_for_broadcasts.rb
+++ b/lib/data_update_scripts/20200226193303_backfill_column_for_broadcasts.rb
@@ -1,6 +1,8 @@
 module DataUpdateScripts
   class BackfillColumnForBroadcasts
     def run
+      return unless Broadcast.column_names.include?("sent")
+
       Broadcast.find_each { |broadcast| broadcast.update!(active: broadcast.sent) }
     end
   end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When you first install the DEV app locally running `bin/setup` or if you `rails db:reset` and then run the scripts you end up with the following state:

```sql
PracticalDeveloper_development=# select file_name, status from data_update_scripts;
┌────────────────────────────────────────────────────────────────┬────────┐
│                           file_name                            │ status │
├────────────────────────────────────────────────────────────────┼────────┤
│ 20200214171607_index_tags_to_elasticsearch                     │      2 │
│ 20200217131245_re_index_existing_articles_with_approved        │      2 │
│ 20200217215802_index_classified_listings_to_elasticsearch      │      2 │
│ 20200218195023_index_chat_channel_memberships_to_elasticsearch │      2 │
│ 20200225114328_update_tags_social_preview_templates            │      2 │
│ 20200226193303_backfill_column_for_broadcasts                  │      3 │
│ 20200305201627_index_users_to_elasticsearch                    │      2 │
└────────────────────────────────────────────────────────────────┴────────┘
```

`20200226193303_backfill_column_for_broadcasts` fails.

The reason for that is that the column `Broadcast.sent` doesn't exist anymore in the schema, so the script will always fail from now on when run on a migrated DB.

I also thought about removing the file altogether but then we'd have DBs unaligned with the files and the startup check would fail for existing users.

I could technically just remove the content of the script or return before running the code but I like the explicitlness of the guard.

Let me know which approach you'd prefer @mstruve 

