### PR TITLE
Remove redundant yarn step for Docker

### DIFF
--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -69,7 +69,8 @@ you want to update that set the `POSTGRES_VERSION` variable in your environment
 and start the container again_
 
 1. run `docker-compose build`
-1. run `docker-compose run web bin/setup`
+1. run `docker-compose run web rails db:setup`
+1. run `docker-compose run web rails search:setup`
 1. run `docker-compose up`
 1. That's it! Navigate to <http://localhost:3000>
 

--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -69,7 +69,7 @@ you want to update that set the `POSTGRES_VERSION` variable in your environment
 and start the container again_
 
 1. run `docker-compose build`
-1. run `docker-compose run web rails db:setup`
+1. run `docker-compose run web bin/setup`
 1. run `docker-compose up`
 1. That's it! Navigate to <http://localhost:3000>
 

--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -70,8 +70,6 @@ and start the container again_
 
 1. run `docker-compose build`
 1. run `docker-compose run web rails db:setup`
-1. run `docker-compose run web yarn`
-1. run `docker-compose run web rails search:setup`
 1. run `docker-compose up`
 1. That's it! Navigate to <http://localhost:3000>
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Documentation Update

## Description
`docker-compose up` already covers yarn install
## Related Tickets & Documents
n/a
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
n/a
## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] docs.dev.to