### PR TITLE
Allow preview image URL form to be visible for articles with videos

### DIFF
--- a/app/assets/stylesheets/preact/article-form.scss
+++ b/app/assets/stylesheets/preact/article-form.scss
@@ -10,7 +10,6 @@
   padding-top: 60px;
   margin: auto;
   max-width: 880px;
-  margin-bottom: -50px;
   .article-form-video-image-url {
     padding-top: 15px;
     font-family: $monospace;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This change removes a large margin from the "preview image url" input form that:
1) didn't appear to be necessary
2) caused element overlap when viewing a post that had a video attached, which caused the preview image URL form to not be entirely visible!

## Related Tickets & Documents

This fixes #6311!

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Before this change:
<img width="1280" alt="Screen Shot 2020-03-09 at 2 53 28 PM" src="https://user-images.githubusercontent.com/6921610/76260917-19ceb080-6216-11ea-9443-eac51f55a8eb.png">

After this change:
<img width="1247" alt="Screen Shot 2020-03-09 at 2 53 12 PM" src="https://user-images.githubusercontent.com/6921610/76260922-1cc9a100-6216-11ea-962a-7073a5228d9b.png">

## Added tests?

- [ ] yes
- [x] no, because they aren't needed**
- [ ] no, because I need help

**As far as I know, we don't have a built-in way of testing this?

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed