### PR TITLE
Remove Unused algoliaFollowedArticles Function

### DIFF
--- a/app/assets/javascripts/initializePage.js.erb
+++ b/app/assets/javascripts/initializePage.js.erb
@@ -1,7 +1,6 @@
 function initializePage(){
   initializeLocalStorageRender();
   initializeStylesheetAppend();
-  initializeFetchFollowedArticles();
   callInitalizers();
 }
 

--- a/app/assets/javascripts/initializers/initializeFetchFollowedArticles.js.erb
+++ b/app/assets/javascripts/initializers/initializeFetchFollowedArticles.js.erb
@@ -1,10 +1,3 @@
-function initializeFetchFollowedArticles() {
-  if ( document.getElementById("featured-story-marker") && checkUserLoggedIn() ) {
-    algoliaFollowedArticles();
-  }
-  insertTimes();
-}
-
 function insertArticle(article,parent,insertPlace) {
   if (article){
     var newItem = document.createElement("DIV");
@@ -77,53 +70,6 @@ function insertTopArticles(user){
       }
     });
   }
-}
-
-function algoliaFollowedArticles(){
-    var user = userData();
-
-    if (user && user.followed_tag_names && user.followed_tag_names.length > 0) {
-      insertInitialArticles(user)
-      const checkBlockedContentEvent = new CustomEvent('checkBlockedContent')
-      window.dispatchEvent(checkBlockedContentEvent)
-      var followedUsersArray = [];
-      if (user.followed_user_ids){
-        followedUsersArray = user.followed_user_ids.map(function(id){return 'user_'+id});
-      }
-      var publicSearchKey = '<%= ALGOLIASEARCH_PUBLIC_SEARCH_ONLY_KEY %>'
-      var client = algoliasearch('<%= ApplicationConfig["ALGOLIASEARCH_APPLICATION_ID"] %>', publicSearchKey);
-      var index = client.initIndex('ordered_articles_<%= Rails.env %>');
-      var searchObj = {
-          hitsPerPage: 20,
-          page: "0",
-          attributesToHighlight: [],
-          tagFilters: [user.followed_tag_names.concat(followedUsersArray)],
-      }
-
-      var homeEl = document.getElementById("index-container");
-      if (homeEl.dataset.feed === "base-feed") {
-        articlesIndex = client.initIndex('ordered_articles_<%= Rails.env %>');
-      } else if (homeEl.dataset.feed === "latest") {
-        articlesIndex = client.initIndex('ordered_articles_by_published_at_<%= Rails.env %>');
-      } else {
-        searchObj["filters"] = ('published_at_int > ' + homeEl.dataset.articlesSince);
-        articlesIndex = client.initIndex('ordered_articles_by_positive_reactions_count_<%= Rails.env %>');
-      }
-      articlesIndex.search("*", searchObj)
-      .then(function searchDone(content) {
-        var insertPlace = document.getElementById("article-index-hidden-div");
-        if (insertPlace) {
-          var parent = insertPlace.parentNode;
-          content.hits.forEach(function(article){
-            if ( !document.getElementById("article-link-"+article.id) ) {
-              insertArticle(article,parent,insertPlace);
-            }
-          });
-        }
-        var el = document.getElementById("home-articles-object")
-        if (el){el.outerHTML = ''}
-      });
-    }
 }
 
 function findOne(haystack, arr) {


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
When trying to find where in the code we search Algolia for articles I came across this `algoliaFollowedArticles` function. We initialize it but I could not find anywhere in the code it is used so I went ahead and removed it. Let me know if I am mistaken and if this is actually used!

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-32289432

## Added tests?
- [x] no, because they aren't needed

![alt_text](https://media.giphy.com/media/26FmRtD5ApkC9qjtK/giphy.gif)
