### PR TITLE
Lightalloy/remove active job remainders

### DIFF
--- a/spec/jobs/shared_examples/enqueues_job.rb
+++ b/spec/jobs/shared_examples/enqueues_job.rb
@@ -1,9 +1,0 @@
-RSpec.shared_examples "#enqueues_job" do |queue_name, args|
-  describe "#perform_later" do
-    it "enqueues the job" do
-      expect do
-        described_class.perform_later(args)
-      end.to have_enqueued_job.with(args).on_queue(queue_name)
-    end
-  end
-end

--- a/spec/services/articles/creator_spec.rb
+++ b/spec/services/articles/creator_spec.rb
@@ -71,9 +71,9 @@ RSpec.describe Articles::Creator, type: :service do
     end
 
     it "doesn't schedule a job" do
-      expect do
+      sidekiq_assert_no_enqueued_jobs only: Notifications::NotifiableActionWorker do
         described_class.call(user, invalid_body_attributes)
-      end.not_to have_enqueued_job(1).on_queue(:send_notifiable_action_notification)
+      end
     end
 
     it "doesn't create a notification subscription" do

--- a/spec/services/podcasts/get_episode_spec.rb
+++ b/spec/services/podcasts/get_episode_spec.rb
@@ -50,9 +50,9 @@ RSpec.describe Podcasts::GetEpisode, type: :service do
       ep = create(:podcast_episode, published_at: Time.current, reachable: true, https: false, podcast: podcast)
       ep.update_columns(created_at: 2.days.ago)
       allow(podcast).to receive(:existing_episode).and_return(ep)
-      expect do
+      sidekiq_assert_no_enqueued_jobs only: PodcastEpisodes::UpdateMediaUrlWorker do
         get_episode.call(item: item)
-      end.not_to have_enqueued_job.on_queue("podcast_episode_update")
+      end
     end
 
     it "updates published_at when it was nil" do
@@ -105,9 +105,9 @@ RSpec.describe Podcasts::GetEpisode, type: :service do
     end
 
     it "doesn't schedule jobs" do
-      expect do
+      sidekiq_assert_no_enqueued_jobs do
         described_class.new(podcast).call(item: item)
-      end.not_to have_enqueued_job
+      end
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor

## Description
- removed the unused shared example
- changed the tests that used `have_enqueued_job` helper to use the sidekiq one

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

