### PR TITLE
Add profile image field to Elasticsearch for presenting after search

### DIFF
--- a/app/serializers/search/user_serializer.rb
+++ b/app/serializers/search/user_serializer.rb
@@ -11,6 +11,7 @@ module Search
                :name,
                :path,
                :positive_reactions_count,
+               :profile_image_90,
                :reactions_count,
                :username
   end

--- a/config/elasticsearch/mappings/users.json
+++ b/config/elasticsearch/mappings/users.json
@@ -32,6 +32,9 @@
     "positive_reactions_count": {
       "type": "integer"
     },
+    "profile_image_90": {
+      "type": "keyword"
+    },
     "reactions_count": {
       "type": "integer"
     },


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Even though we dont search this field we need it for presenting the information in the view. 

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-34388442

## Added tests?
- [x] no, because they aren't needed

![alt_text](https://66.media.tumblr.com/d2fc064e6e02fc045a044796a9cf40be/tumblr_pjqysubTEA1twfuwto1_540.gifv)
