### PR TITLE
Dont let HTTParty::RedirectionTooDeep Errors kill Podcast Ep. Update Workers

### DIFF
--- a/app/services/podcasts/feed.rb
+++ b/app/services/podcasts/feed.rb
@@ -20,11 +20,11 @@ module Podcasts
       end
       podcast.update_columns(reachable: true, status_notice: "")
       feed.items.size
-    rescue Net::OpenTimeout, Errno::ECONNREFUSED, SocketError => _e
+    rescue Net::OpenTimeout, Errno::ECONNREFUSED, SocketError, HTTParty::RedirectionTooDeep
       set_unreachable(:unreachable, force_update)
-    rescue OpenSSL::SSL::SSLError => _e
+    rescue OpenSSL::SSL::SSLError
       set_unreachable(:ssl_failed, force_update)
-    rescue RSS::NotWellFormedError => _e
+    rescue RSS::NotWellFormedError
       set_unreachable(:unparsable, force_update)
     end
 

--- a/spec/services/podcasts/feed_spec.rb
+++ b/spec/services/podcasts/feed_spec.rb
@@ -34,6 +34,13 @@ RSpec.describe Podcasts::Feed, type: :service, vcr: vcr_option do
       expect(unpodcast.status_notice).to include("is not reachable")
     end
 
+    it "sets reachable when there redirection is too deep" do
+      allow(HTTParty).to receive(:get).with("http://podcast.example.com/podcast", httparty_options).and_raise(HTTParty::RedirectionTooDeep, "too deep")
+      described_class.new(unpodcast).get_episodes(limit: 2)
+      unpodcast.reload
+      expect(unpodcast.reachable).to be false
+    end
+
     it "schedules the update url jobs when setting as unreachable" do
       allow(HTTParty).to receive(:get).with("http://podcast.example.com/podcast", httparty_options).and_raise(Errno::ECONNREFUSED)
       create_list(:podcast_episode, 2, podcast: unpodcast)


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Currently have a couple of Podcasts that have feed URLs that are suffering from too many redirects and try are causing a lot of failed Sidekiq Workers. Rather than trying over and over again lets mark them as problematic and fail gracefully. Also removed the unused `_e` variable.

## Related Tickets & Documents
https://app.honeybadger.io/fault/66984/83055eaafe5a38462a3f2f6e149a6f08

## Added tests?
- [x] no, because they aren't needed

![alt_text](https://media1.giphy.com/media/3ohuAwaX6Q13W78tdS/giphy.gif)
