### PR TITLE
Adds Podcast Episode metadata as JSON to avoid scraping the HTML

### DIFF
--- a/app/assets/javascripts/initializers/initializePodcastPlayback.js
+++ b/app/assets/javascripts/initializers/initializePodcastPlayback.js
@@ -276,15 +276,19 @@ function initializePodcastPlayback() {
 
   function startAudioPlayback(audio) {
     if (isNativeIOS()) {
-      var titleElement = document.getElementsByClassName('title')[0];
-      if (titleElement !== undefined) {
-        // We do have the Podcast data (not always true)
+      try {
+        var episodeContainer = document.getElementsByClassName('podcast-episode-container')[0];
+        var metadata = JSON.parse(episodeContainer.dataset.meta);
         var message = {
           'action': 'metadata',
-          'episodeName': titleElement.querySelector('h1').innerText,
-          'podcastName': titleElement.querySelector('img').alt
+          'episodeName': metadata.episodeName,
+          'podcastName': metadata.podcastName,
+          'podcastImageUrl': metadata.podcastImageUrl
         }
         sendPodcastMessage(message);
+      } catch(e) {
+        console.log('Unable to load Podcast Episode metadata', e); // eslint-disable-line no-console
+        return;
       }
     }
 

--- a/app/assets/javascripts/initializers/initializePodcastPlayback.js
+++ b/app/assets/javascripts/initializers/initializePodcastPlayback.js
@@ -18,9 +18,16 @@
  * - initializeMedia()
  * - currentAudioState()
  * - saveMediaState()
+ *
+ * The following are useful eslint disables for this file in particular. Because
+ * of the way it's wrapped around it's own function (own context) we don't have
+ * the problem of using a method before it's defined:
  */
 
- var audioInitialized = false;
+/* eslint no-use-before-define: 0 */
+/* eslint no-param-reassign: 0 */
+
+var audioInitialized = false;
 
 function initializePodcastPlayback() {
   function getById(name) {

--- a/app/assets/javascripts/initializers/initializePodcastPlayback.js
+++ b/app/assets/javascripts/initializers/initializePodcastPlayback.js
@@ -295,7 +295,6 @@ function initializePodcastPlayback() {
         sendPodcastMessage(message);
       } catch(e) {
         console.log('Unable to load Podcast Episode metadata', e); // eslint-disable-line no-console
-        return;
       }
     }
     playAudio(audio).then(function() {

--- a/app/assets/javascripts/initializers/initializePodcastPlayback.js
+++ b/app/assets/javascripts/initializers/initializePodcastPlayback.js
@@ -298,7 +298,6 @@ function initializePodcastPlayback() {
         return;
       }
     }
-
     playAudio(audio).then(function() {
         spinPodcastRecord();
         startPodcastBar();

--- a/app/models/podcast_episode.rb
+++ b/app/models/podcast_episode.rb
@@ -136,6 +136,14 @@ class PodcastEpisode < ApplicationRecord
     []
   end
 
+  def mobile_player_metadata
+    {
+      podcastName: podcast.title,
+      episodeName: title,
+      podcastImageUrl: ApplicationController.helpers.app_url(podcast.image_url)
+    }
+  end
+
   private
 
   def index_id

--- a/app/views/podcast_episodes/show.html.erb
+++ b/app/views/podcast_episodes/show.html.erb
@@ -28,7 +28,7 @@
 
 <% end %>
 
-<div class="podcast-episode-container" data-meta='{"podcastName":"<%= @podcast.title %>","episodeName":"<%= @episode.title %>","podcastImageUrl":"<%= "#{app_protocol_and_domain}#{@podcast.image_url}" %>"}'>
+<div class="podcast-episode-container" data-meta='{"podcastName":"<%= @podcast.title %>","episodeName":"<%= @episode.title %>","podcastImageUrl":"<%= "#{app_url(@podcast.image_url)}" %>"}'>
   <div class="hero">
     <% image_url = cl_image_path(@podcast.pattern_image_url || "https://i.imgur.com/fKYKgo4.png",
                                  type: "fetch",

--- a/app/views/podcast_episodes/show.html.erb
+++ b/app/views/podcast_episodes/show.html.erb
@@ -28,7 +28,7 @@
 
 <% end %>
 
-<div class="podcast-episode-container" data-meta='{"podcastName":"<%= @podcast.title %>","episodeName":"<%= @episode.title %>","podcastImageUrl":"<%= "#{app_url(@podcast.image_url)}" %>"}'>
+<div class="podcast-episode-container" data-meta="<%= @episode.mobile_player_metadata.to_json %>">
   <div class="hero">
     <% image_url = cl_image_path(@podcast.pattern_image_url || "https://i.imgur.com/fKYKgo4.png",
                                  type: "fetch",

--- a/app/views/podcast_episodes/show.html.erb
+++ b/app/views/podcast_episodes/show.html.erb
@@ -28,7 +28,7 @@
 
 <% end %>
 
-<div class="podcast-episode-container">
+<div class="podcast-episode-container" data-meta='{"podcastName":"<%= @podcast.title %>","episodeName":"<%= @episode.title %>","podcastImageUrl":"<%= "#{app_protocol_and_domain}#{@podcast.image_url}" %>"}'>
   <div class="hero">
     <% image_url = cl_image_path(@podcast.pattern_image_url || "https://i.imgur.com/fKYKgo4.png",
                                  type: "fetch",

--- a/spec/models/podcast_episode_spec.rb
+++ b/spec/models/podcast_episode_spec.rb
@@ -61,6 +61,16 @@ RSpec.describe PodcastEpisode, type: :model do
     end
   end
 
+  describe "#mobile_player_metadata" do
+    it "responds with a hash with metadata used in native mobile players" do
+      metadata = podcast_episode.mobile_player_metadata
+      expect(metadata).to be_instance_of(Hash)
+      expect(metadata[:podcastName]).to eq(podcast_episode.podcast.title)
+      expect(metadata[:episodeName]).to eq(podcast_episode.title)
+      expect(metadata[:podcastImageUrl]).to include(podcast_episode.podcast.image_url)
+    end
+  end
+
   describe ".available" do
     let_it_be(:podcast) { create(:podcast) }
 

--- a/spec/system/podcasts/user_visits_podcast_episode_spec.rb
+++ b/spec/system/podcasts/user_visits_podcast_episode_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe "User visits podcast show page", type: :system do
   let(:podcast) { create(:podcast) }
   let(:podcast_episode) { create(:podcast_episode, podcast_id: podcast.id) }
+  let(:single_quote_episode) { create(:podcast_episode, title: "What's up doc?!") }
 
   it "they see the content of the hero", retry: 3 do
     visit podcast_episode.path.to_s
@@ -16,6 +17,24 @@ RSpec.describe "User visits podcast show page", type: :system do
     expect(page).to have_css "form#new_comment"
     expect(find("#comment_commentable_type", visible: false).value).to eq("PodcastEpisode")
     expect(find("#comment_commentable_id", visible: false).value).to eq(podcast_episode.id.to_s)
+  end
+
+  context "when mobile apps read the podcast episode metadata" do
+    it "renders the Episode & Podcast data" do
+      visit podcast_episode.path.to_s
+      metadata = JSON.parse(find(".podcast-episode-container")["data-meta"])
+      expect(metadata["podcastName"]).to eq(podcast.title)
+      expect(metadata["episodeName"]).to eq(podcast_episode.title)
+      expect(metadata["podcastImageUrl"]).to include(podcast.image_url)
+    end
+
+    it "doesn't break with single quotes inside the metadata" do
+      visit single_quote_episode.path.to_s
+      metadata = JSON.parse(find(".podcast-episode-container")["data-meta"])
+      expect(metadata["podcastName"]).to eq(single_quote_episode.podcast.title)
+      expect(metadata["episodeName"]).to eq(single_quote_episode.title)
+      expect(metadata["podcastImageUrl"]).to include(single_quote_episode.podcast.image_url)
+    end
   end
 
   context "when episode may not be playable" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The Podcast player for mobile apps requires information that is sent through the `metadata` message. This PR adds the Podcast Image to be displayed with the locked screen controls.

It also includes the metadata as JSON in the HTML to avoid having to scrape the HTML using `querySelector`, which makes it more resilient to change in the future.

## Related Tickets & Documents

[The PR in the iOS repo meant to handle the podcast image](https://github.com/thepracticaldev/DEV-ios/pull/222)

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

Nope
