### PR TITLE
Add response templates to user settings

### DIFF
--- a/app/assets/stylesheets/settings.scss
+++ b/app/assets/stylesheets/settings.scss
@@ -529,8 +529,13 @@ $input-width: 650px;
     }
     .github-repo-row-name {
       font-weight: bold;
-      button {
-        transition: all 0.6s ease;
+      form {
+        display: block;
+        float: right;
+      }
+      button,
+      a[role='button'] {
+        transition: all 0.4s ease;
         cursor: pointer;
         font-size: 1.2em;
         font-weight: bold;
@@ -545,12 +550,27 @@ $input-width: 650px;
         &:hover,
         &:focus {
           background: $green;
+          &.danger-button {
+            background: $red;
+          }
         }
         &:disabled {
           cursor: wait;
           background: white url(image-src('loading-ellipsis.svg')) no-repeat
             center center;
           background-size: 75px;
+        }
+        a {
+          color: $black;
+        }
+      }
+      &.response-template-row-name {
+        button,
+        a[role='button'] {
+          width: 80px;
+          margin-left: 2.5px;
+          margin-right: 2.5px;
+          text-align: center;
         }
       }
     }
@@ -565,7 +585,6 @@ $input-width: 650px;
     }
     .github-repo-featured-indicator {
       display: inline-block;
-      float: right;
       background: $green;
       color: white;
       border: 0px;

--- a/app/assets/stylesheets/settings.scss
+++ b/app/assets/stylesheets/settings.scss
@@ -574,21 +574,6 @@ $input-width: 650px;
         }
       }
     }
-    .github-repo-fork {
-      margin-left: 5px;
-      font-weight: 400;
-      background: $purple;
-      color: $bold-blue;
-      border-radius: 3px;
-      padding: 1px 6px;
-      font-size: 0.9em;
-    }
-    .github-repo-featured-indicator {
-      display: inline-block;
-      background: $green;
-      color: white;
-      border: 0px;
-    }
   }
 }
 

--- a/app/controllers/response_templates_controller.rb
+++ b/app/controllers/response_templates_controller.rb
@@ -3,53 +3,51 @@ class ResponseTemplatesController < ApplicationController
 
   def create
     authorize ResponseTemplate
-    @response_template = ResponseTemplate.new(permitted_attributes(ResponseTemplate))
-    @response_template.user_id = current_user.id
-    @response_template.content_type = "body_markdown"
-    @response_template.type_of = "personal_comment"
+    response_template.user_id = current_user.id
+    response_template.content_type = "body_markdown"
+    response_template.type_of = "personal_comment"
 
-    if @response_template.save
-      flash[:settings_notice] = "Your response template \"#{@response_template.title}\" was created."
+    if response_template.save
+      flash[:settings_notice] = "Your response template \"#{response_template.title}\" was created."
     else
-      flash[:error] = "Response template error: #{@response_template.errors.full_messages.to_sentence}"
+      flash[:error] = "Response template error: #{response_template.errors.full_messages.to_sentence}"
+      previous_title = permitted_attributes(ResponseTemplate)[:title]
+      previous_content = permitted_attributes(ResponseTemplate)[:content]
     end
 
     redirect_to user_settings_path(tab: "response-templates", id: @response_template.id)
   end
 
   def destroy
-    @response_template = ResponseTemplate.find(params[:id])
-    authorize @response_template
+    authorize response_template
 
-    if @response_template.destroy
-      flash[:settings_notice] = "Your response template \"#{@response_template.title}\" was deleted."
+    if response_template.destroy
+      flash[:settings_notice] = "Your response template \"#{response_template.title}\" was deleted."
     else
-      flash[:error] = @response_template.errors.full_messages.to_sentence # this will probably never fail
+      flash[:error] = response_template.errors.full_messages.to_sentence # this will probably never fail
     end
 
     redirect_to user_settings_path(tab: "response-templates")
   end
 
   def update
-    @response_template = ResponseTemplate.find(params[:id])
-    authorize @response_template
+    authorize response_template
 
-    if @response_template.update(permitted_attributes(ResponseTemplate))
-      flash[:settings_notice] = "Your response template \"#{@response_template.title}\" was updated."
+    if response_template.update(permitted_attributes(ResponseTemplate))
+      flash[:settings_notice] = "Your response template \"#{response_template.title}\" was updated."
+      redirect_to user_settings_path(tab: "response-templates", id: response_template.id)
     else
       flash[:error] = "Response template error: #{@response_template.errors.full_messages.to_sentence}"
     end
-    redirect_to user_settings_path(tab: "response-templates", id: @response_template.id, previous_content: permitted_attributes(ResponseTemplate)[:content])
   end
 
   private
 
-  def handle_authorization(records)
-    case params[:type_of]
-    when "mod_comment"
-      authorize records, :moderator_index?
+  def response_template
+    @response_template ||= if params[:id].present?
+      ResponseTemplate.find(params[:id])
     else
-      authorize records, :admin_index?
+      ResponseTemplate.new(permitted_attributes(ResponseTemplate))
     end
   end
 end

