### PR TITLE
Add welcome thread to seeds file

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -202,7 +202,7 @@ end
 
 ##############################################################################
 
-Rails.logger.info "7. Creating Broadcasts"
+Rails.logger.info "7. Creating Broadcasts and Welcome Thread"
 
 # TODO: [@thepracticaldev/delightful] Remove this once we have launched welcome notifications.
 Broadcast.create!(
@@ -227,6 +227,26 @@ broadcast_messages.each do |type, message|
     active: true,
   )
 end
+
+welcome_thread_content = <<~HEREDOC
+  ---
+  title: Welcome Thread - v0
+  published: true
+  description: Introduce yourself to the community!
+  tags: welcome
+  ---
+
+  Hey there! Welcome to #{ApplicationConfig['COMMUNITY_NAME']}!
+
+  ![WELCOME TO THE INTERNET](https://slack-imgs.com/?c=1&url=http%3A%2F%2Fmedia0.giphy.com%2Fmedia%2FzhbrTTpmSCYog%2Fgiphy-downsized.gif)
+
+  Leave a comment below to introduce yourself to the community!✌️
+HEREDOC
+
+Article.create(
+  body_markdown: welcome_thread_content,
+  user: User.dev_account,
+)
 
 ##############################################################################
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
@juliannatetreault and I were just doing some 🍐ing and found ourselves wishing that this was just a part of our seeds file, so I went ahead and added it! This will be super useful for some of the work we're doing around welcome notifications for us folks on @thepracticaldev/delightful.

The HEREDOC is what we currently use as the default content when creating a welcome thread via the `/internal/welcome` pages, so I just used that as the default body markdown here for the seeds!

## Related Tickets & Documents
N/A

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
N/A

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed