### PR TITLE
Use dynamic community name rather than hardcoding "DEV"

### DIFF
--- a/app/views/users/_notifications.html.erb
+++ b/app/views/users/_notifications.html.erb
@@ -49,7 +49,7 @@
     </div>
     <div class="sub-field">
       <%= f.check_box :email_unread_notifications %>
-      <%= f.label :email_unread_notifications, "Send me occasional reminders that I have unread notifications on DEV" %>
+      <%= f.label :email_unread_notifications, "Send me occasional reminders that I have unread notifications on #{ApplicationConfig['COMMUNITY_NAME']}" %>
     </div>
   </div>
   <h3>Mobile Notification Settings (Beta)</h3>
@@ -69,7 +69,7 @@
   <div class="checkbox-field">
     <div class="sub-field">
       <%= f.check_box :welcome_notifications %>
-      <%= f.label :welcome_notifications, "Send me occasional tips on how to enhance my DEV experience" %>
+      <%= f.label :welcome_notifications, "Send me occasional tips on how to enhance my #{ApplicationConfig['COMMUNITY_NAME']} experience" %>
     </div>
   </div>
   <% if current_user.trusted %>


### PR DESCRIPTION
What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
A quick fix to #6852, which hardcoded `"DEV"` rather than using `ApplicationConfig['COMMUNITY_NAME']`. Oops! 🙈 

## Related Tickets & Documents
Shoutout to @rhymes for [pointing this out](https://github.com/thepracticaldev/dev.to/pull/6852#issuecomment-604605493).

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed