### PR TITLE
Filter Elasticsearch Source Feed Docs and Add User Fields

### DIFF
--- a/app/services/search/query_builders/feed_content.rb
+++ b/app/services/search/query_builders/feed_content.rb
@@ -37,6 +37,21 @@ module Search
         body_text
       ].freeze
 
+      SOURCE = %i[
+        id
+        title
+        path
+        class_name
+        comments_count
+        tags
+        readable_publish_date_string
+        positive_reactions_count
+        flare_tag_hash
+        user
+        reading_time
+        published_at
+      ].freeze
+
       attr_accessor :params, :body
 
       def initialize(params)
@@ -58,6 +73,10 @@ module Search
           highlight_fields[:fields][field_name] = { order: :score, number_of_fragments: 2, fragment_size: 75 }
         end
         @body[:highlight] = highlight_fields
+      end
+
+      def filter_source
+        @body[:_source] = SOURCE
       end
 
       def build_queries

--- a/app/services/search/query_builders/query_base.rb
+++ b/app/services/search/query_builders/query_base.rb
@@ -15,9 +15,12 @@ module Search
         add_sort
         set_size
         add_highlight_fields
+        filter_source
       end
 
       def add_highlight_fields; end
+
+      def filter_source; end
 
       def add_sort
         sort_key = @params[:sort_by] || self.class::DEFAULT_PARAMS[:sort_by]

--- a/app/services/search/user.rb
+++ b/app/services/search/user.rb
@@ -29,7 +29,9 @@ module Search
           },
           "title" => hit["name"],
           "path" => hit["path"],
-          "id" => hit["id"]
+          "id" => hit["id"],
+          "class_name" => "User",
+          "positive_reactions_count" => hit["positive_reactions_count"]
         }
       end
 


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
When we are returning documents for the view we don't want to return ALL of the documents since we only need a few fields. Using the [_source filtering option](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#request-body-search-source-filtering) is the same as doing `select(<fields>)` for Postgres. It will limit what fields are returned. 

## Added tests?
- [x] no, because they aren't needed

![alt_text](https://i.makeagif.com/media/4-29-2017/l7TPFj.gif)
