### PR TITLE
Disallow /mod/ in robots.txt

### DIFF
--- a/app/views/articles/tags/_sidebar.html.erb
+++ b/app/views/articles/tags/_sidebar.html.erb
@@ -1,4 +1,4 @@
-<% cache "tag-sidebar-#{@tag}-#{@tag_model&.updated_at}-#{@tag_model&.taggings_count}", expires_in: 5.hours do %>
+<% cache "tag-sidebar-#{@tag}-#{@tag_model&.updated_at}-#{@tag_model&.taggings_count}-#{user_signed_in?}", expires_in: 5.hours do %>
   <div id="sidebar-wrapper-left" class="sidebar-wrapper sidebar-wrapper-left">
     <div class="sidebar-bg" id="sidebar-bg-left"></div>
     <div class="side-bar">

--- a/app/views/pages/robots.text.erb
+++ b/app/views/pages/robots.text.erb
@@ -6,5 +6,7 @@ Disallow: /connect/@*
 Disallow: /search?q=*
 Disallow: /search/?q=*
 Disallow: /listings*?q=*
+Disallow: /mod/*
+Disallow: /mod?*
 
 Sitemap: https://<%= ApplicationConfig["AWS_BUCKET_NAME"] %>.s3.amazonaws.com/sitemaps/sitemap.xml.gz


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We currently get some bot traffic to endpoints like `/mod/javascript` which is just a waste of their resources since it shows nothing relevant and it's best to prevent that.

But why do they get there in the first place if we don't link to it? Of course, it's a public page so anyone could link to it, but that would be odd.

Ohhhhhhh we do link to it because we have a cache leak because we ask `user_signed_in?` inside a fragment cache that doesn't account for that. Not a sensitive leak or anything, but definitely a bug.