### PR TITLE
Add App.url and use it with Slack messengers

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -166,9 +166,6 @@ module ApplicationHelper
   # @example Add a path
   #  app_url("internal") #=> "https://dev.to/internal"
   def app_url(uri = nil)
-    base_url = "#{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}"
-    return base_url unless uri
-
-    URI.parse(base_url).merge(uri).to_s
+    App.url(uri)
   end
 end

--- a/app/services/slack/messengers/feedback.rb
+++ b/app/services/slack/messengers/feedback.rb
@@ -4,7 +4,7 @@ module Slack
       MESSAGE_TEMPLATE = <<~TEXT.chomp.freeze
         %<user_detail>s
         Category: %<category>s
-        Internal Report: #{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}/internal/reports
+        Internal Report: %<reports_url>s
         *_ Reported URL: %<reported_url>s _*
         -----
         *Message:* %<message>s
@@ -29,10 +29,15 @@ module Slack
       end
 
       def call
+        reports_url = App.url(
+          Rails.application.routes.url_helpers.internal_reports_path,
+        )
+
         final_message = format(
           MESSAGE_TEMPLATE,
           user_detail: user_detail,
           category: category,
+          reports_url: reports_url,
           reported_url: reported_url,
           message: message,
         )
@@ -52,12 +57,10 @@ module Slack
       def user_detail
         return "*Anonymous report:" unless user
 
-        username = user.username
-        url = "#{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}/#{username}"
         format(
           USER_DETAIL_TEMPLATE,
-          username: username,
-          url: url,
+          username: user.username,
+          url: App.url("/#{user.username}"),
           email: user.email,
         )
       end

--- a/app/services/slack/messengers/note.rb
+++ b/app/services/slack/messengers/note.rb
@@ -4,7 +4,7 @@ module Slack
       MESSAGE_TEMPLATE = <<~TEXT.chomp.freeze
         *New note from %<name>s:*
         *Report status: %<status>s*
-        Report page: #{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}/internal/reports/%<report_id>s
+        Report page: %<report_url>s
         --------
         Message: %<message>s
       TEXT
@@ -22,11 +22,15 @@ module Slack
       end
 
       def call
+        report_url = App.url(
+          Rails.application.routes.url_helpers.internal_report_path(report_id),
+        )
+
         final_message = format(
           MESSAGE_TEMPLATE,
           name: author_name,
           status: status,
-          report_id: report_id,
+          report_url: report_url,
           message: message,
         )
 

--- a/app/services/slack/messengers/potential_spammer.rb
+++ b/app/services/slack/messengers/potential_spammer.rb
@@ -14,11 +14,9 @@ module Slack
       end
 
       def call
