### PR TITLE
Validate file name length for file uploads

### DIFF
--- a/spec/system/comments/user_fills_out_comment_spec.rb
+++ b/spec/system/comments/user_fills_out_comment_spec.rb
@@ -101,4 +101,24 @@ RSpec.describe "Creating Comment", type: :system, js: true do
       text: "Invalid file format (image). Only video files are permitted.",
     )
   end
+
+  it "User attaches a file with too long of a name" do
+    visit article.path.to_s
+
+    limit_file_name_length = 'document.querySelector("#image-upload-main").setAttribute("data-max-file-name-length", "5")'
+    page.execute_script(limit_file_name_length)
+    expect(page).to have_selector('input[data-max-file-name-length="5"]', visible: false)
+
+    attach_file(
+      "image-upload-main",
+      Rails.root.join("app/assets/images/sloan.png"),
+      visible: false,
+    )
+
+    expect(page).to have_css("div.file-upload-error")
+    expect(page).to have_css(
+      "div.file-upload-error",
+      text: "File name is too long. It can't be longer than 5 characters.",
+    )
+  end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)
- [x] Feature

## Description
There was an [error](https://github.com/thepracticaldev/dev.to/projects/9#card-35296954) where a user tried to upload an image with a _very_ long file name. I updated the client-side validation to check the length of the file name. The default max is set to 250 characters and it can be overridden with a data attribute on the file form field as needed.

## Related Tickets & Documents
- https://app.honeybadger.io/projects/66984/faults/62329414
- https://github.com/thepracticaldev/dev.to/projects/9#card-35296954

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
<img width="422" alt="Screen Shot 2020-03-27 at 11 25 51 AM" src="https://user-images.githubusercontent.com/15987080/77789436-3b0a0c00-7020-11ea-8b13-ccd4c2072f50.png">

## Added tests?
- [x] yes

## Added to documentation?
- [x] no documentation needed

![mr_robot_quote_gif](https://media.giphy.com/media/ZKQpx4TYrxTtS/giphy.gif)
