### PR TITLE
Add internal sidebar navigation

### DIFF
--- a/app/assets/stylesheets/internal/layout.scss
+++ b/app/assets/stylesheets/internal/layout.scss
@@ -1,3 +1,5 @@
+@import '../variables';
+
 #siteConfigBodyContainer {
   padding: 20px;
 }
@@ -63,4 +65,27 @@
 
 .highlighted-border {
   border: 20px solid black;
+}
+
+.sidebar-nav {
+  min-height: 100vh;
+  background: $light-gray;
+  position: sticky;
+  top: 0;
+  align-self: flex-start;
+  max-width: 135px;
+
+  .sidebar-nav-item {
+    display: block;
+    padding: 0.2em;
+
+    &:hover {
+      text-decoration: none;
+      background: $light-medium-gray;
+    }
+  }
+
+  .sidebar-nav-item.active {
+    background: $light-medium-gray;
+  }
 }

--- a/app/views/internal/shared/_navbar.html.erb
+++ b/app/views/internal/shared/_navbar.html.erb
@@ -1,9 +1,9 @@
-<% menu_items = %w[comments articles users tags welcome broadcasts reports pages tools chat_channels permissions growth mods config events badges organizations sponsorships podcasts].each_with_object({}) { |v, h| h[v] = v } %>
+<% menu_items = %w[comments articles users tags welcome broadcasts reports pages tools chat_channels permissions growth mods config events badges organizations sponsorships podcasts].sort.each_with_object({}) { |v, h| h[v] = v } %>
 <% menu_items[:listings] = "classified_listings" %>
 <% menu_items[:webhooks] = "webhook_endpoints" %>
 
-<div class="navbar-nav justify-content-center">
+<div class="mt-4">
   <% menu_items.each do |name, controller| %>
-    <a class="nav-item nav-link <%= "active" if request.path.include?(controller) %>" href="/internal/<%= controller %>"><%= name.to_s.titleize %></a>
+    <a class="sidebar-nav-item px-2 <%= "active" if request.path.include?(controller) %>" href="/internal/<%= controller %>"><%= name.to_s.titleize %></a>
   <% end %>
 </div>

--- a/app/views/layouts/internal.html.erb
+++ b/app/views/layouts/internal.html.erb
@@ -24,29 +24,26 @@
 
 </head>
 <body>
-  <nav class="navbar navbar-expand-xl navbar-light bg-light">
-    <a class="navbar-brand" href="#">
-      <img src="<%= asset_path("rainbowdev.svg") %>" width="30" height="30" class="d-inline-block align-top" alt="DEV Logo">
-    </a>
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavAltMarkup" aria-controls="navbarNavAltMarkup" aria-expanded="false" aria-label="Toggle navigation">
-        <span class="navbar-toggler-icon"></span>
-    </button>
-    <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
-      <%= render "internal/shared/navbar" %>
-    </div>
-  </nav>
+  <div class="d-flex">
+    <nav class="sidebar-nav">
+      <a href="/internal">
+        <img class="d-block mx-auto mt-3" src="<%= asset_path("rainbowdev.svg") %>" width="40" height="40" alt="DEV Logo">
+      </a>
+        <%= render "internal/shared/navbar" %>
+    </nav>
 
-  <div class="container mt-3">
-    <% flash.each do |type, message| %>
-      <div class="alert alert-<%= type == "notice" ? "success" : "danger" %>">
-        <button class="close" data-dismiss="alert">
-          <i class="fa fa-times" aria-hidden="true"></i>
-        </button>
-        <%= message %>
-      </div>
-    <% end %>
-    <h1><%= controller_name.titleize %></h1>
-    <%= yield %>
+    <div class="container mt-3">
+      <% flash.each do |type, message| %>
+        <div class="alert alert-<%= type == "notice" ? "success" : "danger" %>">
+          <button class="close" data-dismiss="alert">
+            <i class="fa fa-times" aria-hidden="true"></i>
+          </button>
+          <%= message %>
+        </div>
+      <% end %>
+      <h1 class="mt-3"><%= controller_name.titleize %></h1>
+      <%= yield %>
+    </div>
   </div>
 
   <!-- Bootstrap Dependencies -->


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The navbar in internal is a bit too much for a horizontal nav.

Because we aren't using breadcrumbs, it also indicates to users where
they are, so it needs to be visible and not collapsed.

Making this a sidebar fixes both of those problems. In this state, it is
definitely a barebones implmentation, but it is also an improvement over
the hornizontal nav.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Before:
![image](https://user-images.githubusercontent.com/11466782/76905825-bd503e80-6870-11ea-898b-110dac865dd3.png)

After:

![Peek 2020-03-17 16-58](https://user-images.githubusercontent.com/11466782/76905833-c17c5c00-6870-11ea-9c7f-bdc121943f5b.gif)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![giphy](https://user-images.githubusercontent.com/11466782/76905977-099b7e80-6871-11ea-8784-8af254a5f4b7.gif)

