### PR TITLE
Remove redundant Puma silencing in system specs

### DIFF
--- a/spec/support/initializers/capybara.rb
+++ b/spec/support/initializers/capybara.rb
@@ -16,10 +16,6 @@ Capybara.register_driver :headless_chrome do |app|
 end
 
 RSpec.configure do |config|
-  config.before(:all, type: :system) do
-    Capybara.server = :puma, { Silent: true }
-  end
-
   config.before(:each, type: :system) do
     driven_by :rack_test
   end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

After merging #6865 we don't need to explicitly silence Puma in system tests anymore, as it's the default now: https://github.com/rspec/rspec-rails/pull/2289

## Related Tickets & Documents

#6865 

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
