### PR TITLE
Edited bottom of .global-signup-modal--inner-a

### DIFF
--- a/app/assets/stylesheets/signup-modal.scss
+++ b/app/assets/stylesheets/signup-modal.scss
@@ -36,7 +36,7 @@
     top: calc(15% - 33px);
     left: calc(15% - 33px);
     right: calc(15% - 33px);
-    bottom: calc(15% - 33px);
+    bottom: calc(10% - 33px);
     background: white;
     z-index: 899902;
     text-align: center;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
More px to bottom on .global-signup-modal--inner-a class for small computers. Better design.

With my little screen, I could see the popup like this.
![dev to_thomasbnt](https://user-images.githubusercontent.com/14293805/77483469-780bae00-6e28-11ea-9801-c40521b9d75a.png)


## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
with 
```css
	bottom: calc(10% - 33px);
```
it is now better presented :
![dev to_thomasbnt (1)](https://user-images.githubusercontent.com/14293805/77483561-bbfeb300-6e28-11ea-9199-4703f042b65e.png)



## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

