### PR TITLE
Fixing Crayons indicators

### DIFF
--- a/app/assets/stylesheets/components/indicators.scss
+++ b/app/assets/stylesheets/components/indicators.scss
@@ -13,6 +13,7 @@
 @mixin indicator($this, $name, $color-1, $color-2) {
   &#{'--' + $name} {
     background-color: $color-1;
+    border-color: $color-1;
     color: $color-2;
 
     &#{$this + '--outlined'} {
@@ -27,22 +28,33 @@
 .crayons-indicator {
   font-family: $ff-accent;
   font-size: $fs-xs;
-  padding: $su-1;
+  padding: 0.3335em 0.25em;
   background-color: var(--indicator-default-bg);
+  border: 1px solid var(--indicator-default-bg);
   color: var(--indicator-default-color);
   text-align: center;
-  line-height: $lh-tight;
+  line-height: 1;
   border-radius: $br-default;
   display: inline-block;
 
   &--outlined {
     background-color: transparent;
-    border: 1px solid var(--indicator-default-bg);
+    border-color: var(--indicator-default-bg);
     color: var(--indicator-default-color);
   }
 
-  @include indicator(&, accent, var(--indicator-accent-bg), var(--indicator-accent-color));
-  @include indicator(&, critical, var(--indicator-critical-bg), var(--indicator-critical-color));
+  @include indicator(
+    &,
+    accent,
+    var(--indicator-accent-bg),
+    var(--indicator-accent-color)
+  );
+  @include indicator(
+    &,
+    critical,
+    var(--indicator-critical-bg),
+    var(--indicator-critical-color)
+  );
 
   // Circle, no text
   &--bullet {

--- a/app/assets/stylesheets/components/indicators.scss
+++ b/app/assets/stylesheets/components/indicators.scss
@@ -28,7 +28,7 @@
 .crayons-indicator {
   font-family: $ff-accent;
   font-size: $fs-xs;
-  padding: 0.3335em 0.25em;
+  padding: $su-1;
   background-color: var(--indicator-default-bg);
   border: 1px solid var(--indicator-default-bg);
   color: var(--indicator-default-color);

--- a/app/assets/stylesheets/components/indicators.scss
+++ b/app/assets/stylesheets/components/indicators.scss
@@ -10,10 +10,11 @@
 // @param {string} $name          Value for border-radius
 // @param {color} $color-1        Main color.
 
-@mixin indicator($this, $name, $color-1) {
+@mixin indicator($this, $name, $color-1, $color-2) {
   &#{'--' + $name} {
     background-color: $color-1;
-    color: var(--body-color-inverted);
+    color: $color-2;
+
     &#{$this + '--outlined'} {
       background-color: transparent;
       color: $color-1;
@@ -27,7 +28,8 @@
   font-family: $ff-accent;
   font-size: $fs-xs;
   padding: $su-1;
-  background-color: var(--button-secondary-bg);
+  background-color: var(--indicator-default-bg);
+  color: var(--indicator-default-color);
   text-align: center;
   line-height: $lh-tight;
   border-radius: $br-default;
@@ -35,14 +37,12 @@
 
   &--outlined {
     background-color: transparent;
-    border: 1px solid var(--button-secondary-bg);
-    color: var(--button-secondary-color);
+    border: 1px solid var(--indicator-default-bg);
+    color: var(--indicator-default-color);
   }
 
-  @include indicator(&, accent, var(--accent-brand));
-  @include indicator(&, critical, var(--accent-danger));
-  @include indicator(&, success, var(--accent-success));
-  @include indicator(&, inverted, var(--widget-color));
+  @include indicator(&, accent, var(--indicator-accent-bg), var(--indicator-accent-color));
+  @include indicator(&, critical, var(--indicator-critical-bg), var(--indicator-critical-color));
 
   // Circle, no text
   &--bullet {

--- a/app/assets/stylesheets/config/_colors.scss
+++ b/app/assets/stylesheets/config/_colors.scss
@@ -130,4 +130,12 @@
   // Default box
   --box: var(--base-90);
   --box-darker: var(--base-100);
+
+  // Indicators
+  --indicator-accent-bg: var(--accent-brand);
+  --indicator-accent-color: var(--body-color-inverted);
+  --indicator-critical-bg: var(--accent-danger);
+  --indicator-critical-color: var(--body-color-inverted);
+  --indicator-default-bg: var(--button-secondary-bg);
+  --indicator-default-color: var(--button-secondary-color);
 }

--- a/app/assets/stylesheets/themes/minimal.scss
+++ b/app/assets/stylesheets/themes/minimal.scss
@@ -120,4 +120,12 @@
   // Default box
   --box: var(--base-90);
   --box-darker: var(--base-100);
+
+  // Indicators
+  --indicator-accent-bg: var(--accent-brand);
+  --indicator-accent-color: var(--body-color-inverted);
+  --indicator-critical-bg: var(--accent-danger);
+  --indicator-critical-color: var(--body-color-inverted);
+  --indicator-default-bg: var(--button-secondary-bg);
+  --indicator-default-color: var(--button-secondary-color);
 }

--- a/app/assets/stylesheets/themes/night.scss
+++ b/app/assets/stylesheets/themes/night.scss
@@ -120,4 +120,12 @@
   // Default box
   --box: var(--base-90);
   --box-darker: var(--base-100);
+
+  // Indicators
+  --indicator-accent-bg: var(--accent-brand);
+  --indicator-accent-color: var(--body-color);
+  --indicator-critical-bg: var(--accent-danger);
+  --indicator-critical-color: var(--body-color);
+  --indicator-default-bg: var(--button-secondary-bg);
+  --indicator-default-color: var(--button-secondary-color);
 }

--- a/app/assets/stylesheets/themes/pink.scss
+++ b/app/assets/stylesheets/themes/pink.scss
@@ -120,4 +120,12 @@
   // Default box
   --box: var(--container-bg);
   --box-darker: var(--base-100);
+
+  // Indicators
+  --indicator-accent-bg: var(--link-brand-color);
+  --indicator-accent-color: var(--body-color-inverted);
+  --indicator-critical-bg: var(--base-80);
+  --indicator-critical-color: var(--body-color-inverted);
+  --indicator-dimmed-bg: var(--base-30);
+  --indicator-dimmed-color: var(--base-70);
 }

--- a/app/views/layouts/_top_bar.html.erb
+++ b/app/views/layouts/_top_bar.html.erb
@@ -32,7 +32,7 @@
       
       <a href="/connect" id="connect-link" class="top-bar__link" aria-label="Connect">
         <%= inline_svg_tag("connect.svg", aria: true, class: "crayons-icon", title: "Connect") %>
-        <span class="crayons-indicator crayons-indicator--success hidden" id="connect-number"></span>
+        <span class="crayons-indicator crayons-indicator--accent hidden" id="connect-number"></span>
       </a>
       <a href="/notifications" id="notifications-link" class="top-bar__link" aria-label="Notifications">
         <%= inline_svg_tag("bell.svg", aria: true, class: "crayons-icon", title: "Notifications") %>

--- a/app/views/pages/crayons.html.erb
+++ b/app/views/pages/crayons.html.erb
@@ -811,12 +811,11 @@
       <li>Rectangle with label (text or number)</li>
       <li>Bullet - just a circle without any text on it.</li>
     </ul>
-    <p>And there're four styles to pick from:</p>
+    <p>And there're 3 styles to pick from:</p>
     <ul>
-      <li>Default (grey) - nothing really crucial, basic information about something.</li>
-      <li>Accent (blueish) - something we want user to be aware of but it's also not crucial information</li>
+      <li>Default (dimmed grey) - nothing really crucial, basic information about something.</li>
+      <li>Accent - something we want user to be aware of but it's also not crucial information</li>
       <li>Critical (red) - something super important, don't overuse it!!</li>
-      <li>Inverted (dark grey) - alternative to the default one, especially when we need to show two defautl indicators next to each other.</li>
     </ul>
   </div>
   <div>
@@ -828,23 +827,16 @@
 
   <div>
     <span class="crayons-indicator crayons-indicator--accent">Label</span>
-    <span class="crayons-indicator crayons-indicator--outlined crayons-indicator--accent">Outlined</span>
+    <span class="crayons-indicator crayons-indicator--accent crayons-indicator--outlined">Outlined</span>
     <span class="crayons-indicator crayons-indicator--accent">1</span>
     <span class="crayons-indicator crayons-indicator--accent crayons-indicator--bullet"></span>
   </div>
 
   <div>
     <span class="crayons-indicator crayons-indicator--critical">Label</span>
-    <span class="crayons-indicator crayons-indicator--outlined crayons-indicator--critical">Outlined</span>
+    <span class="crayons-indicator crayons-indicator--critical crayons-indicator--outlined">Outlined</span>
     <span class="crayons-indicator crayons-indicator--critical">1</span>
     <span class="crayons-indicator crayons-indicator--critical crayons-indicator--bullet"></span>
-  </div>
-
-  <div>
-    <span class="crayons-indicator crayons-indicator--inverted">Label</span>
-    <span class="crayons-indicator crayons-indicator--outlined crayons-indicator--inverted">Outlined</span>
-    <span class="crayons-indicator crayons-indicator--inverted">1</span>
-    <span class="crayons-indicator crayons-indicator--inverted crayons-indicator--bullet"></span>
   </div>
 
   <pre><%='
@@ -852,10 +844,9 @@
   <span class="crayons-indicator">1</span>
   <span class="crayons-indicator crayons-indicator--bullet"></span>
 
-  <!-- styles: accent, critical, inverted -->
+  <!-- styles: accent, critical -->
   <span class="... crayons-indicator--accent">...</span>
   <span class="... crayons-indicator--critical">...</span>
-  <span class="... crayons-indicator--inverted">...</span>
   '.rstrip %></pre>
 </div>
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Optimization

## Description

This PR is meant to fix some coloring issues for Crayons' indicators. They were looking a a little off on certain themes. I have also introduced variables for these colors.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![image](https://user-images.githubusercontent.com/108287/77997217-4d8d8980-732f-11ea-8f41-2b86ec70d74a.png)

## Added to documentation?

- [x] no documentation needed