### PR TITLE
UX: fix API description color in dark themes

### DIFF
--- a/app/assets/stylesheets/settings.scss
+++ b/app/assets/stylesheets/settings.scss
@@ -711,6 +711,7 @@ ul.delete__account {
     float: left;
 
     .title {
+      color: $dark-gray;
       font-weight: bold;
       margin: 0;
       padding-bottom: 0.25rem;

--- a/app/views/users/_theme_selector.html.erb
+++ b/app/views/users/_theme_selector.html.erb
@@ -1,5 +1,10 @@
-<label class="rich-selector theme-selector theme-selector--<%= theme.tr(" ", "-") %>">
-  <%= f.radio_button :config_theme, theme, checked: @user.config_theme.tr("_", " ") == theme, class: "rich-selector__radio" %>
+<label
+  class="rich-selector theme-selector theme-selector--<%= theme.tr(" ", "-") %>"
+  title="<%= theme.titlecase %>">
+  <%= f.radio_button :config_theme,
+                     theme,
+                     checked: @user.config_theme.tr("_", " ") == theme,
+                     class: "rich-selector__radio" %>
   <div class="rich-selector__indicator"></div>
   <div class="rich-selector__outline"></div>
   <div class="theme-selector__nav">


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The current color for the API description is invisible for the night theme

![theme_night_1](https://user-images.githubusercontent.com/146201/77253558-5c06e180-6c5b-11ea-9d48-2ff0982a42e0.png)

and very hard to read in the ten x theme

![theme_ten_x_1](https://user-images.githubusercontent.com/146201/77253564-6aed9400-6c5b-11ea-9ee8-d52d948d0d0d.png)

This fixes those by using a constant color across all themes.

I also added a description for all the themes:

![Screenshot 2020-03-22 at 4 38 46 PM](https://user-images.githubusercontent.com/146201/77253617-ab4d1200-6c5b-11ea-884a-8b40a949c0bf.png)

## Related Tickets & Documents

Closes https://github.com/thepracticaldev/dev.to/issues/6339

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![theme_all](https://user-images.githubusercontent.com/146201/77253582-7b057380-6c5b-11ea-8510-e572aaa6ac2e.png)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
