### PR TITLE
Allow users to opt-out of welcome notifications

### DIFF
--- a/app/assets/stylesheets/notifications.scss
+++ b/app/assets/stylesheets/notifications.scss
@@ -52,6 +52,13 @@
               font-weight: 500;
             }
           }
+          &.broadcast-content {
+            .opt-out {
+              padding-top: 24px;
+              font-size: 12px;
+              font-style: italic;
+            }
+          }
           &.reaction-content {
             width: calc(100% - 145px);
           }

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -44,6 +44,7 @@ class UserPolicy < ApplicationPolicy
     medium_url
     mobile_comment_notifications
     mod_roundrobin_notifications
+    welcome_notifications
     mostly_work_with
     name
     password

--- a/app/services/broadcasts/welcome_notification/generator.rb
+++ b/app/services/broadcasts/welcome_notification/generator.rb
@@ -11,6 +11,8 @@ module Broadcasts
       end
 
       def call
+        # TODO: [@thepracticaldev/delightful] Move this check into the rake task logic once it has been implemented.
+        return unless user.welcome_notifications
         return if commented_on_welcome_thread? || received_notification?
 
         Notification.send_welcome_notification(user.id, welcome_broadcast.id)

--- a/app/services/notifications/welcome_notification/send.rb
+++ b/app/services/notifications/welcome_notification/send.rb
@@ -19,7 +19,8 @@ module Notifications
           user: user_data(mascot_account),
           broadcast: {
             title: welcome_broadcast.title,
-            processed_html: welcome_broadcast.processed_html
+            processed_html: welcome_broadcast.processed_html,
+            type_of: welcome_broadcast.type_of
           }
         }
         Notification.create!(

--- a/app/views/notifications/_broadcast.html.erb
+++ b/app/views/notifications/_broadcast.html.erb
@@ -10,7 +10,7 @@
     <%= json_data["broadcast"]["processed_html"].html_safe %>
 
     <% if notification.json_data['broadcast']['type_of'] == "Welcome" %>
-      <div class="opt-out"><a href="#">Click here</a> to opt-out of these kinds of notifications.</<div>
+      <div class="opt-out"><a href="/settings/notifications">Go to your settings to manage your notification settings.</a></<div>
     <% end %>
   </div>
 <% end %>

--- a/app/views/notifications/_broadcast.html.erb
+++ b/app/views/notifications/_broadcast.html.erb
@@ -10,7 +10,7 @@
     <%= json_data["broadcast"]["processed_html"].html_safe %>
 
     <% if notification.json_data['broadcast']['type_of'] == "Welcome" %>
-      <div class="opt-out"><a href="/settings/notifications">Go to your settings to manage your notification settings.</a></<div>
+      <div class="opt-out"><a href="<%= user_settings_path(tab: :notifications) %>">Go to your settings to manage your notification settings.</a></<div>
     <% end %>
   </div>
 <% end %>

--- a/app/views/notifications/_broadcast.html.erb
+++ b/app/views/notifications/_broadcast.html.erb
@@ -8,5 +8,9 @@
   </a>
   <div class="content notification-content broadcast-content">
     <%= json_data["broadcast"]["processed_html"].html_safe %>
+
+    <% if notification.json_data['broadcast']['type_of'] == "Welcome" %>
+      <div class="opt-out"><a href="#">Click here</a> to opt-out of these kinds of notifications.</<div>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/users/_notifications.html.erb
+++ b/app/views/users/_notifications.html.erb
@@ -49,7 +49,7 @@
     </div>
     <div class="sub-field">
       <%= f.check_box :email_unread_notifications %>
-      <%= f.label :email_unread_notifications, "Send me occasional reminders that I have unread notifications on dev.to" %>
+      <%= f.label :email_unread_notifications, "Send me occasional reminders that I have unread notifications on DEV" %>
     </div>
   </div>
   <h3>Mobile Notification Settings (Beta)</h3>
@@ -64,12 +64,12 @@
   </div>
   <h3>Platform Notification Settings</h3>
   <p>
-    <em>Notifications that only appear on the <a href="/notifications">notifications page</a>.</em>
+    <em>Notifications that only appear on the <a href="<%= notifications_path %>">notifications page</a>.</em>
   </p>
   <div class="checkbox-field">
     <div class="sub-field">
       <%= f.check_box :welcome_notifications %>
-      <%= f.label :welcome_notifications, "Send me occasional tips and tricks" %>
+      <%= f.label :welcome_notifications, "Send me occasional tips on how to enhance my DEV experience" %>
     </div>
   </div>
   <% if current_user.trusted %>

--- a/app/views/users/_notifications.html.erb
+++ b/app/views/users/_notifications.html.erb
@@ -62,6 +62,16 @@
       <%= f.label :mobile_comment_notifications, "Notify me when someone replies to me in a comment thread" %>
     </div>
   </div>
+  <h3>Platform Notification Settings</h3>
+  <p>
+    <em>Notifications that only appear on the <a href="/notifications">tab</a>.</em>
+  </p>
+  <div class="checkbox-field">
+    <div class="sub-field">
+      <%= f.check_box :welcome_notifications %>
+      <%= f.label :welcome_notifications, "Send me occasional tips and tricks" %>
+    </div>
+  </div>
   <% if current_user.trusted %>
     <h3>Mod Notification Settings</h3>
     <div class="checkbox-field">

--- a/app/views/users/_notifications.html.erb
+++ b/app/views/users/_notifications.html.erb
@@ -64,7 +64,7 @@
   </div>
   <h3>Platform Notification Settings</h3>
   <p>
-    <em>Notifications that only appear on the <a href="/notifications">tab</a>.</em>
+    <em>Notifications that only appear on the <a href="/notifications">notifications page</a>.</em>
   </p>
   <div class="checkbox-field">
     <div class="sub-field">

--- a/db/migrate/20200324170819_add_welcome_notifications_to_users.rb
+++ b/db/migrate/20200324170819_add_welcome_notifications_to_users.rb
@@ -1,0 +1,5 @@
+class AddWelcomeNotificationsToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :welcome_notifications, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_24_113133) do
+ActiveRecord::Schema.define(version: 2020_03_24_170819) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1263,6 +1263,7 @@ ActiveRecord::Schema.define(version: 2020_03_24_113133) do
     t.datetime "updated_at", null: false
     t.string "username"
     t.string "website_url"
