### PR TITLE
Store Flare Tag as a Hash in Elasticsearch

### DIFF
--- a/app/serializers/search/article_serializer.rb
+++ b/app/serializers/search/article_serializer.rb
@@ -14,9 +14,7 @@ module Search
     attribute :video_duration_string, &:video_duration_in_minutes
     attribute :video_duration_in_minutes, &:video_duration_in_minutes_integer
 
-    attribute :flare_tag do |article|
-      article.flare_tag.to_json
-    end
+    attribute :flare_tag_hash, if: proc { |a| a.flare_tag.present? }, &:flare_tag
 
     attribute :tags do |article|
       article.tags.map do |tag|

--- a/config/elasticsearch/mappings/feed_content.json
+++ b/config/elasticsearch/mappings/feed_content.json
@@ -32,8 +32,19 @@
     "featured_number": {
       "type": "integer"
     },
-    "flare_tag": {
-      "type": "keyword"
+    "flare_tag_hash": {
+      "dynamic": "strict",
+      "properties": {
+        "name": {
+          "type": "keyword"
+        },
+        "bg_color_hex": {
+          "type": "keyword"
+        },
+        "text_color_hex": {
+          "type": "keyword"
+        }
+      }
     },
     "hotness_score": {
       "type": "integer"

--- a/spec/serializers/search/article_serializer_spec.rb
+++ b/spec/serializers/search/article_serializer_spec.rb
@@ -3,13 +3,21 @@ require "rails_helper"
 RSpec.describe Search::ArticleSerializer do
   let(:user) { create(:user) }
   let(:organization) { create(:organization) }
-  let(:article) { create(:article, user: user, organization: organization) }
+  let(:tag) { create(:tag, name: "ama", bg_color_hex: "#f3f3f3", text_color_hex: "#cccccc") }
+  let(:article) { create(:article, user: user, organization: organization, tags: tag.name) }
 
   it "serializes an article" do
     data_hash = described_class.new(article).serializable_hash.dig(:data, :attributes)
     user_data = Search::NestedUserSerializer.new(user).serializable_hash.dig(:data, :attributes)
     expect(data_hash[:user]).to eq(user_data)
     expect(data_hash.dig(:organization, :id)).to eq(organization.id)
+    expect(data_hash.dig(:flare_tag_hash, :name)).to eq(tag.name)
     expect(data_hash.keys).to include(:id, :body_text, :hotness_score)
+  end
+
+  it "creates valid json for Elasticsearch", elasticsearch: true do
+    data_hash = described_class.new(article).serializable_hash.dig(:data, :attributes)
+    result = Article::SEARCH_CLASS.index(article.id, data_hash)
+    expect(result["result"]).to eq("created")
   end
 end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Bug Fix
- [x] Optimization

## Description
Rather than trying to store the flare tag, which is actually a hash(see below), as a string and then having to parse it for the view lets store it as a hash.
```
{:name=>"help", :bg_color_hex=>"#111111", :text_color_hex=>"#FFFFFF"}
```
I also added a test to the serializer to confirm that it makes a valid hash for Elasticsearch. This will prevent us from adding a field to the serializer and then forget to add it to Elasticsearch bc the new test would raise a strict mappings error. 

## Added tests?
- [x] yes

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media1.giphy.com/media/IbUUbU4xUDJWcgGMGP/giphy.gif)
