### PR TITLE
More Backend Feed Search Updates

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -53,30 +53,34 @@ class SearchController < ApplicationController
   end
 
   def users
-    user_docs = Search::User.search_documents(params: user_params.to_h)
-
-    render json: { result: user_docs }
+    render json: { result: user_search }
   end
 
   def feed_content
     feed_docs = if params[:class_name].blank?
                   # If we are in the main feed and not filtering by type return
                   # all articles, podcast episodes, and users
-                  Search::FeedContent.search_documents(params: feed_params.to_h).concat(
-                    Search::User.search_documents(params: user_params.to_h),
-                  )
+                  feed_content_search.concat(user_search)
                 elsif params[:class_name] == "User"
                   # No need to check for articles or podcast episodes if we know we only want users
-                  Search::User.search_documents(params: user_params.to_h)
+                  user_search
                 else
                   # if params[:class_name] == PodcastEpisode or Article then skip user lookup
-                  Search::FeedContent.search_documents(params: feed_params.to_h)
+                  feed_content_search
                 end
 
     render json: { result: feed_docs }
   end
 
   private
+
+  def feed_content_search
+    Search::FeedContent.search_documents(params: feed_params.to_h)
+  end
+
+  def user_search
+    Search::User.search_documents(params: user_params.to_h)
+  end
 
   def chat_channel_params
     accessible = %i[

--- a/app/services/search/feed_content.rb
+++ b/app/services/search/feed_content.rb
@@ -23,9 +23,28 @@ module Search
       def prepare_doc(hit)
         source = hit.dig("_source")
         source["tag_list"] = hit["tags"]&.map { |t| t["name"] } || []
+        source["id"] = hit.dig("_source", "id").split("_").last.to_i
+        source["tag_list"] = hit.dig("_source", "tags")&.map { |t| t["name"] } || []
+        source["flare_tag"] = hit.dig("_source", "flare_tag_hash")
         source["user_id"] = hit.dig("_source", "user", "id")
         source["highlight"] = hit["highlight"]
+        source["readable_publish_date"] = hit.dig("_source", "readable_publish_date_string")
+
+        source.merge!(timestamps_hash(hit))
+
         source
+      end
+
+      def timestamps_hash(hit)
+        if hit.dig("_source", "published_at")
+          published_at_timestamp = DateTime.parse(hit.dig("_source", "published_at"))
+          {
+            "published_at_int" => published_at_timestamp.to_i,
+            "published_timestamp" => published_at_timestamp
+          }
+        else
+          { "published_at_int" => nil, "published_timestamp" => nil }
+        end
       end
 
       def index_settings

--- a/app/services/search/feed_content.rb
+++ b/app/services/search/feed_content.rb
@@ -37,7 +37,7 @@ module Search
 
       def timestamps_hash(hit)
         if hit.dig("_source", "published_at")
-          published_at_timestamp = DateTime.parse(hit.dig("_source", "published_at"))
+          published_at_timestamp = DateTime.parse(hit.dig("_source", "published_at")).in_time_zone
           {
             "published_at_int" => published_at_timestamp.to_i,
             "published_timestamp" => published_at_timestamp

--- a/app/services/search/feed_content.rb
+++ b/app/services/search/feed_content.rb
@@ -23,28 +23,23 @@ module Search
       def prepare_doc(hit)
         source = hit.dig("_source")
         source["tag_list"] = hit["tags"]&.map { |t| t["name"] } || []
-        source["id"] = hit.dig("_source", "id").split("_").last.to_i
-        source["tag_list"] = hit.dig("_source", "tags")&.map { |t| t["name"] } || []
-        source["flare_tag"] = hit.dig("_source", "flare_tag_hash")
-        source["user_id"] = hit.dig("_source", "user", "id")
+        source["id"] = source["id"].split("_").last.to_i
+        source["tag_list"] = source["tags"]&.map { |t| t["name"] } || []
+        source["flare_tag"] = source["flare_tag_hash"]
+        source["user_id"] = source.dig("user", "id")
         source["highlight"] = hit["highlight"]
-        source["readable_publish_date"] = hit.dig("_source", "readable_publish_date_string")
+        source["readable_publish_date"] = source["readable_publish_date_string"]
 
-        source.merge!(timestamps_hash(hit))
-
-        source
+        source.merge(timestamps_hash(hit))
       end
 
       def timestamps_hash(hit)
-        if hit.dig("_source", "published_at")
-          published_at_timestamp = DateTime.parse(hit.dig("_source", "published_at")).in_time_zone
-          {
-            "published_at_int" => published_at_timestamp.to_i,
-            "published_timestamp" => published_at_timestamp
-          }
-        else
-          { "published_at_int" => nil, "published_timestamp" => nil }
-        end
+        published_at = hit.dig("_source", "published_at")
+        published_at_timestamp = Time.zone.parse(published_at || "")
+        {
+          "published_at_int" => published_at_timestamp.to_i,
+          "published_timestamp" => published_at
+        }
       end
 
       def index_settings

--- a/app/services/search/query_builders/feed_content.rb
+++ b/app/services/search/query_builders/feed_content.rb
@@ -19,7 +19,8 @@ module Search
         tag_names: "tags.name",
         approved: "approved",
         user_id: "user.id",
-        class_name: "class_name"
+        class_name: "class_name",
+        published: "published"
       }.freeze
 
       RANGE_KEYS = %i[
@@ -40,6 +41,10 @@ module Search
 
       def initialize(params)
         @params = params.deep_symbolize_keys
+
+        # Default to only showing published articles to start
+        @params[:published] = true
+
         build_body
       end
 
@@ -50,7 +55,7 @@ module Search
         HIGHLIGHT_FIELDS.each do |field_name|
           # This hash can be filled with options to further customize our highlighting
           # https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#request-body-search-highlighting
-          highlight_fields[:fields][field_name] = { order: :score }
+          highlight_fields[:fields][field_name] = { order: :score, number_of_fragments: 2, fragment_size: 75 }
         end
         @body[:highlight] = highlight_fields
       end

--- a/spec/requests/search_spec.rb
+++ b/spec/requests/search_spec.rb
@@ -79,8 +79,47 @@ RSpec.describe "Search", type: :request, proper_status: true do
       allow(Search::FeedContent).to receive(:search_documents).and_return(
         mock_documents,
       )
+
       get "/search/feed_content"
       expect(response.parsed_body).to eq("result" => mock_documents)
+    end
+
+    it "queries only the user index if class_name=User" do
+      sign_in authorized_user
+      allow(Search::FeedContent).to receive(:search_documents)
+      allow(Search::User).to receive(:search_documents).and_return(
+        mock_documents,
+      )
+
+      get "/search/feed_content?class_name=User"
+      expect(Search::User).to have_received(:search_documents)
+      expect(Search::FeedContent).not_to have_received(:search_documents)
+    end
+
+    it "queries for Articles, Podcast Episodes and Users if no class_name filter is present" do
+      sign_in authorized_user
+      allow(Search::FeedContent).to receive(:search_documents).and_return(
+        mock_documents,
+      )
+      allow(Search::User).to receive(:search_documents).and_return(
+        mock_documents,
+      )
+
+      get "/search/feed_content"
+      expect(Search::User).to have_received(:search_documents)
+      expect(Search::FeedContent).to have_received(:search_documents)
+    end
+
+    it "queries for only Articles and Podcast Episodes if class_name!=User" do
+      sign_in authorized_user
+      allow(Search::FeedContent).to receive(:search_documents).and_return(
+        mock_documents,
+      )
+      allow(Search::User).to receive(:search_documents)
+
+      get "/search/feed_content?class_name=Article"
+      expect(Search::User).not_to have_received(:search_documents)
+      expect(Search::FeedContent).to have_received(:search_documents)
     end
   end
 end

--- a/spec/services/search/feed_content_spec.rb
+++ b/spec/services/search/feed_content_spec.rb
@@ -30,6 +30,22 @@ RSpec.describe Search::FeedContent, type: :service do
       expect(doc_highlights).to include("I <em>love</em> <em>ruby</em>", "<em>Ruby</em> Tuesday is yummy")
     end
 
+    it "returns fields necessary for the view" do
+      allow(article1).to receive(:flare_tag).and_return(name: "help", bg_color_hex: nil, text_color_hex: nil)
+      view_keys = %w[
+        id title path class_name flare_tag tag_list user_id user published_at_int
+        published_timestamp readable_publish_date
+      ]
+      flare_tag_keys = %w[name bg_color_hex text_color_hex]
+      user_keys = %w[username name profile_image_90]
+      index_documents([article1])
+
+      feed_doc = described_class.search_documents(params: { size: 1 }).first
+      expect(feed_doc.keys).to include(*view_keys)
+      expect(feed_doc["user"].keys).to include(*user_keys)
+      expect(feed_doc["flare_tag"].keys).to include(*flare_tag_keys)
+    end
+
     context "with a query" do
       it "searches by search_fields" do
         allow(article1).to receive(:title).and_return("ruby")
@@ -40,7 +56,7 @@ RSpec.describe Search::FeedContent, type: :service do
         feed_docs = described_class.search_documents(params: query_params)
         expect(feed_docs.count).to eq(2)
         doc_ids = feed_docs.map { |t| t.dig("id") }
-        expect(doc_ids).to include(article1.search_id, article2.search_id)
+        expect(doc_ids).to include(article1.id, article2.id)
       end
     end
 
@@ -54,7 +70,7 @@ RSpec.describe Search::FeedContent, type: :service do
         feed_docs = described_class.search_documents(params: query_params)
         expect(feed_docs.count).to eq(1)
         doc_ids = feed_docs.map { |t| t.dig("id") }
-        expect(doc_ids).to include(article1.search_id)
+        expect(doc_ids).to include(article1.id)
       end
 
       it "filters by user_id" do
@@ -64,7 +80,7 @@ RSpec.describe Search::FeedContent, type: :service do
         feed_docs = described_class.search_documents(params: query_params)
         expect(feed_docs.count).to eq(1)
         doc_ids = feed_docs.map { |t| t.dig("id") }
-        expect(doc_ids).to include(article1.search_id)
+        expect(doc_ids).to include(article1.id)
       end
 
       it "filters by approved" do
@@ -76,7 +92,7 @@ RSpec.describe Search::FeedContent, type: :service do
         feed_docs = described_class.search_documents(params: query_params)
         expect(feed_docs.count).to eq(1)
         doc_ids = feed_docs.map { |t| t.dig("id") }
-        expect(doc_ids).to include(article2.search_id)
+        expect(doc_ids).to include(article2.id)
       end
 
       it "filters by class_name" do
@@ -87,7 +103,7 @@ RSpec.describe Search::FeedContent, type: :service do
         feed_docs = described_class.search_documents(params: query_params)
         expect(feed_docs.count).to eq(1)
         doc_ids = feed_docs.map { |t| t.dig("id") }
-        expect(doc_ids).to include(pde.search_id)
+        expect(doc_ids).to include(pde.id)
       end
     end
 
@@ -101,7 +117,7 @@ RSpec.describe Search::FeedContent, type: :service do
         feed_docs = described_class.search_documents(params: query_params)
         expect(feed_docs.count).to eq(1)
         doc_ids = feed_docs.map { |t| t.dig("id") }
-        expect(doc_ids).to include(article2.search_id)
+        expect(doc_ids).to include(article2.id)
       end
     end
   end

--- a/spec/services/search/query_builders/feed_content_spec.rb
+++ b/spec/services/search/query_builders/feed_content_spec.rb
@@ -12,6 +12,11 @@ RSpec.describe Search::QueryBuilders::FeedContent, type: :service do
       filter = described_class.new({})
       expect(filter.body).not_to be_nil
     end
+
+    it "sets published to true" do
+      filter = described_class.new({})
+      expect(filter.params).to include(published: true)
+    end
   end
 
   describe "#as_hash" do
@@ -36,6 +41,7 @@ RSpec.describe Search::QueryBuilders::FeedContent, type: :service do
         { "terms" => { "tags.name" => ["beginner"] } },
         { "terms" => { "user.id" => [777] } },
         { "terms" => { "class_name" => ["Article"] } },
+        { "terms" => { "published" => [true] } },
       ]
       expect(filter.as_hash.dig("query", "bool", "filter")).to match_array(exepcted_filters)
     end
@@ -46,6 +52,7 @@ RSpec.describe Search::QueryBuilders::FeedContent, type: :service do
         filter = described_class.new(params)
         exepcted_filters = [
           { "range" => { "published_at" => { lte: Time.current } } },
+          { "terms" => { "published" => [true] } },
         ]
         expect(filter.as_hash.dig("query", "bool", "filter")).to match_array(exepcted_filters)
       end
@@ -61,6 +68,7 @@ RSpec.describe Search::QueryBuilders::FeedContent, type: :service do
         exepcted_filters = [
           { "range" => { "published_at" => { lte: Time.current } } },
           { "terms" => { "tags.name" => ["cfp"] } },
+          { "terms" => { "published" => [true] } },
         ]
         expect(filter.as_hash.dig("query", "bool", "must")).to match_array(exepcted_query)
         expect(filter.as_hash.dig("query", "bool", "filter")).to match_array(exepcted_filters)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
This PR fills in a few more things we need to search for feed content on the backend
1. Make sure User docs are returns with Articles and Podcast Episodes for the main feed. Optimize the flow for when we do filter by class name
2. By default only return published articles. We can change this later when we decide we want to be able to see unpublished ones like in internal
3. Update returned documents to have fields necessary for the view. 
4. Add fragment options to limit fragments to 2 and 75 characters. I tested this in the view and it seems to return the right chunk of data. 
![Screen Shot 2020-03-23 at 9 59 47 AM](https://user-images.githubusercontent.com/1813380/77330245-0f6be680-6ced-11ea-8e9c-ada477904d96.png)


## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-34785956

## Added tests?
- [x] yes

![alt_text](https://media.tenor.com/images/698885f9345f7861a47fca20cf0cfabc/tenor.gif)
