### PR TITLE
Add Feed Content Backend Search Code

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -17,6 +17,16 @@ class SearchController < ApplicationController
     per_page
   ].freeze
 
+  FEED_PARAMS = %i[
+    page
+    per_page
+    published_at
+    search_fields
+    sort_by
+    tag_names
+    user_id
+  ].freeze
+
   def tags
     tag_docs = Search::Tag.search_documents("name:#{params[:name]}* AND supported:true")
 
@@ -47,6 +57,12 @@ class SearchController < ApplicationController
     render json: { result: user_docs }
   end
 
+  def feed_content
+    feed_docs = Search::FeedContent.search_documents(params: feed_params.to_h)
+
+    render json: { result: feed_docs }
+  end
+
   private
 
   def chat_channel_params
@@ -68,6 +84,10 @@ class SearchController < ApplicationController
 
   def user_params
     params.permit(USER_PARAMS)
+  end
+
+  def feed_params
+    params.permit(FEED_PARAMS)
   end
 
   def format_integer_params

--- a/app/services/search/query_builders/feed_content.rb
+++ b/app/services/search/query_builders/feed_content.rb
@@ -1,0 +1,77 @@
+module Search
+  module QueryBuilders
+    class FeedContent < QueryBase
+      QUERY_KEYS = %i[
+        search_fields
+      ].freeze
+
+      TERM_KEYS = {
+        tag_names: "tags.name",
+        approved: "approved",
+        user_id: "user.id"
+      }.freeze
+
+      RANGE_KEYS = %i[
+        published_at
+      ].freeze
+
+      DEFAULT_PARAMS = {
+        sort_by: "hotness_score",
+        sort_direction: "desc",
+        size: 0
+      }.freeze
+
+      attr_accessor :params, :body
+
+      def initialize(params)
+        @params = params.deep_symbolize_keys
+        build_body
+      end
+
+      private
+
+      def build_queries
+        @body[:query] = { bool: {} }
+        @body[:query][:bool][:filter] = filter_conditions if filter_keys_present?
+        @body[:query][:bool][:must] = query_conditions if query_keys_present?
+      end
+
+      def filter_conditions
+        filter_conditions = []
+
+        filter_conditions.concat(term_keys) if terms_keys_present?
+        filter_conditions.concat(range_keys) if range_keys_present?
+
+        filter_conditions
+      end
+
+      def filter_keys_present?
+        range_keys_present? || terms_keys_present?
+      end
+
+      def terms_keys_present?
+        TERM_KEYS.detect { |key, _| @params[key].present? }
+      end
+
+      def range_keys_present?
+        RANGE_KEYS.detect { |key| @params[key].present? }
+      end
+
+      def term_keys
+        TERM_KEYS.map do |term_key, search_key|
+          next unless @params.key? term_key
+
+          { term: { search_key => @params[term_key] } }
+        end.compact
+      end
+
+      def range_keys
+        RANGE_KEYS.map do |range_key|
+          next unless @params.key? range_key
+
+          { range: { range_key => @params[range_key] } }
+        end.compact
+      end
+    end
+  end
+end

