### PR TITLE
Add name to tags component

### DIFF
--- a/app/javascript/article-form/__tests__/__snapshots__/articleForm.test.jsx.snap
+++ b/app/javascript/article-form/__tests__/__snapshots__/articleForm.test.jsx.snap
@@ -34,6 +34,7 @@ exports[`<ArticleForm /> renders properly 1`] = `
             autoComplete="off"
             class="articleform__tags"
             id="tag-input"
+            name="classified_listing[tag_list]"
             onBlur={[Function]}
             onFocus={[Function]}
             onInput={[Function]}

--- a/app/javascript/article-form/elements/__tests__/__snapshots__/tags.test.jsx.snap
+++ b/app/javascript/article-form/elements/__tests__/__snapshots__/tags.test.jsx.snap
@@ -19,6 +19,7 @@ exports[`<Tags /> renders properly 1`] = `
     autoComplete="off"
     class="articleform__tags"
     id="tag-input"
+    name="classified_listing[tag_list]"
     onBlur={[Function]}
     onFocus={[Function]}
     onInput={[Function]}

--- a/app/javascript/shared/components/tags.jsx
+++ b/app/javascript/shared/components/tags.jsx
@@ -432,6 +432,7 @@ class Tags extends Component {
             return this.textArea;
           }}
           className={`${classPrefix}__tags`}
+          name="classified_listing[tag_list]"
           placeholder={`${maxTags} tags max, comma separated, no spaces or special characters`}
           autoComplete="off"
           value={defaultValue}

--- a/app/views/classified_listings/_form.html.erb
+++ b/app/views/classified_listings/_form.html.erb
@@ -32,6 +32,10 @@
             <summary>Category details/rules</summary>
           </details>
         </div>
+        <div class="field">
+          <%= form.label "tag_list", "Tags" %>
+          <%= form.text_field "tag_list", placeholder: "8 tags max, comma separated, no spaces or special characters", name: "classified_listing[tag_list]" %>
+        </div>
       <% if @organizations.present? && @organizations.size > 0 %>
         <div class="field">
           <%= form.label "organization_id", "Post under an organization:" %>

--- a/app/views/classified_listings/_form.html.erb
+++ b/app/views/classified_listings/_form.html.erb
@@ -32,6 +32,11 @@
             <summary>Category details/rules</summary>
           </details>
         </div>
+        <%# The following tag_list field is overriden by the Tags JS component
+        from the listingForm. We keep this form field in place to faciliate
+        SSR. By having the form field loaded on the DOM first with this view,
+        we prevent the screen from "jumping" once the deferred JS is loaded
+        and executed. %>
         <div class="field">
           <%= form.label "tag_list", "Tags" %>
           <%= form.text_field "tag_list", placeholder: "8 tags max, comma separated, no spaces or special characters" %>

--- a/app/views/classified_listings/_form.html.erb
+++ b/app/views/classified_listings/_form.html.erb
@@ -34,7 +34,7 @@
         </div>
         <div class="field">
           <%= form.label "tag_list", "Tags" %>
-          <%= form.text_field "tag_list", placeholder: "8 tags max, comma separated, no spaces or special characters", name: "classified_listing[tag_list]" %>
+          <%= form.text_field "tag_list", placeholder: "8 tags max, comma separated, no spaces or special characters" %>
         </div>
       <% if @organizations.present? && @organizations.size > 0 %>
         <div class="field">

--- a/app/views/classified_listings/_form.html.erb
+++ b/app/views/classified_listings/_form.html.erb
@@ -33,7 +33,7 @@
           </details>
         </div>
         <%# The following tag_list field is overriden by the Tags JS component
-        from the listingForm. We keep this form field in place to faciliate
+        from the listingForm. We keep this form field in place to facilitate
         SSR. By having the form field loaded on the DOM first with this view,
         we prevent the screen from "jumping" once the deferred JS is loaded
         and executed. %>

--- a/app/views/classified_listings/_form.html.erb
+++ b/app/views/classified_listings/_form.html.erb
@@ -32,10 +32,6 @@
             <summary>Category details/rules</summary>
           </details>
         </div>
-        <div class="field">
-          <%= form.label "tags_list", "Tags" %>
-          <%= form.text_field "tags_list", placeholder: "8 tags max, comma separated, no spaces or special characters" %>
-        </div>
       <% if @organizations.present? && @organizations.size > 0 %>
         <div class="field">
           <%= form.label "organization_id", "Post under an organization:" %>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
In #6741 we found a [bug](https://github.com/thepracticaldev/dev.to/pull/6741#issuecomment-601875812) when it comes to adding tags to listings. This PR fixes adding tags to a new listing. Previously, the input field wasn't being included in the form submission because the input field wasn't named properly.

We can ignore my comment about the script being loaded twice. Looks like the conditions are just slightly different.

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/pull/6741#issuecomment-601875812

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

![will_smith_magnifying_glass_gif](https://media.giphy.com/media/xGdvlOVSWaDvi/giphy.gif)
