### PR TITLE
Remove extra HoneycombClient

### DIFF
--- a/config/initializers/honeycomb.rb
+++ b/config/initializers/honeycomb.rb
@@ -2,8 +2,6 @@ if Rails.env.test? || ApplicationConfig["HONEYCOMB_API_KEY"].blank?
   Honeycomb.configure do |config|
     config.client = Libhoney::TestClient.new
   end
-
-  HoneycombClient = Libhoney::TestClient.new
 else
   honeycomb_api_key = ApplicationConfig["HONEYCOMB_API_KEY"]
 
@@ -32,7 +30,4 @@ else
       end
     end
   end
-
-  # here we create an additional Honeycomb client that can be used to send custom events
-  HoneycombClient = Libhoney::Client.new(writekey: honeycomb_api_key, dataset: "dev-ruby")
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

We have an extra Honeycomb client we don't use anywhere, we'll likely re-create it when we need it. In the meantime, one less object in memory :D 

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
