### PR TITLE
Allow Blazer to be queried by Tech Admins

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,7 +38,7 @@ Rails.application.routes.draw do
   namespace :internal do
     get "/", to: redirect("/internal/articles")
 
-    authenticate :user, ->(user) { user.has_role?(:super_admin) } do
+    authenticate :user, ->(user) { user.has_role?(:tech_admin) } do
       mount Blazer::Engine, at: "blazer"
     end
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)
- [x] Feature

## Description
I have implemented Hypershield manually so Blazer is now ready for prime time. Getting Hypershield set up within our application so it is automatic is going to take some work and likely some PRs to the gem itself and I didnt want to wait for all of that to allow devs access to this data. I am actually thinking to implement it ourselves might be the easiest and quickest solution since the gem is only a couple of files. But I wanted to get this out bc I think this will be a huge help for a lot of people. 

FOLLOW UP: https://github.com/thepracticaldev/dev.to/projects/5#card-34379497 

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/5#card-33593263

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

![alt_text](https://media0.giphy.com/media/6baQhIFFDiJZaLYDqT/giphy.gif)
