### PR TITLE
Serialize ActionController::Parameters as JSON

### DIFF
--- a/config/initializers/honeycomb.rb
+++ b/config/initializers/honeycomb.rb
@@ -1,3 +1,7 @@
+ActiveSupport.on_load(:action_controller) do
+  wrap_parameters format: [:json]
+end
+
 if Rails.env.test? || ApplicationConfig["HONEYCOMB_API_KEY"].blank?
   Honeycomb.configure do |config|
     config.client = Libhoney::TestClient.new


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
This allows Honeycomb to create columns for each key in the ActionController::Parameters hash, which will save on Honeycomb storage and make the data more searchable.

## Related Tickets & Documents
n/a

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
n/a

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
