### PR TITLE
Sync Feed Content Documents in Elasticsearch

### DIFF
--- a/lib/data_update_scripts/20200326145114_re_index_feed_content_to_elasticsearch.rb
+++ b/lib/data_update_scripts/20200326145114_re_index_feed_content_to_elasticsearch.rb
@@ -1,0 +1,28 @@
+module DataUpdateScripts
+  class ReIndexFeedContentToElasticsearch
+    def run
+      clear_existing_feed_documents
+
+      index_docs(Article.pluck(:id), "Article")
+      index_docs(PodcastEpisode.pluck(:id), "PodcastEpisode")
+      index_docs(Comment.pluck(:id), "Comment")
+    end
+
+    private
+
+    def clear_existing_feed_documents
+      # Clear out documents with incorrect IDs before reindex
+      Search::Client.delete_by_query(
+        index: Search::FeedContent::INDEX_ALIAS, body: { query: { match_all: {} } },
+      )
+    end
+
+    def index_docs(ids, doc_type)
+      ids.each do |id|
+        Search::IndexToElasticsearchWorker.set(queue: :low_priority).perform_async(
+          doc_type, id
+        )
+      end
+    end
+  end
+end

--- a/spec/lib/data_update_scripts/re_index_feed_content_to_elasticsearch_spec.rb
+++ b/spec/lib/data_update_scripts/re_index_feed_content_to_elasticsearch_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+require Rails.root.join("lib/data_update_scripts/20200326145114_re_index_feed_content_to_elasticsearch.rb")
+
+describe DataUpdateScripts::ReIndexFeedContentToElasticsearch, elasticsearch: true do
+  it "indexes feed content(articles, comments, podcast episodes) to Elasticsearch" do
+    article = create(:article)
+    podcast_episode = create(:podcast_episode)
+    comment = create(:comment)
+    expect { article.elasticsearch_doc }.to raise_error(Search::Errors::Transport::NotFound)
+    expect { podcast_episode.elasticsearch_doc }.to raise_error(Search::Errors::Transport::NotFound)
+    expect { comment.elasticsearch_doc }.to raise_error(Search::Errors::Transport::NotFound)
+
+    sidekiq_perform_enqueued_jobs { described_class.new.run }
+    expect(article.elasticsearch_doc).not_to be_nil
+    expect(podcast_episode.elasticsearch_doc).not_to be_nil
+    expect(comment.elasticsearch_doc).not_to be_nil
+  end
+end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)
- [x] Feature

## Description
First we clear out the incorrectly indexed documents that are in Elasticsearch(due to the ID bug #6729) then we index Articles, Podcast Episodes, and Comments. This PR needs to be merged before #6847 so that we can ensure all documents are in Elasticsearch and ready to go

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-35222706

## Added tests?
- [x] yes

![alt_text](https://media3.giphy.com/media/LoCDk7fecj2dwCtSB3/source.gif)