-        url = "#{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}/#{user.username}"
-
         message = format(
           MESSAGE_TEMPLATE,
-          url: url,
+          url: App.url("/#{user.username}"),
         )
 
         SlackBotPingWorker.perform_async(

--- a/app/services/slack/messengers/rate_limit.rb
+++ b/app/services/slack/messengers/rate_limit.rb
@@ -15,12 +15,10 @@ module Slack
       end
 
       def call
-        url = "#{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}/#{user.username}"
-
         message = format(
           MESSAGE_TEMPLATE,
           action: action,
-          url: url,
+          url: App.url("/#{user.username}"),
         )
 
         SlackBotPingWorker.perform_async(

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -1,0 +1,26 @@
+module App
+  module_function
+
+  def protocol
+    ApplicationConfig["APP_PROTOCOL"]
+  end
+
+  def domain
+    ApplicationConfig["APP_DOMAIN"]
+  end
+
+  # Creates an app internal URL
+  #
+  # @note Uses protocol and domain specified in the environment, ensure they are set.
+  # @param uri [URI, String] parts we want to merge into the URL, e.g. path, fragment
+  # @example Retrieve the base URL
+  #  app_url #=> "https://dev.to"
+  # @example Add a path
+  #  app_url("internal") #=> "https://dev.to/internal"
+  def url(uri = nil)
+    base_url = "#{protocol}#{domain}"
+    return base_url unless uri
+
+    URI.parse(base_url).merge(uri).to_s
+  end
+end

--- a/spec/lib/app_spec.rb
+++ b/spec/lib/app_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe App, type: :lib do
+  describe ".protocol" do
+    it "returns the value of APP_PROTOCOL env variable" do
+      expect(described_class.protocol).to eq(ApplicationConfig["APP_PROTOCOL"])
+    end
+  end
+
+  describe ".domain" do
+    it "returns the value of APP_DOMAIN env variable" do
+      expect(described_class.domain).to eq(ApplicationConfig["APP_DOMAIN"])
+    end
+  end
+
+  describe ".url" do
+    before do
+      allow(ApplicationConfig).to receive(:[]).with("APP_PROTOCOL").and_return("https://")
+      allow(ApplicationConfig).to receive(:[]).with("APP_DOMAIN").and_return("dev.to")
+    end
+
+    it "creates the correct base app URL" do
+      expect(described_class.url).to eq("https://dev.to")
+    end
+
+    it "creates a URL with a path" do
+      expect(described_class.url("internal")).to eq("https://dev.to/internal")
+    end
+
+    it "creates the correct URL even if the path starts with a slash" do
+      expect(described_class.url("/internal")).to eq("https://dev.to/internal")
+    end
+
+    it "works when called with an URI object" do
+      uri = URI::Generic.build(path: "internal", fragment: "test")
+      expect(described_class.url(uri)).to eq("https://dev.to/internal#test")
+    end
+  end
+end

--- a/spec/services/slack/messengers/feedback_spec.rb
+++ b/spec/services/slack/messengers/feedback_spec.rb
@@ -28,10 +28,9 @@ RSpec.describe Slack::Messengers::Feedback, type: :service do
     end
 
     message = get_argument_from_last_job("message")
-    url = "#{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}/#{user.username}"
 
     expect(message).to include(user.username)
-    expect(message).to include(url)
+    expect(message).to include(App.url("/#{user.username}"))
     expect(message).to include(user.email)
   end
 
@@ -41,7 +40,9 @@ RSpec.describe Slack::Messengers::Feedback, type: :service do
     end
 
     message = get_argument_from_last_job("message")
-    url = "#{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}/internal/reports"
+    url = App.url(
+      Rails.application.routes.url_helpers.internal_reports_path,
+    )
 
     [
       url, user.email, default_params[:category], default_params[:reported_url]

--- a/spec/services/slack/messengers/note_spec.rb
+++ b/spec/services/slack/messengers/note_spec.rb
@@ -21,7 +21,11 @@ RSpec.describe Slack::Messengers::Note, type: :service do
 
     expect(message).to include(default_params[:author_name])
     expect(message).to include(default_params[:status])
-    url = "#{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}/internal/reports/#{default_params[:report_id]}"
+    url = App.url(
+      Rails.application.routes.url_helpers.internal_report_path(
+        default_params[:report_id],
+      ),
+    )
     expect(message).to include(url)
     expect(message).to include(default_params[:message])
   end

--- a/spec/services/slack/messengers/potential_spammer_spec.rb
+++ b/spec/services/slack/messengers/potential_spammer_spec.rb
@@ -13,8 +13,7 @@ RSpec.describe Slack::Messengers::PotentialSpammer, type: :service do
     job = sidekiq_enqueued_jobs(worker: SlackBotPingWorker).last
     message = job["args"].first["message"]
 
-    url = "#{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}/#{user.username}"
-    expect(message).to include(url)
+    expect(message).to include(App.url("/#{user.username}"))
   end
 
   it "messages the proper channel with the proper username and emoji", :aggregate_failures do

--- a/spec/services/slack/messengers/rate_limit_spec.rb
+++ b/spec/services/slack/messengers/rate_limit_spec.rb
@@ -19,8 +19,7 @@ RSpec.describe Slack::Messengers::RateLimit, type: :service do
     message = job["args"].first["message"]
 
     expect(message).to include(default_params[:action])
-    url = "#{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}/#{user.username}"
-    expect(message).to include(url)
+    expect(message).to include(App.url("/#{user.username}"))
   end
 
   it "messages the proper channel with the proper username and emoji", :aggregate_failures do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Thanks to the awesome work by @citizen428 in #6715 and a brief discussion we had in private about extending `ApplicationHelper.app_url` outside the views I added this new module: `App`, which contains this three methods:

- `App.protocol` which returns `ApplicationConfig["APP_PROTOCOL"]`
- `App.domain` which returns `ApplicationConfig["APP_DOMAIN"]`
- `App.url(path)` which can be used to generate a full URL outside the views

I also changed `ApplicationHelper.app_url` to call this, I haven't removed the existing tests.

Finally, I started using in Slack messengers, see #6748 

`App.url()` shoud save us quite a lot of typing, and probably we can add `.protocol` and `.domain` to the `ApplicationHelper` in the future.

ps. initially we were about to call this `Utils.app_url` but `utils` modules have the tendencies to include everything but the kitchen sink eventually, at least in my experience. `App.url` seemed the minimum amount of keystrokes still able to communicate its purpose

## Related Tickets & Documents

#6715 
#6748 

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