--- a/app/controllers/response_templates_controller.rb
+++ b/app/controllers/response_templates_controller.rb
@@ -4,19 +4,19 @@ class ResponseTemplatesController < ApplicationController
   def index
     not_found unless current_user
     @response_templates = if params[:type_of] && params[:personal_included] != "true"
-                          result = ResponseTemplate.where(user_id: nil, type_of: params[:type_of])
-                          handle_authorization(result)
-                          result
-                        elsif params[:type_of] == "mod_comment" && params[:personal_included] == "true"
-                          result = ResponseTemplate.
-                            where(user_id: nil, type_of: "mod_comment").
-                            union(user_id: current_user.id, type_of: "personal_comment")
-                          handle_authorization(result)
-                          result
-                        else
-                          skip_authorization
-                          ResponseTemplate.where(user_id: current_user.id)
-                        end
+                            result = ResponseTemplate.where(user_id: nil, type_of: params[:type_of])
+                            handle_authorization(result)
+                            result
+                          elsif params[:type_of] == "mod_comment" && params[:personal_included] == "true"
+                            result = ResponseTemplate.
+                              where(user_id: nil, type_of: "mod_comment").
+                              union(user_id: current_user.id, type_of: "personal_comment")
+                            handle_authorization(result)
+                            result
+                          else
+                            skip_authorization
+                            ResponseTemplate.where(user_id: current_user.id)
+                          end
   end
 
   def create

--- a/app/controllers/response_templates_controller.rb
+++ b/app/controllers/response_templates_controller.rb
@@ -1,8 +1,8 @@
 class ResponseTemplatesController < ApplicationController
   after_action :verify_authorized, except: %i[index]
+  before_action :authenticate_user!, only: %i[index]
 
   def index
-    not_found unless current_user
     @response_templates = if params[:type_of] && params[:personal_included] != "true"
                             result = ResponseTemplate.where(user_id: nil, type_of: params[:type_of])
                             handle_authorization(result)

--- a/app/controllers/response_templates_controller.rb
+++ b/app/controllers/response_templates_controller.rb
@@ -47,7 +47,8 @@ class ResponseTemplatesController < ApplicationController
         tab: "response-templates",
         id: response_template.id,
         previous_title: attributes[:title],
-        previous_content: attributes[:content])
+        previous_content: attributes[:content]
+      )
     end
   end
 
@@ -55,9 +56,9 @@ class ResponseTemplatesController < ApplicationController
 
   def response_template
     @response_template ||= if params[:id].present?
-      ResponseTemplate.find(params[:id])
-    else
-      ResponseTemplate.new(permitted_attributes(ResponseTemplate))
-    end
+                             ResponseTemplate.find(params[:id])
+                           else
+                             ResponseTemplate.new(permitted_attributes(ResponseTemplate))
+                           end
   end
 end

--- a/app/controllers/response_templates_controller.rb
+++ b/app/controllers/response_templates_controller.rb
@@ -11,15 +11,14 @@ class ResponseTemplatesController < ApplicationController
       flash[:settings_notice] = "Your response template \"#{response_template.title}\" was created."
     else
       flash[:error] = "Response template error: #{response_template.errors.full_messages.to_sentence}"
-      previous_title = permitted_attributes(ResponseTemplate)[:title]
-      previous_content = permitted_attributes(ResponseTemplate)[:content]
+      attributes = permitted_attributes(ResponseTemplate)
     end
 
     redirect_to user_settings_path(
       tab: "response-templates",
       id: response_template.id,
-      previous_title: previous_title,
-      previous_content: previous_content
+      previous_title: attributes[:title],
+      previous_content: attributes[:content]
     )
   end
 
@@ -38,7 +37,8 @@ class ResponseTemplatesController < ApplicationController
   def update
     authorize response_template
 
-    if response_template.update(permitted_attributes(ResponseTemplate))
+    attributes = permitted_attributes(ResponseTemplate)
+    if response_template.update(attributes)
       flash[:settings_notice] = "Your response template \"#{response_template.title}\" was updated."
       redirect_to user_settings_path(tab: "response-templates", id: response_template.id)
     else
@@ -46,8 +46,8 @@ class ResponseTemplatesController < ApplicationController
       redirect_to user_settings_path(
         tab: "response-templates",
         id: response_template.id,
-        previous_title: permitted_attributes(ResponseTemplate)[:title],
-        previous_content: permitted_attributes(ResponseTemplate)[:content])
+        previous_title: attributes[:title],
+        previous_content: attributes[:content])
     end
   end
 

--- a/app/controllers/response_templates_controller.rb
+++ b/app/controllers/response_templates_controller.rb
@@ -9,17 +9,17 @@ class ResponseTemplatesController < ApplicationController
 
     if response_template.save
       flash[:settings_notice] = "Your response template \"#{response_template.title}\" was created."
+      redirect_to user_settings_path(tab: "response-templates", id: response_template.id)
     else
       flash[:error] = "Response template error: #{response_template.errors.full_messages.to_sentence}"
       attributes = permitted_attributes(ResponseTemplate)
