### PR TITLE
Revert rating_votes_count removal

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -17,7 +17,6 @@ class Article < ApplicationRecord
     main_tag_name_for_social
     name_within_collection
     paid
-    rating_votes_count
     removed_for_abuse
   ]
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

I sleepily merged this PR and then realized the problem.

https://github.com/thepracticaldev/dev.to/pull/6781

`rating_votes_count` actually is used via the `counter_culture` gem. I noticed some possible further confusion in the thread to this regard.

This behavior is only found in within the `RatingVote` model.

```ruby
  counter_culture :article
```

### Rails magic at it agian.

![](https://media.giphy.com/media/12NUbkX6p4xOO4/giphy.gif)

Sorry about confusion here.