### PR TITLE
Skip /welcome in serviceworkers

### DIFF
--- a/app/views/service_worker/index.js.erb
+++ b/app/views/service_worker/index.js.erb
@@ -113,6 +113,7 @@
         !url.href.includes('/social_previews') && // Skip for social previews
         !url.href.includes('/users/auth') && // Don't run on authentication.
         !url.href.includes('/enter') && // Don't run on registration.
+        !url.href.includes('/welcome') && // Don't run on welcome reroutes.
 
         // Don't run on search endpoints
         !url.href.includes('/search/tags') &&


### PR DESCRIPTION
### What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description
`/welcome` is a redirect route and should be ignored by our service worker.
## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/issues/5546#issuecomment-596078464
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
n/a
## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a
