### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Declare SVG files to have LF endings on checkout
+# On Windows, the default git setting for `core.autocrlf`
+# means that when checking out code, LF endings get converted
+# to CRLF.
+*.svg text eol=lf


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Developer experience

## Description

This PR adds a [`.gitattributes`](https://git-scm.com/docs/gitattributes) file in the root directory, so git will take care of managing the line endings of SVG files it in the future:

```
*.svg text eol=lf
```

When you try to add a file with Windows line endings, you'll see the following message:

```
❯ g a image.svg
warning: CRLF will be replaced by LF in image.svg.
The file will have its original line endings in your working directory
```

## Related Tickets & Documents

Based on a recent [discussion with @rhymes](https://github.com/thepracticaldev/dev.to/pull/6978#discussion_r401075356).

## Added tests?

- [X] no, because they aren't needed

## Added to documentation?

- [X] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![image](https://user-images.githubusercontent.com/47985/78113058-5bbfd080-7429-11ea-9db2-edfd062d8d2d.png)

