### PR TITLE
Refactor internal user page

### DIFF
--- a/app/controllers/internal/users_controller.rb
+++ b/app/controllers/internal/users_controller.rb
@@ -23,11 +23,17 @@ class Internal::UsersController < Internal::ApplicationController
 
   def edit
     @user = User.find(params[:id])
+    @notes = @user.notes.order(created_at: :desc).limit(10).load
   end
 
   def show
     @user = User.find(params[:id])
-    @organizations = @user.organizations
+    @organizations = @user.organizations.order(:name)
+    @notes = @user.notes.order(created_at: :desc).limit(10).load
+    @organization_memberships = @user.organization_memberships.
+      joins(:organization).
+      order("organizations.name ASC").
+      includes(:organization).load
   end
 
   def update

--- a/app/controllers/internal/users_controller.rb
+++ b/app/controllers/internal/users_controller.rb
@@ -29,11 +29,11 @@ class Internal::UsersController < Internal::ApplicationController
   def show
     @user = User.find(params[:id])
     @organizations = @user.organizations.order(:name)
-    @notes = @user.notes.order(created_at: :desc).limit(10).load
+    @notes = @user.notes.order(created_at: :desc).limit(10)
     @organization_memberships = @user.organization_memberships.
       joins(:organization).
       order("organizations.name ASC").
-      includes(:organization).load
+      includes(:organization)
   end
 
   def update

--- a/app/views/internal/users/_activity.erb
+++ b/app/views/internal/users/_activity.erb
@@ -2,10 +2,10 @@
   <div class="col-sm-6">
     <h2>Activity</h2>
     <ul>
-      <li><%= @user.comments.size %> comments</li>
-      <li><%= @user.articles.size %> articles</li>
-      <li><%= @user.reactions.size %> reactions</li>
-      <li><%= @user.followers.size %> followers</li>
+      <li><%= @user.comments_count %> comments</li>
+      <li><%= @user.articles_count %> articles</li>
+      <li><%= @user.reactions_count %> reactions</li>
+      <li><%= @user.followers_count %> followers</li>
       <li><%= @user.following_users_count %> users following</li>
       <li><%= @user.badge_achievements_count %> badges</li>
     </ul>

--- a/app/views/internal/users/_credits.erb
+++ b/app/views/internal/users/_credits.erb
@@ -4,14 +4,14 @@
     <hr>
     <h4 class="mt-3"><%= @user.username %></h4>
     <p>Available User Credits: <%= @user.unspent_credits_count %></p>
-    <%= form_for [:internal, @user], html: { class: "form-inline justify-content-between mb-2" } do |f| %>
+    <%= form_with scope: :user, url: internal_user_path(@user), method: :patch, local: true, html: { class: "form-inline justify-content-between mb-2" } do |f| %>
       <div class="form-group">
         <%= f.text_field :add_credits, placeholder: "#", size: 5, class: "form-control mr-3" %>
         <%= f.text_field :new_note, placeholder: "Why are you adding these credits?", size: 50, required: true, class: "form-control" %>
       </div>
       <%= f.submit "Add Credits", class: "btn btn-primary" %>
     <% end %>
-    <%= form_for [:internal, @user], html: { class: "form-inline justify-content-between mb-2" } do |f| %>
+    <%= form_with scope: :user, url: internal_user_path(@user), method: :patch, local: true, html: { class: "form-inline justify-content-between mb-2" } do |f| %>
       <div class="form-group">
         <%= f.text_field :remove_credits, placeholder: "#", size: 5, class: "form-control mr-3" %>
         <%= f.text_field :new_note, placeholder: "Why are you removing these credits?", size: 50, required: true, class: "form-control" %>
@@ -22,7 +22,7 @@
   </div>
   <div class="col-12">
     <h4>Organizations</h4>
-    <%= form_with scope: :user, url: internal_user_path(@user), html: { class: "form-inline justify-content-between mb-2" }, local: true, method: :patch do |f| %>
+    <%= form_with scope: :user, url: internal_user_path(@user), method: :patch, local: true, html: { class: "form-inline justify-content-between mb-2" } do |f| %>
       <div class="form-group">
         <%= f.text_field :add_org_credits, placeholder: "#", size: 5, class: "form-control mr-3" %>
         <%= f.text_field :new_note, placeholder: "Why are you adding these credits?", size: 50, required: true, class: "form-control mr-3" %>
@@ -30,7 +30,7 @@
       </div>
       <%= f.submit "Add Org Credits", class: "btn btn-primary" %>
     <% end %> 
