### PR TITLE
Github Liquid tag: Fix error when repository has no README + refactor

### DIFF
--- a/app/views/liquids/_github_readme.html.erb
+++ b/app/views/liquids/_github_readme.html.erb
@@ -1,7 +1,7 @@
 <div class="ltag-github-readme-tag">
   <div class="readme-overview">
     <h2>
-      <img src="<%= ActionController::Base.helpers.asset_path('github-logo.svg') %>" alt="GitHub logo">
+      <img src="<%= ActionController::Base.helpers.asset_path("github-logo.svg") %>" alt="GitHub logo">
       <a href="https://github.com/<%= content.owner.login %>">
         <%= content.owner.login %>
       </a> / <a style="font-weight: 600;" href="<%= content.html_url %>">
@@ -14,7 +14,7 @@
   </div>
   <% if show_readme %>
   <div class="ltag-github-body">
-    <p><%= (HTML_Truncator.truncate updated_html, 150).html_safe %></p>
+    <p><%= (HTML_Truncator.truncate readme_html, 150).html_safe %></p>
   </div>
   <div class="gh-btn-container"><a class="gh-btn" href="<%= content.html_url %>">View on GitHub</a></div>
   <% end %>

--- a/spec/liquid_tags/github_tag/github_readme_tag_spec.rb
+++ b/spec/liquid_tags/github_tag/github_readme_tag_spec.rb
@@ -43,5 +43,14 @@ RSpec.describe GithubTag::GithubReadmeTag, type: :liquid_tag, vcr: vcr_option do
       readme_class = "ltag-github-body"
       expect(template).not_to include(readme_class)
     end
+
+    it "handles respositories with a missing README" do
+      allow(my_ocktokit_client).to receive(:readme).and_raise(Octokit::NotFound)
+
+      template = generate_github_readme(path, "no-readme").render
+      readme_class = "ltag-github-body"
+
+      expect(template).not_to include(readme_class)
+    end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor
- [X] Bug Fix

## Description

Our Github liquid tag raised an error when we tried to display a repository with no README unless the user specified the "no-readme" option. This PR fixes that.

Note: I found the code relatively hard to follow, so I refactored it quite a bit in the process. I'll add some more comments inline regarding the what/why.

## Related Tickets & Documents

Closes #6382 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Before:

<img width="898" alt="Screen Shot 2020-03-11 at 11 43 58" src="https://user-images.githubusercontent.com/47985/76387577-d735e100-6399-11ea-94e9-c80e1c44fb35.png">

After:

<img width="800" alt="Screen Shot 2020-03-11 at 11 44 21" src="https://user-images.githubusercontent.com/47985/76387589-e026b280-6399-11ea-8b4f-b1b9bff00225.png">

Repositories with READMEs work like before:

<img width="806" alt="Screen Shot 2020-03-11 at 12 19 42" src="https://user-images.githubusercontent.com/47985/76387608-ee74ce80-6399-11ea-8cf9-e151ecff5f3c.png">

## Added tests?

- [X] yes

## Added to documentation?

- [X] no documentation needed
