### PR TITLE
Bug Fix: Return default aspect ratio of 1 if gif id is not present

### DIFF
--- a/app/labor/random_gif.rb
+++ b/app/labor/random_gif.rb
@@ -1,32 +1,32 @@
 class RandomGif
-  def initialize(_action = "congratulations")
-    @random_gifs = {
-      "xjZtu4qi1biIo" => { aspect_ratio: 1.000 },
-      "12P29BwtrvsbbW" => { aspect_ratio: 0.760 },
-      "9PyhoXey73EpW" => { aspect_ratio: 0.753 },
-      "OcZp0maz6ALok" => { aspect_ratio: 1.000 },
-      "Is1O1TWV0LEJi" => { aspect_ratio: 0.565 },
-      "lz24Z42jLcTa8" => { aspect_ratio: 0.776 },
-      "g9582DNuQppxC" => { aspect_ratio: 0.562 },
-      "l4HodBpDmoMA5p9bG" => { aspect_ratio: 1.000 },
-      "3oxOCfV7z28QtXXAtO" => { aspect_ratio: 0.750 },
-      "y8Mz1yj13s3kI" => { aspect_ratio: 0.750 },
-      "111ebonMs90YLu" => { aspect_ratio: 0.750 },
-      "Sk5uipPXyBjfW" => { aspect_ratio: 0.422 },
-      "l0K48FkLfeSCzRA4M" => { aspect_ratio: 0.573 },
-      "3o7qDRd1DlF7P2TP3O" => { aspect_ratio: 0.517 },
-      "26h0qt6UOumsbJkyI" => { aspect_ratio: 0.442 },
-      "l0K4glBiv82lZ0Zuo" => { aspect_ratio: 0.563 },
-      "Gf3fU0qPtI6uk" => { aspect_ratio: 0.750 },
-      "5GoVLqeAOo6PK" => { aspect_ratio: 0.780 }
-    }
+  RANDOM_GIFS = {
+    "xjZtu4qi1biIo" => { aspect_ratio: 1.000 },
+    "12P29BwtrvsbbW" => { aspect_ratio: 0.760 },
+    "9PyhoXey73EpW" => { aspect_ratio: 0.753 },
+    "OcZp0maz6ALok" => { aspect_ratio: 1.000 },
+    "Is1O1TWV0LEJi" => { aspect_ratio: 0.565 },
+    "lz24Z42jLcTa8" => { aspect_ratio: 0.776 },
+    "g9582DNuQppxC" => { aspect_ratio: 0.562 },
+    "l4HodBpDmoMA5p9bG" => { aspect_ratio: 1.000 },
+    "3oxOCfV7z28QtXXAtO" => { aspect_ratio: 0.750 },
+    "y8Mz1yj13s3kI" => { aspect_ratio: 0.750 },
+    "111ebonMs90YLu" => { aspect_ratio: 0.750 },
+    "Sk5uipPXyBjfW" => { aspect_ratio: 0.422 },
+    "l0K48FkLfeSCzRA4M" => { aspect_ratio: 0.573 },
+    "3o7qDRd1DlF7P2TP3O" => { aspect_ratio: 0.517 },
+    "26h0qt6UOumsbJkyI" => { aspect_ratio: 0.442 },
+    "l0K4glBiv82lZ0Zuo" => { aspect_ratio: 0.563 },
+    "Gf3fU0qPtI6uk" => { aspect_ratio: 0.750 },
+    "5GoVLqeAOo6PK" => { aspect_ratio: 0.780 }
+  }.freeze
+
+  DEFAULT_RATIO = 1.000
+
+  def self.random_id
+    RANDOM_GIFS.keys.sample
   end
 
-  def random_id
-    @random_gifs.keys.sample
-  end
-
-  def get_aspect_ratio(id)
-    (@random_gifs[id] || "xjZtu4qi1biIo")[:aspect_ratio]
+  def self.get_aspect_ratio(id)
+    RANDOM_GIFS.dig(id, :aspect_ratio) || DEFAULT_RATIO
   end
 end

--- a/app/services/notifications/milestone/send.rb
+++ b/app/services/notifications/milestone/send.rb
@@ -38,7 +38,7 @@ module Notifications
       end
 
       def json_data
-        { article: Notifications.article_data(article), gif_id: RandomGif.new.random_id }
+        { article: Notifications.article_data(article), gif_id: RandomGif.random_id }
       end
 
       def article_published_behind_time?

--- a/app/views/notifications/_milestone.html.erb
+++ b/app/views/notifications/_milestone.html.erb
@@ -7,7 +7,7 @@
   <p class="badge-description milestone-emojis">🎉🎉🎉🎉🎉🎉🎉🎉</p>
 
   <a href="https://giphy.com/gifs/<%= json_data["gif_id"] %>" rel="noopener noreferrer" target="_blank">
-    <img style="height: <%= RandomGif.new.get_aspect_ratio(json_data["gif_id"]) * 300 %>px;" class="milestone-gif" src="https://media.giphy.com/media/<%= json_data["gif_id"] %>/giphy-downsized.gif" alt="A random celebratory gif!">
+    <img style="height: <%= RandomGif.get_aspect_ratio(json_data["gif_id"]) * 300 %>px;" class="milestone-gif" src="https://media.giphy.com/media/<%= json_data["gif_id"] %>/giphy-downsized.gif" alt="A random celebratory gif!">
   </a>
   <br>
   <a href="/dashboard">

--- a/spec/labor/random_gif_spec.rb
+++ b/spec/labor/random_gif_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe RandomGif, type: :labor do
+  describe "#random_id" do
+    it "returns a random gif ID from RANDOM_GIFS" do
+      id_options = described_class::RANDOM_GIFS.keys
+      expect(id_options).to include(described_class.random_id)
+    end
+  end
+
+  describe "#get_aspect_ratio" do
+    it "returns aspect ratio for given ID" do
+      gif_id = described_class.random_id
+      aspect_ratio = described_class::RANDOM_GIFS.dig(gif_id, :aspect_ratio)
+      expect(described_class.get_aspect_ratio(gif_id)).to eq(aspect_ratio)
+    end
+
+    it "returns default 1.00 when gif ID is not present" do
+      expect(described_class.get_aspect_ratio("not_there")).to eq(described_class::DEFAULT_RATIO)
+    end
+  end
+end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Bug Fix

## Description
Refactored this class in order to fix: https://app.honeybadger.io/fault/66984/964ed1cc582e1de60601668839a2a279
```
ActionView::Template::Error: no implicit conversion of Symbol into Integer
random_gif.rb  30 [](...)
[PROJECT_ROOT]/app/labor/random_gif.rb:30:in `[]'
28 
29   def get_aspect_ratio(id)
30     (@random_gifs[id] || "xjZtu4qi1biIo")[:aspect_ratio]
31   end
32 end
```

## Added tests?
- [x] yes

![alt_text](https://media1.giphy.com/media/QsnQsvAkrkKGiHZuo8/giphy.gif)
