### PR TITLE
Improved the podcasts seeds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,9 @@ docs/.static/api/
 # rvm
 .ruby-gemset
 
+# rbenv
+.rbenv-vars
+
 # asdf
 .tool-versions
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -150,7 +150,8 @@ podcast_objects = [
     main_color_hex: "2faa4a",
     overcast_url: "https://overcast.fm/itunes919219256/codenewbie",
     android_url: "https://subscribeonandroid.com/feeds.podtrac.com/q8s8ba9YtM6r",
-    image: Rack::Test::UploadedFile.new(image_file, "image/jpeg")
+    image: Rack::Test::UploadedFile.new(image_file, "image/jpeg"),
+    published: true
   },
   {
     title: "CodingBlocks",
@@ -162,7 +163,8 @@ podcast_objects = [
     main_color_hex: "111111",
     overcast_url: "https://overcast.fm/itunes769189585/coding-blocks",
     android_url: "http://subscribeonandroid.com/feeds.podtrac.com/c8yBGHRafqhz",
-    image: Rack::Test::UploadedFile.new(image_file, "image/jpeg")
+    image: Rack::Test::UploadedFile.new(image_file, "image/jpeg"),
+    published: true
   },
   {
     title: "Talk Python",
@@ -174,7 +176,8 @@ podcast_objects = [
     main_color_hex: "181a1c",
     overcast_url: "https://overcast.fm/itunes979020229/talk-python-to-me",
     android_url: "https://subscribeonandroid.com/talkpython.fm/episodes/rss",
-    image: Rack::Test::UploadedFile.new(image_file, "image/jpeg")
+    image: Rack::Test::UploadedFile.new(image_file, "image/jpeg"),
+    published: true
   },
   {
     title: "Developer on Fire",
@@ -187,12 +190,14 @@ podcast_objects = [
     main_color_hex: "343d46",
     overcast_url: "https://overcast.fm/itunes1006105326/developer-on-fire",
     android_url: "http://subscribeonandroid.com/developeronfire.com/rss.xml",
-    image: Rack::Test::UploadedFile.new(image_file, "image/jpeg")
+    image: Rack::Test::UploadedFile.new(image_file, "image/jpeg"),
+    published: true
   },
 ]
 
 podcast_objects.each do |attributes|
-  Podcast.create!(attributes)
+  podcast = Podcast.create!(attributes)
+  Podcasts::GetEpisodesWorker.perform_async(podcast_id: podcast.id)
 end
 
 ##############################################################################


### PR DESCRIPTION
# What type of PR is this? (check all applicable)
- [x] Refactor

## Description
- create published podcasts while seeding, so that they could be displayed on the site after fetching the episodes
- schedule a worker to fetch podcast episodes after creating podcasts while seeding
The episodes will appear on the sire after the sidekiq jobs are executed.

We discussed the problem with the empty `/pod` section with @ludwiczakpawel before.

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help