-    <%= form_with scope: :user, url: internal_user_path(@user), html: { class: "form-inline justify-content-between mb-2" }, local: true, method: :patch do |f| %>
+    <%= form_with scope: :user, url: internal_user_path(@user), method: :patch, local: true, html: { class: "form-inline justify-content-between mb-2" } do |f| %>
       <div class="form-group">
         <%= f.text_field :remove_org_credits, placeholder: "#", size: 5, class: "form-control mr-3" %>
         <%= f.text_field :new_note, placeholder: "Why are you removing these credits?", size: 50, required: true, class: "form-control mr-3" %>

--- a/app/views/internal/users/_credits.erb
+++ b/app/views/internal/users/_credits.erb
@@ -4,8 +4,6 @@
     <hr>
     <h4 class="mt-3"><%= @user.username %></h4>
     <p>Available User Credits: <%= @user.unspent_credits_count %></p>
-
-    <h3>Add Credits</h3>
     <%= form_for [:internal, @user], html: { class: "form-inline justify-content-between mb-2" } do |f| %>
       <div class="form-group">
         <%= f.text_field :add_credits, placeholder: "#", size: 5, class: "form-control mr-3" %>
@@ -13,8 +11,6 @@
       </div>
       <%= f.submit "Add Credits", class: "btn btn-primary" %>
     <% end %>
-
-    <h3>Remove Credits</h3>
     <%= form_for [:internal, @user], html: { class: "form-inline justify-content-between mb-2" } do |f| %>
       <div class="form-group">
         <%= f.text_field :remove_credits, placeholder: "#", size: 5, class: "form-control mr-3" %>
@@ -25,30 +21,23 @@
     <hr>
   </div>
   <div class="col-12">
-    <% @organizations.sort.each do |org| %>
-      <h4 class="mt-3"><%= org.name %></h4>
-      <p>Available <%= org.name %> Credits: <%= org.unspent_credits_count %></p>
-
-      <h3>Add Org Credits</h3>
-      <%= form_for [:internal, @user], html: { class: "form-inline justify-content-between mb-2" } do |f| %>
-        <div class="form-group">
-          <%= f.hidden_field :organization_id, value: org.id %>
-          <%= f.text_field :add_org_credits, placeholder: "#", size: 5, class: "form-control mr-3" %>
-          <%= f.text_field :new_note, placeholder: "Why are you adding these credits?", size: 50, required: true, class: "form-control" %>
-        </div>
-        <%= f.submit "Add Org Credits", class: "btn btn-primary" %>
-      <% end %>
-
-      <h3>Remove Org Credits</h3>
-      <%= form_for [:internal, @user], html: { class: "form-inline justify-content-between mb-2" } do |f| %>
-        <div class="form-group">
-          <%= f.hidden_field :organization_id, value: org.id %>
-          <%= f.text_field :remove_org_credits, placeholder: "#", size: 5, class: "form-control mr-3" %>
-          <%= f.text_field :new_note, placeholder: "Why are you removing these credits?", size: 50, required: true, class: "form-control" %>
-        </div>
-        <%= f.submit "Remove Org Credits", class: "btn btn-danger" %>
-      <% end %>
-      <hr>
+    <h4>Organizations</h4>
+    <%= form_with scope: :user, url: internal_user_path(@user), html: { class: "form-inline justify-content-between mb-2" }, local: true, method: :patch do |f| %>
+      <div class="form-group">
+        <%= f.text_field :add_org_credits, placeholder: "#", size: 5, class: "form-control mr-3" %>
+        <%= f.text_field :new_note, placeholder: "Why are you adding these credits?", size: 50, required: true, class: "form-control mr-3" %>
+        <%= f.collection_select :organization_id, @organizations, :id, :name, {}, { class: 'form-control' } %>
+      </div>
+      <%= f.submit "Add Org Credits", class: "btn btn-primary" %>
+    <% end %> 
+    <%= form_with scope: :user, url: internal_user_path(@user), html: { class: "form-inline justify-content-between mb-2" }, local: true, method: :patch do |f| %>
+      <div class="form-group">
+        <%= f.text_field :remove_org_credits, placeholder: "#", size: 5, class: "form-control mr-3" %>
+        <%= f.text_field :new_note, placeholder: "Why are you removing these credits?", size: 50, required: true, class: "form-control mr-3" %>
+        <%= f.collection_select :organization_id, @organizations, :id, :name, {}, { class: 'form-control' } %>
+      </div>
+      <%= f.submit "Remove Org Credits", class: "btn btn-danger" %>
     <% end %>
