### PR TITLE
Handle a missing commentable in new reply email

### DIFF
--- a/app/views/mailers/notify_mailer/new_reply_email.html.erb
+++ b/app/views/mailers/notify_mailer/new_reply_email.html.erb
@@ -9,7 +9,7 @@
   </tr>
   <tr>
     <td style='padding:20px;padding-bottom:30px;border-radius:3px;font-size:19px;background:#f4f4f4'>
-      <h2 style="font-size:22px;color:rgb(107, 107, 107)">re: <em><%= @comment.commentable.title %></em></h2>
+      <h2 style="font-size:22px;color:rgb(107, 107, 107)">re: <em><%= @comment.commentable&.title || "Content No Longer Available" %></em></h2>
       <%= @comment.processed_html.html_safe %>
       <a style="background:#3c7dc1;color:white;padding:5px 14px;border-radius:3px;text-decoration:none;display:inline-block;margin-top:4px;" href='https://dev.to<%= @comment.path %>'>view on dev.to</a>&nbsp;
       <a style="background:#1f1f1f;color:white;padding:5px 14px;border-radius:3px;text-decoration:none;display:inline-block;margin-top:4px;" href='https://dev.to<%= @comment.commentable.path %>'>read original post</a>


### PR DESCRIPTION


## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
When we send a new_reply_email for a comment we assume that there is a commendable. This is not always the case since an Article can be deleted and its comments will still remain. In the event that this happens, our email should not fail to send. I replaced the missing title with a "Content No Longer Available" message but we could also leave it blank. 
```
ActionView::Template::Error: undefined method `title' for nil:NilClass
 new_reply_email.html.erb  12 _app_views_mailers_notify_mailer_new_reply_email_html_erb(...)
[PROJECT_ROOT]/app/views/mailers/notify_mailer/new_reply_email.html.erb:12:in `_app_views_mailers_notify_mailer_new_reply_email_html_erb'
10   <tr>
11     <td style='padding:20px;padding-bottom:30px;border-radius:3px;font-size:19px;background:#f4f4f4'>
12       <h2 style="font-size:22px;color:rgb(107, 107, 107)">re: <em><%= @comment.commentable.title %></em></h2>
13       <%= @comment.processed_html.html_safe %>
14       <a style="background:#3c7dc1;color:white;padding:5px 14px;border-radius:3px;text-decoration:none;display:inline
```

## Related Tickets & Documents
Fixes: https://app.honeybadger.io/fault/66984/347445d8a77a0899d26e5ccf758c069e

## Added tests?
- [x] no, because they aren't needed

![alt_text](https://media3.giphy.com/media/l2QE5a4vEYIpINHWM/giphy.gif)
