### PR TITLE
Convert Flare Tag to json string before indexing

### DIFF
--- a/app/serializers/search/article_serializer.rb
+++ b/app/serializers/search/article_serializer.rb
@@ -4,7 +4,7 @@ module Search
 
     attributes :id, :approved, :body_text, :class_name, :cloudinary_video_url,
                :comments_count, :experience_level_rating, :experience_level_rating_distribution,
-               :featured, :featured_number, :flare_tag, :hotness_score, :language,
+               :featured, :featured_number, :hotness_score, :language,
                :main_image, :path, :positive_reactions_count, :published,
                :published_at, :reactions_count, :reading_time, :score, :title
 
@@ -13,6 +13,10 @@ module Search
     # added an extra field to handle that string
     attribute :video_duration_string, &:video_duration_in_minutes
     attribute :video_duration_in_minutes, &:video_duration_in_minutes_integer
+
+    attribute :flare_tag do |article|
+      article.flare_tag.to_json
+    end
 
     attribute :tags do |article|
       article.tags.map do |tag|


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Turns out flare tag is a hash and therefore needs to be converted to a string before getting sent to ES. I figured json would be the easiest to parse on the way back to the view. 

## Tests?
Patched a console and was able to index a previously failed article. Will plan on adding a spec for this Monday
```
irb(main):047:0> Article.find(74153).index_to_elasticsearch_inline
ETHON: Libcurl initialized
ETHON: performed EASY 
=> {"_index"=>"feed_content_production", "_type"=>"_doc", "_id"=>"74153", "_version"=>1, "result"=>"created", "_shards"=>{"total"=>2, "successful"=>2, "failed"=>0}, "_seq_no"=>7529, "_primary_term"=>1}
```