### PR TITLE
Ignore unused display_ads columns

### DIFF
--- a/app/controllers/display_ad_events_controller.rb
+++ b/app/controllers/display_ad_events_controller.rb
@@ -18,12 +18,16 @@ class DisplayAdEventsController < ApplicationMetalController
     return if Rails.env.production? && rand(20) != 1 # We need to do this operation only once in a while.
 
     @display_ad = DisplayAd.find(display_ad_event_params[:display_ad_id])
+
     num_impressions = @display_ad.display_ad_events.where(category: "impression").size
     num_clicks = @display_ad.display_ad_events.where(category: "click").size
     rate = num_clicks.to_f / num_impressions
 
-    @display_ad.
-      update_columns(success_rate: rate, clicks_count: num_clicks, impressions_count: num_impressions)
+    @display_ad.update_columns(
+      success_rate: rate,
+      clicks_count: num_clicks,
+      impressions_count: num_impressions,
+    )
   end
 
   def display_ad_event_params

--- a/app/dashboards/display_ad_dashboard.rb
+++ b/app/dashboards/display_ad_dashboard.rb
@@ -13,8 +13,6 @@ class DisplayAdDashboard < Administrate::BaseDashboard
     placement_area: Field::String,
     body_markdown: Field::Text,
     processed_html: Field::Text,
-    cost_per_impression: Field::Number.with_options(decimals: 2),
-    cost_per_click: Field::Number.with_options(decimals: 2),
     impressions_count: Field::Number,
     clicks_count: Field::Number,
     success_rate: Field::Number,
@@ -47,8 +45,6 @@ class DisplayAdDashboard < Administrate::BaseDashboard
     placement_area
     body_markdown
     processed_html
-    cost_per_impression
-    cost_per_click
     impressions_count
     clicks_count
     success_rate
@@ -65,8 +61,6 @@ class DisplayAdDashboard < Administrate::BaseDashboard
     organization
     placement_area
     body_markdown
-    cost_per_impression
-    cost_per_click
     published
     approved
   ].freeze

--- a/app/models/display_ad.rb
+++ b/app/models/display_ad.rb
@@ -1,4 +1,9 @@
 class DisplayAd < ApplicationRecord
+  self.ignored_columns = %w[
+    cost_per_click
+    cost_per_impression
+  ]
+
   belongs_to :organization
   has_many :display_ad_events
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

The `display_ads` table has 14 columns, 2 of them seem to be unused:

```
cost_per_click
cost_per_impression
```

The first step is to tell Rails to ignore the columns, once tests pass, we deployed and we know nothing has broken, then we can actually remove the columns.

This will also save us memory with `SELECT *` operations.

Let me know if any of these should be kept for any reason.

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
