### PR TITLE
Hotness Score for Tags Should Use Article positive_reactions_count 

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -87,7 +87,7 @@ class Tag < ActsAsTaggableOn::Tag
     self.hotness_score = Article.tagged_with(name).
       where("articles.featured_number > ?", 7.days.ago.to_i).
       map do |article|
-        (article.comments_count * 14) + (article.reactions_count * 4) + rand(6) + ((taggings_count + 1) / 2)
+        (article.comments_count * 14) + (article.positive_reactions_count * 4) + rand(6) + ((taggings_count + 1) / 2)
       end.
       sum
   end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -87,7 +87,7 @@ class Tag < ActsAsTaggableOn::Tag
     self.hotness_score = Article.tagged_with(name).
       where("articles.featured_number > ?", 7.days.ago.to_i).
       map do |article|
-        (article.comments_count * 14) + (article.positive_reactions_count * 4) + rand(6) + ((taggings_count + 1) / 2)
+        (article.comments_count * 14) + article.positive_reactions_count + rand(6) + ((taggings_count + 1) / 2)
       end.
       sum
   end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -87,7 +87,7 @@ class Tag < ActsAsTaggableOn::Tag
     self.hotness_score = Article.tagged_with(name).
       where("articles.featured_number > ?", 7.days.ago.to_i).
       map do |article|
-        (article.comments_count * 14) + article.positive_reactions_count + rand(6) + ((taggings_count + 1) / 2)
+        (article.comments_count * 14) + article.score + rand(6) + ((taggings_count + 1) / 2)
       end.
       sum
   end

--- a/lib/data_update_scripts/20200324133751_update_tag_hotness_scores.rb
+++ b/lib/data_update_scripts/20200324133751_update_tag_hotness_scores.rb
@@ -1,0 +1,8 @@
+module DataUpdateScripts
+  class UpdateTagHotnessScores
+    def run
+      # Saving a tag will trigger calculate_hotness_score
+      Tag.find_each(&:save)
+    end
+  end
+end

--- a/spec/lib/data_update_scripts/update_tag_hotness_scores_spec.rb
+++ b/spec/lib/data_update_scripts/update_tag_hotness_scores_spec.rb
@@ -1,0 +1,8 @@
+require "rails_helper"
+require Rails.root.join("lib/data_update_scripts/20200324133751_update_tag_hotness_scores.rb")
+
+describe DataUpdateScripts::UpdateTagHotnessScores do
+  it "can save all tags" do
+    expect(Tag.new).to respond_to(:save)
+  end
+end

--- a/spec/lib/data_update_scripts/update_tag_hotness_scores_spec.rb
+++ b/spec/lib/data_update_scripts/update_tag_hotness_scores_spec.rb
@@ -1,8 +1,0 @@
-require "rails_helper"
-require Rails.root.join("lib/data_update_scripts/20200324133751_update_tag_hotness_scores.rb")
-
-describe DataUpdateScripts::UpdateTagHotnessScores do
-  it "can save all tags" do
-    expect(Tag.new).to respond_to(:save)
-  end
-end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Through some investigative work, I found that [we are not using reactions_count](https://github.com/thepracticaldev/dev.to/pull/6781#issuecomment-602835034) for articles or comments but instead we only [update `postive_reactions_count`](https://github.com/thepracticaldev/dev.to/blob/master/app/models/concerns/reactable.rb#L9) therefore that is the value we should be used when calculating the Tag hotness score. I included a data update job to fix all Tag hotness scores.

## Added tests?
- [x] yes

![alt_text](https://media3.giphy.com/media/1BdIPQfBbxb4gP7JFw/giphy.gif)
