### PR TITLE
Make prerun.sh actually set the environment

### DIFF
--- a/datadog/prerun.sh
+++ b/datadog/prerun.sh
@@ -6,5 +6,5 @@ if [ "$DYNOTYPE" == "scheduler" ] || [ "$DYNOTYPE" == "run" ]; then
   # Disable Automatic Beeline integrations to prevent unnecessary
   # data from being tracked in Honeycomb
   # more info here: https://docs.honeycomb.io/getting-data-in/ruby/beeline/#using-env-variables-to-control-framework-integrations
-  HONEYCOMB_DISABLE_AUTOCONFIGURE="true"
+  export HONEYCOMB_DISABLE_AUTOCONFIGURE="true"
 fi


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
HONEYCOMB_DISABLE_AUTOCONFIGURE is evaluated within ruby, not as a shell variable.

## Related Tickets & Documents
https://ui.honeycomb.io/thepracticaldev/datasets/rails/result/crZqCFVuCQh/trace/mPgCgm2pUzT
https://ui.honeycomb.io/thepracticaldev/datasets/rails/result/yqQ8KgSJtC9/trace/cqT2zegzRbD

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
n/a

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
