### PR TITLE
Add some margin above onboarding h2

### DIFF
--- a/app/assets/stylesheets/preact/onboarding-modal.scss
+++ b/app/assets/stylesheets/preact/onboarding-modal.scss
@@ -93,6 +93,7 @@
   }
 
   h2 {
+    margin-top: 20px;
     font-size: 15px;
 
     @media screen and (min-width: 600px) {


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Small, somewhat temporary UI change to fix the awkward spacing on onboarding...

<img width="696" alt="Screen Shot 2020-03-24 at 4 28 38 PM" src="https://user-images.githubusercontent.com/3102842/77473881-85a34280-6dec-11ea-9783-4a60a7e21121.png">

(Temporary because we have bigger changes in the pipeline)