### PR TITLE
Fix intermittent service worker runtime error 

### DIFF
--- a/app/views/service_worker/index.js.erb
+++ b/app/views/service_worker/index.js.erb
@@ -37,40 +37,45 @@
   function createPageStream(request) {
     const stream = new ReadableStream({
       start(controller) {
-        if (!caches.match('/shell_top') || !caches.match('/shell_bottom')) { //return if shell isn't cached.
-          return
-        }
+        Promise.all([caches.match('/shell_top'), caches.match('/shell_bottom')])
+          .then((cachedShellMatches) => {
+            const cachedShellTop = cachedShellMatches[0];
+            const cachedShellBottom = cachedShellMatches[1];
+            if (!cachedShellTop || !cachedShellBottom) { // return if shell isn't cached.
+              return
+            }
+            // the body url is the request url plus 'include'
+            const url = new URL(request.url);
+            url.searchParams.set('i', 'i'); // Adds ?i=i or &i=i, which is our indicator for "internal" partial page
+            const startFetch = Promise.resolve(cachedShellTop);
+            const endFetch = Promise.resolve(cachedShellBottom);
+            const middleFetch = fetch(url).then(response => {
+              if (!response.ok && response.status === 404) {
+                return caches.match('/404.html');
+              }
+              if (!response.ok && response.status != 404) {
+                return caches.match('/500.html');
+              }
+              return response;
+            }).catch(err => caches.match('/offline.html'));
 
-        // the body url is the request url plus 'include'
-        const url = new URL(request.url);
-        url.searchParams.set('i', 'i'); // Adds ?i=i or &i=i, which is our indicator for "internal" partial page
-        const startFetch = caches.match('/shell_top');
-        const endFetch = caches.match('/shell_bottom');
-        const middleFetch = fetch(url).then(response => {
-          if (!response.ok && response.status === 404) {
-            return caches.match('/404.html');
-          }
-          if (!response.ok && response.status != 404) {
-            return caches.match('/500.html');
-          }
-          return response;
-        }).catch(err => caches.match('/offline.html'));
+            function pushStream(stream) {
+              const reader = stream.getReader();
+              return reader.read().then(function process(result) {
+                if (result.done) return;
+                controller.enqueue(result.value);
+                return reader.read().then(process);
+              });
+            }
+            startFetch
+              .then(response => pushStream(response.body))
+              .then(() => middleFetch)
+              .then(response => pushStream(response.body))
+              .then(() => endFetch)
+              .then(response => pushStream(response.body))
+              .then(() => controller.close());
+          })
 
-        function pushStream(stream) {
-          const reader = stream.getReader();
-          return reader.read().then(function process(result) {
-            if (result.done) return;
-            controller.enqueue(result.value);
-            return reader.read().then(process);
-          });
-        }
-        startFetch
-          .then(response => pushStream(response.body))
-          .then(() => middleFetch)
-          .then(response => pushStream(response.body))
-          .then(() => endFetch)
-          .then(response => pushStream(response.body))
-          .then(() => controller.close());
       }
     });
 


### PR DESCRIPTION
:wrench: :turtle:

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Some short-circuiting :zap: logic in the service worker was checking the truthiness of the result to a call to `caches.match`. The match api, however, is asynchronous and always returns a promise.

Hence, this guard did not accomplish what it was supposed to, and now whenever the cache for `shell_top` or `shell_bottom` is empty, the service worker hits a runtime error that, at least in my experience in Safari, blocks the main page from loading. (See the related bug for my _story_ 📚.)

## Related Tickets & Documents

Inspired by this issue: #5434 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

No UI changes.

## Added tests?

- [ ] yes
- [ ] no, because they aren't needed
- [x] no, because I need help

I've never tested a service worker before `¯\_(ツ)_/¯`, and neither I nor the other users who hit this issue ever actually determined the conditions under which it would occur. All I know is it happened to me enough that I was determined to do something about it 😁 

My point is: This is tricky to test. We'd have to manually invalidate the cache inside the service worker, reload the page, and make sure no error is thrown in the service worker? Or possibly mock the `caches.match` api? At which point it just feels....... overly _mocky_. 

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

Nope.

## [optional] What gif best describes this PR or how it makes you feel?

![Merkel Amusedly Spinning Spinner Thingy](https://media.giphy.com/media/gL9mLbFys7HBo596S8/giphy.gif)
