### PR TITLE
API: add docs for /followers/users and remove organizations endpoint

### DIFF
--- a/app/controllers/api/v0/followers_controller.rb
+++ b/app/controllers/api/v0/followers_controller.rb
@@ -4,15 +4,6 @@ module Api
       before_action :authenticate_with_api_key_or_current_user!
       before_action -> { limit_per_page(default: 80, max: 1000) }
 
-      def organizations
-        @follows = Follow.followable_organization(@user.organization_ids).
-          includes(:follower).
-          select(ORGANIZATIONS_ATTRIBUTES_FOR_SERIALIZATION).
-          order("created_at DESC").
-          page(params[:page]).
-          per(@follows_limit)
-      end
-
       def users
         @follows = Follow.followable_user(@user.id).
           includes(:follower).
@@ -22,10 +13,9 @@ module Api
           per(@follows_limit)
       end
 
-      ORGANIZATIONS_ATTRIBUTES_FOR_SERIALIZATION = %i[id follower_id follower_type followable_id].freeze
-      private_constant :ORGANIZATIONS_ATTRIBUTES_FOR_SERIALIZATION
-
-      USERS_ATTRIBUTES_FOR_SERIALIZATION = %i[id follower_id follower_type].freeze
+      USERS_ATTRIBUTES_FOR_SERIALIZATION = %i[
+        id follower_id follower_type
+      ].freeze
       private_constant :USERS_ATTRIBUTES_FOR_SERIALIZATION
 
       private

--- a/app/controllers/api/v0/followers_controller.rb
+++ b/app/controllers/api/v0/followers_controller.rb
@@ -8,7 +8,7 @@ module Api
         @follows = Follow.followable_user(@user.id).
           includes(:follower).
           select(USERS_ATTRIBUTES_FOR_SERIALIZATION).
-          order("created_at DESC").
+          order(created_at: :desc).
           page(params[:page]).
           per(@follows_limit)
       end

--- a/app/models/follow.rb
+++ b/app/models/follow.rb
@@ -7,7 +7,6 @@ class Follow < ApplicationRecord
   belongs_to :follower,   polymorphic: true
 
   scope :followable_user, ->(id) { where(followable_id: id, followable_type: "User") }
-  scope :followable_organization, ->(id) { where(followable_id: id, followable_type: "Organization") }
   scope :followable_tag, ->(id) { where(followable_id: id, followable_type: "ActsAsTaggableOn::Tag") }
 
   scope :follower_user, ->(id) { where(follower_id: id, followable_type: "User") }

--- a/app/views/api/v0/followers/_follows.json.jbuilder
+++ b/app/views/api/v0/followers/_follows.json.jbuilder
@@ -1,5 +1,0 @@
-json.array! follows do |follow|
-  json.type_of  type_of
-  json.id       follow.id
-  json.partial! "api/v0/shared/follows", user: follow.follower
-end

--- a/app/views/api/v0/followers/organizations.json.jbuilder
+++ b/app/views/api/v0/followers/organizations.json.jbuilder
@@ -1,6 +1,0 @@
-json.array! @follows do |follow|
-  json.type_of                 "organization_follower"
-  json.id                      follow.id
-  json.organization_id         follow.followable_id
-  json.partial! "api/v0/shared/follows", user: follow.follower
-end

