### PR TITLE
Move dev/mascot account to class methods

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -161,9 +161,6 @@ class User < ApplicationRecord
 
   alias_attribute :positive_reactions_count, :reactions_count
 
-  scope :dev_account, -> { find_by(id: SiteConfig.staff_user_id) }
-  scope :mascot_account, -> { find_by(id: SiteConfig.mascot_user_id) }
-
   scope :with_this_week_comments, lambda { |number|
     includes(:counters).joins(:counters).where("(user_counters.data -> 'comments_these_7_days')::int >= ?", number)
   }
@@ -225,14 +222,22 @@ class User < ApplicationRecord
     end
   end
 
-  def estimated_default_language
-    language_settings["estimated_default_language"]
-  end
-
   def self.trigger_delayed_index(record, remove)
     return if remove
 
     Search::IndexWorker.perform_async("User", record.id)
+  end
+
+  def self.dev_account
+    find_by(id: SiteConfig.staff_user_id)
+  end
+
+  def self.mascot_account
+    find_by(id: SiteConfig.mascot_user_id)
+  end
+
+  def estimated_default_language
+    language_settings["estimated_default_language"]
   end
 
   def tag_line

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -243,7 +243,7 @@ welcome_thread_content = <<~HEREDOC
   Leave a comment below to introduce yourself to the community!✌️
 HEREDOC
 
-Article.create(
+Article.create!(
   body_markdown: welcome_thread_content,
   user: User.dev_account,
 )

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -957,4 +957,28 @@ RSpec.describe User, type: :model do
       expect(user.receives_follower_email_notifications?).to be(true)
     end
   end
+
+  describe ".dev_account" do
+    it "returns nil if the account does not exist" do
+      expect(described_class.dev_account).to be_nil
+    end
+
+    it "returns the user if the account exists" do
+      allow(SiteConfig).to receive(:staff_user_id).and_return(user.id)
+
+      expect(described_class.dev_account).to eq(user)
+    end
+  end
+
+  describe ".mascot_account" do
+    it "returns nil if the account does not exist" do
+      expect(described_class.mascot_account).to be_nil
+    end
+
+    it "returns the user if the account exists" do
+      allow(SiteConfig).to receive(:mascot_user_id).and_return(user.id)
+
+      expect(described_class.mascot_account).to eq(user)
+    end
+  end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

I noticed how `User.dev_account` returns a `ActiveRecord_Relation` instead of a `User` object. The reason it does it's because it's defined as a `scope` but in this case we should define it as a regular method, as we're loading a specific object, not composing scopes.

I also wasn't able to create the welcome thread in the seed file, when I ran:

```ruby
Article.create!(
  body_markdown: welcome_thread_content,
  user: User.dev_account,
)
```

I got the following error:

```
ActiveRecord::AssociationTypeMismatch: User(#70164944078580) expected, got #<ActiveRecord::Relation [#<User id: 3
```

## Related Tickets & Documents

https://github.com/thepracticaldev/dev.to/pull/6687 

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
