### PR TITLE
Dont Issue Destroy Call to Chat Channel Memberships Multiple Times

### DIFF
--- a/app/services/users/cleanup_chat_channels.rb
+++ b/app/services/users/cleanup_chat_channels.rb
@@ -3,18 +3,10 @@ module Users
     def self.call(user)
       # We only destroy direct message channels, not open and invite-only ones
       direct_channels = user.chat_channels.where(channel_type: "direct")
-      direct_channels.each do |direct_channel|
-        cleanup_memberships(direct_channel.chat_channel_memberships)
-        direct_channel.destroy!
-      end
+      direct_channels.each(&:destroy!)
 
       # Clean up the banished user's remaining channel memberships
-      cleanup_memberships(user.chat_channel_memberships)
+      user.reload.chat_channel_memberships.each(&:destroy!)
     end
-
-    def self.cleanup_memberships(chat_channel_memberships)
-      chat_channel_memberships.each(&:destroy!)
-    end
-    private_class_method :cleanup_memberships
   end
 end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Lately, we have been seeing Sidekiq jobs fail due to this error which comes from trying to delete a chat channel membership from Elasticsearch that is not present. 
```
Search::Errors::Transport::NotFound: [404] {"_index":"chat_channel_memberships_production","_type":"_doc","_id":"123","_version":1,"result":"not_found","_shards":{"total":2,"successful":2,"failed":0
```
I traced the error back to the banish user endpoint and found in our `Users::CleanupChatChannels` that we were issueing multiple destroy commands on the same chat channels causing multiple jobs for removing them from Elasticsearch to get kicked off. I was able to verify this locally with a bit of logging(see below).

To fix this I refactored the job to allow the chat channel destroy to destroy the memberships and then reload the user before loading any additional memberships that need to be destroyed to ensure we dont double up. 
```
2020-03-09T19:34:45.525Z pid=73098 tid=ove037f6u class=Search::IndexToElasticsearchWorker jid=e30a7715437b8adf23a3c0f3 elapsed=0.043 INFO: done
15:34:45 web.1       |   Message Destroy (20.8ms)  DELETE FROM "messages" WHERE "messages"."user_id" = $1  [["user_id", 5]]
15:34:45 web.1       |   ChatChannel Load (2.2ms)  SELECT "chat_channels".* FROM "chat_channels" INNER JOIN "chat_channel_memberships" ON "chat_channels"."id" = "chat_channel_memberships"."chat_channel_id" WHERE "chat_channel_memberships"."user_id" = $1 AND "chat_channels"."channel_type" = $2  [["user_id", 5], ["channel_type", "direct"]]
15:34:45 web.1       |   ChatChannelMembership Load (0.3ms)  SELECT "chat_channel_memberships".* FROM "chat_channel_memberships" WHERE "chat_channel_memberships"."chat_channel_id" = $1  [["chat_channel_id", 7]]
15:34:45 web.1       |    (0.2ms)  BEGIN
15:34:45 web.1       |   ChatChannelMembership Destroy (0.3ms)  DELETE FROM "chat_channel_memberships" WHERE "chat_channel_memberships"."id" = $1  [["id", 8]]
15:34:45 web.1       |    (0.3ms)  COMMIT
15:34:45 web.1       | ****************************************************************************************************
15:34:45 web.1       | DELETING 8 for class Search::ChatChannelMembership
15:34:45 web.1       | ****************************************************************************************************
15:34:45 sidekiq.1   | 2020-03-09T19:34:45.584Z pid=73098 tid=ove037dp2 class=Search::RemoveFromElasticsearchIndexWorker jid=7665c49c9f3fbfb8f7d634ae INFO: start
15:34:45 web.1       |    (0.1ms)  BEGIN
15:34:45 web.1       |   ChatChannelMembership Destroy (0.2ms)  DELETE FROM "chat_channel_memberships" WHERE "chat_channel_memberships"."id" = $1  [["id", 7]]
15:34:45 web.1       |    (2.0ms)  COMMIT
15:34:45 web.1       | ****************************************************************************************************
15:34:45 web.1       | DELETING 7 for class Search::ChatChannelMembership
15:34:45 web.1       | ****************************************************************************************************
15:34:45 sidekiq.1   | 2020-03-09T19:34:45.588Z pid=73098 tid=ove037dxm class=Search::RemoveFromElasticsearchIndexWorker jid=62da74f846671c45258f2204 INFO: start
15:34:45 web.1       |    (0.1ms)  BEGIN
15:34:45 web.1       |   Message Load (0.2ms)  SELECT "messages".* FROM "messages" WHERE "messages"."chat_channel_id" = $1  [["chat_channel_id", 7]]
15:34:45 web.1       |   Message Destroy (0.9ms)  DELETE FROM "messages" WHERE "messages"."id" = $1  [["id", 2]]
15:34:45 web.1       |   ChatChannel Destroy (1.7ms)  DELETE FROM "chat_channels" WHERE "chat_channels"."id" = $1  [["id", 7]]
15:34:45 web.1       |    (0.4ms)  COMMIT
15:34:45 web.1       | ****************************************************************************************************
15:34:45 web.1       | DELETING 8 for class Search::ChatChannelMembership
15:34:45 web.1       | ****************************************************************************************************
15:34:45 sidekiq.1   | 2020-03-09T19:34:45.606Z pid=73098 tid=ove037e8u class=Search::RemoveFromElasticsearchIndexWorker jid=cc0b0d9304ed4f8fdf2fe558 INFO: start
15:34:45 web.1       | ****************************************************************************************************
15:34:45 web.1       | DELETING 7 for class Search::ChatChannelMembership
15:34:45 web.1       | ****************************************************************************************************
```
## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-34153523

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media.giphy.com/media/4QFAH0qZ0LQnIwVYKT/200w_d.gif)