+    <hr>
   </div>
 </div>

--- a/app/views/internal/users/_notes.erb
+++ b/app/views/internal/users/_notes.erb
@@ -1,12 +1,9 @@
 <div class="row">
   <div class="col-12">
-    <h2>Notes</h2>
+    <h2>Recent Notes</h2>
 
-    <%# notes are going to be iterated upon in the following line,
-        thus we can preload them, to avoid a second SELECT COUNT(*)
-        that would instead happen when ActiveRecord calls .each on a collection #%>
-    <% if @user.notes.load.size > 0 %>
-      <% @user.notes.each do |note| %>
+    <% if @notes.any? %>
+      <% @notes.each do |note| %>
         <p><em><%= note.created_at.strftime("%d %B %Y %H:%M UTC") %> by <%= User.find(note.author_id).username if note.author_id.present? %></em> -
           <% if !note.reason.blank? %><strong><%= note.reason %>:</strong>
           <% end %><%= note.content %></p>

--- a/app/views/internal/users/_notes.erb
+++ b/app/views/internal/users/_notes.erb
@@ -1,17 +1,23 @@
 <div class="row">
   <div class="col-12">
-    <h2>Recent Notes</h2>
+    <h2>Recent Notes (last 10)</h2>
 
-    <% if @notes.any? %>
+    <% unless @notes.load.empty? %>
       <% @notes.each do |note| %>
-        <p><em><%= note.created_at.strftime("%d %B %Y %H:%M UTC") %> by <%= User.find(note.author_id).username if note.author_id.present? %></em> -
-          <% if !note.reason.blank? %><strong><%= note.reason %>:</strong>
-          <% end %><%= note.content %></p>
+        <p>
+          <em>
+            <%= note.created_at.strftime("%d %B %Y %H:%M UTC") %> by <%= User.find(note.author_id).username if note.author_id.present? %>
+          </em> - 
+          <% unless note.reason.blank? %>
+            <strong><%= note.reason %>:</strong>
+          <% end %>
+          <%= note.content %>
+        </p>
       <% end %>
     <% else %>
       <p><em>No notes yet!</em></p>
     <% end %>
-    <%= form_for [:internal, @user], html: { class: "mb-2" }  do |f| %>
+    <%= form_with model: @user, url: internal_user_path(@user), method: :patch, html: { class: "mb-2" }, local: true  do |f| %>
       <div class="form-group">
         <%= f.label "Add new note: ", class: "d-block" %>
         <%= f.text_area :new_note, class: "form-control" %>

--- a/app/views/internal/users/_user_organizations.html.erb
+++ b/app/views/internal/users/_user_organizations.html.erb
@@ -2,7 +2,7 @@
   <div class="col-12">
     <h2>Organization Memberships</h2>
     <h3>Add to New Organization</h3>
-    <%= form_for [:internal, OrganizationMembership.new], html: { class: "form-inline justify-content-between my-3" } do |f| %>
+    <%= form_with model: [:internal, OrganizationMembership.new], local: true, html: { class: "form-inline justify-content-between my-3" } do |f| %>
       <%= f.hidden_field :user_id, value: @user.id %>
       <div class="form-group">
         <%= f.label "Organization ID:", class: "mr-3" %>
@@ -14,7 +14,7 @@
         <%= f.submit "Add to Org", class: "btn btn-primary" %>
       </div>
     <% end %>
-    <% if @organization_memberships.any? %>
+    <% unless @organization_memberships.load.empty? %>
       <h3>Manage Memberships</h3>
       <table class='table'>
         <tbody>
@@ -26,7 +26,7 @@
                 </a>
               </td>
               <td>
-                <%= form_for [:internal, org_membership], html: { class: "form-inline justify-content-between" } do |f| %>
+                <%= form_with model: [:internal, org_membership], method: :patch, local: true, html: { class: "form-inline justify-content-between" } do |f| %>
                   <div class="form-group">
                     <%= f.label "Permission Level:", class: "mr-3" %>
                     <%= f.select("type_of_user", options_for_select(%w[member admin], selected: org_membership.type_of_user)) %>
@@ -35,7 +35,7 @@
                 <% end %>
               </td>
               <td>