+      redirect_to user_settings_path(
+        tab: "response-templates",
+        id: response_template.id,
+        previous_title: attributes[:title],
+        previous_content: attributes[:content]
+      )
     end
-
-    redirect_to user_settings_path(
-      tab: "response-templates",
-      id: response_template.id,
-      previous_title: attributes[:title],
-      previous_content: attributes[:content]
-    )
   end
 
   def destroy

--- a/app/controllers/response_templates_controller.rb
+++ b/app/controllers/response_templates_controller.rb
@@ -17,7 +17,7 @@ class ResponseTemplatesController < ApplicationController
         tab: "response-templates",
         id: response_template.id,
         previous_title: attributes[:title],
-        previous_content: attributes[:content]
+        previous_content: attributes[:content],
       )
     end
   end
@@ -47,7 +47,7 @@ class ResponseTemplatesController < ApplicationController
         tab: "response-templates",
         id: response_template.id,
         previous_title: attributes[:title],
-        previous_content: attributes[:content]
+        previous_content: attributes[:content],
       )
     end
   end

--- a/app/controllers/response_templates_controller.rb
+++ b/app/controllers/response_templates_controller.rb
@@ -1,23 +1,5 @@
 class ResponseTemplatesController < ApplicationController
-  after_action :verify_authorized, except: %i[index]
-  before_action :authenticate_user!, only: %i[index]
-
-  def index
-    @response_templates = if params[:type_of] && params[:personal_included] != "true"
-                            result = ResponseTemplate.where(user_id: nil, type_of: params[:type_of])
-                            handle_authorization(result)
-                            result
-                          elsif params[:type_of] == "mod_comment" && params[:personal_included] == "true"
-                            result = ResponseTemplate.
-                              where(user_id: nil, type_of: "mod_comment").
-                              union(user_id: current_user.id, type_of: "personal_comment")
-                            handle_authorization(result)
-                            result
-                          else
-                            skip_authorization
-                            ResponseTemplate.where(user_id: current_user.id)
-                          end
-  end
+  after_action :verify_authorized
 
   def create
     authorize ResponseTemplate

--- a/app/controllers/response_templates_controller.rb
+++ b/app/controllers/response_templates_controller.rb
@@ -15,7 +15,12 @@ class ResponseTemplatesController < ApplicationController
       previous_content = permitted_attributes(ResponseTemplate)[:content]
     end
 
-    redirect_to user_settings_path(tab: "response-templates", id: @response_template.id)
+    redirect_to user_settings_path(
+      tab: "response-templates",
+      id: response_template.id,
+      previous_title: previous_title,
+      previous_content: previous_content
+    )
   end
 
   def destroy
@@ -37,7 +42,12 @@ class ResponseTemplatesController < ApplicationController
       flash[:settings_notice] = "Your response template \"#{response_template.title}\" was updated."
       redirect_to user_settings_path(tab: "response-templates", id: response_template.id)
     else
-      flash[:error] = "Response template error: #{@response_template.errors.full_messages.to_sentence}"
+      flash[:error] = "Response template error: #{response_template.errors.full_messages.to_sentence}"
+      redirect_to user_settings_path(
+        tab: "response-templates",
+        id: response_template.id,
+        previous_title: permitted_attributes(ResponseTemplate)[:title],
+        previous_content: permitted_attributes(ResponseTemplate)[:content])
     end
   end
 

--- a/app/controllers/response_templates_controller.rb
+++ b/app/controllers/response_templates_controller.rb
@@ -1,0 +1,74 @@
+class ResponseTemplatesController < ApplicationController
+  after_action :verify_authorized, except: %i[index]
+
+  def index
+    not_found unless current_user
+    @response_templates = if params[:type_of] && params[:personal_included] != "true"
+                          result = ResponseTemplate.where(user_id: nil, type_of: params[:type_of])
+                          handle_authorization(result)
+                          result
+                        elsif params[:type_of] == "mod_comment" && params[:personal_included] == "true"
+                          result = ResponseTemplate.
+                            where(user_id: nil, type_of: "mod_comment").
+                            union(user_id: current_user.id, type_of: "personal_comment")
+                          handle_authorization(result)
+                          result
+                        else
+                          skip_authorization
+                          ResponseTemplate.where(user_id: current_user.id)
+                        end
+  end
+
+  def create
+    authorize ResponseTemplate
+    @response_template = ResponseTemplate.new(permitted_attributes(ResponseTemplate))
+    @response_template.user_id = current_user.id
+    @response_template.content_type = "body_markdown"
+    @response_template.type_of = "personal_comment"
+
+    if @response_template.save
+      flash[:settings_notice] = "Your response template \"#{@response_template.title}\" was created."
+    else
+      flash[:error] = "Response template error: #{@response_template.errors.full_messages.to_sentence}"
+    end
+
+    redirect_back(fallback_location: user_settings_path)
+  end
+
+  def destroy
+    @response_template = ResponseTemplate.find(params[:id])
+    authorize @response_template
+
+    if @response_template.destroy
+      flash[:settings_notice] = "Your response template \"#{@response_template.title}\" was deleted."
+    else
+      flash[:error] = @response_template.errors.full_messages.to_sentence # this will probably never fail
+    end
+
+    redirect_back(fallback_location: user_settings_path)
+  end
+
+  def update
+    @response_template = ResponseTemplate.find(params[:id])
+    authorize @response_template
+
+    if @response_template.update(permitted_attributes(ResponseTemplate))
+      flash[:settings_notice] = "Your response template \"#{@response_template.title}\" was updated."
+    else
+      flash[:error] = "Response template error: #{@response_template.errors.full_messages.to_sentence}"
+    end
+
+    redirect_back(fallback_location: user_settings_path)
+  end
+
+  private
+
+  def handle_authorization(records)
+    case params[:type_of]
+    when "mod_comment"
+      authorize records, :moderator_index?
+    else
+      authorize records, :admin_index?
+    end
+  end
+end