--- a/app/services/search/query_builders/feed_content.rb
+++ b/app/services/search/query_builders/feed_content.rb
@@ -8,7 +8,8 @@ module Search
       TERM_KEYS = {
         tag_names: "tags.name",
         approved: "approved",
-        user_id: "user.id"
+        user_id: "user.id",
+        class_name: "class_name"
       }.freeze
 
       RANGE_KEYS = %i[

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -225,6 +225,7 @@ Rails.application.routes.draw do
   get "/search/chat_channels" => "search#chat_channels"
   get "/search/classified_listings" => "search#classified_listings"
   get "/search/users" => "search#users"
+  get "/search/feed_content" => "search#feed_content"
   get "/chat_channel_memberships/find_by_chat_channel_id" => "chat_channel_memberships#find_by_chat_channel_id"
   get "/listings/dashboard" => "classified_listings#dashboard"
   get "/listings/:category" => "classified_listings#index"

--- a/spec/requests/search_spec.rb
+++ b/spec/requests/search_spec.rb
@@ -55,4 +55,32 @@ RSpec.describe "Search", type: :request, proper_status: true do
       expect(response.parsed_body).to eq("result" => mock_documents)
     end
   end
+
+  describe "GET /search/users" do
+    let(:authorized_user) { create(:user) }
+    let(:mock_documents) { [{ "username" => "firstlast" }] }
+
+    it "returns json" do
+      sign_in authorized_user
+      allow(Search::User).to receive(:search_documents).and_return(
+        mock_documents,
+      )
+      get "/search/users"
+      expect(response.parsed_body).to eq("result" => mock_documents)
+    end
+  end
+
+  describe "GET /search/feed_content" do
+    let(:authorized_user) { create(:user) }
+    let(:mock_documents) { [{ "title" => "article1" }] }
+
+    it "returns json" do
+      sign_in authorized_user
+      allow(Search::FeedContent).to receive(:search_documents).and_return(
+        mock_documents,
+      )
+      get "/search/feed_content"
+      expect(response.parsed_body).to eq("result" => mock_documents)
+    end
+  end
 end

--- a/spec/services/search/feed_content_spec.rb
+++ b/spec/services/search/feed_content_spec.rb
@@ -25,9 +25,9 @@ RSpec.describe Search::FeedContent, type: :service do
         index_documents([article1, article2])
         query_params = { size: 5, search_fields: "ruby" }
 
-        article_docs = described_class.search_documents(params: query_params)
-        expect(article_docs.count).to eq(2)
-        doc_ids = article_docs.map { |t| t.dig("id") }
+        feed_docs = described_class.search_documents(params: query_params)
+        expect(feed_docs.count).to eq(2)
+        doc_ids = feed_docs.map { |t| t.dig("id") }
         expect(doc_ids).to include(article1.id, article2.id)
       end
     end
@@ -39,9 +39,9 @@ RSpec.describe Search::FeedContent, type: :service do
         index_documents([article1, article2])
         query_params = { size: 5, tag_names: "ruby" }
 
-        article_docs = described_class.search_documents(params: query_params)
-        expect(article_docs.count).to eq(1)
-        doc_ids = article_docs.map { |t| t.dig("id") }
+        feed_docs = described_class.search_documents(params: query_params)
+        expect(feed_docs.count).to eq(1)
+        doc_ids = feed_docs.map { |t| t.dig("id") }
         expect(doc_ids).to include(article1.id)
       end
 
@@ -49,9 +49,9 @@ RSpec.describe Search::FeedContent, type: :service do
         index_documents([article1, article2])
         query_params = { size: 5, user_id: article1.user_id }
 
-        article_docs = described_class.search_documents(params: query_params)
-        expect(article_docs.count).to eq(1)
-        doc_ids = article_docs.map { |t| t.dig("id") }
+        feed_docs = described_class.search_documents(params: query_params)
+        expect(feed_docs.count).to eq(1)
+        doc_ids = feed_docs.map { |t| t.dig("id") }
         expect(doc_ids).to include(article1.id)
       end
 
@@ -61,10 +61,21 @@ RSpec.describe Search::FeedContent, type: :service do
         index_documents([article1, article2])
         query_params = { size: 5, approved: true }
 
-        article_docs = described_class.search_documents(params: query_params)
-        expect(article_docs.count).to eq(1)
-        doc_ids = article_docs.map { |t| t.dig("id") }
+        feed_docs = described_class.search_documents(params: query_params)
+        expect(feed_docs.count).to eq(1)
+        doc_ids = feed_docs.map { |t| t.dig("id") }
         expect(doc_ids).to include(article2.id)
+      end
+
+      it "filters by class_name" do
+        pde = create(:podcast_episode)
+        index_documents([pde, article1, article2])
+        query_params = { size: 5, class_name: "PodcastEpisode" }
+
+        feed_docs = described_class.search_documents(params: query_params)
+        expect(feed_docs.count).to eq(1)
+        doc_ids = feed_docs.map { |t| t.dig("id") }
+        expect(doc_ids).to include(pde.id)
       end
     end
 
@@ -75,9 +86,9 @@ RSpec.describe Search::FeedContent, type: :service do
         index_documents([article1, article2])
         query_params = { size: 5, published_at: { gte: 2.months.ago.iso8601 } }
 
-        article_docs = described_class.search_documents(params: query_params)
-        expect(article_docs.count).to eq(1)
-        doc_ids = article_docs.map { |t| t.dig("id") }
+        feed_docs = described_class.search_documents(params: query_params)
+        expect(feed_docs.count).to eq(1)
+        doc_ids = feed_docs.map { |t| t.dig("id") }
         expect(doc_ids).to include(article2.id)
       end
     end

--- a/spec/services/search/feed_content_spec.rb
+++ b/spec/services/search/feed_content_spec.rb
@@ -6,4 +6,80 @@ RSpec.describe Search::FeedContent, type: :service do
     expect(described_class::INDEX_ALIAS).not_to be_nil
     expect(described_class::MAPPINGS).not_to be_nil
   end
+
+  describe "::search_documents", elasticsearch: true do
+    let(:article1) { create(:article) }
+    let(:article2) { create(:article) }
+
+    it "parses feed content document hits from search response" do
+      mock_search_response = { "hits" => { "hits" => {} } }
+      allow(described_class).to receive(:search) { mock_search_response }
+      described_class.search_documents(params: {})
+      expect(described_class).to have_received(:search).with(body: a_kind_of(Hash))
+    end
+
+    context "with a query" do
+      it "searches by search_fields" do
+        allow(article1).to receive(:title).and_return("ruby")
+        allow(article2).to receive(:body_text).and_return("Ruby Tuesday")
+        index_documents([article1, article2])
+        query_params = { size: 5, search_fields: "ruby" }
+
+        article_docs = described_class.search_documents(params: query_params)
+        expect(article_docs.count).to eq(2)
+        doc_ids = article_docs.map { |t| t.dig("id") }
+        expect(doc_ids).to include(article1.id, article2.id)
+      end
+    end
+
+    context "with a filter term" do
+      it "filters by tag names" do
+        article1.tags << create(:tag, name: "ruby")
+        article2.tags << create(:tag, name: "python")
+        index_documents([article1, article2])
+        query_params = { size: 5, tag_names: "ruby" }
+
+        article_docs = described_class.search_documents(params: query_params)
+        expect(article_docs.count).to eq(1)
+        doc_ids = article_docs.map { |t| t.dig("id") }
+        expect(doc_ids).to include(article1.id)
+      end
+
+      it "filters by user_id" do
+        index_documents([article1, article2])
+        query_params = { size: 5, user_id: article1.user_id }
+
+        article_docs = described_class.search_documents(params: query_params)
+        expect(article_docs.count).to eq(1)
+        doc_ids = article_docs.map { |t| t.dig("id") }
+        expect(doc_ids).to include(article1.id)
+      end
+
+      it "filters by approved" do
+        article1.update(approved: false)
+        article2.update(approved: true)
+        index_documents([article1, article2])
+        query_params = { size: 5, approved: true }
+
+        article_docs = described_class.search_documents(params: query_params)
+        expect(article_docs.count).to eq(1)
+        doc_ids = article_docs.map { |t| t.dig("id") }
+        expect(doc_ids).to include(article2.id)
+      end
+    end
+
+    context "with range keys" do
+      it "searches by published_at" do
+        article1.update(published_at: 1.year.ago)
+        article2.update(published_at: 1.month.ago)
+        index_documents([article1, article2])
+        query_params = { size: 5, published_at: { gte: 2.months.ago.iso8601 } }
+
+        article_docs = described_class.search_documents(params: query_params)
+        expect(article_docs.count).to eq(1)
+        doc_ids = article_docs.map { |t| t.dig("id") }
+        expect(doc_ids).to include(article2.id)
+      end
+    end
+  end
 end

--- a/spec/services/search/query_builders/feed_content_spec.rb
+++ b/spec/services/search/query_builders/feed_content_spec.rb
@@ -1,0 +1,85 @@
+require "rails_helper"
+
+RSpec.describe Search::QueryBuilders::FeedContent, type: :service do
+  describe "::intialize" do
+    it "sets params" do
+      filter_params = { foo: "bar" }
+      filter = described_class.new(filter_params)
+      expect(filter.params).to include(filter_params)
+    end
+
+    it "builds query body" do
+      filter = described_class.new({})
+      expect(filter.body).not_to be_nil
+    end
+  end
+
+  describe "#as_hash" do
+    it "applies QUERY_KEYS from params" do
+      params = { search_fields: "test" }
+      filter = described_class.new(params)
+      exepcted_query = [{
+        "simple_query_string" => {
+          "query" => "test*", "fields" => [:search_fields], "lenient" => true, "analyze_wildcard" => true
+        }
+      }]
+      expect(filter.as_hash.dig("query", "bool", "must")).to match_array(exepcted_query)
+    end
+
+    it "applies TERM_KEYS from params" do
+      params = { approved: true, tag_names: "beginner", user_id: 777 }
+      filter = described_class.new(params)
+      exepcted_filters = [
+        { "term" => { "approved" => true } },
+        { "term" => { "tags.name" => "beginner" } },
+        { "term" => { "user.id" => 777 } },
+      ]
+      expect(filter.as_hash.dig("query", "bool", "filter")).to match_array(exepcted_filters)
+    end
+
+    it "applies RANGE_KEYS from params" do
+      Timecop.freeze(Time.current) do
+        params = { published_at: { lte: Time.current } }
+        filter = described_class.new(params)
+        exepcted_filters = [
+          { "range" => { "published_at" => { lte: Time.current } } },
+        ]
+        expect(filter.as_hash.dig("query", "bool", "filter")).to match_array(exepcted_filters)
+      end
+    end
+
+    it "applies QUERY_KEYS, TERM_KEYS, and RANGE_KEYS from params" do
+      Timecop.freeze(Time.current) do
+        params = { search_fields: "ruby", published_at: { lte: Time.current }, tag_names: "cfp" }
+        filter = described_class.new(params)
+        exepcted_query = [{
+          "simple_query_string" => { "query" => "ruby*", "fields" => [:search_fields], "lenient" => true, "analyze_wildcard" => true }
+        }]
+        exepcted_filters = [
+          { "range" => { "published_at" => { lte: Time.current } } },
+          { "term" => { "tags.name" => "cfp" } },
+        ]
+        expect(filter.as_hash.dig("query", "bool", "must")).to match_array(exepcted_query)
+        expect(filter.as_hash.dig("query", "bool", "filter")).to match_array(exepcted_filters)
+      end
+    end
+
+    it "ignores params we don't support" do
+      params = { not_supported: "trash", search_fields: "cfp" }
+      filter = described_class.new(params)
+      exepcted_query = [{
+        "simple_query_string" => {
+          "query" => "cfp*", "fields" => [:search_fields], "lenient" => true, "analyze_wildcard" => true
+        }
+      }]
+      expect(filter.as_hash.dig("query", "bool", "must")).to match_array(exepcted_query)
+    end
+
+    it "allows default params to be overriden" do
+      params = { sort_by: "published_at", sort_direction: "asc", size: 20 }
+      filter = described_class.new(params).as_hash
+      expect(filter.dig("sort")).to eq("published_at" => "asc")
+      expect(filter.dig("size")).to eq(20)
+    end
+  end
+end

--- a/spec/services/search/query_builders/feed_content_spec.rb
+++ b/spec/services/search/query_builders/feed_content_spec.rb
@@ -27,12 +27,13 @@ RSpec.describe Search::QueryBuilders::FeedContent, type: :service do
     end
 
     it "applies TERM_KEYS from params" do
-      params = { approved: true, tag_names: "beginner", user_id: 777 }
+      params = { approved: true, tag_names: "beginner", user_id: 777, class_name: "Article" }
       filter = described_class.new(params)
       exepcted_filters = [
         { "term" => { "approved" => true } },
         { "term" => { "tags.name" => "beginner" } },
         { "term" => { "user.id" => 777 } },
+        { "term" => { "class_name" => "Article" } },
       ]
       expect(filter.as_hash.dig("query", "bool", "filter")).to match_array(exepcted_filters)
     end

--- a/spec/services/search/user_spec.rb
+++ b/spec/services/search/user_spec.rb
@@ -1,13 +1,13 @@
 require "rails_helper"
 
-RSpec.describe Search::User, type: :service, elasticsearch: true do
+RSpec.describe Search::User, type: :service do
   it "defines INDEX_NAME, INDEX_ALIAS, and MAPPINGS", :aggregate_failures do
     expect(described_class::INDEX_NAME).not_to be_nil
     expect(described_class::INDEX_ALIAS).not_to be_nil
     expect(described_class::MAPPINGS).not_to be_nil
   end
 
-  describe "::search_documents" do
+  describe "::search_documents", elasticsearch: true do
     let(:user1) { create(:user) }
     let(:user2) { create(:user) }
 


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Feature

## Description
This PR adds the code to the backend that we will need to search for feed content(articles and podcast episodes) on the front end. Following this will be a PR that hooks up the frontend search which will be pretty involved so I definitely think splitting the front and backend code in this case is ideal. 

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-34785956

## Added tests?
- [x] yes

## Added to documentation?
- [x] no documentation needed

![alt_text](https://68.media.tumblr.com/ae7df07ab085eed28fa99a60ba7a7c41/tumblr_nzis22zWTU1tpn7s0o1_250.gif)
