### PR TITLE
Fix scripts startup check for development mode

### DIFF
--- a/app/models/data_update_script.rb
+++ b/app/models/data_update_script.rb
@@ -30,7 +30,7 @@ class DataUpdateScript < ApplicationRecord
     def scripts_to_run?
       db_scripts = DataUpdateScript.pluck(:file_name, :status).to_h
 
-      return true unless filenames.to_set == db_scripts.keys.to_set
+      return true if filenames.size > db_scripts.size
       return true if db_scripts.values.any? { |s| s.to_sym == :enqueued }
 
       false

--- a/app/models/data_update_script.rb
+++ b/app/models/data_update_script.rb
@@ -26,7 +26,7 @@ class DataUpdateScript < ApplicationRecord
       DataUpdateScript.where(id: load_script_ids).select(&:enqueued?)
     end
 
-    # true if there are any new files on disk or any scripts to run, false otherwise
+    # true if there are more files on disk or any scripts to run, false otherwise
     def scripts_to_run?
       db_scripts = DataUpdateScript.pluck(:file_name, :status).to_h
 

--- a/spec/models/data_update_script_spec.rb
+++ b/spec/models/data_update_script_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe DataUpdateScript do
+  let(:test_directory) { Rails.root.join("spec/support/fixtures/data_update_scripts") }
+
   it { is_expected.to validate_uniqueness_of(:file_name) }
 
   it "can constantize all script names" do
@@ -18,8 +20,6 @@ RSpec.describe DataUpdateScript do
   end
 
   describe ".load_script_ids" do
-    let(:test_directory) { Rails.root.join("spec/support/fixtures/data_update_scripts") }
-
     before { stub_const "#{described_class}::DIRECTORY", test_directory }
 
     it "creates new DataUpdateScripts from files" do
@@ -42,8 +42,6 @@ RSpec.describe DataUpdateScript do
   end
 
   describe ".scripts_to_run" do
-    let(:test_directory) { Rails.root.join("spec/support/fixtures/data_update_scripts") }
-
     before { stub_const "#{described_class}::DIRECTORY", test_directory }
 
     it "creates new DataUpdateScripts from files" do
@@ -64,16 +62,9 @@ RSpec.describe DataUpdateScript do
   end
 
   describe ".scripts_to_run?" do
-    let(:test_directory) { Rails.root.join("spec/support/fixtures/data_update_scripts") }
-
     before { stub_const "#{described_class}::DIRECTORY", test_directory }
 
     it "returns true for a new set of files" do
-      expect(described_class.scripts_to_run?).to be(true)
-    end
-
-    it "returns true if there is a script on disk but not in the DB" do
-      create(:data_update_script, file_name: "not_the_one_on_disk")
       expect(described_class.scripts_to_run?).to be(true)
     end
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This fixes a bug we see as reviewers.

The startup check checks if the set of files on disk is different than the set of files in the DB. Unfortunately, when reviewing multiple branches, `master` might be ahead of other branches in terms of scripts ran, so this check will prevent the app from loading and it can't be fixed by re-running the scripts, because the number of scripts on disk is fewer than the number of scripts the DB has knowledge of.

To reproduce:

1. run the scripts on master
2. checkout an older PR which is not up to date with master
3. start the console or the server

Thus I think the only check we can do is: does the file system has more files than there are rows in the DB? If so we can be certain there are files to be executed, if there are less, we don't care, as it might be an earlier branch.

This function is only used in development mode.

## Added tests?

- [ ] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
