### PR TITLE
Disable CORS logging by default in development

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -61,7 +61,8 @@ module PracticalDeveloper
 
     # Enable CORS for API v0
     # (logging is only activated when debug is enabled)
-    config.middleware.insert_before 0, Rack::Cors, debug: Rails.env.development?, logger: (-> { Rails.logger }) do
+    debug_cors = ENV["DEBUG_CORS"].present? ? true : false
+    config.middleware.insert_before 0, Rack::Cors, debug: debug_cors, logger: (-> { Rails.logger }) do
       allow do
         origins do |source, _env|
           source # echo back the client's `Origin` header instead of using `*`

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -80,3 +80,13 @@ end
 If instead you want to tune the Elasticsearch disk allocator's settings, please
 refer to
 [Disk-based shard allocation](https://www.elastic.co/guide/en/elasticsearch/reference/current/disk-allocator.html#disk-allocator).
+
+## CORS
+
+If you are experiencing CORS issues locally or are in need to display more
+information about the CORS headers, add the following varable to your
+`application.yml`:
+
+```yml
+DEBUG_CORS: true
+```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -83,9 +83,8 @@ refer to
 
 ## CORS
 
-If you are experiencing CORS issues locally or are in need to display more
-information about the CORS headers, add the following varable to your
-`application.yml`:
+If you are experiencing CORS issues locally or need to display more information
+about the CORS headers, add the following variable to your `application.yml`:
 
 ```yml
 DEBUG_CORS: true


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

When we enabled CORS in #6116 we activated debugging only in development. The unfortunate side effect is that there's a lot of verbosity added to the logs and additional debugging headers sent with the request. All of this is unnecessary if a person is not actually trying to debug a CORS issue.

Therefore I propose we disable them by default and add an environment variable that allows quick debug if necessary. 

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [x] docs.dev.to
- [ ] readme
- [ ] no documentation needed
