### PR TITLE
Added box-sizing border-box to crayon components.

### DIFF
--- a/app/assets/stylesheets/base/reset.scss
+++ b/app/assets/stylesheets/base/reset.scss
@@ -15,7 +15,8 @@
 //   box-sizing: border-box;
 // }
 
-// Remove default padding ul[class],
+// Remove default padding
+ul[class],
 ol[class] {
   padding: 0;
 }

--- a/app/assets/stylesheets/base/reset.scss
+++ b/app/assets/stylesheets/base/reset.scss
@@ -1,3 +1,13 @@
+// TODO: Remove this once we enable box-sixing: border-box globally.
+[class^='crayons'],
+[class^='crayons']::before,
+[class^='crayons']::after,
+[class^='crayons'] *,
+[class^='crayons'] *::before,
+[class^='crayons'] *::after {
+  box-sizing: border-box;
+}
+
 // TODO: uncomment when we're ready!
 // *,
 // *::before,
@@ -5,8 +15,7 @@
 //   box-sizing: border-box;
 // }
 
-// Remove default padding
-ul[class],
+// Remove default padding ul[class],
 ol[class] {
   padding: 0;
 }


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix?
- [ ] Optimization
- [ ] Documentation Update

## Description

We're currently not using `box-sizing: border-box;` in our reset.scss because it will probably break things visually with our current CSS. This laser focuses on just our design system components and adds `box-sizing: border-box;` to them.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![Cats shooting laser beams out of their eyes](https://media.giphy.com/media/ruCg20L6H72TK/giphy.gif)
