### PR TITLE
Log Elasticsearch index counts to Datadog

### DIFF
--- a/app/services/search/base.rb
+++ b/app/services/search/base.rb
@@ -37,6 +37,10 @@ module Search
         Search::Client.indices.put_mapping(index: index_alias, body: self::MAPPINGS)
       end
 
+      def document_count
+        Search::Client.count(index: self::INDEX_ALIAS).dig("count")
+      end
+
       private
 
       def search(body:)

--- a/app/workers/metrics/record_data_counts_worker.rb
+++ b/app/workers/metrics/record_data_counts_worker.rb
@@ -12,7 +12,7 @@ module Metrics
 
         next unless model.const_defined?(:SEARCH_CLASS)
 
-        document_count = Search::Client.count(index: model::SEARCH_CLASS::INDEX_ALIAS).dig("count")
+        document_count = model::SEARCH_CLASS.document_count
         DatadogStatsClient.gauge("elasticsearch.document_count", document_count, tags: { table_name: model.table_name })
       end
     end

--- a/app/workers/metrics/record_data_counts_worker.rb
+++ b/app/workers/metrics/record_data_counts_worker.rb
@@ -12,8 +12,8 @@ module Metrics
 
         next unless model.const_defined?(:SEARCH_CLASS)
 
-        index_size = Search::Client.count(index: model::SEARCH_CLASS::INDEX_ALIAS).dig("count")
-        DatadogStatsClient.gauge("elasticsearch.index_size", index_size, tags: { table_name: model.table_name })
+        document_count = Search::Client.count(index: model::SEARCH_CLASS::INDEX_ALIAS).dig("count")
+        DatadogStatsClient.gauge("elasticsearch.document_count", document_count, tags: { table_name: model.table_name })
       end
     end
   end

--- a/lib/tasks/fetch.rake
+++ b/lib/tasks/fetch.rake
@@ -117,8 +117,8 @@ task fix_credits_count_cache: :environment do
   Credit.counter_culture_fix_counts only: %i[user organization]
 end
 
-task record_db_table_counts: :environment do
-  Metrics::RecordDbTableCountsWorker.perform_async
+task record_data_counts: :environment do
+  Metrics::RecordDataCountsWorker.perform_async
 end
 
 task log_worker_queue_stats: :environment do

--- a/spec/workers/metrics/record_data_counts_worker_spec.rb
+++ b/spec/workers/metrics/record_data_counts_worker_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Metrics::RecordDataCountsWorker, type: :worker do
 
       expect(
         DatadogStatsClient,
-      ).to have_received(:gauge).with("elasticsearch.index_size", 0, Hash).at_least(1)
+      ).to have_received(:gauge).with("elasticsearch.document_count", 0, Hash).at_least(1)
     end
   end
 end

--- a/spec/workers/metrics/record_data_counts_worker_spec.rb
+++ b/spec/workers/metrics/record_data_counts_worker_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Metrics::RecordDbTableCountsWorker, type: :worker do
+RSpec.describe Metrics::RecordDataCountsWorker, type: :worker do
   default_logger = Rails.logger
 
   include_examples "#enqueues_on_correct_queue", "low_priority", 1
@@ -21,6 +21,15 @@ RSpec.describe Metrics::RecordDbTableCountsWorker, type: :worker do
       expect(
         DatadogStatsClient,
       ).to have_received(:gauge).with("postgres.db_table_size", 0, Hash).at_least(1)
+    end
+
+    it "logs index counts in Datadog" do
+      allow(DatadogStatsClient).to receive(:gauge)
+      described_class.new.perform
+
+      expect(
+        DatadogStatsClient,
+      ).to have_received(:gauge).with("elasticsearch.index_size", 0, Hash).at_least(1)
     end
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)
- [x] Feature

## Description
This PR renames the `RecordDbTableCountsWorker` to `RecordDataCountsWorker` and adds logic to also record Elasticsearch index sizes to Datadog.

It should be fine to rename the worker in one go without aliasing this since the current task only runs daily. There shouldn't be any hanging jobs as long as we don't deploy this close to the scheduled run time of that task.

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-34722425

## Added tests?
- [x] yes

## Added to documentation?
- [x] no documentation needed

## Are there any post deployment tasks we need to perform?
Someone with Heroku access will need to remove the `record_db_table_counts` task from the scheduler and replace it with the `record_db_counts` task.

![try_again_gif](https://media.giphy.com/media/CjP6yN17qiaG63ejx2/giphy.gif)