### PR TITLE
Bump Octokit to 4.0.18

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -510,7 +510,7 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    octokit (4.17.0)
+    octokit (4.18.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     oj (3.10.5)


### PR DESCRIPTION
##  What type of PR is this? (check all applicable)

- [X] Bug Fix

## Description

Our bundle was locked to Octokit 4.0.17, which got yanked from RubyGems:

![Screen Shot 2020-03-26 at 11 54 30](https://user-images.githubusercontent.com/47985/77611689-98d32100-6f58-11ea-97ce-2763d8842108.png)

This means we can't bundle on Travis and all builds fail. 

According to the Octokit docs:

> This library aims to adhere to Semantic Versioning 2.0.0. Violations of this scheme should be reported as bugs. Specifically, if a minor or patch version is released that breaks backward compatibility, that version should be immediately yanked and/or a new version should be immediately released that restores compatibility.

## Related Tickets & Documents

n/a

## Added tests?

- [X] no, because they aren't needed

## Added to documentation?

- [X] no documentation needed
