### PR TITLE
Ignore unused display_ad_events columns

### DIFF
--- a/app/models/display_ad_event.rb
+++ b/app/models/display_ad_event.rb
@@ -1,4 +1,9 @@
 class DisplayAdEvent < ApplicationRecord
+  self.ignored_columns = %w[
+    context_id
+    counts_for
+  ]
+
   belongs_to :display_ad
   belongs_to :user
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

The `display_ad_events` table has 9 columns, 2 of them seem to be unused:

```text
context_id
counts_for
```

The first step is to tell Rails to ignore the columns, once tests pass, we deployed and we know nothing has broken, then we can actually remove the columns.

This will also save us memory with SELECT * operations.

Let me know if any of these should be kept for any reason.

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
