### PR TITLE
Fix fragment caching bug for SEO tag pagination.

### DIFF
--- a/app/assets/stylesheets/sidebar-data.scss
+++ b/app/assets/stylesheets/sidebar-data.scss
@@ -25,7 +25,7 @@
     margin-bottom: 5px;
   }
   .olderposts-pagenumber {
-    padding: 8px;
-    margin-right: -8px;
+    padding: 4px;
+    margin-right: -4px;
   }
 }

--- a/app/views/articles/tag_index.html.erb
+++ b/app/views/articles/tag_index.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 <% expiry_minutes = params[:timeframe].blank? || params[:timeframe] == "latest" ? 4 : 20 %>
 <% flag = true %>
-<% cache("tag-stories-index-#{params}-#{flag}-#{@tag_model.updated_at}", expires_in: expiry_minutes.minutes) do %>
+<% cache("tag-stories-index-#{params}-#{flag}-#{@tag_model.updated_at}-#{user_signed_in?}", expires_in: expiry_minutes.minutes) do %>
   <style>
     .tag-header {
       border: 2px solid<%= HexComparer.new([@tag_model.bg_color_hex || "#0000000", @tag_model.text_color_hex || "#ffffff"]).brightness(0.88) %>;

--- a/app/views/articles/tags/_sidebar.html.erb
+++ b/app/views/articles/tags/_sidebar.html.erb
@@ -78,13 +78,12 @@
           </span>
         <% else %>
           <% number_of_pages = @num_published_articles / @number_of_articles %>
-          <% range = (number_of_pages < 10 || @page < 3) ? 1..[number_of_pages, 9].min : [@page - 3, 1].max..[@page + 5, number_of_pages].min %>
+          <% range = (number_of_pages < 10 || @page < 4) ? 1..[number_of_pages, 9].min : [@page - 3, 1].max..[@page + 5, number_of_pages].min %>
           <% if number_of_pages > 1 %>
             <hr />
             <div class="olderposts-header">Older #<%= @tag %> posts</div>
             <div class="olderposts-links">
               <% range.each do |n| %>
-                <% next if (@page - n).abs > 10 && number_of_pages > 10 %>
                 <% if @page == n %>
                     <span class="olderposts-pagenumber"><%= n %></span>
                 <% else %>

--- a/app/views/articles/tags/_sidebar.html.erb
+++ b/app/views/articles/tags/_sidebar.html.erb
@@ -1,4 +1,4 @@
-<% cache "tag-sidebar-#{@tag}-#{@tag_model&.updated_at}-#{@tag_model&.taggings_count}-#{user_signed_in?}", expires_in: 5.hours do %>
+<% cache "tag-sidebar-#{@tag}-#{@tag_model&.updated_at}-#{@tag_model&.taggings_count}-#{user_signed_in?}-#{@page}", expires_in: 5.hours do %>
   <div id="sidebar-wrapper-left" class="sidebar-wrapper sidebar-wrapper-left">
     <div class="sidebar-bg" id="sidebar-bg-left"></div>
     <div class="side-bar">
@@ -67,7 +67,7 @@
         </div>
         <% if user_signed_in? %>
           <span style="display:none;" id="tag-edit-button" data-tag="<%= @tag_model.name %>">
-            <a class="cta mod-action-button" href="/t/<%= @tag_model.name %>/edit" style="color:<%= @tag_model.text_color_hex %>;background-color:<%= @tag_model.bg_color_hex %>">
+            <a class="cta mod-action-button" href="<%= tag_url(@tag_model, @page) %>/edit" style="color:<%= @tag_model.text_color_hex %>;background-color:<%= @tag_model.bg_color_hex %>">
               EDIT
             </a>
           </span>
@@ -78,17 +78,24 @@
           </span>
         <% else %>
           <% number_of_pages = @num_published_articles / @number_of_articles %>
+          <% range = (number_of_pages < 10 || @page < 3) ? 1..[number_of_pages, 9].min : [@page - 3, 1].max..[@page + 5, number_of_pages].min %>
           <% if number_of_pages > 1 %>
             <hr />
             <div class="olderposts-header">Older #<%= @tag %> posts</div>
             <div class="olderposts-links">
-              <% (1..number_of_pages).each do |n| %>
-                <% next if (@page - n).abs > 5 && number_of_pages > 10 %>
+              <% range.each do |n| %>
+                <% next if (@page - n).abs > 10 && number_of_pages > 10 %>
                 <% if @page == n %>
                     <span class="olderposts-pagenumber"><%= n %></span>
                 <% else %>
-                    <a href="/t/<%= @tag_model.name %><%= "/page/#{n}" if n > 1 %>" class="olderposts-pagenumber"><%= n %></a>
+                    <a href="<%= tag_url(@tag_model, n) %>" class="olderposts-pagenumber"><%= n %></a>
                 <% end %>
+              <% end %>
+              <% if @page == 1 && number_of_pages > 100 %>
+                <div>
+                  …<a href="<%= tag_url(@tag_model, 75) %>" class="olderposts-pagenumber">75</a>
+                  …<a href="<%= tag_url(@tag_model, number_of_pages) %>" class="olderposts-pagenumber"><%= number_of_pages %></a>
+                </div>
               <% end %>
             </div>
           <% end %>


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The pagination PR #6771 mostly works as intended with no critical issues, except that is not respecting the `user_signed_in?` logic and proper `@page` logic due to caching in prod.

Also messed with some of the range logic because we weren't really counting all the cases properly. Also added a "midpoint" and "endpoint" link in order to create fewer jumps from the home page to all tagged content

More info here about that concept:

https://www.portent.com/blog/seo/pagination-tunnels-experiment-click-depth.htm

Due to the caching bug in prod right now, I'd like to get this in quickly if tests continue to pass.