### PR TITLE
Add internal and admin to robots.txt disallow

### DIFF
--- a/app/views/pages/robots.text.erb
+++ b/app/views/pages/robots.text.erb
@@ -8,5 +8,7 @@ Disallow: /search/?q=*
 Disallow: /listings*?q=*
 Disallow: /mod/*
 Disallow: /mod?*
+Disallow: /internal/*
+Disallow: /admin/*
 
 Sitemap: https://<%= ApplicationConfig["AWS_BUCKET_NAME"] %>.s3.amazonaws.com/sitemaps/sitemap.xml.gz


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This disallows robots from `/internal/*` and `/admin/*` pages where they are not needed.

It still allows, for now, bots to go straight to `/internal` etc. without the trailing slash, which could be a log-in page instead of a strict disallow.