--- a/app/controllers/response_templates_controller.rb
+++ b/app/controllers/response_templates_controller.rb
@@ -14,7 +14,7 @@ class ResponseTemplatesController < ApplicationController
       flash[:error] = "Response template error: #{@response_template.errors.full_messages.to_sentence}"
     end
 
-    redirect_back(fallback_location: user_settings_path)
+    redirect_to user_settings_path(tab: "response-templates", id: @response_template.id)
   end
 
   def destroy
@@ -27,7 +27,7 @@ class ResponseTemplatesController < ApplicationController
       flash[:error] = @response_template.errors.full_messages.to_sentence # this will probably never fail
     end
 
-    redirect_back(fallback_location: user_settings_path)
+    redirect_to user_settings_path(tab: "response-templates")
   end
 
   def update
@@ -39,8 +39,7 @@ class ResponseTemplatesController < ApplicationController
     else
       flash[:error] = "Response template error: #{@response_template.errors.full_messages.to_sentence}"
     end
-
-    redirect_back(fallback_location: user_settings_path)
+    redirect_to user_settings_path(tab: "response-templates", id: @response_template.id)
   end
 
   private

--- a/app/controllers/response_templates_controller.rb
+++ b/app/controllers/response_templates_controller.rb
@@ -39,7 +39,7 @@ class ResponseTemplatesController < ApplicationController
     else
       flash[:error] = "Response template error: #{@response_template.errors.full_messages.to_sentence}"
     end
-    redirect_to user_settings_path(tab: "response-templates", id: @response_template.id)
+    redirect_to user_settings_path(tab: "response-templates", id: @response_template.id, previous_content: permitted_attributes(ResponseTemplate)[:content])
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -241,6 +241,8 @@ class UsersController < ApplicationController
       handle_pro_membership_tab
     when "account"
       handle_account_tab
+    when "response-templates"
+      handle_response_templates_tab
     else
       not_found unless @tab_list.map { |t| t.downcase.tr(" ", "-") }.include? @tab
     end
@@ -305,6 +307,11 @@ class UsersController < ApplicationController
       %0A
       YOUR-DEV-USERNAME-HERE
     HEREDOC
+  end
+
+  def handle_response_templates_tab
+    @response_templates = current_user.response_templates
+    @response_template = ResponseTemplate.find_or_initialize_by(id: params[:id], user: current_user)
   end
 
   def set_user

--- a/app/views/response_templates/index.json.jbuilder
+++ b/app/views/response_templates/index.json.jbuilder
@@ -1,0 +1,8 @@
+json.array!(@response_templates) do |response_template|
+  json.id response_template.id
+  json.type_of response_template.type_of
+  json.user_id response_template.user_id
+  json.title response_template.title
+  json.content response_template.content
+  json.content_truncated truncate(response_template.content, length: 200)
+end

--- a/app/views/users/_response_templates.html.erb
+++ b/app/views/users/_response_templates.html.erb
@@ -30,6 +30,6 @@
   <%= f.label :title %>
   <%= f.text_field :title, placeholder: "Memorable cue for template" %>
   <%= f.label :content, "Comment body (Markdown)" %>
-  <%= f.text_area :content, value: @response_template.content %>
+  <%= f.text_area :content, value: params[:previous_content] || @response_template.content %>
   <%= f.submit "Submit", class: "cta" %>
 <% end %>

--- a/app/views/users/_response_templates.html.erb
+++ b/app/views/users/_response_templates.html.erb
@@ -9,7 +9,7 @@
       <div class="github-repo-row <%= "github-repo-row-selected" if response_template.id == params[:id].to_i %>">
         <div class="github-repo-row-name response-template-row-name">
           <%= response_template.title %>
-          <%= form_tag "/response_templates/#{response_template.id}", method: :delete, onsubmit: "return confirm('Are you sure you want to delete: #{response_template.title}?');" do %>
+          <%= form_with path: response_template_path(response_template), method: :delete, onsubmit: "return confirm('Are you sure you want to delete: #{response_template.title}?');" do %>
             <button type="submit" class="cta danger-button">DELETE</button>
           <% end %>
           <a class="cta" href="/settings/response-templates?id=<%= response_template.id %>" role="button">EDIT</a>
