### PR TITLE
Change profile metadata link color for night theme

### DIFF
--- a/app/assets/stylesheets/user-profile-header.scss
+++ b/app/assets/stylesheets/user-profile-header.scss
@@ -282,6 +282,10 @@
         display: inline-block;
         font-size: 0.85em;
         margin-bottom: 4px;
+
+        a {
+          color: var(--button-primary-bg);
+        }
       }
     }
   }


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The links in the profile metadata section, for the night theme, have low contrast issues. I made them pop a bit. Used https://webaim.org/resources/contrastchecker/ to check.

**before**

![night_before](https://user-images.githubusercontent.com/146201/77749117-c637d180-7021-11ea-8e3a-1a6289b320ee.png)

**after**

![night_after](https://user-images.githubusercontent.com/146201/77749158-d485ed80-7021-11ea-843c-2c1057053930.png)

## Related Tickets & Documents

Closes #4879

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
