### PR TITLE
Add logo_png SiteConfig for manifest etc. use

### DIFF
--- a/app/controllers/internal/configs_controller.rb
+++ b/app/controllers/internal/configs_controller.rb
@@ -23,7 +23,7 @@ class Internal::ConfigsController < Internal::ApplicationController
       default_site_email social_networks_handle mascot_user_id
       campaign_hero_html_variant_name campaign_sidebar_enabled campaign_featured_tags
       campaign_sidebar_image
-      main_social_image favicon_url logo_svg
+      main_social_image favicon_url logo_svg logo_png
       rate_limit_follow_count_daily
       ga_view_id ga_fetch_rate community_description authentication_providers
       mailchimp_newsletter_id mailchimp_sustaining_members_id

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -1,6 +1,9 @@
 # Site configuration based on RailsSettings models,
 # see <https://github.com/huacnlee/rails-settings-cached> for further info
 
+# Defaults are currently very DEV-oriented.
+# Should change to more truly generic values in future.
+
 class SiteConfig < RailsSettings::Base
   self.table_name = "site_configs"
 
@@ -31,6 +34,7 @@ class SiteConfig < RailsSettings::Base
   # images
   field :main_social_image, type: :string, default: "https://thepracticaldev.s3.amazonaws.com/i/6hqmcjaxbgbon8ydw93z.png"
   field :favicon_url, type: :string, default: "favicon.ico"
+  field :logo_png, type: :string, default: "https://practicaldev-herokuapp-com.freetls.fastly.net/assets/devlogo-pwa-512.png"
   field :logo_svg, type: :string, default: ""
 
   # rate limits

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -47,7 +47,7 @@
     <meta name="keywords" content="<%= @article.cached_tag_list %>, software, coding, development, engineering, inclusive, community">
 
     <meta property="og:type" content="article" />
-    <meta property="og:url" content="https://dev.to<%= @article.path %>" />
+    <meta property="og:url" content="<%= app_url(@article.path) %>" />
     <meta property="og:title" content="<%= @article.title %>" />
     <meta property="og:description" content="<%= @article.description || "An article from the community" %>" />
     <meta property="og:site_name" content="<%= community_qualified_name %>" />
@@ -81,15 +81,15 @@
       <h1 style="text-align:center;">⏳ Video Transcoding In Progress ⏳</h1>
     <% end %>
     <article itemscope itemtype="http://schema.org/Article" itemprop="mainEntity">
-      <meta itemprop="url" content="https://dev.to<%= @article.path %>">
+      <meta itemprop="url" content="<%= app_url(@article.path) %>">
       <meta itemprop="image" content="<%= article_social_image_url(@article) %>">
       <div itemprop="publisher" itemscope itemtype="https://schema.org/Organization">
         <div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject">
-          <meta itemprop="url" content="<%= asset_path "android-icon-192x192.png" %>">
+          <meta itemprop="url" content="<%= cloudinary(SiteConfig.logo_png, 192, "png") %>">
           <meta itemprop="width" content="192">
           <meta itemprop="height" content="192">
         </div>
-        <meta itemprop="name" content="DEV Community">
+        <meta itemprop="name" content="<%= ApplicationConfig["COMMUNITY_NAME"] %> Community">
       </div>
       <section>
         <% if !@article.published %>
@@ -120,7 +120,7 @@
         </h1>
         <h3>
           <span itemprop="author" itemscope itemtype="http://schema.org/Person">
-            <meta itemprop="url" content="https://dev.to/<%= @user.username %>">
+            <meta itemprop="url" content="<%= app_url(@user.username) %>">
             <a href="/<%= @user.username %>" class="author">
               <img class="profile-pic" src="<%= ProfileImage.new(@user).get(width: 50) %>" alt="<%= @user.username %> profile image" />
               <span itemprop="name"><%= @user.name %></span>

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -163,7 +163,15 @@
                 <div class="alert alert-info">Used as the site favicon</div>
                 <img alt="favicon" class="preview" src="<%= SiteConfig.favicon_url %>" />
               </div>
-
+              <div class="form-group">
+                <%= f.label :logo_png %>
+                <%= f.text_area :logo_png,
+                                class: "form-control",
+                                value: SiteConfig.logo_png,
+                                 placeholder: "https://image.url/image.png" %>
+                <div class="alert alert-info">Minimum 1024px, used for PWA etc.</div>
+                <img alt="favicon" class="preview" src="<%= SiteConfig.logo_png %>" />
+              </div>
               <div class="form-group">
                 <%= f.label :logo_svg %>
                 <%= f.text_area :logo_svg,

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -165,9 +165,9 @@
               </div>
               <div class="form-group">
                 <%= f.label :logo_png %>
-                <%= f.text_area :logo_png,
-                                class: "form-control",
-                                value: SiteConfig.logo_png,
+                <%= f.text_field :logo_png,
+                                 class: "form-control",
+                                 value: SiteConfig.logo_png,
                                  placeholder: "https://image.url/image.png" %>
                 <div class="alert alert-info">Minimum 1024px, used for PWA etc.</div>
                 <img alt="favicon" class="preview" src="<%= SiteConfig.logo_png %>" />

