### PR TITLE
Move banishing spam users to async job

### DIFF
--- a/app/controllers/internal/users_controller.rb
+++ b/app/controllers/internal/users_controller.rb
@@ -45,13 +45,9 @@ class Internal::UsersController < Internal::ApplicationController
   end
 
   def banish
-    @user = User.find(params[:id])
-    begin
-      Moderator::BanishUser.call(admin: current_user, user: @user)
-    rescue StandardError => e
-      flash[:danger] = e.message
-    end
-    redirect_to "/internal/users/#{@user.id}/edit"
+    Moderator::BanishUserWorker.perform_async(current_user.id, params[:id].to_i)
+    flash[:success] = "This user is being banished in the background. The job will complete soon."
+    redirect_to "/internal/users/#{params[:id]}/edit"
   end
 
   def full_delete

--- a/app/workers/moderator/banish_user_worker.rb
+++ b/app/workers/moderator/banish_user_worker.rb
@@ -1,0 +1,16 @@
+module Moderator
+  class BanishUserWorker
+    include Sidekiq::Worker
+
+    sidekiq_options queue: :high_priority, retry: 10
+
+    def perform(admin_id, abuser_id)
+      abuser = User.find(abuser_id)
+      admin = User.find(admin_id)
+      Moderator::BanishUser.call(admin: admin, user: abuser)
+    rescue StandardError => e
+      DatadogStatsClient.count("moderators.banishuser", 1, tags: ["action:failed", "user_id:#{abuser.id}"])
+      Honeybadger.notify(e)
+    end
+  end
+end

--- a/spec/requests/internal/users_spec.rb
+++ b/spec/requests/internal/users_spec.rb
@@ -41,8 +41,10 @@ RSpec.describe "internal/users", type: :request do
 
   describe "POST /internal/users/:id/banish" do
     it "bans user for spam" do
+      allow(Moderator::BanishUserWorker).to receive(:perform_async)
       post "/internal/users/#{user.id}/banish"
-      expect(user.reload.username).to include("spam")
+      expect(Moderator::BanishUserWorker).to have_received(:perform_async).with(admin.id, user.id)
+      expect(request.flash[:success]).to include("This user is being banished in the background")
     end
   end
 

--- a/spec/workers/moderator/banish_user_worker_spec.rb
+++ b/spec/workers/moderator/banish_user_worker_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe Moderator::BanishUserWorker, type: :worker do
+  include_examples "#enqueues_on_correct_queue", "high_priority", 1
+
+  describe "#perform" do
+    let(:user) { create(:user) }
+    let(:admin) { create(:user, :super_admin) }
+
+    it "makes user banned and username spam" do
+      described_class.new.perform(admin.id, user.id)
+      user.reload
+      expect(user.username).to include("spam")
+      expect(user.has_role?(:banned)).to be true
+    end
+
+    it "deletes user articles" do
+      create(:article, user_id: user.id)
+      create(:article, user_id: user.id)
+      described_class.new.perform(admin.id, user.id)
+      user.reload
+      expect(user.articles.size).to be 0
+    end
+  end
+end

--- a/spec/workers/moderator/banish_user_worker_spec.rb
+++ b/spec/workers/moderator/banish_user_worker_spec.rb
@@ -31,11 +31,11 @@ RSpec.describe Moderator::BanishUserWorker, type: :worker do
       expect(user.follows.count).to eq(0)
       expect(user.classified_listings.count).to eq(0)
     end
-  
+
     it "reassigns profile info" do
       expect(user.currently_hacking_on).to eq("")
     end
-    
+
     it "creates an entry in the BanishedUsers table" do
       expect(BanishedUser.all.size).to be 1
     end

--- a/spec/workers/moderator/banish_user_worker_spec.rb
+++ b/spec/workers/moderator/banish_user_worker_spec.rb
@@ -4,22 +4,44 @@ RSpec.describe Moderator::BanishUserWorker, type: :worker do
   include_examples "#enqueues_on_correct_queue", "high_priority", 1
 
   describe "#perform" do
-    let(:user) { create(:user) }
+    let(:user) { create(:user, currently_hacking_on: "text is here") }
+    let(:user2) { create(:user) }
     let(:admin) { create(:user, :super_admin) }
 
-    it "makes user banned and username spam" do
+    before do
+      create(:article, user_id: user.id)
+      create(:article, user_id: user.id)
+      create(:classified_listing, user: user)
+      ChatChannel.create_with_users([user, user2])
+      user.follow(user2)
       described_class.new.perform(admin.id, user.id)
       user.reload
+    end
+
+    it "makes user banned and username spam" do
       expect(user.username).to include("spam")
       expect(user.has_role?(:banned)).to be true
     end
 
-    it "deletes user articles" do
-      create(:article, user_id: user.id)
-      create(:article, user_id: user.id)
-      described_class.new.perform(admin.id, user.id)
-      user.reload
-      expect(user.articles.size).to be 0
+    it "deletes user content" do
+      expect(user.reactions.count).to eq(0)
+      expect(user.comments.count).to eq(0)
+      expect(user.articles.count).to eq(0)
+      expect(user.chat_channels.count).to eq(0)
+      expect(user.follows.count).to eq(0)
+      expect(user.classified_listings.count).to eq(0)
+    end
+  
+    it "reassigns profile info" do
+      expect(user.currently_hacking_on).to eq("")
+    end
+    
+    it "creates an entry in the BanishedUsers table" do
+      expect(BanishedUser.all.size).to be 1
+    end
+
+    it "records who banished a user" do
+      expect(BanishedUser.last.banished_by).to eq admin
     end
   end
 end


### PR DESCRIPTION

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Banishing users sometimes does a lot of work, and can time out. This moves the request to the background and delivers a an appropriate flash message to the user.

It's a `high_priority` job, so the admin should be able to refresh after a few seconds to verify the success. I think in an ideal world we deliver the news as a real-time websocket notice, but all in all this is an improvement.

Should `flash[:success]` be red? Probably not, but outside scope of this issue.

<img width="1154" alt="Screen Shot 2020-03-20 at 9 30 21 AM" src="https://user-images.githubusercontent.com/3102842/77167981-6ecbbb80-6a8d-11ea-9b47-eabb7dea831c.png">