### PR TITLE
Add last_indexed_at Timestamp to all Elasticsearch indexes

### DIFF
--- a/app/services/search/base.rb
+++ b/app/services/search/base.rb
@@ -5,7 +5,7 @@ module Search
         Search::Client.index(
           id: doc_id,
           index: self::INDEX_ALIAS,
-          body: serialized_data,
+          body: serialized_data.merge(last_indexed_at: Time.current),
         )
       end
 

--- a/config/elasticsearch/mappings/chat_channel_memberships.json
+++ b/config/elasticsearch/mappings/chat_channel_memberships.json
@@ -50,6 +50,9 @@
     },
     "channel_messages_count": {
       "type": "integer"
+    },
+    "last_indexed_at": {
+      "type": "date"
     }
   }
 }

--- a/config/elasticsearch/mappings/classified_listings.json
+++ b/config/elasticsearch/mappings/classified_listings.json
@@ -37,6 +37,9 @@
     "expires_at": {
       "type": "date"
     },
+    "last_indexed_at": {
+      "type": "date"
+    },
     "location": {
       "type": "text",
       "copy_to": "classified_listing_search",

--- a/config/elasticsearch/mappings/feed_content.json
+++ b/config/elasticsearch/mappings/feed_content.json
@@ -52,6 +52,9 @@
     "language": {
       "type": "keyword"
     },
+    "last_indexed_at": {
+      "type": "date"
+    },
     "main_image": {
       "type": "keyword"
     },

--- a/config/elasticsearch/mappings/tags.json
+++ b/config/elasticsearch/mappings/tags.json
@@ -4,6 +4,9 @@
     "id": {
       "type": "keyword"
     },
+    "last_indexed_at": {
+      "type": "date"
+    },
     "name": {
       "type": "text",
       "fields": {

--- a/config/elasticsearch/mappings/users.json
+++ b/config/elasticsearch/mappings/users.json
@@ -18,6 +18,9 @@
     "hotness_score": {
       "type": "integer"
     },
+    "last_indexed_at": {
+      "type": "date"
+    },
     "mostly_work_with": {
       "type": "keyword",
       "copy_to": "search_fields"

--- a/spec/services/search/base_spec.rb
+++ b/spec/services/search/base_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Search::Base, type: :service, elasticsearch: true do
       Timecop.freeze(Time.current) do
         described_class.index(document_id, id: document_id)
         last_indexed_at = described_class.find_document(document_id).dig("_source", "last_indexed_at")
-        expect(Time.parse(last_indexed_at).to_i).to eq(Time.current.to_i)
+        expect(Time.zone.parse(last_indexed_at).to_i).to eq(Time.current.to_i)
       end
     end
   end

--- a/spec/services/search/base_spec.rb
+++ b/spec/services/search/base_spec.rb
@@ -17,6 +17,14 @@ RSpec.describe Search::Base, type: :service, elasticsearch: true do
       described_class.index(document_id, id: document_id)
       expect(described_class.find_document(document_id)).not_to be_nil
     end
+
+    it "sets last_indexed_at field" do
+      Timecop.freeze(Time.current) do
+        described_class.index(document_id, id: document_id)
+        last_indexed_at = described_class.find_document(document_id).dig("_source", "last_indexed_at")
+        expect(Time.parse(last_indexed_at).to_i).to eq(Time.current.to_i)
+      end
+    end
   end
 
   describe "::find_document" do


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
The same way we have updated_at on the majority of our Postgres tables, we also want a timestamp on our Elasticsearch documents to tell us when they were indexed. This is not going to be used for anything immediately but in my experience this is something we will want in the future for debugging or just looking up recently created or updated documents. It also gives us a timestamp to use when setting up [Kibana for our cluster](https://www.elastic.co/kibana).

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-35285752

## Added tests?
- [x] yes

![alt_text](https://media0.giphy.com/media/l3mZasrfwrWUMnndS/giphy.gif)
