### PR TITLE
refactor(offline.html): allow paint over pallete

### DIFF
--- a/public/offline.html
+++ b/public/offline.html
@@ -201,6 +201,8 @@
     let activePalette = 'default' // match key inside the palettes variable
 
     // Globally DOM nodes + variables
+    const paletteSelector = document.querySelector(".paletteSelector")
+    const colorSelector = document.querySelector(".colors")
     const canvas = document.querySelector('canvas')
     const context = canvas.getContext('2d')
     const colorDiv = document.querySelector(".colors")
@@ -297,6 +299,9 @@
     }
 
     function startPaint(event) {
+      colorSelector.style.pointerEvents = 'none'
+      paletteSelector.style.pointerEvents = 'none'
+
       addClick(event, this)
       paint = true
     }
@@ -304,6 +309,9 @@
     canvas.addEventListener('touchstart', startPaint)
 
     const exit = _ => {
+      colorSelector.style.pointerEvents = 'all'
+      paletteSelector.style.pointerEvents = 'all'
+
       paint = false
       firstX = null
       firstY = null
@@ -321,7 +329,6 @@
     canvas.addEventListener('mousemove', endPaint)
     canvas.addEventListener('touchmove', endPaint)
 
-    const paletteSelector = document.querySelector(".paletteSelector")
     paletteSelector.onchange = (event) => {
       activePalette = event.target.value
       render(palettes[activePalette])


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor

## Description
This is really a minor thing, but when I'm on the offline page, I can't seem to draw freely on top of certain elements:

![Peek 2020-03-29 19-45](https://user-images.githubusercontent.com/8046636/77848365-c3420a00-71f6-11ea-9577-a1ea9c79a6c3.gif)

Since it says I can draw anywhere on the page, it should have been like this:

![Peek 2020-03-29 19-48](https://user-images.githubusercontent.com/8046636/77848384-dbb22480-71f6-11ea-9c1e-1dcc9b3b5dae.gif)

I think it can be achieved with `pointer-events: none` on both elements when drawing. Looks like a hack, sure, but let me know what you think!

## Related Tickets & Documents
N/A

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
Yep, up there

## Added tests?

- [x] no, because I don't know how


## Added to documentation?

- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://i.giphy.com/media/jrc1hv0UD0qlQrTwVt/200.webp)
