### PR TITLE
Add response templates model and table

### DIFF
--- a/app/models/response_template.rb
+++ b/app/models/response_template.rb
@@ -1,0 +1,10 @@
+class ResponseTemplate < ApplicationRecord
+  belongs_to :user, optional: true
+  validates :type_of, :content_type, :content, :title, presence: true
+  validates :content, uniqueness: { scope: %i[user_id type_of content_type] }
+  validates :type_of, inclusion: { in: %w[personal_comment mod_comment abuse_report_reply email_reply] }
+  validates :content_type, inclusion: { in: %w[plain_text html body_markdown] }
+  validates :content_type,
+            inclusion: { in: %w[body_markdown], message: "Comment templates must use Markdown as its content type." },
+            if: -> { type_of&.include?("comment") }
+end

--- a/app/models/response_template.rb
+++ b/app/models/response_template.rb
@@ -1,10 +1,17 @@
 class ResponseTemplate < ApplicationRecord
   belongs_to :user, optional: true
+
+  UNIQUENESS_SCOPE = %i[user_id type_of content_type].freeze
+  TYPE_OF_TYPES = %w[personal_comment mod_comment abuse_report_reply email_reply].freeze
+  CONTENT_TYPES = %w[plain_text html body_markdown].freeze
+  COMMENT_CONTENT_TYPE = %w[body_markdown].freeze
+  COMMENT_VALIDATION_MSG = "Comment templates must use Markdown as its content type.".freeze
+
   validates :type_of, :content_type, :content, :title, presence: true
-  validates :content, uniqueness: { scope: %i[user_id type_of content_type] }
-  validates :type_of, inclusion: { in: %w[personal_comment mod_comment abuse_report_reply email_reply] }
-  validates :content_type, inclusion: { in: %w[plain_text html body_markdown] }
+  validates :content, uniqueness: { scope: UNIQUENESS_SCOPE }
+  validates :type_of, inclusion: { in: TYPE_OF_TYPES }
+  validates :content_type, inclusion: { in: CONTENT_TYPES }
   validates :content_type,
-            inclusion: { in: %w[body_markdown], message: "Comment templates must use Markdown as its content type." },
+            inclusion: { in: COMMENT_CONTENT_TYPE, message: COMMENT_VALIDATION_MSG },
             if: -> { type_of&.include?("comment") }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,6 +48,7 @@ class User < ApplicationRecord
   has_many :affected_feedback_messages, class_name: "FeedbackMessage", inverse_of: :affected, foreign_key: :affected_id, dependent: :nullify
 
   has_many :rating_votes, dependent: :destroy
+  has_many :response_templates, foreign_key: :user_id, inverse_of: :user, dependent: :destroy
   has_many :html_variants, dependent: :destroy
   has_many :page_views, dependent: :destroy
   has_many :credits, dependent: :destroy

--- a/app/services/users/delete_activity.rb
+++ b/app/services/users/delete_activity.rb
@@ -36,6 +36,7 @@ module Users
       user.pro_membership.delete if user.pro_membership.present?
       user.profile_pins.delete_all
       user.rating_votes.delete_all
+      user.response_templates.delete_all
       user.tweets.delete_all
       user.classified_listings.destroy_all
 

--- a/db/migrate/20200311170959_create_response_templates_table.rb
+++ b/db/migrate/20200311170959_create_response_templates_table.rb
@@ -1,0 +1,15 @@
+class CreateResponseTemplatesTable < ActiveRecord::Migration[5.2]
+  def change
+    create_table :response_templates do |t|
+      t.string "type_of", null: false # abuse_report_reply, mod_comment, email_reply, personal_comment
+      t.string "content_type", null: false # body_markdown, plain_text, html
+      t.text "content", null: false
+      t.string "title", null: false
+      t.references :user, foreign_key: true # allow null for app wide usage of templates
+
+      t.timestamps null: false
+    end
+
+    add_index :response_templates, :type_of
+  end
+end

--- a/db/migrate/20200311201103_add_moderator_id_to_comments.rb
+++ b/db/migrate/20200311201103_add_moderator_id_to_comments.rb
@@ -1,5 +1,0 @@
-class AddModeratorIdToComments < ActiveRecord::Migration[5.2]
-  def change
-    add_column :comments, :moderator_id, :bigint, references: "users"
-  end
-end

