### PR TITLE
Prune old field tests for ongoing experiments

### DIFF
--- a/app/workers/field_tests/prune_old_experiments_worker.rb
+++ b/app/workers/field_tests/prune_old_experiments_worker.rb
@@ -1,0 +1,13 @@
+module FieldTests
+  class PruneOldExperimentsWorker
+    include Sidekiq::Worker
+    sidekiq_options queue: :low_priority, retry: 10
+
+    def perform
+      five_precent_membership_count = FieldTest::Membership.count / 20
+      memberships = FieldTest::Membership.first(five_precent_membership_count)
+      FieldTest::Event.where(field_test_membership_id: memberships.pluck(:id)).delete_all
+      memberships.map(&:delete)
+    end
+  end
+end

--- a/lib/tasks/fetch.rake
+++ b/lib/tasks/fetch.rake
@@ -98,6 +98,13 @@ task award_contributor_badges_from_github: :environment do
   BadgeRewarder.award_contributor_badges_from_github
 end
 
+# This task is meant to be scheduled daily
+task prune_old_field_tests: :environment do
+  # For rolling ongoing experiemnts, we remove old experiment memberships
+  # So that they can be re-tested.
+  FieldTests::PruneOldExperimentsWorker.perform_async
+end
+
 task remove_old_html_variant_data: :environment do
   HtmlVariantTrial.where("created_at < ?", 2.weeks.ago).destroy_all
   HtmlVariantSuccess.where("created_at < ?", 2.weeks.ago).destroy_all

--- a/spec/factories/field_test_memberships.rb
+++ b/spec/factories/field_test_memberships.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :field_test_memberships, class: "FieldTest::Membership" do
+    converted         { false }
+    experiment        { :user_home_feed }
+    participant_type  { "User" }
+    variant           { "base" }
+  end
+end

--- a/spec/workers/field_tests/prune_old_experiments_worker_spec.rb
+++ b/spec/workers/field_tests/prune_old_experiments_worker_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe FieldTests::PruneOldExperimentsWorker, type: :worker do
+  include_examples "#enqueues_on_correct_queue", "low_priority", 1
+  include FieldTest::Helpers
+
+  describe "#perform" do
+    let(:worker) { subject }
+
+    it "prunes first 5% of memberships and events" do
+      create_list(:user, 40)
+      User.all.each do |user|
+        create(:field_test_memberships, participant_id: user.id.to_s)
+        field_test_converted(:user_home_feed, participant: user, goal: "user_creates_comment")
+      end
+      worker.perform
+      expect(FieldTest::Membership.count).to be(38)
+      expect(FieldTest::Event.count).to be(38)
+      expect(FieldTest::Event.pluck(:field_test_membership_id).sort).to eq(FieldTest::Membership.pluck(:id).sort)
+    end
+  end
+end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR creates a task to remove the oldest 5% of a/b test participants and lets them go back into the pool. This will help the rolling tests stay relevant and let us test old participants with new approaches.

We may not want to do this for certain kinds of tests where we want to send someone through one dedicated path until we fully finish the experiment and ship a winner, but with the kind of everlasting experiment I think this is a solid approach.

Our logic for the ephemerality of a/b test results can change depending on experiment type, but I think something like this should apply to any "rolling/ongoing" test.

**After deploy we need to add this to Heroku Scheduler for once per day.**