### PR TITLE
Fix flaky response_template test

### DIFF
--- a/spec/requests/internal/response_templates_spec.rb
+++ b/spec/requests/internal/response_templates_spec.rb
@@ -54,16 +54,22 @@ RSpec.describe "/internal/response_templates", type: :request do
   end
 
   describe "GET /internal/response_templates/:id/edit" do
+    let(:response_template) { create(:response_template) }
+
     it "renders successfully if a valid response template was found" do
-      response_template = create(:response_template)
       get "/internal/response_templates/#{response_template.id}/edit"
-      expect(response.status).to eq 200
+      expect(response).to have_http_status(:ok)
     end
 
     it "renders the response template's attributes" do
-      response_template = create(:response_template)
       get "/internal/response_templates/#{response_template.id}/edit"
-      expect(response.body).to include(response_template.content, response_template.title, response_template.content_type, response_template.type_of)
+
+      expect(response.body).to include(
+        CGI.escapeHTML(response_template.content),
+        CGI.escapeHTML(response_template.title),
+        response_template.content_type,
+        response_template.type_of,
+      )
     end
   end
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

[This dependabot build](https://travis-ci.com/github/thepracticaldev/dev.to/builds/155520748#L1842) failed because of a single quote:

```text
  1) /internal/response_templates GET /internal/response_templates/:id/edit renders the response template's attributes

     Failure/Error: expect(response.body).to include(response_template.content, response_template.title, response_template.content_type, response_template.type_of)
       expected "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n  <meta charset=\"utf-8\">\n  <meta http-equiv=\"X-UA-C...793a4a09813d06453eaebf59524563d836c30580ab1a1f169d7f7d085733b8.js\"></script>\n\n</body>\n</html>\n" to include "The Needle's Eye684"
     # ./spec/requests/internal/response_templates_spec.rb:66:in `block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:89:in `block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:89:in `block (2 levels) in <top (required)>'
```

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
