### PR TITLE
Use constraints and different params for settings

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -338,7 +338,8 @@ Rails.application.routes.draw do
   end
 
   get "/settings/(:tab)" => "users#edit", :as => :user_settings
-  get "/settings/:tab/:org_id" => "users#edit"
+  get "/settings/:tab/:org_id" => "users#edit", :constraints => { tab: /organization/ }
+  get "/settings/:tab/:id" => "users#edit", :constraints => { tab: /response-templates/ }
   get "/signout_confirm" => "users#signout_confirm"
   get "/dashboard" => "dashboards#show"
   get "/dashboard/pro" => "dashboards#pro"

--- a/spec/requests/user/user_settings_spec.rb
+++ b/spec/requests/user/user_settings_spec.rb
@@ -71,6 +71,20 @@ RSpec.describe "UserSettings", type: :request do
         expect(response.body).not_to include "CONNECT TWITTER ACCOUNT"
         SiteConfig.authentication_providers = current_auth_value # restore prior value
       end
+
+      it "renders the proper organization page" do
+        first_org, second_org = create_list(:organization, 2)
+        create(:organization_membership, user: user, organization: first_org)
+        create(:organization_membership, user: user, organization: second_org, type_of_user: "admin")
+        get user_settings_path(tab: "organization", org_id: second_org.id) # /settings/organization/:org_id
+        expect(response.body).to include "Grow the team"
+      end
+
+      it "renders the proper response template" do
+        response_template = create(:response_template, user: user)
+        get user_settings_path(tab: "response-templates", id: response_template.id)
+        expect(response.body).to include "Editing a response template"
+      end
     end
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Bug Fix

## Description
This fixes a routing issue where response templates wouldn't work because the `:id` param was blocked.

## Added tests?
- [x] yes

## Added to documentation?
- [x] no documentation needed
