### PR TITLE
Index Reading List Reactions 

### DIFF
--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -31,8 +31,8 @@ class Reaction < ApplicationRecord
   before_save :assign_points
   after_create_commit :record_field_test_event
   after_commit :async_bust, :bust_reactable_cache, :update_reactable
-  after_commit :index_to_elasticsearch, if: proc { |r| r.category == "readinglist" && r.reactable && r.reactable.published }, on: %i[create update]
-  after_commit :remove_from_elasticsearch, if: proc { |r| r.category == "readinglist" && r.reactable && r.reactable.published }, on: [:destroy]
+  after_commit :index_to_elasticsearch, if: :indexable?, on: %i[create update]
+  after_commit :remove_from_elasticsearch, if: :indexable?, on: [:destroy]
   after_save :index_to_algolia
   after_save :touch_user
   before_destroy :update_reactable_without_delay, unless: :destroyed_by_association
@@ -107,6 +107,10 @@ class Reaction < ApplicationRecord
   end
 
   private
+
+  def indexable?
+    category == "readinglist" && reactable && reactable.published
+  end
 
   def touch_user
     user.touch

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -30,6 +30,8 @@ class Reaction < ApplicationRecord
   before_save :assign_points
   after_create_commit :record_field_test_event
   after_commit :async_bust, :bust_reactable_cache, :update_reactable
+  after_commit :index_to_elasticsearch, if: proc { |r| r.category == "readinglist" && r.reactable && r.reactable.published }, on: %i[create update]
+  after_commit :remove_from_elasticsearch, if: proc { |r| r.category == "readinglist" && r.reactable && r.reactable.published }, on: [:destroy]
   after_save :index_to_algolia
   after_save :touch_user
   before_destroy :update_reactable_without_delay, unless: :destroyed_by_association

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -19,6 +19,7 @@ class Reaction < ApplicationRecord
   counter_culture :user
 
   scope :positive, -> { where("points > ?", 0) }
+  scope :readinglist, -> { where(category: "readinglist") }
 
   validates :category, inclusion: { in: CATEGORIES }
   validates :reactable_type, inclusion: { in: REACTABLE_TYPES }

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -46,6 +46,43 @@ RSpec.describe Article, type: :model do
       end
     end
 
+    describe "#after_update_commit" do
+      it "if article is unpublished removes reading list reactions from index" do
+        reaction = create(:reaction, reactable: article, category: "readinglist")
+        sidekiq_perform_enqueued_jobs
+        expect(reaction.elasticsearch_doc).not_to be_nil
+
+        unpublished_body = "---\ntitle: Hellohnnnn#{rand(1000)}\npublished: false\ntags: hiring\n---\n\nHello"
+        article.update(body_markdown: unpublished_body)
+        sidekiq_perform_enqueued_jobs
+        expect { reaction.elasticsearch_doc }.to raise_error(Search::Errors::Transport::NotFound)
+      end
+
+      it "if article is published indexes reading list reactions" do
+        reaction = create(:reaction, reactable: article, category: "readinglist")
+        sidekiq_perform_enqueued_jobs
+        unpublished_body = "---\ntitle: Hellohnnnn#{rand(1000)}\npublished: false\ntags: hiring\n---\n\nHello"
+        article.update(body_markdown: unpublished_body)
+        sidekiq_perform_enqueued_jobs
+        expect { reaction.elasticsearch_doc }.to raise_error(Search::Errors::Transport::NotFound)
+
+        published_body = "---\ntitle: Hellohnnnn#{rand(1000)}\npublished: true\ntags: hiring\n---\n\nHello"
+        article.update(body_markdown: published_body)
+        sidekiq_perform_enqueued_jobs
+        expect(reaction.elasticsearch_doc).not_to be_nil
+      end
+
+      it "indexes reaction if a REACTION_INDEXED_FIELDS is changed" do
+        reaction = create(:reaction, reactable: article, category: "readinglist")
+        allow(article).to receive(:index_to_elasticsearch)
+        allow(article.user).to receive(:index_to_elasticsearch)
+
+        sidekiq_assert_enqueued_with(job: Search::IndexToElasticsearchWorker, args: ["Reaction", reaction.search_id]) do
+          article.update(body_markdown: "---\ntitle: NEW TITLE#{rand(1000)}\n")
+        end
+      end
+    end
+
     context "when published" do
       before do
         # rubocop:disable RSpec/NamedSubject

--- a/spec/models/reaction_spec.rb
+++ b/spec/models/reaction_spec.rb
@@ -68,6 +68,61 @@ RSpec.describe Reaction, type: :model do
     end
   end
 
+  describe "#after_commit" do
+    context "when category is readingList and reactable is published" do
+      it "on update enqueues job to index reaction to elasticsearch" do
+        reaction.save
+        sidekiq_assert_enqueued_with(job: Search::IndexToElasticsearchWorker, args: [described_class.to_s, reaction.id]) do
+          reaction.update(category: "readinglist")
+        end
+      end
+
+      it "on create enqueues job to index reaction to elasticsearch" do
+        reaction.category = "readinglist"
+        sidekiq_assert_enqueued_with(job: Search::IndexToElasticsearchWorker) do
+          reaction.save
+        end
+      end
+
+      it "on destroy enqueues job to delete reaction from elasticsearch" do
+        reaction.category = "readinglist"
+        reaction.save
+        sidekiq_assert_enqueued_with(job: Search::RemoveFromElasticsearchIndexWorker, args: [described_class::SEARCH_CLASS.to_s, reaction.id]) do
+          reaction.destroy
+        end
+      end
+    end
+
+    context "when category is not readinglist" do
+      before do
+        reaction.category = "like"
+        allow(reaction.user).to receive(:index_to_elasticsearch)
+        allow(reaction.reactable).to receive(:index_to_elasticsearch)
+        sidekiq_perform_enqueued_jobs
+      end
+
+      it "on update does not enqueue job to index reaction to elasticsearch" do
+        reaction.save
+        sidekiq_assert_no_enqueued_jobs(only: Search::IndexToElasticsearchWorker) do
+          reaction.update(category: "unicorn")
+        end
+      end
+
+      it "on create does not enqueue job to index reaction to elasticsearch" do
+        sidekiq_assert_no_enqueued_jobs(only: Search::IndexToElasticsearchWorker) do
+          reaction.save
+        end
+      end
+
+      it "on destroy does not enqueue job to delete reaction from elasticsearch" do
+        reaction.save
+        sidekiq_assert_no_enqueued_jobs(only: Search::RemoveFromElasticsearchIndexWorker) do
+          reaction.destroy
+        end
+      end
+    end
+  end
+
   describe "#skip_notification_for?" do
     let_it_be(:receiver) { build(:user) }
     let_it_be(:reaction) { build(:reaction, reactable: build(:article), user: nil) }


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Feature

## Description
This PR begins indexing reactions to Elasticsearch. As I have done in the past I am not including a full reindex DataUpdate Worker in this PR bc I want to make sure I am not missing anything which I usually find out when I implement search 😉 

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-35297922

## Added tests?
- [x] yes

![alt_text](https://media1.tenor.com/images/86166be9b3a674826f1e61a40795bd9e/tenor.gif?itemid=13243304)