--- a/docs/api_v0.yml
+++ b/docs/api_v0.yml
@@ -8,7 +8,7 @@ info:
 
     Dates and date times, unless otherwise specified, must be in
     the [RFC 3339](https://tools.ietf.org/html/rfc3339) format.
-  version: "0.6.4"
+  version: "0.6.5"
   termsOfService: https://dev.to/terms
   contact:
     name: DEV Team
@@ -510,6 +510,32 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Comment"
+
+    Follower:
+      type: object
+      required:
+        - type_of
+        - id
+        - name
+        - path
+        - username
+        - profile_image
+      properties:
+        type_of:
+          type: string
+        id:
+          description: Follow id
+          type: integer
+          format: int32
+        name:
+          type: string
+        path:
+          type: string
+        username:
+          type: string
+        profile_image:
+          description: Profile image (60x60)
+          type: string
 
     Listing:
       type: object
@@ -1132,6 +1158,21 @@ components:
             profile_image_90: https://res.cloudinary.com/...jpeg
           children: []
 
+    Followers:
+      value:
+        - type_of: user_follower
+          id: 12
+          name: Mrs. Neda Morissette
+          path: "/nedamrsmorissette"
+          username: nedamrsmorissette
+          profile_image: https://res.cloudinary.com/...
+        - type_of: user_follower
+          id: 11
+          name: Yoko Hintz
+          path: "/yokohintz"
+          username: yokohintz
+          profile_image: https://res.cloudinary.com/...
+
     Listings:
       value:
         - type_of: classified_listing
@@ -1251,6 +1292,8 @@ tags:
     description: Articles are all the posts users create on DEV
   - name: comments
     description: Users can leave comments to articles and podcasts episodes
+  - name: followers
+    description: Users can follow other users on the website
   - name: listings
     description: Listings are classified ads
   - name: users
@@ -1649,6 +1692,15 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/ArticleMe"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/APIError"
+              examples:
+                error-unauthorized:
+                  $ref: "#/components/examples/ErrorUnauthorized"
       security:
         - api_key: []
         - oauth2: []
@@ -1701,6 +1753,15 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/ArticleMe"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/APIError"
+              examples:
+                error-unauthorized:
+                  $ref: "#/components/examples/ErrorUnauthorized"
       security:
         - api_key: []
         - oauth2: []
@@ -1753,6 +1814,15 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/ArticleMe"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/APIError"
+              examples:
+                error-unauthorized:
+                  $ref: "#/components/examples/ErrorUnauthorized"
       security:
         - api_key: []
         - oauth2: []
@@ -1807,6 +1877,15 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/ArticleMe"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/APIError"
+              examples:
+                error-unauthorized:
+                  $ref: "#/components/examples/ErrorUnauthorized"
       security:
         - api_key: []
         - oauth2: []
@@ -1917,6 +1996,64 @@ paths:
           label: curl (a comment and its descendants)
           source: |
             curl https://dev.to/api/comments/m51e
+
+  /followers/users:
+    get:
+      operationId: getFollowers
+      summary: Followers
+      description: |
+        This endpoint allows the client to retrieve a list of the followers
+        they have.
+
+        "Followers" are users that are following other users on the website.
+
+        It supports pagination, each page will contain `80` followers by default.
+      tags:
+        - followers
+      parameters:
+        - name: page
+          in: query
+          description: Pagination page.
+          schema:
+            type: integer
+            format: int32
+          example: 1
+        - name: per_page
+          in: query
+          description: Page size (defaults to 80 with a maximum of 1000).
+          schema:
+            type: integer
+            format: int32
+          example: 80
+      responses:
+        "200":
+          description: A list of followers
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Follower"
+              examples:
+                followers-success:
+                  $ref: "#/components/examples/Followers"
+
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/APIError"
+              examples:
+                error-unauthorized:
+                  $ref: "#/components/examples/ErrorUnauthorized"
+      security:
+        - api_key: []
+      x-code-samples: # https://github.com/Redocly/redoc/blob/master/docs/redoc-vendor-extensions.md#x-code-samples
+        - lang: Shell
+          label: curl
+          source: |
+            curl -H "api-key: API_KEY" https://dev.to/api/followers/users
 
   /listings:
     get:
@@ -2324,6 +2461,15 @@ paths:
                       events:
                         - article_created
                       created_at: "2019-09-02T09:47:39.230Z"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/APIError"
+              examples:
+                error-unauthorized:
+                  $ref: "#/components/examples/ErrorUnauthorized"
       security:
         - api_key: []
         - oauth2: []

--- a/spec/requests/api/v0/followers_spec.rb
+++ b/spec/requests/api/v0/followers_spec.rb
@@ -6,61 +6,6 @@ RSpec.describe "Api::V0::FollowersController", type: :request do
   let(:headers) { { "api-key" => api_secret.secret } }
   let(:follower) { create(:user) }
 
-  describe "GET /api/followers/organizations" do
-    context "when user is unauthorized" do
-      it "returns unauthorized" do
-        get api_followers_organizations_path
-
-        expect(response).to have_http_status(:unauthorized)
-      end
-    end
-
-    context "when the user is authorized as current_user" do
-      it "returns ok" do
-        sign_in user
-
-        get api_followers_organizations_path
-        expect(response).to have_http_status(:ok)
-      end
-    end
-
-    context "when user is authorized with api keys" do
-      let(:orgs) { create_list(:organization, 2) }
-
-      before do
-        orgs.each { |org| follower.follow(org) }
-
-        # add the user to each organization
-        orgs.each do |org|
-          create(:organization_membership, user: user, organization: org, type_of_user: "admin")
-        end
-      end
-
-      it "returns all the followers of all organizations the user is part of" do
-        get api_followers_organizations_path, headers: headers
-        expect(response).to have_http_status(:ok)
-
-        followers = response.parsed_body
-        expect(followers.map { |f| f["id"] }).to match_array(follower.follows.pluck(:id))
-        expect(followers.map { |f| f["organization_id"] }).to match_array(orgs.map(&:id))
-      end
-
-      it "returns the followers with the correct format" do
-        get api_followers_organizations_path, headers: headers
-        expect(response).to have_http_status(:ok)
-
-        response_follower = response.parsed_body.first
-        expect(response_follower["type_of"]).to eq("organization_follower")
-        expect(response_follower["id"]).to eq(follower.follows.last.id)
-        expect(response_follower["organization_id"]).to eq(follower.follows.last.followable.id)
-        expect(response_follower["name"]).to eq(follower.name)
-        expect(response_follower["path"]).to eq(follower.path)
-        expect(response_follower["username"]).to eq(follower.username)
-        expect(response_follower["profile_image"]).to eq(ProfileImage.new(follower).get(width: 60))
-      end
-    end
-  end
-
   describe "GET /api/followers/users" do
     before do
       follower.follow(user)


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

This PR does the following two things:

- documents `/api/followers/users`
- removes `/api/followers/organizations`

The organizations endpoint currently returns all the users of all the organizations a user belongs to, but other than being it'misleading (as the other one instead returns all the followers the authenticated user has), it also doesn't seem to respond to an actual need.

We also checked that it hasn't being recently used in production.

I think it's safe for removal.

## Related Tickets & Documents

https://github.com/thepracticaldev/dev.to/issues/4474

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [x] docs.dev.to
- [ ] readme
- [ ] no documentation needed
