### PR TITLE
Rearrange order to fix iframe logic

### DIFF
--- a/app/views/layouts/_user_config.html.erb
+++ b/app/views/layouts/_user_config.html.erb
@@ -1,15 +1,5 @@
 <script>
   try {
-    if (navigator.userAgent === 'DEV-Native-ios') {
-      document.getElementsByTagName("body")[0].classList.add("dev-ios-native-body");
-    }
-    if (localStorage.getItem('config_minimize_newest_listings') === 'yes') {
-      document.getElementsByTagName("body")[0].classList.add("config_minimize_newest_listings");
-    }
-    if (window.frameElement) { // Hide top bar and footer when loaded within iframe
-      document.getElementsByTagName("body")[0].classList.add("hidden-shell");
-    }
-
     const bodyClass = localStorage.getItem('config_body_class');
 
     if (bodyClass) {
@@ -33,6 +23,15 @@
         link.href = '<%= asset_path "OpenDyslexic-Regular.otf" %>';
         document.getElementsByTagName('head')[0].appendChild(link);
       }
+    }
+    if (navigator.userAgent === 'DEV-Native-ios') {
+      document.getElementsByTagName("body")[0].classList.add("dev-ios-native-body");
+    }
+    if (localStorage.getItem('config_minimize_newest_listings') === 'yes') {
+      document.getElementsByTagName("body")[0].classList.add("config_minimize_newest_listings");
+    }
+    if (window.frameElement) { // Hide top bar and footer when loaded within iframe
+      document.getElementsByTagName("body")[0].classList.add("hidden-shell");
     }
   } catch(e) {
       Honeybadger.notify(e);


### PR DESCRIPTION


<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We have some logic to hide the top nav if in the context of an iframe. because we use this for spinning up pages in some contexts..

Right now, due to a rearranging of the functions, the logic isn't working and the top bar is showing up _within_ the page, which doesn't make sense.

This was originally rearranged because we were using a guard clause in the original proposal, but if it's a simple `if` statement, there's nothing wrong with it coming after.

<img width="1647" alt="Screen Shot 2020-03-31 at 1 16 39 PM" src="https://user-images.githubusercontent.com/3102842/78055666-dd442f80-7351-11ea-9626-fba4463724b4.png">