### PR TITLE
Now webpack logs only display errors on Travis

### DIFF
--- a/config/webpack/test.js
+++ b/config/webpack/test.js
@@ -1,3 +1,7 @@
 const environment = require('./environment');
 
-module.exports = environment.toWebpackConfig();
+const config = environment.toWebpackConfig();
+
+config.stats = 'errors-only';
+
+module.exports = config;


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [x] CI Configuration Change

## Description

webpacker no longer outputs full webpack logs, only errors, if any. For more information, see the webpack [stats](https://webpack.js.org/configuration/stats/) documentation.

Current Travis Build 👇🏻

![image](https://user-images.githubusercontent.com/833231/77693581-f67a6400-6f7e-11ea-90a0-411d0f605570.png)

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![Snape from Harry Potter screaming "Silence!"](https://media.giphy.com/media/UAJpANY0bGPhS/giphy.gif)
