### PR TITLE
destroy_all classified_listings when deleting User activity

### DIFF
--- a/app/services/users/delete_activity.rb
+++ b/app/services/users/delete_activity.rb
@@ -2,6 +2,8 @@ module Users
   module DeleteActivity
     module_function
 
+    # If you're removing data that is in Elasticsearch, make sure to use
+    # .destroy_all to trigger the callback to remove the document(s)
     def call(user)
       user.notifications.delete_all
       user.reactions.delete_all
@@ -35,7 +37,7 @@ module Users
       user.profile_pins.delete_all
       user.rating_votes.delete_all
       user.tweets.delete_all
-      user.classified_listings.delete_all
+      user.classified_listings.destroy_all
 
       handle_feedback_messages(user)
     end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
We have a bug in production where our database has become out of sync with Elasticsearch. We identified some `ClassifiedListings` that were in Elasticsearch, but not in our database. This should never be the case.

I found that it was due to deleting user activity when banishing a user. We were calling `.delete_all` on `classified_listings` which skips callbacks and therefore we never deleted it from Elasticsearch.

This PR changes the logic to `.destroy_all` to trigger the callback so that any time a user is banished, their `classified_listings` will also be removed from Elasticsearch.

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## Are there any post deployment tasks we need to perform?
We'll want to manually remove the handful of affected `ClassifiedListings` from Elasticsearch using the production console to get things back in sync.

![power_rangers_gif](https://media.giphy.com/media/aDDSWPDlrckrS/giphy.gif)