### PR TITLE
Lower Blazer timeout to be closer to app STATEMENT_TIMEOUT

### DIFF
--- a/config/blazer.yml
+++ b/config/blazer.yml
@@ -6,7 +6,7 @@ data_sources:
 
     # statement timeout, in seconds
     # none by default
-    timeout: 60
+    timeout: 10
 
     # caching settings
     # can greatly improve speed


### PR DESCRIPTION


## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
STATEMENT_TIMEOUT is 8 seconds, I lowered Blazer to be closer to that since I am not totally sure that would take precedence over this Blazer setting. 

![alt_text](https://media1.tenor.com/images/c308dd63023751a55724c04bc4436121/tenor.gif?itemid=12999375)