-                <%= form_for([:internal, org_membership], html: { method: :delete, class: "d-flex justify-content-end" }) do |f| %>
+                <%= form_with model: [:internal, org_membership], method: :delete, local: true, html: { class: "d-flex justify-content-end" } do |f| %>
                   <%= f.submit "Remove From Org", class: "btn btn-danger", data: { confirm: "Are you sure you want to remove them from #{org_membership.organization.name}?" } %>
                 <% end %>
               </td>

--- a/app/views/internal/users/_user_organizations.html.erb
+++ b/app/views/internal/users/_user_organizations.html.erb
@@ -14,27 +14,35 @@
         <%= f.submit "Add to Org", class: "btn btn-primary" %>
       </div>
     <% end %>
-    <% if @user.organization_memberships.size.positive? %>
+    <% if @organization_memberships.any? %>
       <h3>Manage Memberships</h3>
-      <hr>
-      <% @user.organization_memberships.includes(:organization).each do |org_membership| %>
-        <h3>
-          <a href="<%= org_membership.organization.path %>" target="_blank" rel="noopener">
-            <%= org_membership.organization.name %>
-          </a>
-        </h3>
-        <%= form_for [:internal, org_membership], html: { class: "form-inline justify-content-between" } do |f| %>
-          <div class="form-group">
-            <%= f.label "Permission Level:", class: "mr-3" %>
-            <%= f.select("type_of_user", options_for_select(%w[member admin], selected: org_membership.type_of_user)) %>
-          </div>
-          <%= f.submit "Update Permissions", class: "btn btn-primary " %>
-        <% end %>
-        <%= form_for([:internal, org_membership], html: { method: :delete, onsubmit: "return confirm('Are you sure you want to remove them from #{org_membership.organization.name}?)", class: "d-flex justify-content-end my-2" }) do |f| %>
-          <%= f.submit "Remove From Org", class: "btn btn-danger" %>
-        <% end %>
-        <hr>
-      <% end %>
+      <table class='table'>
+        <tbody>
+          <% @organization_memberships.each do |org_membership| %>
+            <tr>
+              <td>
+                <a href="<%= org_membership.organization.path %>" target="_blank" rel="noopener">
+                  <h3><%= org_membership.organization.name %></h3>
+                </a>
+              </td>
+              <td>
+                <%= form_for [:internal, org_membership], html: { class: "form-inline justify-content-between" } do |f| %>
+                  <div class="form-group">
+                    <%= f.label "Permission Level:", class: "mr-3" %>
+                    <%= f.select("type_of_user", options_for_select(%w[member admin], selected: org_membership.type_of_user)) %>
+                  </div>
+                  <%= f.submit "Update Permissions", class: "btn btn-primary " %>
+                <% end %>
+              </td>
+              <td>
+                <%= form_for([:internal, org_membership], html: { method: :delete, class: "d-flex justify-content-end" }) do |f| %>
+                  <%= f.submit "Remove From Org", class: "btn btn-danger", data: { confirm: "Are you sure you want to remove them from #{org_membership.organization.name}?" } %>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
     <% end %>
   </div>
 </div>

--- a/app/views/internal/users/edit.html.erb
+++ b/app/views/internal/users/edit.html.erb
@@ -8,7 +8,7 @@
   </div>
 </div>
 
-<%= render "internal/users/activity" %>
+<%= render "activity" %>
 
 <div class="row">
   <div class="col-12">


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
 The `/internal/users/{id}` could be very costly to load for users with many notes and organizations, since it was loading all notes and organizations and memberships.

Changes:
- Use counter caches instead of counting from databases. (activities)
- Refactor organization credit UI to one form with select, instead of many forms.
- Loads only 10 most recent notes for the user. (I could add a link to a users/{id}/notes if you guys use that information a lot)
- Refactor Membership UI into a table to minimize screen space usage.


## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/issues/6674

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![Screen Shot 2020-03-29 at 20 43 07](https://user-images.githubusercontent.com/141650/77857485-02278e00-71fe-11ea-9d5e-2ed68569512e.png)
![Screen Shot 2020-03-29 at 20 43 23](https://user-images.githubusercontent.com/141650/77857486-02c02480-71fe-11ea-8111-38d4349436f4.png)
![Screen Shot 2020-03-29 at 20 43 34](https://user-images.githubusercontent.com/141650/77857494-123f6d80-71fe-11ea-9ae3-a4b344171112.png)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
No.

## [optional] What gif best describes this PR or how it makes you feel?

![Okey](https://media.giphy.com/media/kRXnZwKrPTwVq/giphy.gif)
