### PR TITLE
Setup ES test environment during bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -44,6 +44,7 @@ FileUtils.chdir APP_ROOT do
 
   puts "\n== Preparing Elasticsearch =="
   system! 'bin/rails search:setup'
+  system! 'RAILS_ENV="test" bin/rails search:setup'
 
   puts "\n== Updating Data =="
   system! 'bin/rails data_updates:run'


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Feature

## Description
When we setup the app we automatically update Elasticsearch in development mode. This PR adds the setup task for the testing environment as well. 

When you run the entire test suite the first thing we do is set up out Elasticsearch indexes so they are there if a spec needs them. To refresh them for a spec you add the tag `elasticsearch: true`. The problem with this is if you are running a single spec that inadvertently tries to index a document but you have never run an `elasticsearch: true` spec before or the whole suite, you will be missing those Elasticsearch test indexes.  This ensures that never happens. 

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-35229387

## Added tests?
- [x] no, because they aren't needed

![alt_text](https://media1.tenor.com/images/15c2d72913015715ace644236a49d84e/tenor.gif?itemid=14513951)