@@ -26,7 +26,7 @@
 <% else %>
   <h3>Add a new response template</h3>
 <% end %>
-<%= form_for(@response_template) do |f| %>
+<%= form_with model: @response_template do |f| %>
   <%= f.label :title %>
   <%= f.text_field :title, placeholder: "Memorable cue for template" %>
   <%= f.label :content, "Comment body (Markdown)" %>

--- a/app/views/users/_response_templates.html.erb
+++ b/app/views/users/_response_templates.html.erb
@@ -6,7 +6,7 @@
   <div class="github-repos-container">
     <div class="github-repos">
     <% @response_templates.each do |response_template| %>
-      <div class="github-repo-row <%= "github-repo-row-selected" if @response_template.id == params[:id].to_i %>">
+      <div class="github-repo-row <%= "github-repo-row-selected" if response_template.id == params[:id].to_i %>">
         <div class="github-repo-row-name response-template-row-name">
           <%= response_template.title %>
           <%= form_tag "/response_templates/#{response_template.id}", method: :delete, onsubmit: "return confirm('Are you sure you want to delete: #{response_template.title}?');" do %>

--- a/app/views/users/_response_templates.html.erb
+++ b/app/views/users/_response_templates.html.erb
@@ -1,0 +1,35 @@
+<h3>Personal Response Templates</h3>
+<p>Response templates are snippets that you can re-use for quick and accurate comments.</p>
+
+<% if @response_templates.size.positive? %>
+  <h3>Your templates</h3>
+  <div class="github-repos-container">
+    <div class="github-repos">
+    <% @response_templates.each do |response_template| %>
+      <div class="github-repo-row <%= "github-repo-row-selected" if @response_template.id == params[:id].to_i %>">
+        <div class="github-repo-row-name response-template-row-name">
+          <%= response_template.title %>
+          <%= form_tag "/response_templates/#{response_template.id}", method: :delete, onsubmit: "return confirm('Are you sure you want to delete: #{response_template.title}?');" do %>
+            <button type="submit" class="cta danger-button">DELETE</button>
+          <% end %>
+          <a class="cta" href="/settings/response-templates?id=<%= response_template.id %>" role="button">EDIT</a>
+        </div>
+      </div>
+    <% end %>
+    </div>
+  </div>
+<% end %>
+<hr>
+<% if @response_template.persisted? %>
+  <h3>Editing a response template</h3>
+  <a href="/settings/response-templates">Create a new response template</a>
+<% else %>
+  <h3>Add a new response template</h3>
+<% end %>
+<%= form_for(@response_template) do |f| %>
+  <%= f.label :title %>
+  <%= f.text_field :title, placeholder: "Memorable cue for template" %>
+  <%= f.label :content, "Comment body (Markdown)" %>
+  <%= f.text_area :content, value: @response_template.content %>
+  <%= f.submit "Submit", class: "cta" %>
+<% end %>

--- a/app/views/users/_response_templates.html.erb
+++ b/app/views/users/_response_templates.html.erb
@@ -1,7 +1,7 @@
 <h3>Personal Response Templates</h3>
 <p>Response templates are snippets that you can re-use for quick and accurate comments.</p>
 
-<% if @response_templates.exists? %>
+<% if @response_templates.present? %>
   <h3>Your templates</h3>
   <div class="github-repos-container">
     <div class="github-repos">

--- a/app/views/users/_response_templates.html.erb
+++ b/app/views/users/_response_templates.html.erb
@@ -1,7 +1,7 @@
 <h3>Personal Response Templates</h3>
 <p>Response templates are snippets that you can re-use for quick and accurate comments.</p>
 
-<% if @response_templates.size.positive? %>
+<% if @response_templates.exists? %>
   <h3>Your templates</h3>
   <div class="github-repos-container">
     <div class="github-repos">

--- a/app/views/users/_response_templates.html.erb
+++ b/app/views/users/_response_templates.html.erb
@@ -21,15 +21,19 @@
 <% end %>
 <hr>
 <% if @response_template.persisted? %>
+  <% title = params[:previous_title] || @response_template.title %>
+  <% content = params[:previous_content] || @response_template.content %>
   <h3>Editing a response template</h3>
   <a href="/settings/response-templates">Create a new response template</a>
 <% else %>
+  <% title = params[:previous_title] %>
+  <% content = params[:previous_content] %>
   <h3>Add a new response template</h3>
 <% end %>
 <%= form_with model: @response_template do |f| %>
   <%= f.label :title %>
-  <%= f.text_field :title, placeholder: "Memorable cue for template" %>
+  <%= f.text_field :title, placeholder: "Memorable cue for template", value: title %>
   <%= f.label :content, "Comment body (Markdown)" %>
-  <%= f.text_area :content, value: params[:previous_content] || @response_template.content %>
+  <%= f.text_area :content, value: content %>
   <%= f.submit "Submit", class: "cta" %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,7 +61,7 @@ Rails.application.routes.draw do
       end
     end
     resources :reactions, only: [:update]
