### PR TITLE
Refactor WelcomeNotification::Generator to ::Dispatcher

### DIFF
--- a/app/services/broadcasts/welcome_notification/dispatcher.rb
+++ b/app/services/broadcasts/welcome_notification/dispatcher.rb
@@ -1,7 +1,7 @@
 # Generates a broadcast to be delivered as a notification.
 module Broadcasts
   module WelcomeNotification
-    module Generator
+    module Dispatcher
       def self.call(user_id)
         user = User.find(user_id)
 

--- a/app/services/broadcasts/welcome_notification/generator.rb
+++ b/app/services/broadcasts/welcome_notification/generator.rb
@@ -1,37 +1,15 @@
 # Generates a broadcast to be delivered as a notification.
 module Broadcasts
   module WelcomeNotification
-    class Generator
-      def initialize(receiver_id)
-        @user = User.find(receiver_id)
+    module Generator
+      def self.call(user_id)
+        user = User.find(user_id)
+
+        Introduction.send(user)
+        # Authentication.send(user)
+        # CustomizeFeed.send(user)
+        # CustomizeExperience.send(user)
       end
-
-      def self.call(*args)
-        new(*args).call
-      end
-
-      def call
-        return if commented_on_welcome_thread? || received_notification?
-
-        Notification.send_welcome_notification(user.id, welcome_broadcast.id)
-      end
-
-      def received_notification?
-        Notification.exists?(notifiable: welcome_broadcast, user: user)
-      end
-
-      def commented_on_welcome_thread?
-        welcome_thread = Article.admin_published_with("welcome").first
-        Comment.where(commentable: welcome_thread, user: user).any?
-      end
-
-      private
-
-      def welcome_broadcast
-        @welcome_broadcast ||= Broadcast.find_by(title: "Welcome Notification: welcome_thread")
-      end
-
-      attr_reader :user
     end
   end
 end

--- a/app/services/broadcasts/welcome_notification/introduction.rb
+++ b/app/services/broadcasts/welcome_notification/introduction.rb
@@ -1,0 +1,36 @@
+module Broadcasts
+  module WelcomeNotification
+    class Introduction
+      attr_reader :user
+
+      def initialize(user)
+        @user = user
+      end
+
+      def self.send(*args)
+        new(*args).send
+      end
+
+      def send
+        return if commented_on_welcome_thread? || received_notification?
+
+        Notification.send_welcome_notification(user.id, welcome_broadcast.id)
+      end
+
+      private
+
+      def commented_on_welcome_thread?
+        welcome_thread = Article.admin_published_with("welcome").first
+        Comment.where(commentable: welcome_thread, user: user).any?
+      end
+
+      def received_notification?
+        Notification.exists?(notifiable: welcome_broadcast, user: user)
+      end
+
+      def welcome_broadcast
+        @welcome_broadcast ||= Broadcast.find_by(title: "Welcome Notification: welcome_thread")
+      end
+    end
+  end
+end

--- a/spec/factories/broadcasts.rb
+++ b/spec/factories/broadcasts.rb
@@ -3,15 +3,27 @@ FactoryBot.define do
     active { false }
 
     factory :welcome_broadcast do
-      title { "Welcome Notification: welcome_thread" }
-      type_of { "Welcome" }
+      title          { "Welcome Notification: welcome_thread" }
+      type_of        { "Welcome" }
       processed_html { "Sloan here again! 👋 DEV is a friendly community. Why not introduce yourself by leaving a comment in <a href='/welcome'>the welcome thread</a>!" }
+    end
+
+    factory :twitter_connect_broadcast do
+      title          { "Welcome Notification: twitter_connect" }
+      type_of        { "Welcome" }
+      processed_html { "You're on a roll! 🎉 Let's connect your <a href='/settings'> Twitter account</a> to complete your identity so that we don't think you're a robot. 🤖" }
+    end
+
+    factory :github_connect_broadcast do
+      title          { "Welcome Notification: github_connect" }
+      type_of        { "Welcome" }
+      processed_html { "You're on a roll! 🎉 Let's connect your <a href='/settings'> GitHub account</a> to complete your identity so that we don't think you're a robot. 🤖" }
     end
 
     # TODO: [@thepracticaldev/delightful] Remove onboarding factory once welcome notifications are live.
     factory :onboarding_broadcast do
-      title { "Welcome Notification" }
-      type_of { "Onboarding" }
+      title          { "Welcome Notification" }
+      type_of        { "Onboarding" }
       processed_html { "Welcome! Introduce yourself in our <a href='/welcome'>welcome thread!</a>" }
     end
   end

--- a/spec/services/broadcasts/welcome_notification/dispatcher_spec.rb
+++ b/spec/services/broadcasts/welcome_notification/dispatcher_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Broadcasts::WelcomeNotification::Generator, type: :service do
+RSpec.describe Broadcasts::WelcomeNotification::Dispatcher, type: :service do
   let(:user) { create(:user) }
 
   describe "::call" do

--- a/spec/services/broadcasts/welcome_notification/generator_spec.rb
+++ b/spec/services/broadcasts/welcome_notification/generator_spec.rb
@@ -1,69 +1,16 @@
 require "rails_helper"
 
 RSpec.describe Broadcasts::WelcomeNotification::Generator, type: :service do
+  let(:user) { create(:user) }
+
   describe "::call" do
