### PR TITLE
Added missing dependencies for Heroku deploys

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,8 +112,10 @@
   },
   "dependencies": {
     "@babel/core": "^7.0.0",
+    "@babel/plugin-proposal-class-properties": "^7.8.3",
     "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@babel/plugin-transform-react-jsx": "^7.0.0",
+    "@babel/preset-env": "^7.9.0",
     "@github/clipboard-copy-element": "^1.1.2",
     "@rails/webpacker": "5.0.0",
     "babel-preset-preact": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -908,7 +908,7 @@
     levenary "^1.1.1"
     semver "^5.5.0"
 
-"@babel/preset-env@^7.8.7":
+"@babel/preset-env@^7.8.7", "@babel/preset-env@^7.9.0":
   version "7.9.0"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.9.0.tgz#a5fc42480e950ae8f5d9f8f2bbc03f52722df3a8"
   integrity sha512-712DeRXT6dyKAM/FMbQTV/FvRCms2hPCx+3weRjZ8iQVQWZejWWk1wwG6ViWMyqb/ouBbGOl5b6aCk0+j1NmsQ==


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Follow up from attempt one in #6799.

I did the steps I did last time, which I should have done before putting the PR up for the webpack 5 upgrade. Steps to fake a Heroku deploy precompile step:

* run `bin/setup`
* run `yarn install --production=true`
* Temporarily explicitly set NODE_ENV in bin/webpack to “production” and run `bin/webpack`

After running those steps, any dependencies that need to be in dependencies in package.json (not devDependencies) will pop up in the webpack error logs.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![Obama saying, "By the way, we have to fix that."](https://media.giphy.com/media/l2YWmdzX0DkNHk3ew/giphy.gif)
