### PR TITLE
Ignore unused articles columns

### DIFF
--- a/app/dashboards/article_dashboard.rb
+++ b/app/dashboards/article_dashboard.rb
@@ -26,25 +26,19 @@ class ArticleDashboard < Administrate::BaseDashboard
     published: Field::Boolean,
     featured: Field::Boolean,
     approved: Field::Boolean,
-    allow_small_edits: Field::Boolean,
-    allow_big_edits: Field::Boolean,
     featured_number: Field::Number,
     password: Field::String,
     published_at: Field::DateTime,
     social_image: Field::String,
     collection: Field::BelongsTo,
-    collection_position: Field::Number,
-    name_within_collection: Field::String,
     show_comments: Field::Boolean,
     main_image_background_hex_color: Field::String,
-    ids_for_suggested_articles: Field::String,
     comments: Field::HasMany,
     video: Field::String,
     video_code: Field::String,
     video_source_url: Field::String,
     video_thumbnail_url: Field::String,
-    video_closed_caption_track_url: Field::String,
-    main_tag_name_for_social: Field::String
+    video_closed_caption_track_url: Field::String
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -83,17 +77,13 @@ class ArticleDashboard < Administrate::BaseDashboard
     password
     published_at
     collection
-    collection_position
-    name_within_collection
     show_comments
     main_image_background_hex_color
-    ids_for_suggested_articles
     video
     video_code
     video_source_url
     video_thumbnail_url
     video_closed_caption_track_url
-    main_tag_name_for_social
   ].freeze
 
   # Overwrite this method to customize how articles are displayed

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -103,7 +103,6 @@ class Article < ApplicationRecord
 
   before_destroy :before_destroy_actions, prepend: true
 
-  serialize :ids_for_suggested_articles
   serialize :cached_user
   serialize :cached_organization
 
@@ -540,7 +539,6 @@ class Article < ApplicationRecord
     self.description = front_matter["description"] if front_matter["description"].present? || front_matter["title"].present? # Do this if frontmatte exists at all
     self.collection_id = nil if front_matter["title"].present?
     self.collection_id = Collection.find_series(front_matter["series"], user).id if front_matter["series"].present?
-    self.automatically_renew = front_matter["automatically_renew"] if front_matter["automatically_renew"].present? && tag_list.include?("hiring")
   end
 
   def determine_image(front_matter)

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,4 +1,26 @@
 class Article < ApplicationRecord
+  self.ignored_columns = %w[
+    abuse_removal_reason
+    allow_big_edits
+    allow_small_edits
+    amount_due
+    amount_paid
+    automatically_renew
+    collection_position
+    featured_clickthrough_rate
+    featured_impressions
+    ids_for_suggested_articles
+    job_opportunity_id
+    last_invoiced_at
+    lat
+    long
+    main_tag_name_for_social
+    name_within_collection
+    paid
+    rating_votes_count
+    removed_for_abuse
+  ]
+
   include CloudinaryHelper
   include ActionView::Helpers
   include AlgoliaSearch

--- a/app/policies/article_policy.rb
+++ b/app/policies/article_policy.rb
@@ -29,7 +29,7 @@ class ArticlePolicy < ApplicationPolicy
 
   def permitted_attributes
     %i[title body_html body_markdown main_image published canonical_url
-       description allow_small_edits allow_big_edits tag_list publish_under_org
+       description tag_list publish_under_org
        video video_code video_source_url video_thumbnail_url receive_notifications
        archived]
   end

--- a/spec/policies/article_policy_spec.rb
+++ b/spec/policies/article_policy_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ArticlePolicy do
   let(:article) { build_stubbed(:article) }
   let(:valid_attributes) do
     %i[title body_html body_markdown main_image published
-       description allow_small_edits allow_big_edits tag_list publish_under_org
+       description tag_list publish_under_org
        video video_code video_source_url video_thumbnail_url receive_notifications]
   end
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

The `articles` table has 90 columns, I've identified 19 of them that seem to be unused:

```text
abuse_removal_reason
allow_big_edits
allow_small_edits
amount_due
amount_paid
automatically_renew
collection_position
featured_clickthrough_rate
featured_impressions
ids_for_suggested_articles
job_opportunity_id
last_invoiced_at
lat
long
main_tag_name_for_social
name_within_collection
paid
rating_votes_count
removed_for_abuse
```

The first step is to tell Rails to ignore the columns, once tests pass, we deployed and we know nothing has broken,
then we can actually remove the columns.

This will also save us memory with `SELECT *` operations.

Let me know if any of these should be kept for any reason.

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
