### PR TITLE
Prompt new users to customize their experience 

### DIFF
--- a/app/services/broadcasts/welcome_notification/generator.rb
+++ b/app/services/broadcasts/welcome_notification/generator.rb
@@ -16,7 +16,7 @@ module Broadcasts
 
         send_welcome_notification unless notification_enqueued
         send_authentication_notification unless notification_enqueued
-        send_customize_notification unless notification_enqueued
+        send_ux_customization_notification unless notification_enqueued
       end
 
       private
@@ -37,7 +37,7 @@ module Broadcasts
         @notification_enqueued = true
       end
 
-      def send_customize_notification
+      def send_ux_customization_notification
         return if received_notification?(customize_broadcast) || user.created_at > 5.days.ago
 
         Notification.send_welcome_notification(user.id, customize_broadcast.id)

--- a/app/services/broadcasts/welcome_notification/generator.rb
+++ b/app/services/broadcasts/welcome_notification/generator.rb
@@ -53,15 +53,19 @@ module Broadcasts
         @welcome_broadcast ||= Broadcast.find_by(title: "Welcome Notification: welcome_thread")
       end
 
+      def customize_ux_broadcast
+        @customize_ux_broadcast ||= Broadcast.find_by(title: "Welcome Notification: customize_experience")
+      end
+
       def identities
         @identities ||= user.identities.where(provider: SiteConfig.authentication_providers)
       end
 
       def authentication_broadcast
-        @authentication_broadcast ||= find_broadcast
+        @authentication_broadcast ||= find_auth_broadcast
       end
 
-      def find_broadcast
+      def find_auth_broadcast
         missing_identities = SiteConfig.authentication_providers.map do |provider|
           identities.exists?(provider: provider) ? nil : "#{provider}_connect"
         end.compact

--- a/app/services/broadcasts/welcome_notification/generator.rb
+++ b/app/services/broadcasts/welcome_notification/generator.rb
@@ -16,6 +16,7 @@ module Broadcasts
 
         send_welcome_notification unless notification_enqueued
         send_authentication_notification unless notification_enqueued
+        send_customize_notification unless notification_enqueued
       end
 
       private
@@ -36,6 +37,13 @@ module Broadcasts
         @notification_enqueued = true
       end
 
+      def send_customize_notification
+        return if received_notification?(customize_broadcast) || user.created_at > 5.days.ago
+
+        Notification.send_welcome_notification(user.id, customize_broadcast.id)
+        @notification_enqueued = true
+      end
+
       def received_notification?(broadcast)
         Notification.exists?(notifiable: broadcast, user: user)
       end
@@ -53,8 +61,8 @@ module Broadcasts
         @welcome_broadcast ||= Broadcast.find_by(title: "Welcome Notification: welcome_thread")
       end
 
-      def customize_ux_broadcast
-        @customize_ux_broadcast ||= Broadcast.find_by(title: "Welcome Notification: customize_experience")
+      def customize_broadcast
+        @customize_broadcast ||= Broadcast.find_by(title: "Welcome Notification: customize_experience")
       end
 
       def identities

--- a/app/views/notifications/_broadcast.html.erb
+++ b/app/views/notifications/_broadcast.html.erb
@@ -10,7 +10,7 @@
     <%= json_data["broadcast"]["processed_html"].html_safe %>
 
     <% if notification.json_data['broadcast']['type_of'] == "Welcome" %>
-      <div class="opt-out"><a href="<%= user_settings_path(tab: :notifications) %>">Go to your settings to manage your notification settings.</a></<div>
+      <div class="opt-out"><a href="<%= user_settings_path(tab: :notifications) %>">Go to your settings to manage your notification settings.</a></div>
     <% end %>
   </div>
 <% end %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -249,7 +249,8 @@ broadcast_messages = {
   set_up_profile: "Welcome to DEV! 👋 I'm Sloan, the community mascot and I'm here to help get you started. Let's begin by <a href='/settings'>setting up your profile</a>!",
   welcome_thread: "Sloan here again! 👋 DEV is a friendly community. Why not introduce yourself by leaving a comment in <a href='/welcome'>the welcome thread</a>!",
   twitter_connect: "You're on a roll! 🎉 Let's connect your <a href='/settings'> Twitter account</a> to complete your identity so that we don't think you're a robot. 🤖",
-  github_connect: "You're on a roll! 🎉 Let's connect your <a href='/settings'> GitHub account</a> to complete your identity so that we don't think you're a robot. 🤖"
+  github_connect: "You're on a roll! 🎉 Let's connect your <a href='/settings'> GitHub account</a> to complete your identity so that we don't think you're a robot. 🤖",
+  customize_experience: "Sloan here! 👋 Did you know that that you can customize your DEV experience? Try changing <a href='settings/ux'>your font and theme</a> and find the best style for you!"
 }
 
 broadcast_messages.each do |type, message|

