### PR TITLE
Increase the number of negative reactions per page

### DIFF
--- a/app/controllers/internal/negative_reactions_controller.rb
+++ b/app/controllers/internal/negative_reactions_controller.rb
@@ -10,6 +10,6 @@ class Internal::NegativeReactionsController < Internal::ApplicationController
       where("category IN (?)", NEGATIVE_REACTION_CATEGORIES).
       order("reactions.created_at DESC").
       ransack(params[:q])
-    @negative_reactions = @q.result.page(params[:page] || 1).per(5)
+    @negative_reactions = @q.result.page(params[:page] || 1).per(25)
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

After looking at this UI in production, I realized that showing only
five negative reactions per page was way too few! Bumping this up to 25
which I feel is more reasonable.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![external-content duckduckgo com](https://user-images.githubusercontent.com/11466782/77563472-52fe5600-6e8f-11ea-9c50-133f67da62ac.gif)

