### PR TITLE
Bug Fix: Handle Missing @displayed_classified_listing for Moderate Views

### DIFF
--- a/app/controllers/classified_listings_controller.rb
+++ b/app/controllers/classified_listings_controller.rb
@@ -12,6 +12,7 @@ class ClassifiedListingsController < ApplicationController
     @displayed_classified_listing = published_listings.find_by(slug: params[:slug]) if params[:slug]
 
     if params[:view] == "moderate"
+      not_found unless @displayed_classified_listing
       return redirect_to "/internal/listings/#{@displayed_classified_listing.id}/edit"
     end
 

--- a/spec/requests/classified_listings_spec.rb
+++ b/spec/requests/classified_listings_spec.rb
@@ -63,6 +63,19 @@ RSpec.describe "ClassifiedListings", type: :request do
         expect(response.body).not_to include(CGI.escapeHTML(expired_listing.title))
       end
     end
+
+    context "when view is moderate" do
+      it "redirects to internal/listings/:id/edit" do
+        get "/listings", params: { view: "moderate", slug: listing.slug }
+        expect(response.redirect_url).to include("/internal/listings/#{listing.id}/edit")
+      end
+
+      it "without a slug raises an ActiveRecord::RecordNotFound error" do
+        expect do
+          get "/listings", params: { view: "moderate" }
+        end.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
   end
 
   describe "GET /listings/new" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Fixes: https://app.honeybadger.io/fault/66984/0d65dc7ed8553fc9234e71bbdf5f059a
```
NoMethodError: undefined method `id' for nil:NilClass
 classified_listings_controller.rb  15 index(...)
[PROJECT_ROOT]/app/controllers/classified_listings_controller.rb:15:in `index'
13 
14     if params[:view] == "moderate"
15       return redirect_to "/internal/listings/#{@displayed_classified_listing.id}/edit"
16     end
```

## Added tests?
- [x] yes

![alt_text](https://i.imgflip.com/2u3rn3.gif)
