### PR TITLE
refactor(docker): move redis env config to docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,10 @@ ENV	DATABASE_URL="postgresql://devto:devto@db:5432/PracticalDeveloper_developmen
 ENV DB_SETUP="false" \
   DB_MIGRATE="false"
 
+# In order for redis to work, these should be set
+ENV REDIS_URL="redis://redis:6379" \
+  REDIS_SESSIONS_URL="redis://redis:6379"
+
 #
 # Let's setup the public uploads folder volume
 #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       YARN_INTEGRITY_ENABLED: "false"
       ELASTICSEARCH_URL: http://elasticsearch:9200
       REDIS_URL: redis://redis:6379
+      REDIS_SESSIONS_URL: redis://redis:6379
     volumes:
       - .:/usr/src/app
     command: bundle exec rails server -b 0.0.0.0 -p 3000

--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -50,14 +50,6 @@ well.
      GITHUB_SECRET: "ANOTHER_REAL_SECURE_KEY_HERE"
      ```
 
-   - Update the redis url variables by adding the following lines into
-     `config/application.yml`:
-
-     ```shell
-      REDIS_URL: "redis://redis:6379"
-      REDIS_SESSIONS_URL: "redis://redis:6379"
-     ```
-
    - You do not need "real" keys for basic development. Some features require
      certain keys, so you may be able to add them as you go.
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Documentation Update

## Description
I had an issue when setting up dev.to in my local environment using docker, similar to #4962. I thought I could just add it in my `docker-compose.yml`, and as it turns out there's only one value for the redis setup in docker-compose, which is `REDIS_URL` while it also needs `REDIS_SESSIONS_URL`. And I was supposed to put them in `config/application.yml`.

In my opinion, these are specific setup for the tools, and it should have been in their respective tool's config, not in `application.yml`. My idea is to set them on `docker-compose.yml` and `Dockerfile` and I can confirm it works fine on my local at least on the `docker-compose` approach. Adding it in `application.yml` can also be redundant since `REDIS_URL` is already defined in `docker-compose.yml`.

I might be missing something obvious here, and also I'm still new to Docker so I would love to get some feedback if this is really the right thing to do. Or maybe it was done specifically this way for a reason. Let me know!

## Related Tickets & Documents
#4962

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] docs.dev.to

![alt_text](https://media.giphy.com/media/7FgDPLLKh1v4d2XLkl/giphy.gif)