-    resources :response_templates, only: %i[index new edit create update destroy]
+    resources :response_templates, only: %i[new edit create update destroy]
     resources :chat_channels, only: %i[index create update]
     resources :reports, only: %i[index show], controller: "feedback_messages" do
       collection do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -164,6 +164,7 @@ Rails.application.routes.draw do
   end
   resources :twitch_live_streams, only: :show, param: :username
   resources :reactions, only: %i[index create]
+  resources :response_templates, only: %i[index create edit update destroy]
   resources :feedback_messages, only: %i[index create]
   resources :organizations, only: %i[update create]
   resources :followed_articles, only: [:index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,7 +61,7 @@ Rails.application.routes.draw do
       end
     end
     resources :reactions, only: [:update]
-    resources :response_templates, only: %i[new edit create update destroy]
+    resources :response_templates, only: %i[index new edit create update destroy]
     resources :chat_channels, only: %i[index create update]
     resources :reports, only: %i[index show], controller: "feedback_messages" do
       collection do
@@ -164,7 +164,7 @@ Rails.application.routes.draw do
   end
   resources :twitch_live_streams, only: :show, param: :username
   resources :reactions, only: %i[index create]
-  resources :response_templates, only: %i[index create edit update destroy]
+  resources :response_templates, only: %i[create edit update destroy]
   resources :feedback_messages, only: %i[index create]
   resources :organizations, only: %i[update create]
   resources :followed_articles, only: [:index]

--- a/spec/requests/response_templates_spec.rb
+++ b/spec/requests/response_templates_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "ResponseTemplate", type: :request do
   let(:admin) { create(:user, :admin) }
 
   describe "GET /response_templates #index" do
-    it "returns not found if no user is logged in" do
+    xit "returns not found if no user is logged in" do
       expect do
         get response_templates_path, headers: { HTTP_ACCEPT: "application/json" }
       end.to raise_error ActiveRecord::RecordNotFound
@@ -15,13 +15,13 @@ RSpec.describe "ResponseTemplate", type: :request do
     context "when signed in as a regular user" do
       before { sign_in user }
 
-      it "responds with JSON" do
+      xit "responds with JSON" do
         create(:response_template, user: user, type_of: "personal_comment")
         get response_templates_path, headers: { HTTP_ACCEPT: "application/json" }
         expect(response.content_type).to eq "application/json"
       end
 
-      it "returns an array of all the user's response templates" do
+      xit "returns an array of all the user's response templates" do
         total_response_templates = 2
         create(:response_template, user: nil, type_of: "mod_comment")
         create_list(:response_template, total_response_templates, user: user, type_of: "personal_comment")
@@ -29,7 +29,7 @@ RSpec.describe "ResponseTemplate", type: :request do
         expect(JSON.parse(response.body).length).to eq total_response_templates
       end
 
-      it "returns only the users' response templates" do
+      xit "returns only the users' response templates" do
         create(:response_template, user: nil, type_of: "mod_comment")
         create_list(:response_template, 2, user: user, type_of: "personal_comment")
         get response_templates_path, headers: { HTTP_ACCEPT: "application/json" }
@@ -37,7 +37,7 @@ RSpec.describe "ResponseTemplate", type: :request do
         expect(user_ids).to eq [user.id, user.id]
       end
 
-      it "raises an error if trying to view moderator response templates" do
+      xit "raises an error if trying to view moderator response templates" do
         create(:response_template, user: nil, type_of: "mod_comment")
         params = {
           type_of: "mod_comment",
@@ -48,7 +48,7 @@ RSpec.describe "ResponseTemplate", type: :request do
         end.to raise_error Pundit::NotAuthorizedError
       end
 
-      it "raises an error if trying to view admin response templates" do
+      xit "raises an error if trying to view admin response templates" do
         create(:response_template, user: nil, type_of: "email_reply", content_type: "html")
         expect do
           get response_templates_path, params: { type_of: "email_reply" }, headers: { HTTP_ACCEPT: "application/json" }
@@ -59,20 +59,20 @@ RSpec.describe "ResponseTemplate", type: :request do
     context "when signed in as a mod user" do
       before { sign_in moderator }
 
-      it "responds with JSON" do
+      xit "responds with JSON" do
         create(:response_template, user: moderator, type_of: "personal_comment")
         get response_templates_path, params: { type_of: "mod_comment", personal_included: "true" }, headers: { HTTP_ACCEPT: "application/json" }
         expect(response.content_type).to eq "application/json"
       end
 
-      it "returns an array of all relevant response templates" do
+      xit "returns an array of all relevant response templates" do
         create_list(:response_template, 2, user: nil, type_of: "mod_comment")
         create_list(:response_template, 2, user: moderator, type_of: "personal_comment")
         get response_templates_path, params: { type_of: "mod_comment", personal_included: "true" }, headers: { HTTP_ACCEPT: "application/json" }
         expect(JSON.parse(response.body).length).to eq 4
       end
 
-      it "returns only the moderator and personal response templates with the correct params" do
+      xit "returns only the moderator and personal response templates with the correct params" do
         create_list(:response_template, 2, user: nil, type_of: "mod_comment")
         create_list(:response_template, 2, user: moderator, type_of: "personal_comment")
 
@@ -81,14 +81,14 @@ RSpec.describe "ResponseTemplate", type: :request do
         expect(user_ids).to eq [nil, nil, moderator.id, moderator.id]
       end
 
-      it "returns the user's response templates when no params are given" do
+      xit "returns the user's response templates when no params are given" do
         create_list(:response_template, 2, user: moderator, type_of: "personal_comment")
         get response_templates_path, headers: { HTTP_ACCEPT: "application/json" }
         user_ids = JSON.parse(response.body).map { |hash| hash["user_id"] }
         expect(user_ids).to eq [moderator.id, moderator.id]
       end
 
-      it "raises unauthorized error if trying to view admin response templates" do
+      xit "raises unauthorized error if trying to view admin response templates" do
         create_list(:response_template, 2, user: nil, type_of: "email_reply", content_type: "html")
         expect do
           get response_templates_path, params: { type_of: "email_reply" }, headers: { HTTP_ACCEPT: "application/json" }
@@ -99,7 +99,7 @@ RSpec.describe "ResponseTemplate", type: :request do
     context "when signed in as an admin" do
       before { sign_in admin }
 
-      it "returns only the moderator and personal response templates with the correct params" do
+      xit "returns only the moderator and personal response templates with the correct params" do
         create_list(:response_template, 2, user: nil, type_of: "mod_comment")
         create_list(:response_template, 2, user: admin, type_of: "personal_comment")
 
@@ -108,14 +108,14 @@ RSpec.describe "ResponseTemplate", type: :request do
         expect(user_ids).to eq [nil, nil, admin.id, admin.id]
       end
 
-      it "returns the user's response templates" do
+      xit "returns the user's response templates" do
         create_list(:response_template, 2, user: admin, type_of: "personal_comment")
         get response_templates_path, headers: { HTTP_ACCEPT: "application/json" }
         user_ids = JSON.parse(response.body).map { |hash| hash["user_id"] }
         expect(user_ids).to eq [admin.id, admin.id]
       end
 
-      it "allows access and returns an array of admin level response templates" do
+      xit "allows access and returns an array of admin level response templates" do
         create_list(:response_template, 2, user: nil, type_of: "email_reply", content_type: "html")
         get response_templates_path, params: { type_of: "email_reply" }, headers: { HTTP_ACCEPT: "application/json" }
         expect(JSON.parse(response.body).length).to eq 2

--- a/spec/requests/response_templates_spec.rb
+++ b/spec/requests/response_templates_spec.rb
@@ -1,0 +1,125 @@
+require "rails_helper"
+
+RSpec.describe "ResponseTemplate", type: :request do
+  let(:user) { create(:user) }
+  let(:moderator) { create(:user, :tag_moderator) }
+  let(:admin) { create(:user, :admin) }
+
+  describe "GET /response_templates #index" do
+    it "returns not found if no user is logged in" do
+      expect do
+        get response_templates_path, headers: { HTTP_ACCEPT: "application/json" }
+      end.to raise_error ActiveRecord::RecordNotFound
+    end
+
+    context "when signed in as a regular user" do
+      before { sign_in user }
+
+      it "responds with JSON" do
+        create(:response_template, user: user, type_of: "personal_comment")
+        get response_templates_path, headers: { HTTP_ACCEPT: "application/json" }
+        expect(response.content_type).to eq "application/json"
+      end
+
+      it "returns an array of all the user's response templates" do
+        total_response_templates = 2
+        create(:response_template, user: nil, type_of: "mod_comment")
+        create_list(:response_template, total_response_templates, user: user, type_of: "personal_comment")
+        get response_templates_path, headers: { HTTP_ACCEPT: "application/json" }
+        expect(JSON.parse(response.body).length).to eq total_response_templates
+      end
+
+      it "returns only the users' response templates" do
+        create(:response_template, user: nil, type_of: "mod_comment")
+        create_list(:response_template, 2, user: user, type_of: "personal_comment")
+        get response_templates_path, headers: { HTTP_ACCEPT: "application/json" }
+        user_ids = JSON.parse(response.body).map { |hash| hash["user_id"] }
+        expect(user_ids).to eq [user.id, user.id]
+      end
+
+      it "raises an error if trying to view moderator response templates" do
+        create(:response_template, user: nil, type_of: "mod_comment")
+        params = {
+          type_of: "mod_comment",
+          personal_included: "true"
+        }
+        expect do
+          get response_templates_path, params: params, headers: { HTTP_ACCEPT: "application/json" }
+        end.to raise_error Pundit::NotAuthorizedError
+      end
+
+      it "raises an error if trying to view admin response templates" do
+        create(:response_template, user: nil, type_of: "email_reply", content_type: "html")
+        expect do
+          get response_templates_path, params: { type_of: "email_reply" }, headers: { HTTP_ACCEPT: "application/json" }
+        end.to raise_error Pundit::NotAuthorizedError
+      end
+    end
+
+    context "when signed in as a mod user" do
+      before { sign_in moderator }
+
+      it "responds with JSON" do
+        create(:response_template, user: moderator, type_of: "personal_comment")
+        get response_templates_path, params: { type_of: "mod_comment", personal_included: "true" }, headers: { HTTP_ACCEPT: "application/json" }
+        expect(response.content_type).to eq "application/json"
+      end
+
+      it "returns an array of all relevant response templates" do
+        create_list(:response_template, 2, user: nil, type_of: "mod_comment")
+        create_list(:response_template, 2, user: moderator, type_of: "personal_comment")
+        get response_templates_path, params: { type_of: "mod_comment", personal_included: "true" }, headers: { HTTP_ACCEPT: "application/json" }
+        expect(JSON.parse(response.body).length).to eq 4
+      end
+
+      it "returns only the moderator and personal response templates with the correct params" do
+        create_list(:response_template, 2, user: nil, type_of: "mod_comment")
+        create_list(:response_template, 2, user: moderator, type_of: "personal_comment")
+
+        get response_templates_path, params: { type_of: "mod_comment", personal_included: "true" }, headers: { HTTP_ACCEPT: "application/json" }
+        user_ids = JSON.parse(response.body).map { |hash| hash["user_id"] }
+        expect(user_ids).to eq [nil, nil, moderator.id, moderator.id]
+      end
+
+      it "returns the user's response templates when no params are given" do
+        create_list(:response_template, 2, user: moderator, type_of: "personal_comment")
+        get response_templates_path, headers: { HTTP_ACCEPT: "application/json" }
+        user_ids = JSON.parse(response.body).map { |hash| hash["user_id"] }
+        expect(user_ids).to eq [moderator.id, moderator.id]
+      end
+
+      it "raises unauthorized error if trying to view admin response templates" do
+        create_list(:response_template, 2, user: nil, type_of: "email_reply", content_type: "html")
+        expect do
+          get response_templates_path, params: { type_of: "email_reply" }, headers: { HTTP_ACCEPT: "application/json" }
+        end.to raise_error Pundit::NotAuthorizedError
+      end
+    end
+
+    context "when signed in as an admin" do
+      before { sign_in admin }
+
+      it "returns only the moderator and personal response templates with the correct params" do
+        create_list(:response_template, 2, user: nil, type_of: "mod_comment")
+        create_list(:response_template, 2, user: admin, type_of: "personal_comment")
+
+        get response_templates_path, params: { type_of: "mod_comment", personal_included: "true" }, headers: { HTTP_ACCEPT: "application/json" }
+        user_ids = JSON.parse(response.body).map { |hash| hash["user_id"] }
+        expect(user_ids).to eq [nil, nil, admin.id, admin.id]
+      end
+
+      it "returns the user's response templates" do
+        create_list(:response_template, 2, user: admin, type_of: "personal_comment")
+        get response_templates_path, headers: { HTTP_ACCEPT: "application/json" }
+        user_ids = JSON.parse(response.body).map { |hash| hash["user_id"] }
+        expect(user_ids).to eq [admin.id, admin.id]
+      end
+
+      it "allows access and returns an array of admin level response templates" do
+        create_list(:response_template, 2, user: nil, type_of: "email_reply", content_type: "html")
+        get response_templates_path, params: { type_of: "email_reply" }, headers: { HTTP_ACCEPT: "application/json" }
+        expect(JSON.parse(response.body).length).to eq 2
+      end
+    end
+  end
+end

--- a/spec/requests/response_templates_spec.rb
+++ b/spec/requests/response_templates_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "ResponseTemplate", type: :request do
         }
       }
 