-    let(:receiving_user) { create(:user) }
-    let(:user) { create(:user) }
-    let(:mascot_account) { create(:user) }
-    let!(:welcome_broadcast) { create(:welcome_broadcast, :active) }
-
     before do
-      allow(User).to receive(:mascot_account).and_return(mascot_account)
-      SiteConfig.staff_user_id = mascot_account.id
+      allow(Broadcasts::WelcomeNotification::Introduction).to receive(:send)
     end
 
-    after do
-      SiteConfig.staff_user_id = 1
-    end
-
-    context "when sending a set_up_profile notification" do
-      xit "generates the appropriate broadcast to be sent to a user"
-      xit "it sends a welcome notification for that broadcast"
-      xit "it does not send duplicate welcome notification for that broadcast"
-      xit "does not send a notification to a user who has set up their profile"
-    end
-
-    context "when sending a welcome_thread notification" do
-      before do
-        welcome_thread_article = create(:article, title: "Welcome Thread - v0", published: true, tags: "welcome", user: mascot_account)
-        create(:comment, commentable: welcome_thread_article, commentable_type: "Article", user: user)
-      end
-
-      it "generates the correct broadcast type and sends the notification to the user", :aggregate_failures do
-        expect(receiving_user.notifications.count).to eq(0)
-        sidekiq_perform_enqueued_jobs { described_class.call(receiving_user.id) }
-
-        expect(receiving_user.notifications.count).to eq(1)
-        expect(receiving_user.notifications.first.notifiable).to eq(welcome_broadcast)
-      end
-
-      it "does not send a notification to a user who has commented in a welcome thread", :aggregate_failures do
-        expect(user.notifications.count).to eq(0)
-        sidekiq_perform_enqueued_jobs { described_class.call(user.id) }
-        expect(user.notifications.count).to eq(0)
-      end
-
-      it "does not send a duplicate notification" do
-        2.times do
-          sidekiq_perform_enqueued_jobs { described_class.call(receiving_user.id) }
-        end
-
-        expect(receiving_user.notifications.count).to eq(1)
-      end
-    end
-
-    context "when sending a twitter_connect notification" do
-      xit "generates the appropriate broadcast to be sent to a user"
-      xit "it sends a welcome notification for that broadcast"
-      xit "it does not send duplicate welcome notification for that broadcast"
-      xit "does not send a notification to a user who is connected via twitter"
-    end
-
-    context "when sending a github_connect notification" do
-      xit "generates the appropriate broadcast to be sent to a user"
-      xit "it sends a welcome notification for that broadcast"
-      xit "it does not send duplicate welcome notification for that broadcast"
-      xit "does not send a notification to a user who is connected via github"
+    it "evokes Introduction" do
+      described_class.call(user.id)
+      expect(Broadcasts::WelcomeNotification::Introduction).to have_received(:send).with(user)
     end
   end
 end

--- a/spec/services/broadcasts/welcome_notification/introduction_spec.rb
+++ b/spec/services/broadcasts/welcome_notification/introduction_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe Broadcasts::WelcomeNotification::Introduction, type: :service do
+  describe "::send" do
+    let(:receiving_user) { create(:user) }
+    let(:user) { create(:user) }
+    let(:mascot_account) { create(:user) }
+    let!(:welcome_broadcast) { create(:welcome_broadcast, :active) }
+
+    before do
+      allow(User).to receive(:mascot_account).and_return(mascot_account)
+      SiteConfig.staff_user_id = mascot_account.id
+    end
+
+    after do
+      SiteConfig.staff_user_id = 1
+    end
+
+    context "when sending a welcome_thread notification" do
+      before do
+        welcome_thread_article = create(:article, user: mascot_account, published: true, tags: "welcome")
+        create(:comment, commentable: welcome_thread_article, commentable_type: "Article", user: user)
+      end
+
+      it "generates the correct broadcast type and sends the notification to the user", :aggregate_failures do
+        expect(receiving_user.notifications.count).to eq(0)
+        sidekiq_perform_enqueued_jobs { described_class.send(receiving_user) }
+
+        expect(receiving_user.notifications.count).to eq(1)
+        expect(receiving_user.notifications.first.notifiable).to eq(welcome_broadcast)
+      end
+
+      it "does not send a notification to a user who has commented in a welcome thread", :aggregate_failures do
+        expect(user.notifications.count).to eq(0)
+        sidekiq_perform_enqueued_jobs { described_class.send(user) }
+        expect(user.notifications.count).to eq(0)
+      end
+
+      it "does not send a duplicate notification" do
+        2.times do
+          sidekiq_perform_enqueued_jobs { described_class.send(receiving_user) }
+        end
+
+        expect(receiving_user.notifications.count).to eq(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
The goal of this PR is the following
- Extract the welcome notification logic into its own class called `Introduction`
- Change Generator to a module and renamed it, Dispatcher. I think it just makes more sense since it will decide what form of notification to call.
- This makes it really easy to add additional types of notifications.

The class names (`Introduction`, `Authentication`, etc..) is pending. Please feel free to suggest a better name.

side-note: I think we came come up with a more short and semantic name for `WelcomeNotifiations`
## Related Tickets & Documents
n/a
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
n/a
## Added tests?
- [x] yes
## Added to documentation?
- [x] no documentation needed
## [optional] Are there any post deployment tasks we need to perform?
n/a
