### PR TITLE
Tweak /internal/broadcast form

### DIFF
--- a/app/views/internal/broadcasts/_form.html.erb
+++ b/app/views/internal/broadcasts/_form.html.erb
@@ -7,10 +7,10 @@
 </div>
 <div class="form-group">
   <%= label_tag :type, "Type:" %>
-  <%= select_tag "type_of", options_for_select(%w[Onboarding Announcement Welcome]) %>
+  <%= select_tag "type_of", options_for_select(%w[Welcome Onboarding Announcement]) %>
 </div>
 <div class="form-group">
   <%= label_tag :active, "Active:" %>
-  <%= select_tag :active, options_for_select([true, false]) %>
+  <%= select_tag :active, options_for_select([false, true]) %>
 </div>
 <br>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Makes a few tweaks to the default options when an admin visits `/internal/broadcasts`. Mostly prompted because I have been adding broadcasts and I keep accidentally setting them to be active!

* Ensure that "active" defaults to `false`.
* Ensure that the broadcast type is set to `"Welcome"` by default.

## Related Tickets & Documents
N/A

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
<img width="1181" alt="Screen Shot 2020-03-30 at 5 50 43 PM" src="https://user-images.githubusercontent.com/6921610/77975599-59d20200-72af-11ea-95fa-063da774cac5.png">


## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
