### PR TITLE
fix cannot read privacy policy redirect to onboarding

### DIFF
--- a/app/javascript/packs/onboardingRedirectCheck.jsx
+++ b/app/javascript/packs/onboardingRedirectCheck.jsx
@@ -12,7 +12,8 @@ HTMLDocument.prototype.ready = new Promise(resolve => {
 function redirectableLocation() {
   return (
     window.location.pathname !== '/onboarding' &&
-    window.location.pathname !== '/signout_confirm'
+    window.location.pathname !== '/signout_confirm' &&
+    window.location.pathname !== '/privacy'
   );
 }
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
During onboarding, I cannot access the privacy policy. When I try to do so, I am redirected back to the onboarding page.
### To reproduce 
- Start the onboarding process as a new user
- Click "Continue" below the cat animgif on dev.to/onboarding
- Click the link for the Terms and Conditions next to the checkbox labeled "You agree to our Terms and Conditions"
- In the "1. Terms" section, click the link for "Privacy Policy"

## Related Tickets & Documents
#5205 
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
- no
## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
