### PR TITLE
Remove flash notice to avoid cache leak

### DIFF
--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,7 +1,3 @@
-<% flash.each do |type, message| %>
-  <div class="alert alert-<%= type %>"><%= message %></div>
-<% end %>
-
 <% if @comment.errors.any? %>
   <div id="error_explanation">
     <h2><%= pluralize(@comment.errors.count, "error") %> prohibited this comment from being saved:</h2>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

A little while ago we introduced this `flash` message which isn't really used or needed in most context and results in cache leak based on how we do things...

<img width="421" alt="Screen Shot 2020-03-10 at 12 38 38 PM" src="https://user-images.githubusercontent.com/3102842/76336237-139b0b80-62cc-11ea-9c0e-1dafffde50d7.png">