### PR TITLE
Index comments into FeedContent index

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -5,6 +5,10 @@ class Comment < ApplicationRecord
   has_ancestry
   resourcify
   include Reactable
+  include Searchable
+
+  SEARCH_SERIALIZER = Search::CommentSerializer
+  SEARCH_CLASS = Search::FeedContent
 
   belongs_to :commentable, polymorphic: true, optional: true
   counter_culture :commentable
@@ -35,6 +39,8 @@ class Comment < ApplicationRecord
   after_create_commit :send_email_notification, if: :should_send_email_notification?
   after_create_commit :create_first_reaction
   after_create_commit :send_to_moderator
+  after_commit :index_to_elasticsearch, on: %i[create update]
+  after_commit :remove_from_elasticsearch, on: [:destroy]
   before_save    :set_markdown_character_count, if: :body_markdown
   before_create  :adjust_comment_parent_based_on_depth
   after_update   :remove_notifications, if: :deleted
@@ -46,6 +52,10 @@ class Comment < ApplicationRecord
 
   def self.tree_for(commentable, limit = 0)
     commentable.comments.includes(:user).arrange(order: "score DESC").to_a[0..limit - 1].to_h
+  end
+
+  def search_id
+    "comment_#{id}"
   end
 
   def path

--- a/app/serializers/search/comment_serializer.rb
+++ b/app/serializers/search/comment_serializer.rb
@@ -7,6 +7,9 @@ module Search
     attributes :path, :positive_reactions_count
 
     attribute :body_text, &:body_markdown
+    attribute :class_name do |comment|
+      comment.class.name
+    end
     attribute :published do |_comment|
       true
     end

--- a/app/serializers/search/comment_serializer.rb
+++ b/app/serializers/search/comment_serializer.rb
@@ -10,12 +10,12 @@ module Search
     attribute :class_name do |comment|
       comment.class.name
     end
+    attribute :hotness_score, &:score
     attribute :published do |_comment|
       true
     end
     attribute :published_at, &:created_at
     attribute :readable_publish_date_string, &:readable_publish_date
-    attribute :hotness_score, &:score
     attribute :title do |comment|
       comment.commentable&.title
     end

--- a/app/serializers/search/comment_serializer.rb
+++ b/app/serializers/search/comment_serializer.rb
@@ -7,6 +7,9 @@ module Search
     attributes :path, :positive_reactions_count
 
     attribute :body_text, &:body_markdown
+    attribute :published do |_comment|
+      true
+    end
     attribute :published_at, &:created_at
     attribute :readable_publish_date_string, &:readable_publish_date
     attribute :hotness_score, &:score

--- a/app/serializers/search/comment_serializer.rb
+++ b/app/serializers/search/comment_serializer.rb
@@ -1,0 +1,23 @@
+module Search
+  class CommentSerializer
+    include FastJsonapi::ObjectSerializer
+
+    attribute :id, &:search_id
+
+    attributes :path, :positive_reactions_count
+
+    attribute :body_text, &:body_markdown
+    attribute :published_at, &:created_at
+    attribute :readable_publish_date_string, &:readable_publish_date
+    attribute :hotness_score, &:score
+    attribute :title do |comment|
+      comment.commentable&.title
+    end
+
+    attribute :user do |comment|
+      NestedUserSerializer.new(comment.user).serializable_hash.dig(
+        :data, :attributes
+      )
+    end
+  end
+end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -37,6 +37,28 @@ RSpec.describe Comment, type: :model do
       # rubocop:enable RSpec/NamedSubject
     end
 
+    describe "#after_commit" do
+      it "on update enqueues job to index comment to elasticsearch" do
+        sidekiq_assert_enqueued_with(job: Search::IndexToElasticsearchWorker, args: [described_class.to_s, comment.search_id]) do
+          comment.save
+        end
+      end
+
+      it "on destroy enqueues job to delete comment from elasticsearch" do
+        comment = create(:comment)
+
+        sidekiq_assert_enqueued_with(job: Search::RemoveFromElasticsearchIndexWorker, args: [described_class::SEARCH_CLASS.to_s, comment.search_id]) do
+          comment.destroy
+        end
+      end
+    end
+
+    describe "#search_id" do
+      it "returns comment_ID" do
+        expect(comment.search_id).to eq("comment_#{comment.id}")
+      end
+    end
+
     describe "#processed_html" do
       let(:comment) { build(:comment, user: user, commentable: article) }
 

--- a/spec/serializers/search/comment_serializer_spec.rb
+++ b/spec/serializers/search/comment_serializer_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe Search::CommentSerializer do
+  let(:user) { create(:user) }
+  let(:article) { create(:article, user: user) }
+  let(:comment) { create(:comment, user: user, commentable: article) }
+
+  it "serializes an comment" do
+    data_hash = described_class.new(comment).serializable_hash.dig(:data, :attributes)
+    user_data = Search::NestedUserSerializer.new(user).serializable_hash.dig(:data, :attributes)
+    expect(data_hash[:user]).to eq(user_data)
+    expect(data_hash.keys).to include(:id, :body_text, :hotness_score, :title)
+  end
+
+  it "creates valid json for Elasticsearch", elasticsearch: true do
+    data_hash = described_class.new(comment).serializable_hash.dig(:data, :attributes)
+    result = Comment::SEARCH_CLASS.index(comment.id, data_hash)
+    expect(result["result"]).to eq("created")
+  end
+end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Feature

## Description
With our new Feed search is going to come the ability to also search for Comments.
<img width="197" alt="Screen Shot 2020-03-23 at 3 29 09 PM" src="https://user-images.githubusercontent.com/1813380/77360272-101b7180-6d1b-11ea-9054-2b9f39efb6f5.png">

This PR begins indexing Comments into Elasticsearch. I am not including a full index of them yet, bc like articles I want to hook up the front end to make sure everything we need to present them is in Elasticsearch. Once that is validated I will issue a PR to get everything synced

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-35019750

## Added tests?
- [x] yes

![alt_text](https://help.imgur.com/hc/article_attachments/115005220206/comments.gif)
