### PR TITLE
Reindex Related content when a User name is updated

### DIFF
--- a/app/workers/search/reindex_related_documents.rb
+++ b/app/workers/search/reindex_related_documents.rb
@@ -1,0 +1,12 @@
+module Search
+  class ReindexRelatedDocuments
+    include Sidekiq::Worker
+
+    sidekiq_options queue: :high_priority
+
+    def perform(object_class, object_id, relation)
+      object = object_class.constantize.find(object_id)
+      object.send(relation).find_each(&:index_to_elasticsearch_inline)
+    end
+  end
+end

--- a/spec/workers/search/reindex_related_documents_spec.rb
+++ b/spec/workers/search/reindex_related_documents_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe Search::ReindexRelatedDocuments, type: :worker do
+  let(:worker) { subject }
+
+  include_examples "#enqueues_on_correct_queue", "high_priority", ["User", 1, "articles"]
+
+  it "raises an error if record is not found" do
+    expect { worker.perform("User", 1, "articles") }.to raise_error(ActiveRecord::RecordNotFound)
+  end
+
+  it "indexes related documents" do
+    user = create(:user)
+    article = create(:article, user: user)
+    expect { article.elasticsearch_doc }.to raise_error(Search::Errors::Transport::NotFound)
+    worker.perform(user.class.name, user.id, "articles")
+
+    expect(article.elasticsearch_doc.dig("_source", "id")).to eql(article.search_id)
+  end
+end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
We index and often use a user's name or username when searching for feed content or chat channels so we need to make sure those are updated accordingly when a user's name is updated. Since I don't think changing a name happens a lot I think we are fine not reindexing everything. 

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-35439973

## Added tests?
- [x] yes

![alt_text](https://media3.giphy.com/media/26gsr0Ozsd1iAwYhO/source.gif)
