### PR TITLE
Reindex Articles in Elasticsearch When touched by Reactions

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -309,6 +309,7 @@ class Article < ApplicationRecord
   def touch_by_reaction
     async_score_calc
     index!
+    index_to_elasticsearch
   end
 
   def comments_blob

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -851,4 +851,12 @@ RSpec.describe Article, type: :model do
       expect(feed_article.attributes.keys).to match_array(fields)
     end
   end
+
+  describe "#touch_by_reaction" do
+    it "reindexes elasticsearch doc" do
+      sidekiq_assert_enqueued_with(job: Search::IndexToElasticsearchWorker, args: [described_class.to_s, article.search_id]) do
+        article.touch_by_reaction
+      end
+    end
+  end
 end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Make sure articles are reindexed in Elasticsearch when reacted to.

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-35510357

## Added tests?
- [x] yes

![alt_text](https://media.giphy.com/media/BsQAVgY6ksvIY/giphy.gif)
