### PR TITLE
Flaky Spec Fix: Ensure Article Published dates are far enough apart

### DIFF
--- a/spec/system/articles/user_visits_an_article_spec.rb
+++ b/spec/system/articles/user_visits_an_article_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe "Views an article", type: :system do
     context "with regular articles" do
       it "lists the articles in ascending published_at order" do
         articles = create_list(:article, 2)
+        articles.first.update(published_at: 1.week.ago)
         articles.each { |a| a.update_columns(collection_id: collection.id) }
 
         visit articles.first.path


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This spec has been very flaky lately and I believe its because when we create both articles the published_at times sometimes are the same and therefore the order of them gets messed up. This ensures that the first article has a publised_at date way in the past rather than the current time. 

![alt_text](https://media0.giphy.com/media/9x8TMFD6AoRcrnqxNw/giphy.gif)