--- a/app/views/service_worker/manifest.json.erb
+++ b/app/views/service_worker/manifest.json.erb
@@ -1,6 +1,6 @@
 {
   "name": "<%= ApplicationConfig["COMMUNITY_NAME"] %> Community",
-  "short_name": "dev.to",
+  "short_name": "<%= ApplicationConfig["APP_DOMAIN"] %>",
   "description": "<%= SiteConfig.community_description %>",
   "start_url": "/",
   "display": "standalone",
@@ -8,17 +8,17 @@
   "theme_color": "#000000",
   "homepage_url": "<%= ApplicationConfig["APP_PROTOCOL"] %><%= ApplicationConfig["APP_DOMAIN"] %>",
   "icons": [{
-    "src": "<%= image_path "devlogo-pwa-192.png" %>",
+    "src": "<%= ApplicationController.helpers.cloudinary(SiteConfig.logo_png, 192, "png") %>",
     "sizes": "192x192",
     "type": "image/png",
     "purpose": "any maskable"
   }, {
-    "src": "<%= image_path "devlogo-pwa-128.png" %>",
+    "src": "<%= ApplicationController.helpers.cloudinary(SiteConfig.logo_png, 128, "png") %>",
     "sizes": "128x128",
     "type": "image/png",
     "purpose": "any maskable"
   }, {
-    "src": "<%= image_path "devlogo-pwa-512.png" %>",
+    "src": "<%= ApplicationController.helpers.cloudinary(SiteConfig.logo_png, 512, "png") %>",
     "sizes": "512x512",
     "type": "image/png",
     "purpose": "any maskable"

--- a/app/views/shell/_top.html.erb
+++ b/app/views/shell/_top.html.erb
@@ -29,18 +29,18 @@
       <%= yield(:page_meta) %>
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <%= favicon_link_tag SiteConfig.favicon_url %>
-      <link rel="apple-touch-icon" href="<%= asset_path "apple-icon.png" %>">
-      <link rel="apple-touch-icon" sizes="152x152" href="<%= asset_path "apple-icon-152x152.png" %>">
-      <link rel="apple-touch-icon" sizes="180x180" href="<%= asset_path "apple-icon-180x180.png" %>">
-      <link rel="apple-touch-icon" sizes="167x167" href="<%= asset_path "apple-icon-167x167.png" %>">
-      <link href="<%= asset_path "android-icon-192x192.png" %>" rel="icon" sizes="192x192" />
-      <link href="<%= asset_path "android-icon-128x128.png" %>" rel="icon" sizes="128x128" />
-      <meta name="apple-mobile-web-app-title" content="dev.to">
-      <meta name="application-name" content="dev.to">
+      <link rel="apple-touch-icon" href="<%= cloudinary(SiteConfig.logo_png, 180, "png") %>">
+      <link rel="apple-touch-icon" sizes="152x152" href="<%= cloudinary(SiteConfig.logo_png, 152, "png") %>">
+      <link rel="apple-touch-icon" sizes="180x180" href="<%= cloudinary(SiteConfig.logo_png, 180, "png") %>">
+      <link rel="apple-touch-icon" sizes="167x167" href="<%= cloudinary(SiteConfig.logo_png, 167, "png") %>">
+      <link href="<%= cloudinary(SiteConfig.logo_png, 192, "png") %>" rel="icon" sizes="192x192" />
+      <link href="<%= cloudinary(SiteConfig.logo_png, 128, "png") %>" rel="icon" sizes="128x128" />
+      <meta name="apple-mobile-web-app-title" content="<%= ApplicationConfig["APP_DOMAIN"] %>">
+      <meta name="application-name" content="<%= ApplicationConfig["APP_DOMAIN"] %>">
       <meta property="fb:pages" content="568966383279687" />
       <meta name="theme-color" content="#000000" />
       <link rel="manifest" href="/manifest.json" />
-      <link rel="search" href="https://dev.to/search.xml" type="application/opensearchdescription+xml" title="<%= community_qualified_name %>" />
+      <link rel="search" href="<%= app_url("search.xml") %>" type="application/opensearchdescription+xml" title="<%= community_qualified_name %>" />
     <% end %>
   </head>
   <% unless internal_navigation? %>

--- a/spec/requests/internal/configs_spec.rb
+++ b/spec/requests/internal/configs_spec.rb
@@ -90,6 +90,12 @@ RSpec.describe "/internal/config", type: :request do
           expect(SiteConfig.favicon_url).to eq(expected_image_url)
         end
 
+        it "updates logo_png" do
+          expected_image_url = "https://dummyimage.com/300x300"
+          post "/internal/config", params: { site_config: { logo_png: expected_image_url }, confirmation: confirmation_message }
+          expect(SiteConfig.logo_png).to eq(expected_image_url)
+        end
+
         it "updates logo_svg" do
           expected_image_url = "https://dummyimage.com/300x300"
           post "/internal/config", params: { site_config: { logo_svg: expected_image_url }, confirmation: confirmation_message }


### PR DESCRIPTION


## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This image is used by PWA, but also other contexts similar to favicon etc. I believe Slack and other apps might use this data similar to other meta info like open graph etc.

It needs to be rendered to multiple sizes, but I think downsizing programmatically definitely makes more sense than actually naming a bunch of values.