### PR TITLE
Remove unnecessary CSS rule

### DIFF
--- a/app/assets/stylesheets/notifications.scss
+++ b/app/assets/stylesheets/notifications.scss
@@ -418,9 +418,5 @@
     clear: both;
 
     @include load-more;
-
-    button {
-      margin-top: 0;
-    }
   }
 }


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Not really sure why this CSS rule is here and the git history doesn't give much of an explanation. It looks like it might have been added by accident.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

before:
![Screenshot_2020-03-11 Discussion of Firefox's New Multi-Line Console Editor is Awesome](https://user-images.githubusercontent.com/11466782/76441240-17429700-638d-11ea-83a5-147f5d2d0b75.png)

after:
![Screenshot_2020-03-11 Discussion of Firefox's New Multi-Line Console Editor is Awesome(1)](https://user-images.githubusercontent.com/11466782/76441234-16aa0080-638d-11ea-8aaf-1be86d680413.png)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed