### PR TITLE
Ignore unused podcast_episodes columns

### DIFF
--- a/app/dashboards/podcast_episode_dashboard.rb
+++ b/app/dashboards/podcast_episode_dashboard.rb
@@ -14,9 +14,6 @@ class PodcastEpisodeDashboard < Administrate::BaseDashboard
     summary: Field::Text,
     body: Field::Text,
     quote: Field::Text,
-    featured_number: Field::Number,
-    featured: Field::Boolean,
-    order_key: Field::String,
     processed_html: Field::Text,
     comments_count: Field::Number,
     reactions_count: Field::Number,
@@ -25,7 +22,6 @@ class PodcastEpisodeDashboard < Administrate::BaseDashboard
     itunes_url: Field::String,
     image: CarrierwaveField,
     podcast: Field::BelongsTo,
-    duration_in_seconds: Field::Number,
     published_at: Field::DateTime,
     slug: Field::String,
     guid: Field::String,
@@ -58,12 +54,9 @@ class PodcastEpisodeDashboard < Administrate::BaseDashboard
     image
     social_image
     body
-    featured
-    featured_number
     media_url
     website_url
     itunes_url
-    duration_in_seconds
     published_at
     slug
     reachable
@@ -82,7 +75,6 @@ class PodcastEpisodeDashboard < Administrate::BaseDashboard
     media_url
     itunes_url
     social_image
-    duration_in_seconds
     published_at
   ].freeze
 

--- a/app/models/podcast_episode.rb
+++ b/app/models/podcast_episode.rb
@@ -1,4 +1,12 @@
 class PodcastEpisode < ApplicationRecord
+  self.ignored_columns = %w[
+    deepgram_id_code
+    duration_in_seconds
+    featured
+    featured_number
+    order_key
+  ]
+
   include AlgoliaSearch
   include Searchable
 

--- a/app/serializers/search/podcast_episode_serializer.rb
+++ b/app/serializers/search/podcast_episode_serializer.rb
@@ -5,7 +5,7 @@ module Search
     attribute :id, &:search_id
 
     attributes :body_text, :class_name, :comments_count,
-               :featured, :featured_number, :hotness_score, :path,
+               :featured, :hotness_score, :path,
                :positive_reactions_count, :published, :published_at, :quote,
                :reactions_count, :search_score, :subtitle, :summary, :title,
                :website_url

--- a/app/serializers/search/podcast_episode_serializer.rb
+++ b/app/serializers/search/podcast_episode_serializer.rb
@@ -4,8 +4,7 @@ module Search
 
     attribute :id, &:search_id
 
-    attributes :body_text, :class_name, :comments_count,
-               :featured, :hotness_score, :path,
+    attributes :body_text, :class_name, :comments_count, :hotness_score, :path,
                :positive_reactions_count, :published, :published_at, :quote,
                :reactions_count, :search_score, :subtitle, :summary, :title,
                :website_url


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Ignoring columns that are unused in the `PodcastEpisode` model:

```text
deepgram_id_code
duration_in_seconds
featured
featured_number
order_key
```

These will be removed once this is live.

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
