### PR TITLE
Removed unused campaign settings

### DIFF
--- a/app/controllers/internal/configs_controller.rb
+++ b/app/controllers/internal/configs_controller.rb
@@ -21,8 +21,7 @@ class Internal::ConfigsController < Internal::ApplicationController
   def config_params
     allowed_params = %i[
       default_site_email social_networks_handle mascot_user_id
-      campaign_hero_html_variant_name campaign_background_color
-      campaign_text_color campaign_sidebar_enabled campaign_featured_tags
+      campaign_hero_html_variant_name campaign_sidebar_enabled campaign_featured_tags
       campaign_sidebar_image
       main_social_image favicon_url logo_svg
       rate_limit_follow_count_daily

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -18,8 +18,6 @@ class SiteConfig < RailsSettings::Base
 
   # campaign
   field :campaign_hero_html_variant_name, type: :string, default: ""
-  field :campaign_background_color, type: :string, default: "FFFFFF"
-  field :campaign_text_color, type: :string, default: "000000"
   field :campaign_featured_tags, type: :array, default: %w[]
   field :campaign_sidebar_enabled, type: :boolean, default: 0
   field :campaign_sidebar_image, type: :string, default: nil

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -73,24 +73,6 @@
             </div>
 
             <div class="form-group">
-              <%= f.label :campaign_background_color %>
-              <%= f.text_field :campaign_background_color,
-                               class: "form-control",
-                               value: SiteConfig.campaign_background_color,
-                               placeholder: "FFFFFF" %>
-              <div class="alert alert-info">Campaign background color</div>
-            </div>
-
-            <div class="form-group">
-              <%= f.label :campaign_text_color %>
-              <%= f.text_field :campaign_text_color,
-                               class: "form-control",
-                               value: SiteConfig.campaign_text_color,
-                               placeholder: "FFFFFF" %>
-              <div class="alert alert-info">Campaign text color</div>
-            </div>
-
-            <div class="form-group">
               <%= f.label :campaign_sidebar_enabled %>
               <%= f.check_box :campaign_sidebar_enabled, checked: SiteConfig.campaign_sidebar_enabled %>
               <div class="alert alert-info">Campaign sidebar enabled or not</div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
We ended up not using `SiteConfig.campaign_background_color` and `SiteConfig.campaign_text_color` this time, so I removed these settings to avoid confusion in the future. 

## Related Tickets & Documents
#6141 
