### PR TITLE
Avoid requesting reaction counts for draft articles

### DIFF
--- a/app/assets/javascripts/initializers/initializeArticleReactions.js
+++ b/app/assets/javascripts/initializers/initializeArticleReactions.js
@@ -1,6 +1,6 @@
 /* global sendHapticMessage, showModal */
 
-'use strict';
+
 
 // Set reaction count to correct number
 function setReactionCount(reactionName, newCount) {
@@ -83,7 +83,7 @@ function reactToArticle(articleId, reaction) {
 
   getCsrfToken()
     .then(sendFetch('reaction-creation', createFormdata()))
-    .then(response => {
+    .then((response) => {
       if (response.status === 200) {
         return response.json().then(() => {
           document.getElementById('reaction-butt-' + reaction).disabled = false;
@@ -93,7 +93,7 @@ function reactToArticle(articleId, reaction) {
       document.getElementById('reaction-butt-' + reaction).disabled = false;
       return undefined;
     })
-    .catch(error => {
+    .catch((error) => {
       toggleReaction();
       document.getElementById('reaction-butt-' + reaction).disabled = false;
     });
@@ -106,7 +106,7 @@ function setCollectionFunctionality() {
     );
     var inbetweenLinksLength = inbetweenLinks.length;
     for (var i = 0; i < inbetweenLinks.length; i += 1) {
-      inbetweenLinks[i].onclick = e => {
+      inbetweenLinks[i].onclick = (e) => {
         e.preventDefault();
         var els = document.getElementsByClassName('collection-link-hidden');
         var elsLength = els.length;
@@ -131,10 +131,10 @@ function requestReactionCounts(articleId) {
   ajaxReq.onreadystatechange = () => {
     if (ajaxReq.readyState === XMLHttpRequest.DONE) {
       var json = JSON.parse(ajaxReq.response);
-      json.article_reaction_counts.forEach(reaction => {
+      json.article_reaction_counts.forEach((reaction) => {
         setReactionCount(reaction.category, reaction.count);
       });
-      json.reactions.forEach(reaction => {
+      json.reactions.forEach((reaction) => {
         if (document.getElementById('reaction-butt-' + reaction.category)) {
           showUserReaction(reaction.category, 'not-user-animated');
         }
@@ -146,7 +146,7 @@ function requestReactionCounts(articleId) {
 }
 
 function jumpToComments() {
-  document.getElementById('jump-to-comments').onclick = e => {
+  document.getElementById('jump-to-comments').onclick = (e) => {
     e.preventDefault();
     document.getElementById('comments').scrollIntoView({
       behavior: 'instant',
@@ -159,20 +159,26 @@ function initializeArticleReactions() {
   setCollectionFunctionality();
   setTimeout(() => {
     var articleId;
-    if (document.getElementById('article-body')) {
-      articleId = document.getElementById('article-body').dataset.articleId;
-      if (document.getElementById('article-reaction-actions')) {
-        requestReactionCounts(articleId);
-      }
-    }
     var reactionButts = document.getElementsByClassName(
       'article-reaction-butt',
     );
-    for (var i = 0; i < reactionButts.length; i += 1) {
-      reactionButts[i].onclick = function addReactionOnClick(e) {
-        reactToArticle(articleId, this.dataset.category);
-      };
+
+    // we wait for the article to appear,
+    // we also check that reaction buttons are there as draft articles don't have them
+    if (document.getElementById('article-body') && reactionButts.length > 0) {
+      articleId = document.getElementById('article-body').dataset.articleId;
+
+      if (reactionButts.length > 0) {
+        requestReactionCounts(articleId);
+
+        for (var i = 0; i < reactionButts.length; i += 1) {
+          reactionButts[i].onclick = function addReactionOnClick(e) {
+            reactToArticle(articleId, this.dataset.category);
+          };
+        }
+      }
     }
+
     if (document.getElementById('jump-to-comments')) {
       jumpToComments();
     }

--- a/app/assets/javascripts/initializers/initializeArticleReactions.js
+++ b/app/assets/javascripts/initializers/initializeArticleReactions.js
@@ -1,7 +1,5 @@
 /* global sendHapticMessage, showModal */
 
-
-
 // Set reaction count to correct number
 function setReactionCount(reactionName, newCount) {
   var reactionClassList = document.getElementById(
@@ -157,8 +155,8 @@ function jumpToComments() {
 
 function initializeArticleReactions() {
   setCollectionFunctionality();
+
   setTimeout(() => {
-    var articleId;
     var reactionButts = document.getElementsByClassName(
       'article-reaction-butt',
     );
@@ -166,16 +164,14 @@ function initializeArticleReactions() {
     // we wait for the article to appear,
     // we also check that reaction buttons are there as draft articles don't have them
     if (document.getElementById('article-body') && reactionButts.length > 0) {
-      articleId = document.getElementById('article-body').dataset.articleId;
+      var articleId = document.getElementById('article-body').dataset.articleId;
 
-      if (reactionButts.length > 0) {
-        requestReactionCounts(articleId);
+      requestReactionCounts(articleId);
 
-        for (var i = 0; i < reactionButts.length; i += 1) {
-          reactionButts[i].onclick = function addReactionOnClick(e) {
-            reactToArticle(articleId, this.dataset.category);
-          };
-        }
+      for (var i = 0; i < reactionButts.length; i += 1) {
+        reactionButts[i].onclick = function addReactionOnClick(e) {
+          reactToArticle(articleId, this.dataset.category);
+        };
       }
     }
 

--- a/app/views/articles/_actions.html.erb
+++ b/app/views/articles/_actions.html.erb
@@ -9,11 +9,13 @@
     <button id="reaction-butt-readinglist" class="article-reaction-butt readinglist-reaction-button" data-category="readinglist" alt="unicorn-emoji" title="reading list">
       <img alt="reading list" src="<%= asset_path("emoji/emoji-one-bookmark.png") %>" /><span class="reaction-number" id="reaction-number-readinglist"></span>
     </button>
-    <a class="article-actions-tweet-button"
-      id="article-actions-tweet-button"
+
+    <% display_name = @article.user.twitter_username ? "@" + @article.user.twitter_username : @article.user.name %>
+    <a
+      class="article-actions-tweet-button"
       rel="noopener"
       target='_blank'
-      href='https://twitter.com/intent/tweet?text="<%= u @article.title.strip %>" by <%= @article.user.twitter_username ? "@" + @article.user.twitter_username : @article.user.name %> %23DEVcommunity https://dev.to<%= @article.path %>'>
+      href='https://twitter.com/intent/tweet?text="<%= u @article.title.strip %>" by <%= display_name %> %23DEVcommunity <%= article_url(@article) %>'>
       <img src="<%= asset_path("twitter.svg") %>" alt="twitter logo">
     </a>
   <% end %>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Whenever we show a draft article the client asks the reactions count to the server and the fails abruptly because the actual reaction buttons and countners aren't in the DOM at all:

```erb
  <% if @article.published? %>
    <button id="reaction-butt-like" class="article-reaction-butt like-reaction-button" data-category="like" alt="heart-emoji" title="heart">
      <img alt="heart" src="<%= asset_path("emoji/emoji-one-heart.png") %>" /><span class="reaction-number" id="reaction-number-like"></span>
    </button>
...
```

![Screenshot 2020-03-29 at 11 15 06 AM](https://user-images.githubusercontent.com/146201/77845356-9538d780-71ae-11ea-90be-33b0308e112e.png)

With this PR we avoid calling the server at all.

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
