### PR TITLE
Allow KaTeX to render inline

### DIFF
--- a/app/liquid_tags/katex_tag.rb
+++ b/app/liquid_tags/katex_tag.rb
@@ -9,11 +9,12 @@ class KatexTag < Liquid::Block
   def render(context)
     block = Nokogiri::HTML(super).at("body").text
 
-    parsed_content = begin
-                       Katex.render(block, display_mode: true)
-                     rescue ExecJS::ProgramError => e
-                       e.message
-                     end
+    parsed_content =
+      begin
+        Katex.render(block, display_mode: !inline?)
+      rescue ExecJS::ProgramError => e
+        e.message
+      end
 
     should_render_css = !context[KATEX_EXISTED]
 
@@ -23,8 +24,18 @@ class KatexTag < Liquid::Block
 
     ActionController::Base.new.render_to_string(
       partial: PARTIAL,
-      locals: { parsed_content: parsed_content, should_render_css: should_render_css },
+      locals: {
+        parsed_content: parsed_content,
+        should_render_css: should_render_css,
+        inline: inline?
+      },
     )
+  end
+
+  private
+
+  def inline?
+    @inline ||= @markup.split(" ").include?("inline")
   end
 end
 

--- a/app/views/liquids/_katex.html.erb
+++ b/app/views/liquids/_katex.html.erb
@@ -1,7 +1,13 @@
 <% if should_render_css %>
-  <%= stylesheet_link_tag "katex" %>
+<%= stylesheet_link_tag "katex" %>
 <% end %>
 
+<% if inline %>
+<span class="katex-element">
+  <%= parsed_content %>
+</span>
+<% else %>
 <div class="katex-element">
   <%= parsed_content %>
 </div>
+<% end %>

--- a/app/views/pages/_editor_guide_text.html.erb
+++ b/app/views/pages/_editor_guide_text.html.erb
@@ -205,6 +205,8 @@
       <h3><strong>KaTeX Embed</strong></h3>
       <p>Place your mathematical expression within a KaTeX liquid block, as follows:</p>
       <pre>{% katex %}<br> c = \pm\sqrt{a^2 + b^2}<br>{% endkatex %}<br></pre>
+      <p>To render KaTeX inline add the "inline" option:</p>
+      <pre>{% katex inline %}<br> c = \pm\sqrt{a^2 + b^2}<br>{% endkatex %}<br></pre>
 
       <h3><strong>Stackblitz Embed</strong></h3>
       <p>All you need is the ID of the Stackblitz:</p>

--- a/spec/liquid_tags/katex_tag_spec.rb
+++ b/spec/liquid_tags/katex_tag_spec.rb
@@ -32,5 +32,12 @@ RSpec.describe KatexTag, type: :liquid_tag do
       rendered = generate_katex_liquid(content).render
       expect(rendered).to include("ParseError: KaTeX parse error: ")
     end
+
+    it "can render Katex inline" do
+      Liquid::Template.register_tag("katex", described_class)
+      content = "{% katex inline %}\\c = \\pm\\sqrt{a^2 + b^2}{% endkatex %}"
+      render = Liquid::Template.parse(content).render
+      expect(Nokogiri::HTML(render).css("span.katex-element").count).to eq(1)
+    end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor
- [X] Feature

## Description

So far KaTeX tags could only be rendered in block form, this PR adds the option to render them inline instead.

## Related Tickets & Documents

Closes #6627

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![katex](https://user-images.githubusercontent.com/47985/76822507-da224d00-6843-11ea-8ba2-631386d1c59e.png)

## Added tests?

- [X] yes

## Added to documentation?

- [X] editor guide

## [optional] What gif best describes this PR or how it makes you feel?

![science meme](https://media.makeameme.org/created/science-xsny3g.jpg)
