### PR TITLE
Add docker_setup script

### DIFF
--- a/bin/docker_setup
+++ b/bin/docker_setup
@@ -1,0 +1,21 @@
+#!/usr/bin/env ruby
+
+require "fileutils"
+
+# path to your application root.
+APP_ROOT = File.expand_path("..", __dir__)
+
+def system!(*args)
+  system(*args) || abort("\n== Command #{args} failed ==")
+end
+
+FileUtils.chdir APP_ROOT do
+  puts "== Building Docker image (this may take a while) =="
+  system!("docker-compose build")
+
+  puts "== Setting up database =="
+  system!("docker-compose run web rails db:setup db:migrate search:setup")
+
+  puts "== Starting app =="
+  system!("docker-compose up")
+end

--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -2,10 +2,9 @@
 title: Docker
 ---
 
-# Installing DEV with Docker [Beta]
+# Installing DEV with Docker
 
-Our docker implementation is incomplete and may not work smoothly. Please,
-kindly
+If you encounter any errors with our Docker setup, please kindly
 [report any issues](https://github.com/thepracticaldev/dev.to/issues/new/choose)!
 
 ## Installing prerequisites
@@ -62,16 +61,20 @@ well.
    - You do not need "real" keys for basic development. Some features require
      certain keys, so you may be able to add them as you go.
 
-## Running the Docker app (basic)
+## Running the Docker app via docker-compose (recommended)
 
 _Docker compose will by default use postgres:9.6 as the database version, should
 you want to update that set the `POSTGRES_VERSION` variable in your environment
 and start the container again_
 
-1. run `docker-compose build`
-1. run `docker-compose run web rails db:setup db:migrate search:setup`
-1. run `docker-compose up`
-1. That's it! Navigate to <http://localhost:3000>
+1. Run `bin/docker_setup`
+2. That's it! Navigate to <http://localhost:3000>
+
+The script executes the following steps:
+
+1. `docker-compose build`
+2. `docker-compose run web rails db:setup db:migrate search:setup`
+3. `docker-compose up`
 
 ## Running the Docker app (advanced)
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Developer experience

## Description

In a recent PR @rhymes [suggested](https://github.com/thepracticaldev/dev.to/pull/6803#discussion_r397070289) adding a setup task for Docker. I did that initially, but found no compelling reason for this to be a Rake task, so I moved it to `bin/docker_setup` instead and kept it as close as possible to `bin/setup`. I also made several updates to the README, see comments.

## Related Tickets & Documents

n/a

## Added tests?

- [X] no, because they aren't needed

## Added to documentation?

- [X] docs.dev.to
