### PR TITLE
Travis: display only error logs for Storybook preview build

### DIFF
--- a/app/javascript/.storybook/main.js
+++ b/app/javascript/.storybook/main.js
@@ -36,10 +36,6 @@ module.exports = {
       },
     };
 
-    if (configType === 'PRODUCTION') {
-      config.stats = 'errors-only';
-    }
-
     return config;
   },
 };

--- a/app/javascript/.storybook/main.js
+++ b/app/javascript/.storybook/main.js
@@ -1,5 +1,4 @@
 const path = require('path');
-const { ProgressPlugin } = require('webpack');
 
 module.exports = {
   stories: ['../**/__stories__/*.stories.jsx'],
@@ -39,9 +38,6 @@ module.exports = {
 
     if (configType === 'PRODUCTION') {
       config.stats = 'errors-only';
-      config.plugins = config.plugins.filter(
-        plugin => !(plugin instanceof ProgressPlugin),
-      );
     }
 
     return config;

--- a/app/javascript/.storybook/main.js
+++ b/app/javascript/.storybook/main.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const { ProgressPlugin } = require('webpack');
 
 module.exports = {
   stories: ['../**/__stories__/*.stories.jsx'],
@@ -38,6 +39,9 @@ module.exports = {
 
     if (configType === 'PRODUCTION') {
       config.stats = 'errors-only';
+      config.plugins = config.plugins.filter(
+        plugin => !(plugin instanceof ProgressPlugin),
+      );
     }
 
     return config;

--- a/app/javascript/.storybook/main.js
+++ b/app/javascript/.storybook/main.js
@@ -36,6 +36,10 @@ module.exports = {
       },
     };
 
+    if (configType === 'PRODUCTION') {
+      config.stats = 'errors-only';
+    }
+
     return config;
   },
 };

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "api-docs:lint": "spectral lint -F hint -v docs/api_v0.yml && lint-openapi -e docs/api_v0.yml",
     "api-docs:serve": "redoc-cli serve docs/api_v0.yml --options.pathInMiddlePanel --options.jsonSampleExpandLevel=all --options.menuToggle -t docs/api_template.hbs --watch",
-    "build-storybook": "build-storybook -c app/javascript/.storybook -s app/assets --quiet",
+    "build-storybook": "build-storybook -c app/javascript/.storybook -s app/assets",
     "storybook": "start-storybook -p 6006 -c app/javascript/.storybook -s app/assets",
     "test": "jest app/javascript/ --coverage",
     "test:watch": "jest app/javascript/ --watch"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "api-docs:lint": "spectral lint -F hint -v docs/api_v0.yml && lint-openapi -e docs/api_v0.yml",
     "api-docs:serve": "redoc-cli serve docs/api_v0.yml --options.pathInMiddlePanel --options.jsonSampleExpandLevel=all --options.menuToggle -t docs/api_template.hbs --watch",
-    "build-storybook": "build-storybook -c app/javascript/.storybook -s app/assets",
+    "build-storybook": "build-storybook -c app/javascript/.storybook -s app/assets --quiet",
     "storybook": "start-storybook -p 6006 -c app/javascript/.storybook -s app/assets",
     "test": "jest app/javascript/ --coverage",
     "test:watch": "jest app/javascript/ --watch"


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [x] CI Configuration Update

## Description

Similar to #6897 for webpacker, but Storybook is a little different in regards to webpack. It has two webpack builds. One for the Storybook Manager and one for the Storybook’s preview iframe.

Current Build Log 👇🏻

```
yarn run v1.22.4
$ build-storybook -c app/javascript/.storybook -s app/assets
info @storybook/preact v5.3.17
info 
info clean outputDir..
info => Copying static files from: app/assets
info => Copying prebuild dll's..
info => Building manager..
info => Loading manager config..
info => Loading presets
info => Loading custom manager config.
info => Compiling manager..
info => manager built (7.18 s)
info => Building preview..
info => Loading preview config..
info => Loading presets
info => Loading config/preview file in "app/javascript/.storybook".
info => Adding stories defined in "app/javascript/.storybook/main.js".
info => Using default Webpack setup.
info => Using custom .postcssrc.yml
info => Compiling preview..
info => Preview built (4.38 s)
WARN asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
WARN This can impact web performance.
WARN Assets: 
WARN   main.22aa0b7bb9a834148310.bundle.js (644 KiB)
WARN   vendors~main.22aa0b7bb9a834148310.bundle.js (692 KiB)
WARN entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (244 KiB). This can impact web performance.
WARN Entrypoints:
WARN   main (1.31 MiB)
WARN       runtime~main.22aa0b7bb9a834148310.bundle.js
WARN       vendors~main.22aa0b7bb9a834148310.bundle.js
WARN       main.22aa0b7bb9a834148310.bundle.js
WARN 
WARN webpack performance recommendations: 
WARN You can limit the size of your bundles by using import() or require.ensure to lazy load some parts of your application.
WARN For more info visit https://webpack.js.org/guides/code-splitting/
info => Output directory: /home/travis/build/thepracticaldev/dev.to/storybook-static
Done in 12.74s.
The command "yarn build-storybook" exited with 0.
```

The preview  webpack config is configurable and this is the one that has been changed to only output errors if webpack spits out any.

All that to say, there will still be some potential verbose webpack output from the Manager webpack build, but not the Preview webpack build.

For more  more information, see the Storybook [Custom Webpack Config](https://storybook.js.org/docs/configurations/custom-webpack-config/) documentation.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![A cat sitting on a pile of books in a library](https://media.giphy.com/media/vZp4KVpwrWTiE/giphy.gif)
