### PR TITLE
Ensure non-super-admins cannot see ApplicationConfig

### DIFF
--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -384,7 +384,7 @@
   </div>
 </div>
 
-<% if current_user.has_role?(:single_resource_admin, Config) %>
+<% if current_user.has_role?(:single_resource_admin, Config) && current_user.has_role?(:super_admin) %>
   <div class="row my-3" id="siteConfig">
     <div class="card w-100">
       <div class="card-header" id="appConfigHeader">


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
In order to give more team members read-only access to `SiteConfig`, we need to further restrict the part where we print the `ApplicationConfig` which contains a bunch of sensitive keys.