### PR TITLE
Fix comments preview paragraph spacing

### DIFF
--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -333,18 +333,24 @@ a.header-link {
       width: calc(100% - 80px);
       margin: 19px auto 8px;
       border: 1px solid #dbdbdb;
+      line-height: 2em;
+
       p.loading-message {
         opacity: 0.6;
       }
+
       pre {
         overflow-x: auto;
       }
+
       kbd {
         @extend %kbd;
       }
+
       code {
         word-wrap: break-word;
       }
+
       .article-body-image-wrapper img {
         max-width: 100%;
       }

--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -333,7 +333,9 @@ a.header-link {
       width: calc(100% - 80px);
       margin: 19px auto 8px;
       border: 1px solid #dbdbdb;
-      line-height: 2em;
+      > * {
+        margin: 4px 0px calc(1.1vw + 10px); // ok, i'm not a big fan of doing this weird math calc() but this is what we do for real comments sooo 🤷‍♂️
+      }
 
       p.loading-message {
         opacity: 0.6;


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

I noticed how the comments preview doesn't space enough the various paragraphs.

So if this is text:

![Screenshot_2020-03-18 Eyeless in Gaza Commodi pariatur - DEV(local) Community 👩‍💻👨‍💻](https://user-images.githubusercontent.com/146201/76978905-90b32a00-6937-11ea-8c5d-3d9d36d95538.png)

this is the preview:

![Screenshot_2020-03-18 Eyeless in Gaza Commodi pariatur - DEV(local) Community 👩‍💻👨‍💻(1)](https://user-images.githubusercontent.com/146201/76978955-9e68af80-6937-11ea-9229-593b2b13ab21.png)

I added some `line-height` to space them out a little more

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![Screenshot_2020-03-18 Eyeless in Gaza Commodi pariatur - DEV(local) Community 👩‍💻👨‍💻(2)](https://user-images.githubusercontent.com/146201/76979000-aaed0800-6937-11ea-9b7e-cc576d76e719.png)


## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