-      response_template = ResponseTemplate.first
+      response_template = ResponseTemplate.last
       expect(response_template.user_id).to eq user.id
       expect(response_template.title).to eq attributes[:title]
       expect(response_template.content).to eq attributes[:content]
@@ -38,7 +38,7 @@ RSpec.describe "ResponseTemplate", type: :request do
           content: attributes[:content]
         }
       }
-      expect(response.redirect_url).to include user_settings_path(tab: "response-templates", id: ResponseTemplate.first.id)
+      expect(response.redirect_url).to include user_settings_path(tab: "response-templates", id: ResponseTemplate.last.id)
     end
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
This adds response templates to the settings page. Note that it does not make a link visible, but it is technically available via the direct route `/settings/response-templates`.

Users who access this page will be able to complete basic CRUD for personal response templates.

Also removes some dead CSS.

## Related Tickets & Documents
#5419 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![Screen Shot 2020-03-24 at 5 24 35 PM](https://user-images.githubusercontent.com/17884966/77478451-5f81a080-6df4-11ea-94ee-a4556682a9f9.png)


## Added tests?
- [x] yes

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
No

## [optional] What gif best describes this PR or how it makes you feel?

![Kermit plays the banjo with Fozzie, the two in a car ride together with the text "We're close".](https://media.giphy.com/media/VEzlrMWk3F7uuFuRSq/source.gif)
