### PR TITLE
Report ONLY changes in master branch status on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ deploy:
     condition: $TRAVIS_COMMIT_MESSAGE =~ \[deploy\]
 notifications:
   slack:
-    on_pull_requests: false
+    if: branch = master
     on_success: change
     on_failure: always
     rooms:


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
I noticed that in our Slack we are still getting notifications for branches that are not master. I updated our yml file to use [the current suggested method for only getting the master branch](https://docs.travis-ci.com/user/notifications/#conditional-notifications)

## Added tests?
- [x] no, because they aren't needed

![alt_text](https://media.giphy.com/media/h20kL285KDmLzSvqAH/giphy.gif)
