### PR TITLE
Replaced themeable with body-color

### DIFF
--- a/app/assets/stylesheets/notifications.scss
+++ b/app/assets/stylesheets/notifications.scss
@@ -104,7 +104,7 @@
             p.badge-credit-message {
               margin: 8px auto;
               width: 100%;
-              @include themeable(color, theme-color, $dark-gray);
+              color: var(--body-color);
               font-size: 0.94em;
               line-height: 1.35em;
               strong a {


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Replaced `@include themeable(color, theme-color, $dark-gray);` with `color: var(--body-color);`.

The issue is that the text is black regardless of the theme. On light themes, it looks fine, but on dark themes, you cannot see the text. See pictures below:

![img-1](https://i.imgur.com/CbJvd9K.png)
![img-2](https://i.imgur.com/OnjERre.png)

Closes #6995

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

The text looks properly now. **I didn't include white/pink themes because the text already works the same with `color: var(--body-color);`**

![img-fixed-1](https://i.imgur.com/vINoQC2.png)
![img-fixed-2](https://i.imgur.com/umw1YO1.png)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
