### PR TITLE
Fix VCR warnings and use initializers

### DIFF
--- a/spec/models/tweet_spec.rb
+++ b/spec/models/tweet_spec.rb
@@ -1,11 +1,6 @@
 require "rails_helper"
 
-VCR_OPTIONS = {
-  cassette_name: "twitter_fetch_status",
-  allow_playback_repeats: true
-}.freeze
-
-RSpec.describe Tweet, type: :model, vcr: VCR_OPTIONS do
+RSpec.describe Tweet, type: :model, vcr: VCR_OPTIONS[:twitter_fetch_status] do
   let(:tweet_id) { "1018911886862057472" }
 
   it "fetches a tweet" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -51,17 +51,6 @@ allowed_sites = [
 ]
 WebMock.disable_net_connect!(allow_localhost: true, allow: allowed_sites)
 
-# tell VCR to ignore browsers download sites
-# see <https://github.com/titusfortner/webdrivers/wiki/Using-with-VCR-or-WebMock>
-VCR.configure do |config|
-  config.ignore_hosts(
-    "chromedriver.storage.googleapis.com",
-    "github.com/mozilla/geckodriver/releases",
-    "selenium-release.storage.googleapis.com",
-    "developer.microsoft.com/en-us/microsoft-edge/tools/webdriver",
-  )
-end
-
 RSpec::Matchers.define_negated_matcher :not_change, :change
 
 RSpec.configure do |config|
@@ -103,7 +92,7 @@ RSpec.configure do |config|
     end
   end
 
-  # Allow testing with Stripe's test server. BECAREFUL
+  # Allow testing with Stripe's test server. BE CAREFUL
   if config.filter_manager.inclusions.rules.include?(:live)
     WebMock.allow_net_connect!
     StripeMock.toggle_live(true)
@@ -136,9 +125,4 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
-end
-
-Doorkeeper.configure do
-  # hash_token_secrets on its own won't work in test
-  hash_token_secrets fallback: :plain
 end

--- a/spec/requests/liquid_embeds_spec.rb
+++ b/spec/requests/liquid_embeds_spec.rb
@@ -1,11 +1,6 @@
 require "rails_helper"
 
-VCR_OPTIONS = {
-  cassette_name: "twitter_fetch_status",
-  allow_playback_repeats: true
-}.freeze
-
-RSpec.describe "LiquidEmbeds", type: :request, vcr: VCR_OPTIONS do
+RSpec.describe "LiquidEmbeds", type: :request, vcr: VCR_OPTIONS[:twitter_fetch_status] do
   describe "get /embeds" do
     it "renders proper tweet" do
       get "/embed/tweet?args=1018911886862057472"

--- a/spec/support/initializers/doorkeeper.rb
+++ b/spec/support/initializers/doorkeeper.rb
@@ -1,0 +1,4 @@
+Doorkeeper.configure do
+  # hash_token_secrets on its own won't work in test
+  hash_token_secrets fallback: :plain
+end

--- a/spec/support/initializers/vcr.rb
+++ b/spec/support/initializers/vcr.rb
@@ -6,6 +6,15 @@ VCR.configure do |config|
   config.configure_rspec_metadata!
   config.ignore_localhost = true
 
+  # tell VCR to ignore browsers download sites
+  # see <https://github.com/titusfortner/webdrivers/wiki/Using-with-VCR-or-WebMock>
+  config.ignore_hosts(
+    "chromedriver.storage.googleapis.com",
+    "github.com/mozilla/geckodriver/releases",
+    "selenium-release.storage.googleapis.com",
+    "developer.microsoft.com/en-us/microsoft-edge/tools/webdriver",
+  )
+
   # Removes all private data (Basic Auth, Set-Cookie headers...)
   config.before_record do |i|
     i.response.headers.delete("Set-Cookie")
@@ -15,3 +24,10 @@ VCR.configure do |config|
     i.request.uri.sub!(/:\/\/.*#{Regexp.escape(u.host)}/, "://#{u.host}")
   end
 end
+
+VCR_OPTIONS = {
+  twitter_fetch_status: {
+    cassette_name: "twitter_fetch_status",
+    allow_playback_repeats: true
+  }
+}.freeze


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This fixes two warnings we've been having lately:

```
/devto/spec/requests/liquid_embeds_spec.rb:3: warning: already initialized constant VCR_OPTIONS
/devto/spec/models/tweet_spec.rb:3: warning: previous definition of VCR_OPTIONS was here
```

as we have two global constants with the same name. I also moved around Doorkeeper test support initializer into its own file

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
