### PR TITLE
Remove broken image from seeded welcome thread

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -238,8 +238,6 @@ welcome_thread_content = <<~HEREDOC
 
   Hey there! Welcome to #{ApplicationConfig['COMMUNITY_NAME']}!
 
-  ![WELCOME TO THE INTERNET](https://slack-imgs.com/?c=1&url=http%3A%2F%2Fmedia0.giphy.com%2Fmedia%2FzhbrTTpmSCYog%2Fgiphy-downsized.gif)
-
   Leave a comment below to introduce yourself to the community!✌️
 HEREDOC
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The seeded welcome thread that I added in #6687 actually included an image that would be broken in local dev, since attempts to use cloudinary locally via its URL.

I just decided to remove it since we don't necessarily _need_ an image there (I just copied what we use as the default content in `/internal/welcome`'s controller 🙃).

Thanks to @rhymes for catching this! 

## Related Tickets & Documents
#6687

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed