### PR TITLE
Introduce app_url helper

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -158,8 +158,13 @@ module ApplicationHelper
   end
 
   # Creates an app internal URL
+  #
   # @note Uses protocol and domain specified in the environment, ensure they are set.
   # @param uri [URI, String] parts we want to merge into the URL, e.g. path, fragment
+  # @example Retrieve the base URL
+  #  app_url #=> "https://dev.to"
+  # @example Add a path
+  #  app_url("internal") #=> "https://dev.to/internal"
   def app_url(uri = nil)
     base_url = "#{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}"
     return base_url unless uri

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -157,7 +157,13 @@ module ApplicationHelper
     "#{path}-#{heroku_slug_commit}"
   end
 
-  def app_protocol_and_domain
-    "#{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}"
+  # Creates an app internal URL
+  # @note Uses protocol and domain specified in the environment, ensure they are set.
+  # @param uri [URI, String] parts we want to merge into the URL, e.g. path, fragment
+  def app_url(uri = nil)
+    base_url = "#{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}"
+    return base_url unless uri
+
+    URI.parse(base_url).merge(uri).to_s
   end
 end

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -5,12 +5,12 @@
        content_for: true,
      ) %>
 
-  <link rel="canonical" href="<%= app_protocol_and_domain %><%= request.path %>" />
+  <link rel="canonical" href="<%= app_url(request.path) %>" />
   <meta name="description" content="<%= SiteConfig.community_description %>">
   <meta name="keywords" content="software development,engineering,rails,javascript,ruby">
 
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="<%= app_protocol_and_domain %><%= request.path %>" />
+  <meta property="og:url" content="<%= app_url(request.path) %>" />
   <meta property="og:title" content="<%= title_with_timeframe(page_title: community_qualified_name, timeframe: params[:timeframe]) %>" />
   <meta property="og:image" content="<%= SiteConfig.main_social_image %>">
   <meta property="og:description" content="<%= SiteConfig.community_description %>" />
@@ -21,7 +21,7 @@
   <meta name="twitter:description" content="<%= SiteConfig.community_description %>">
   <meta name="twitter:image:src" content="<%= SiteConfig.main_social_image %>">
   <meta name="twitter:card" content="summary_large_image">
-  <%= auto_discovery_link_tag(:rss, "#{app_protocol_and_domain}/feed", title: "#{ApplicationConfig['COMMUNITY_NAME']} RSS Feed") %>
+  <%= auto_discovery_link_tag(:rss, app_url("feed"), title: "#{ApplicationConfig['COMMUNITY_NAME']} RSS Feed") %>
 <% end %>
 <%= javascript_packs_with_chunks_tag "homePage", defer: true %>
 

--- a/app/views/users/_meta.html.erb
+++ b/app/views/users/_meta.html.erb
@@ -1,9 +1,9 @@
-<link rel="canonical" href="<%= app_protocol_and_domain %>/<%= @user.username %>" />
+<link rel="canonical" href="<%= app_url(@user.username) %>" />
 <meta name="description" content="<%= @user.summary %>">
 <meta name="keywords" content="software development,engineering,rails,javascript,ruby">
 
 <meta property="og:type" content="website" />
-<meta property="og:url" content="<%= app_protocol_and_domain %>/<%= @user.username %>" />
+<meta property="og:url" content="<%= app_url(@user.username) %>" />
 <meta property="og:title" content="<%= @user.name %> — DEV Profile" />
 <meta property="og:image" content="<%= user_social_image_url(@user) %>">
 <meta property="og:description" content="<%= @user.summary %>" />
@@ -16,7 +16,7 @@
 <meta name="twitter:description" content="<%= @user.summary %>">
 <meta name="twitter:image:src" content="<%= user_social_image_url(@user) %>">
 <% if @stories.any? %>
-  <%= auto_discovery_link_tag(:rss, "#{app_protocol_and_domain}/feed/#{@user.username}", title: "The Practical Dev RSS Feed") %>
+  <%= auto_discovery_link_tag(:rss, app_url("/feed/#{@user.username}"), title: "The Practical Dev RSS Feed") %>
 <% end %>
 
 <% if @user.banned %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -37,4 +37,28 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(helper.cache_key_heroku_slug("cache-me")).to eq("cache-me-abc123")
     end
   end
+
+  describe "#app_url" do
+    before do
+      allow(ApplicationConfig).to receive(:[]).with("APP_PROTOCOL").and_return("https://")
+      allow(ApplicationConfig).to receive(:[]).with("APP_DOMAIN").and_return("dev.to")
+    end
+
+    it "creates the correct base app URL" do
+      expect(app_url).to eq("https://dev.to")
+    end
+
+    it "creates a URL with a path" do
+      expect(app_url("internal")).to eq("https://dev.to/internal")
+    end
+
+    it "creates the correct URL even if the path starts with a slash" do
+      expect(app_url("/internal")).to eq("https://dev.to/internal")
+    end
+
+    it "works when called with an URI object" do
+      uri = URI::Generic.build(path: "internal", fragment: "test")
+      expect(app_url(uri)).to eq("https://dev.to/internal#test")
+    end
+  end
 end


### PR DESCRIPTION
## What type of PR is this?

- [X] Refactor
- [X] Feature

## Description

A while ago @rhymes and I [discussed adding a helper for app internal URLs](https://github.com/thepracticaldev/dev.to/pull/6249/files#r383084345). Then @benhalpern added an `app_protocol_and_domain` helper, which has a similar intent.

This PR renames the existing method to `app_url` and refactors it so that we can add paths, fragments, etc. The included specs and YARD documentation illustrate this functionality. It relies on Ruby's `URI` implementation to do the heavy lifting.

NOTE: I did *not* yet refactor all places where this could potentially be used, I can do that in a follow-up PR. This only changes places where `app_protocol_and_domain` was used.

## Related Tickets & Documents

No ticket, this was my last personal TODO item for the cooldown period.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [X] yes

## Added to documentation?

- [X] yes, the helper has YARD docs
