### PR TITLE
Remove leading whitespace in tags during RSS import

### DIFF
--- a/app/services/rss_reader/assembler.rb
+++ b/app/services/rss_reader/assembler.rb
@@ -32,7 +32,7 @@ class RssReader
     private
 
     def get_tags
-      @categories.first(4).map { |tag| tag[0..19] }.join(",")
+      @categories.first(4).map { |tag| tag.lstrip[0..19] }.join(",")
     end
 
     def assemble_body_markdown


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Description

A user reported that their feed won't import despite being valid according to the W3C validator. The reason is the way categories are specified:

```xml
<category>
Category1,Category2
</category>
```

instead of 

```xml
<category>Category1</category>
<category>Category2</category>
```

Stripping away leading newlines in the tags fixes this.

## Related Tickets & Documents

https://github.com/thepracticaldev/tech-private/issues/412

## Added tests?

- [X] no, because it turned into a rabbit hole and after a recent negative experience where too much time was sunk into a not super important test, I decided to timebox this (I didn't manage to extract the subset of the feed that produces the error). Here's a manual test:

* No `lstrip`

```ruby
RssReader.get_all_articles(true)
# loads of output trimmed
ArgumentError: wrong number of arguments (given 2, expected 0..1)
from /Users/xxx/.asdf/installs/ruby/2.6.5/lib/ruby/2.6.0/logger.rb:542:in `error'
Caused by ArgumentError: wrong number of arguments (given 2, expected 0..1)
from /Users/xxx/.asdf/installs/ruby/2.6.5/lib/ruby/2.6.0/logger.rb:542:in `error'
Caused by ActiveRecord::RecordInvalid: Validation failed: (<unknown>): could not find expected ':' while scanning a simple key at line 6 column 1, Title can't be blank
from /Users/xxx/.gem/ruby/2.6.0/gems/activerecord-5.2.4.1/lib/active_record/validations.rb:80:in `raise_validation_error'
```

* With `lstrip`:

```ruby
RssReader.get_all_articles(true)
# loads of output trimmed
   (1.1ms)  COMMIT
nil
```

Since the change is minimal and doesn't break anything else, I hope we can agree that sinking more time into this test would not be a good use of resources.

## Added to documentation?

- [X] no documentation needed
