### PR TITLE
Allow tag mods to approve posts even if they mod just one tag

### DIFF
--- a/spec/requests/article_approvals_spec.rb
+++ b/spec/requests/article_approvals_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "ArticleApprovals", type: :request do
   describe "POST article_approvals" do
-    let(:tag)            { create(:tag) }
+    let(:tag)            { create(:tag, requires_approval: true) }
     let(:user)           { create(:user) }
     let(:article)        { create(:article, tags: tag.name) }
 
@@ -26,6 +26,25 @@ RSpec.describe "ArticleApprovals", type: :request do
       it "does allow update" do
         post "/article_approvals", params: { approved: true, id: article.id }
         expect(article.reload.approved).to eq(true)
+      end
+
+      it "does allow update when any tag requires approval" do
+        second_tag = create(:tag, requires_approval: false)
+        article = create(:article, tags: [tag.name, second_tag.name])
+        post "/article_approvals", params: { approved: true, id: article.id }
+        expect(article.reload.approved).to eq(true)
+      end
+
+      it "does not allow update when multiple tags and none require approval" do
+        second_tag = create(:tag, requires_approval: false)
+        third_tag = create(:tag, requires_approval: false)
+        article = create(:article, tags: [third_tag.name, second_tag.name])
+        expect { post "/article_approvals", params: { approved: true, id: article.id } }.to raise_error(Pundit::NotAuthorizedError)
+      end
+
+      it "does not allow update with one tag and does not require approval" do
+        tag.update_column(:requires_approval, false)
+        expect { post "/article_approvals", params: { approved: true, id: article.id } }.to raise_error(Pundit::NotAuthorizedError)
       end
     end
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Allow users to mark articles as approved if they are trusted and mod of _any_ tag on a post that requires approval, not _all_ of them, as it had been.