### PR TITLE
Fetch podcast's episodes from /internal

### DIFF
--- a/app/controllers/internal/podcasts_controller.rb
+++ b/app/controllers/internal/podcasts_controller.rb
@@ -1,7 +1,7 @@
 class Internal::PodcastsController < Internal::ApplicationController
   layout "internal"
 
-  before_action :find_podcast, only: %i[edit update remove_admin add_admin]
+  before_action :find_podcast, only: %i[edit update fetch remove_admin add_admin]
   before_action :find_user, only: %i[remove_admin add_admin]
 
   def index
@@ -20,6 +20,14 @@ class Internal::PodcastsController < Internal::ApplicationController
     else
       render :edit
     end
+  end
+
+  def fetch
+    limit = params[:limit].to_i.zero? ? nil : params[:limit].to_i
+    force = params[:force].to_i == 1
+    Podcasts::GetEpisodesWorker.perform_async(podcast_id: @podcast.id, limit: limit, force: force)
+    flash[:notice] = "Podcasts episodes fetching was scheduled"
+    redirect_to internal_podcasts_path
   end
 
   def remove_admin

--- a/app/controllers/internal/podcasts_controller.rb
+++ b/app/controllers/internal/podcasts_controller.rb
@@ -26,7 +26,7 @@ class Internal::PodcastsController < Internal::ApplicationController
     limit = params[:limit].to_i.zero? ? nil : params[:limit].to_i
     force = params[:force].to_i == 1
     Podcasts::GetEpisodesWorker.perform_async(podcast_id: @podcast.id, limit: limit, force: force)
-    flash[:notice] = "Podcasts episodes fetching was scheduled"
+    flash[:notice] = "Podcast's episodes fetching was scheduled (#{@podcast.title}, ##{@podcast.id})"
     redirect_to internal_podcasts_path
   end
 

--- a/app/views/internal/podcasts/edit.html.erb
+++ b/app/views/internal/podcasts/edit.html.erb
@@ -5,6 +5,23 @@
         <h2 class="m-0"><%= link_to @podcast.title, "/#{@podcast.slug}" %></h2>
       </div>
       <div class="card-body">