--- a/spec/factories/broadcasts.rb
+++ b/spec/factories/broadcasts.rb
@@ -20,6 +20,12 @@ FactoryBot.define do
       processed_html { "You're on a roll! 🎉 Let's connect your <a href='/settings'> GitHub account</a> to complete your identity so that we don't think you're a robot. 🤖" }
     end
 
+    factory :customize_broadcast do
+      title          { "Welcome Notification: customize_experience" }
+      type_of        { "Welcome" }
+      processed_html { "Sloan here! 👋 Did you know that that you can customize your DEV experience? Try changing <a href='settings/ux'>your font and theme</a> and find the best style for you!" }
+    end
+
     # TODO: [@thepracticaldev/delightful] Remove onboarding factory once welcome notifications are live.
     factory :onboarding_broadcast do
       title          { "Welcome Notification" }

--- a/spec/services/broadcasts/welcome_notification/generator_spec.rb
+++ b/spec/services/broadcasts/welcome_notification/generator_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Broadcasts::WelcomeNotification::Generator, type: :service do
     end
   end
 
-  describe "#send_customize_notification" do
+  describe "#send_ux_customization_notification" do
     # Ensure that the user is already authenticated with all providers and has commented on the
     # welcome thread so that we can actually trigger just the customize notification only.
     let(:user) { create(:user, :with_identity, identities: %w[twitter github], created_at: 5.days.ago) }
@@ -122,19 +122,19 @@ RSpec.describe Broadcasts::WelcomeNotification::Generator, type: :service do
 
     it "does not send a notification to a newly-created user" do
       user.update!(created_at: Time.zone.now)
-      sidekiq_perform_enqueued_jobs { described_class.new(user.id).send(:send_customize_notification) }
+      sidekiq_perform_enqueued_jobs { described_class.new(user.id).send(:send_ux_customization_notification) }
       expect(Notification).not_to have_received(:send_welcome_notification)
     end
 
     it "generates the correct broadcast type and sends the notification to the user" do
-      sidekiq_perform_enqueued_jobs { described_class.new(user.id).send(:send_customize_notification) }
+      sidekiq_perform_enqueued_jobs { described_class.new(user.id).send(:send_ux_customization_notification) }
       expect(user.notifications.first.notifiable).to eq(customize_broadcast)
       expect(Notification).to have_received(:send_welcome_notification).with(user.id, customize_broadcast.id)
     end
 
     it "does not send duplicate notifications" do
       2.times do
-        sidekiq_perform_enqueued_jobs { described_class.new(user.id).send(:send_customize_notification) }
+        sidekiq_perform_enqueued_jobs { described_class.new(user.id).send(:send_ux_customization_notification) }
       end
       expect(user.notifications.count).to eq(1)
       expect(Notification).to have_received(:send_welcome_notification).with(user.id, customize_broadcast.id).exactly(:once)


### PR DESCRIPTION
What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Adds a "customize your experience" welcome notification, which will be sent out 5 days after a user has signed up.

Also fixes an HTML typo, and cleans up some specs/renames some methods for clarity.

**Please note that once this PR is approved, I will add the appropriate broadcast to the `/internal/broadcasts` page!**

## Related Tickets & Documents
Closes #6707

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

<img width="1438" alt="Screen Shot 2020-03-30 at 2 25 31 PM" src="https://user-images.githubusercontent.com/6921610/77963875-00f47080-7293-11ea-8d02-b9b5e96ffc1f.png">


## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed