### PR TITLE
Update feed_spec's use of NON_DEFAULT_EXPERIMENTS

### DIFF
--- a/spec/services/articles/feed_spec.rb
+++ b/spec/services/articles/feed_spec.rb
@@ -153,8 +153,8 @@ RSpec.describe Articles::Feed, type: :service do
   describe "all non-default experiments" do
     it "returns articles for all experiments" do
       new_story = create(:article, published_at: 10.minutes.ago, score: 10)
-      NON_DEFAULT_EXPERIMENTS.each do |_method|
-        stories = feed.default_home_feed_with_more_randomness_experiment
+      NON_DEFAULT_EXPERIMENTS.each do |method|
+        stories = feed.send(method)
         expect(stories).to include(old_story)
         expect(stories).to include(new_story)
       end

--- a/spec/services/articles/feed_spec.rb
+++ b/spec/services/articles/feed_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe Articles::Feed, type: :service do
     it "returns articles for all experiments" do
       new_story = create(:article, published_at: 10.minutes.ago, score: 10)
       NON_DEFAULT_EXPERIMENTS.each do |method|
-        stories = feed.send(method)
+        stories = feed.public_send(method)
         expect(stories).to include(old_story)
         expect(stories).to include(new_story)
       end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Spec

## Description
This change seems like the original intention of `NON_DEFAULT_EXPERIMENTS`. This also boosts our test coverage of `Articles::Feed` and reduce the chance of 
```
 codeclimate/total-coverage — 93% (-0.1% change)
```
from appearing on other PRs.
## Related Tickets & Documents
n/a
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
n/a
## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed