### PR TITLE
Ignore unused collection columns

### DIFF
--- a/app/dashboards/collection_dashboard.rb
+++ b/app/dashboards/collection_dashboard.rb
@@ -10,14 +10,8 @@ class CollectionDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
     articles: Field::HasMany,
     user: Field::BelongsTo,
-    organization: Field::BelongsTo,
     id: Field::Number,
-    title: Field::String,
     slug: Field::String,
-    description: Field::String,
-    main_image: Field::String,
-    social_image: Field::String,
-    published: Field::Boolean,
     created_at: Field::DateTime,
     updated_at: Field::DateTime
   }.freeze
@@ -30,7 +24,7 @@ class CollectionDashboard < Administrate::BaseDashboard
   COLLECTION_ATTRIBUTES = %i[
     articles
     user
-    organization
+    slug
     id
   ].freeze
 
@@ -39,14 +33,8 @@ class CollectionDashboard < Administrate::BaseDashboard
   SHOW_PAGE_ATTRIBUTES = %i[
     articles
     user
-    organization
     id
-    title
     slug
-    description
-    main_image
-    social_image
-    published
     created_at
     updated_at
   ].freeze
@@ -57,12 +45,7 @@ class CollectionDashboard < Administrate::BaseDashboard
   FORM_ATTRIBUTES = %i[
     articles
     user
-    organization
-    title
     slug
-    description
-    main_image
-    social_image
     published
   ].freeze
 

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -1,4 +1,13 @@
 class Collection < ApplicationRecord
+  self.ignored_columns = %w[
+    description
+    main_image
+    organization_id
+    published
+    social_image
+    title
+  ]
+
   has_many :articles
   belongs_to :user
   belongs_to :organization, optional: true

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Collection, type: :model do
 
   describe "validations" do
     it { is_expected.to belong_to(:user) }
-    it { is_expected.to belong_to(:organization).optional }
     it { is_expected.to have_many(:articles) }
 
     it { is_expected.to validate_presence_of(:user_id) }


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

The `collections` table has 11 columns, 6 of them seem to be unused:

```text
description
main_image
organization_id
published
social_image
title
```

The first step is to tell Rails to ignore the columns, once tests pass, we deployed and we know nothing has broken, then we can actually remove the columns.

This will also save us memory with `SELECT *` operations.

Let me know if any of these should be kept for any reason.

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
