### PR TITLE
Set search cache header using the current_user id if present

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -31,7 +31,7 @@ class StoriesController < ApplicationController
   def search
     @query = "...searching"
     @article_index = true
-    set_surrogate_key_header "articles-page-with-query"
+    set_surrogate_key_header "articles-page-with-query-#{current_user&.id}"
     render template: "articles/search"
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
The sidebar HTML uses the current_user.id in order to set a filter for a user's post. However that is cached on the edge in Fastly so we need to make sure the cache key contains the current_user.id if there is one. If not that is fine bc that button is not usable if you are not signed in. It will prompt you to signup

![alt_text](https://media2.giphy.com/media/IWDutASqBHs1q/giphy.gif)
