### PR TITLE
Use correct attribute for rendering tags in listings

### DIFF
--- a/app/javascript/listings/__tests__/singleListing.test.jsx
+++ b/app/javascript/listings/__tests__/singleListing.test.jsx
@@ -12,7 +12,7 @@ const listing = {
   slug: 'illo-iure-quos-perspiciatis-5hk7',
   title: 'Illo iure quos perspiciatis.',
   user_id: 7,
-  tag_list: ['go', 'git'],
+  tags: ['go', 'git'],
   author: {
     name: 'Mrs. Yoko Christiansen',
     username: 'mrschristiansenyoko',
@@ -78,7 +78,7 @@ describe('<SingleListing />', () => {
           .find('.single-classified-listing-tags')
           .childAt(0)
           .text(),
-      ).toEqual(listing.tag_list[0]);
+      ).toEqual(listing.tags[0]);
     });
 
     it('for listing category', () => {

--- a/app/javascript/listings/singleListing/index.jsx
+++ b/app/javascript/listings/singleListing/index.jsx
@@ -33,7 +33,7 @@ const SingleListing = ({
           className="single-classified-listing-body"
           dangerouslySetInnerHTML={{ __html: listing.processed_html }} // eslint-disable-line react/no-danger
         />
-        <TagLinks tags={listing.tag_list} onClick={onAddTag} />
+        <TagLinks tags={listing.tags} onClick={onAddTag} />
         <AuthorInfo listing={listing} onCategoryClick={onChangeCategory} />
       </div>
     </div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Description

Tags were no longer displaying for classified listings. After some digging through our Preact components, I think I found the culprit, which is using `tag_list` instead of `tags` as prop for the `TagLinks` component.

@atsmith813 Tagged you directly, since you made changes to the corresponding serializer not too long ago, so I'm hoping you are better able to assess the validity of this fix.

## Related Tickets & Documents

Closes #6726

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Before, tags flashed in and out of existence:

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/47985/77138673-89119380-6aa5-11ea-84ab-2a5b2280485d.gif)

Tags now render fine:

<img width="437" alt="Screen Shot 2020-03-20 at 12 23 24" src="https://user-images.githubusercontent.com/47985/77138703-a5153500-6aa5-11ea-9666-a1aeb080bf73.png">

## Added tests?

- [X] no, because they aren't needed

And if they are needed I need help 😉 

## Added to documentation?

- [X] no documentation needed