+    t.boolean "welcome_notifications", default: true, null: false
     t.datetime "workshop_expiration"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["created_at"], name: "index_users_on_created_at"

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -538,15 +538,15 @@ RSpec.describe "NotificationsIndex", type: :request do
         get "/notifications"
       end
 
-      it "renders the proper message" do
+      it "does not render the notification message" do
         expect(response.body).not_to include "Since they are new to the community, could you leave a nice reply"
       end
 
-      it "renders the article's path" do
+      it "does not render the article's path" do
         expect(response.body).not_to include article.path
       end
 
-      it "renders the comment's processed HTML" do
+      it "does not render the comment's processed HTML" do
         expect(response.body).not_to include comment.processed_html
       end
     end
@@ -566,15 +566,15 @@ RSpec.describe "NotificationsIndex", type: :request do
         get "/notifications"
       end
 
-      it "renders the proper message" do
+      it "does not render the proper message" do
         expect(response.body).not_to include "Since they are new to the community, could you leave a nice reply"
       end
 
-      it "renders the article's path" do
+      it "does not render the article's path" do
         expect(response.body).not_to include article.path
       end
 
-      it "renders the comment's processed HTML" do
+      it "does not render the comment's processed HTML" do
         expect(response.body).not_to include comment.processed_html
       end
     end

--- a/spec/requests/user/user_settings_spec.rb
+++ b/spec/requests/user/user_settings_spec.rb
@@ -98,6 +98,14 @@ RSpec.describe "UserSettings", type: :request do
       expect(user.reload.mod_roundrobin_notifications).to be(false)
     end
 
+    it "can toggle welcome notifications" do
+      put "/users/#{user.id}", params: { user: { tab: "notifications", welcome_notifications: 0 } }
+      expect(user.reload.welcome_notifications).to be(false)
+
+      put "/users/#{user.id}", params: { user: { tab: "notifications", welcome_notifications: 1 } }
+      expect(user.reload.welcome_notifications).to be(true)
+    end
+
     it "updates username to too short username" do
       put "/users/#{user.id}", params: { user: { tab: "profile", username: "h" } }
       expect(response.body).to include("Username is too short")

--- a/spec/services/broadcasts/welcome_notification/generator_spec.rb
+++ b/spec/services/broadcasts/welcome_notification/generator_spec.rb
@@ -52,7 +52,8 @@ RSpec.describe Broadcasts::WelcomeNotification::Generator, type: :service do
       end
 
       it "does not send a duplicate notification" do
-        sidekiq_perform_enqueued_jobs { 2.times { described_class.call(user.id) } }
+        2.times { sidekiq_perform_enqueued_jobs { described_class.call(user.id) } }
+
         expect(user.notifications.count).to eq(1)
       end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
Allows users to opt-out and unsubscribe from welcome notifications! I also refactored the tests and added some `TODO`s for @thepracticaldev/delightful.

Something to note here is that we will _always_ show the "unsubscribe" check box on the `/settings/notifications` page. I went with this approach because it seems weird to not show that option on the settings page (or even on the bottom of the notification) if someone's account was created 7 days ago (imagine someone logging in after 8 days and seeing these welcome notifications and wanting to unsubscribe but not seeing the option to do so?).

In the future, I'm sure we'll have more notifications sent via our platform, so we might want to consider splitting out the `/settings` route into `/settings/email` and `/settings/notifications`.

## Related Tickets & Documents
Resolves #6705.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
<img width="1170" alt="Screen_Shot_2020-03-25_at_4_59_42_PM" src="https://user-images.githubusercontent.com/6921610/77596853-607d0580-6eba-11ea-85be-d20822b13364.png">
<img width="1168" alt="Screen_Shot_2020-03-25_at_4_59_51_PM" src="https://user-images.githubusercontent.com/6921610/77596857-6377f600-6eba-11ea-87f7-1cdec10bf89c.png">

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed **but I added some `TODO`s for our team!**