+        <h3>Fetch episodes</h3>
+        <%= form_with(url: fetch_internal_podcast_path(@podcast.id), method: :post) do %>
+          <div class="form-group">
+            <%= check_box_tag :force %>
+            <%= label_tag :force %>
+            <small>(When checked, the existing episodes' urls will be re-checked and episodes reachable and https fields will be updated accordingly if needed.)</small>
+          </div>
+          <div class="form-group">
+            <%= label_tag :limit %>
+            <small>(The number of episodes to fetch. When set to an empty string, last 1_000 episodes will be fetched.)</small>
+            <%= text_field_tag :limit, 5, class: "form-control" %>
+          </div>
+          <%= submit_tag "Fetch episodes", class: "btn btn-primary" %>
+        <% end %>
+      </div>
+      <hr>
+      <div class="card-body">
         <% if @podcast.admins.present? %>
           <h3>Admins:</h3>
           <ul class="list-group list-group-flush mb-3">

--- a/app/views/internal/podcasts/edit.html.erb
+++ b/app/views/internal/podcasts/edit.html.erb
@@ -6,7 +6,7 @@
       </div>
       <div class="card-body">
         <h3>Fetch episodes</h3>
-        <%= form_with(url: fetch_internal_podcast_path(@podcast.id), method: :post) do %>
+        <%= form_with(url: fetch_internal_podcast_path(@podcast.id), method: :post, local: true) do %>
           <div class="form-group">
             <%= check_box_tag :force %>
             <%= label_tag :force %>

--- a/app/views/internal/podcasts/edit.html.erb
+++ b/app/views/internal/podcasts/edit.html.erb
@@ -1,11 +1,12 @@
+<hr />
+<h2 class="m-0 mb-3"><%= link_to @podcast.title, "/#{@podcast.slug}" %></h2>
 <div class="row">
   <div class="col-12">
-    <div class="card">
+    <div class="card mb-3">
       <div class="card-header">
-        <h2 class="m-0"><%= link_to @podcast.title, "/#{@podcast.slug}" %></h2>
+        <h3>Fetch episodes</h3>
       </div>
       <div class="card-body">
-        <h3>Fetch episodes</h3>
         <%= form_with(url: fetch_internal_podcast_path(@podcast.id), method: :post, local: true) do %>
           <div class="form-group">
             <%= check_box_tag :force %>
@@ -13,17 +14,20 @@
             <small>(When checked, the existing episodes' urls will be re-checked and episodes reachable and https fields will be updated accordingly if needed.)</small>
           </div>
           <div class="form-group">
+            <%= text_field_tag :limit, 5, size: 2 %>
             <%= label_tag :limit %>
             <small>(The number of episodes to fetch. When set to an empty string, last 1_000 episodes will be fetched.)</small>
-            <%= text_field_tag :limit, 5, class: "form-control" %>
           </div>
           <%= submit_tag "Fetch episodes", class: "btn btn-primary" %>
         <% end %>
       </div>
-      <hr>
+    </div>
+    <div class="card mb-3">
+      <div class="card-header">
+        <h3>Manage Admins</h3>
+      </div>
       <div class="card-body">
         <% if @podcast.admins.present? %>
-          <h3>Admins:</h3>
           <ul class="list-group list-group-flush mb-3">
             <% @podcast.admins.each do |admin| %>
               <%= form_for @podcast, url: remove_admin_internal_podcast_path(@podcast.id), html: { method: :delete, class: "form-inline" } do |f| %>
@@ -50,7 +54,13 @@
           </div>
           <%= f.submit "Add Admin", class: "btn btn-primary" %>
         <% end %>
-
+      </div>
+    </div>
+    <div class="card mb-3">
+      <div class="card-header">
+        <h3>Edit Podcast</h3>
+      </div>
+      <div class="card-body">
         <%= form_for [:internal, @podcast] do |f| %>
           <hr>
           <div class="form-group">

--- a/app/workers/podcasts/get_episodes_worker.rb
+++ b/app/workers/podcasts/get_episodes_worker.rb
@@ -4,8 +4,11 @@ module Podcasts
 
     sidekiq_options queue: :high_priority, retry: 10
 
-    # podcast_data should be a Hash with keys :podcast_id, :limit, and :force_update
-    # :limit and :force_update are both optional - there are default values
+    # @param podcast_data [Hash]
+    #   * :podcast_id [Integer]
+    #   * :limit [Integer] (1_000) - number of episodes that will be fetched for this podcast
+    #   * :force_update [Integer] (false) - if set to true, existing episodes' urls will be re-checked
+    #                                       the episodes' `https` and `reachable` fields will be updated accordingly if needed
     def perform(podcast_data = {})
       # Sidekiq turns arguments into Strings so the Ruby keyword argument sorcery doesn't work here
       # prevent any mismatch between String keys and Symbol keys

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,7 @@ Rails.application.routes.draw do
     resources :permissions, only: %i[index]
     resources :podcasts, only: %i[index edit update destroy] do
       member do
+        post :fetch
         post :add_admin
         delete :remove_admin
       end

--- a/spec/requests/internal/podcasts_spec.rb
+++ b/spec/requests/internal/podcasts_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe "/internal/podcasts", type: :request do
     it "redirects back to index with a notice" do
       post fetch_internal_podcast_path(podcast.id)
       expect(response).to redirect_to(internal_podcasts_path)
-      expect(flash[:notice]).to include("scheduled")
+      expect(flash[:notice]).to include("Podcast's episodes fetching was scheduled (#{podcast.title}, ##{podcast.id})")
     end
 
     it "schedules a worker to fetch episodes" do

--- a/spec/requests/internal/podcasts_spec.rb
+++ b/spec/requests/internal/podcasts_spec.rb
@@ -72,4 +72,24 @@ RSpec.describe "/internal/podcasts", type: :request do
       expect(response).to redirect_to(internal_podcasts_path)
     end
   end
+
+  describe "POST /internal/podcasts/:id/fetch_podcasts" do
+    it "redirects back to index with a notice" do
+      post fetch_internal_podcast_path(podcast.id)
+      expect(response).to redirect_to(internal_podcasts_path)
+      expect(flash[:notice]).to include("scheduled")
+    end
+
+    it "schedules a worker to fetch episodes" do
+      sidekiq_assert_enqueued_with(job: Podcasts::GetEpisodesWorker, args: [{ podcast_id: podcast.id, limit: 5, force: false }]) do
+        post fetch_internal_podcast_path(podcast.id), params: { limit: "5", force: nil }
+      end
+    end
+
+    it "schedules a worker without limit and with force" do
+      sidekiq_assert_enqueued_with(job: Podcasts::GetEpisodesWorker, args: [{ podcast_id: podcast.id, force: true, limit: nil }]) do
+        post fetch_internal_podcast_path(podcast.id), params: { force: "1", limit: "" }
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description
- added a feature for admins to manually fetch podcast's episodes from `/internal/podcasts`
Submitting a form will schedule an async job to fetch episodes.
- reorganized podcasts/edit page a bit

## Related Tickets & Documents
#271

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![изображение](https://user-images.githubusercontent.com/30115/76447530-e2a8fc80-63d9-11ea-87c6-120e36930456.png)

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
