### PR TITLE
Allow Any User to Search Feed, Users, and Classified Listings

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,5 +1,5 @@
 class SearchController < ApplicationController
-  before_action :authenticate_user!
+  before_action :authenticate_user!, only: %i[tags chat_channels]
   before_action :format_integer_params
   before_action :sanitize_params, only: %i[classified_listings]
 

--- a/spec/requests/search_spec.rb
+++ b/spec/requests/search_spec.rb
@@ -41,13 +41,11 @@ RSpec.describe "Search", type: :request, proper_status: true do
   end
 
   describe "GET /search/classified_listings" do
-    let(:authorized_user) { create(:user) }
     let(:mock_documents) do
       [{ "title" => "classified_listing1" }]
     end
 
     it "returns json" do
-      sign_in authorized_user
       allow(Search::ClassifiedListing).to receive(:search_documents).and_return(
         mock_documents,
       )
@@ -57,11 +55,9 @@ RSpec.describe "Search", type: :request, proper_status: true do
   end
 
   describe "GET /search/users" do
-    let(:authorized_user) { create(:user) }
     let(:mock_documents) { [{ "username" => "firstlast" }] }
 
     it "returns json" do
-      sign_in authorized_user
       allow(Search::User).to receive(:search_documents).and_return(
         mock_documents,
       )
@@ -71,11 +67,9 @@ RSpec.describe "Search", type: :request, proper_status: true do
   end
 
   describe "GET /search/feed_content" do
-    let(:authorized_user) { create(:user) }
     let(:mock_documents) { [{ "title" => "article1" }] }
 
     it "returns json" do
-      sign_in authorized_user
       allow(Search::FeedContent).to receive(:search_documents).and_return(
         mock_documents,
       )
@@ -85,7 +79,6 @@ RSpec.describe "Search", type: :request, proper_status: true do
     end
 
     it "queries only the user index if class_name=User" do
-      sign_in authorized_user
       allow(Search::FeedContent).to receive(:search_documents)
       allow(Search::User).to receive(:search_documents).and_return(
         mock_documents,
@@ -97,7 +90,6 @@ RSpec.describe "Search", type: :request, proper_status: true do
     end
 
     it "queries for Articles, Podcast Episodes and Users if no class_name filter is present" do
-      sign_in authorized_user
       allow(Search::FeedContent).to receive(:search_documents).and_return(
         mock_documents,
       )
@@ -111,7 +103,6 @@ RSpec.describe "Search", type: :request, proper_status: true do
     end
 
     it "queries for only Articles and Podcast Episodes if class_name!=User" do
-      sign_in authorized_user
       allow(Search::FeedContent).to receive(:search_documents).and_return(
         mock_documents,
       )


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
While doing some testing for feed searching I noticed that if you are not signed in(Incognito window) then you can't search the feed or classified listings. Since we want people to be able to search for things even if they are not signed in I updated the controller to only force authentication for Tags(only used when writing an article which you have to be signed up to do) and chat channels(have to be signed up to search those as well).

## Added tests?
- [x] updated

![alt_text](https://media2.giphy.com/media/hr4lb25LhlQLIUWRO7/giphy.gif?cid=790b76115f6a0aa229f4978de0dbd6370323ce8c55a99d30&rid=giphy.gif)
