### PR TITLE
Use subdomain env var for Netlify deploys

### DIFF
--- a/docs/deploy-script.js
+++ b/docs/deploy-script.js
@@ -1,5 +1,5 @@
 const exec = require('child_process').exec;
-const subdomain = process.env.URL;
+const subdomain = process.env.subdomain;
 
 let buildCommand;
 switch (subdomain) {

--- a/docs/deploy-script.js
+++ b/docs/deploy-script.js
@@ -10,7 +10,7 @@ switch (subdomain) {
     buildCommand = 'cd .. && npm install && npm run build-storybook';
     break;
   default:
-    throw `Domain ${subdomain} is invalid`;
+    throw `Subdomain ${subdomain} is invalid`;
 }
 
 async function execute(command) {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Based on https://docs.netlify.com/configure-builds/environment-variables/#deploy-urls-and-metadata, the environment variable `URL` is taken / used already by Netlify.

This switches the old ENV variable from `URL` to `subdomain`.