--- a/db/migrate/20200311201103_add_moderator_id_to_comments.rb
+++ b/db/migrate/20200311201103_add_moderator_id_to_comments.rb
@@ -1,0 +1,5 @@
+class AddModeratorIdToComments < ActiveRecord::Migration[5.2]
+  def change
+    add_column :comments, :moderator_id, :bigint, references: "users"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_08_144606) do
+ActiveRecord::Schema.define(version: 2020_03_11_201103) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -376,6 +376,7 @@ ActiveRecord::Schema.define(version: 2020_03_08_144606) do
     t.boolean "hidden_by_commentable_user", default: false
     t.string "id_code"
     t.integer "markdown_character_count"
+    t.bigint "moderator_id"
     t.integer "positive_reactions_count", default: 0, null: false
     t.text "processed_html"
     t.integer "reactions_count", default: 0, null: false
@@ -960,6 +961,18 @@ ActiveRecord::Schema.define(version: 2020_03_08_144606) do
     t.index ["user_id"], name: "index_reactions_on_user_id"
   end
 
+  create_table "response_templates", force: :cascade do |t|
+    t.text "content", null: false
+    t.string "content_type", null: false
+    t.datetime "created_at", null: false
+    t.string "title", null: false
+    t.string "type_of", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id"
+    t.index ["type_of"], name: "index_response_templates_on_type_of"
+    t.index ["user_id"], name: "index_response_templates_on_user_id"
+  end
+
   create_table "roles", id: :serial, force: :cascade do |t|
     t.datetime "created_at"
     t.string "name"
@@ -1303,6 +1316,7 @@ ActiveRecord::Schema.define(version: 2020_03_08_144606) do
   add_foreign_key "oauth_access_tokens", "users", column: "resource_owner_id"
   add_foreign_key "page_views", "articles", on_delete: :cascade
   add_foreign_key "podcasts", "users", column: "creator_id"
+  add_foreign_key "response_templates", "users"
   add_foreign_key "sponsorships", "organizations"
   add_foreign_key "sponsorships", "users"
   add_foreign_key "tag_adjustments", "articles", on_delete: :cascade

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_11_201103) do
+ActiveRecord::Schema.define(version: 2020_03_11_170959) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -376,7 +376,6 @@ ActiveRecord::Schema.define(version: 2020_03_11_201103) do
     t.boolean "hidden_by_commentable_user", default: false
     t.string "id_code"
     t.integer "markdown_character_count"
-    t.bigint "moderator_id"
     t.integer "positive_reactions_count", default: 0, null: false
     t.text "processed_html"
     t.integer "reactions_count", default: 0, null: false

--- a/spec/factories/response_templates.rb
+++ b/spec/factories/response_templates.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :response_template do
+    sequence(:content) { |n| "#{Faker::Lorem.sentence}#{n}" }
+
+    user
+    type_of { "personal_comment" }
+    content_type { "body_markdown" }
+    title { generate :title }
+  end
+end

--- a/spec/models/response_template_spec.rb
+++ b/spec/models/response_template_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe ResponseTemplate, type: :model do
+  it { is_expected.to validate_inclusion_of(:type_of).in_array(ResponseTemplate::TYPE_OF_TYPES) }
+  it { is_expected.to validate_inclusion_of(:content_type).in_array(ResponseTemplate::CONTENT_TYPES) }
+
+  describe "comment content type validation" do
+    context "when the type of is a personal comment" do
+      it "validates that the content type is body markdown" do
+        response_template = build(:response_template, type_of: "personal_comment", content_type: "html")
+        expect(response_template.valid?).to eq false
+        expect(response_template.errors.messages[:content_type].to_sentence).to eq ResponseTemplate::COMMENT_VALIDATION_MSG
+      end
+    end
+
+    context "when the type of is a mod comment" do
+      it "validates that the content type is body markdown" do
+        response_template = build(:response_template, type_of: "mod_comment", content_type: "html")
+        expect(response_template.valid?).to eq false
+        expect(response_template.errors.messages[:content_type].to_sentence).to eq ResponseTemplate::COMMENT_VALIDATION_MSG
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
This is a smaller version of https://github.com/thepracticaldev/dev.to/pull/5419, with only the model and database change. The goal is to split the huge PR of #5419 into smaller, more reviewable pieces.

This adds the response templates table to the DB.

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
No

## [optional] What gif best describes this PR or how it makes you feel?

![The fourth Dragonball, a sign of future Dragonballs.](https://media.giphy.com/media/10Av5RyPAgIXhm/source.gif)