### PR TITLE
API Specification: Change type 'date' to 'string' on Create/Update Listings

### DIFF
--- a/docs/api_v0.yml
+++ b/docs/api_v0.yml
@@ -8,7 +8,7 @@ info:
 
     Dates and date times, unless otherwise specified, must be in
     the [RFC 3339](https://tools.ietf.org/html/rfc3339) format.
-  version: "0.6.2"
+  version: "0.6.4"
   termsOfService: https://dev.to/terms
   contact:
     name: DEV Team
@@ -564,7 +564,7 @@ components:
               type: string
             expires_at:
               description: Date and time of expiration.
-              type: date
+              type: string
               format: date-time
             contact_via_connect:
               description: |
@@ -616,7 +616,7 @@ components:
               type: string
             expires_at:
               description: Date and time of expiration.
-              type: date
+              type: string
               format: date-time
             contact_via_connect:
               description: |


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

Doing a PR review I found that Swagger was complaining about `ListingCreate` & `ListingUpdate` having a property declared as `type: date`. It should use `type: string` because it has `format: date-time` to flag it as a Date.

## Related Tickets & Documents

#6482 and that one should be merged first because this PR bumps the patch version.

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [ ] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![swagger dog](https://media.giphy.com/media/l46CBIj9os4Ntj7UY/giphy.gif)
