### PR TITLE
Upgrade recaptcha to 5.4.1 to fix production error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -615,7 +615,7 @@ GEM
     rb-inotify (0.10.0)
       ffi (~> 1.0)
     rdoc (6.2.1)
-    recaptcha (5.4.0)
+    recaptcha (5.4.1)
       json
     redcarpet (3.5.0)
     redis (4.1.3)

--- a/app/controllers/feedback_messages_controller.rb
+++ b/app/controllers/feedback_messages_controller.rb
@@ -11,7 +11,7 @@ class FeedbackMessagesController < ApplicationController
       send_slack_message
       redirect_to "/feedback_messages"
     else
-      flash[:notice] = "Make sure the forms are filled 🤖 "
+      flash[:notice] = "Make sure the forms are filled 🤖"
       @previous_message = feedback_message_params[:message]
       render "pages/report-abuse.html.erb"
     end

--- a/app/controllers/feedback_messages_controller.rb
+++ b/app/controllers/feedback_messages_controller.rb
@@ -21,7 +21,7 @@ class FeedbackMessagesController < ApplicationController
 
   def recaptcha_verified?
     params["g-recaptcha-response"] &&
-      verify_recaptcha(secret_key: ApplicationConfig["RECAPTCHA_SECRET"], response: params["g-recaptcha-response"])
+      verify_recaptcha(secret_key: ApplicationConfig["RECAPTCHA_SECRET"])
   end
 
   def send_slack_message

--- a/app/controllers/feedback_messages_controller.rb
+++ b/app/controllers/feedback_messages_controller.rb
@@ -21,7 +21,7 @@ class FeedbackMessagesController < ApplicationController
 
   def recaptcha_verified?
     params["g-recaptcha-response"] &&
-      verify_recaptcha(secret_key: ApplicationConfig["RECAPTCHA_SECRET"])
+      verify_recaptcha(secret_key: ApplicationConfig["RECAPTCHA_SECRET"], response: params["g-recaptcha-response"])
   end
 
   def send_slack_message


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This fixes the report abuse form, which broke because of an upgrade of the recaptcha gem (https://github.com/ambethia/recaptcha) we use: https://github.com/thepracticaldev/dev.to/pull/6657

Related:
- https://github.com/ambethia/recaptcha/pull/356
- https://github.com/ambethia/recaptcha/pull/354