### PR TITLE
Themes: use default colors for links in notifications

### DIFF
--- a/app/assets/stylesheets/notifications.scss
+++ b/app/assets/stylesheets/notifications.scss
@@ -150,7 +150,6 @@
             max-width: 100%;
             display: inline-block;
             margin-bottom: 3px;
-            @include themeable-important(color, theme-color, $white);
             &:hover {
               @include themeable(
                 background,

--- a/app/assets/stylesheets/notifications.scss
+++ b/app/assets/stylesheets/notifications.scss
@@ -150,7 +150,7 @@
             max-width: 100%;
             display: inline-block;
             margin-bottom: 3px;
-            @include themeable-important(color, theme-color, $black);
+            @include themeable-important(color, theme-color, $white);
             &:hover {
               @include themeable(
                 background,


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Whenever someone reacted to a post, the link colour was black, which is hard to read on dark themes.

~~Changed the colour from black to white.~~

Removed `@include themeable-important(color, theme-color, $black);`.

Now the article title (link) uses the default colours for links. This way it is easier to see the links on both light and dark themes.

## Related Tickets & Documents

[Article link in notifications is black #6907](https://github.com/thepracticaldev/dev.to/issues/6907)

Closes #6907
Closes #6911 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![white-theme](https://i.imgur.com/StPKQP2.png)
![black-theme](https://i.imgur.com/5OzIuf9.png)

`Test post` was black before. It was hard to read on dark themes.

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

