### PR TITLE
Refactor internal mods page

### DIFF
--- a/app/controllers/internal/mods_controller.rb
+++ b/app/controllers/internal/mods_controller.rb
@@ -11,7 +11,8 @@ class Internal::ModsController < Internal::ApplicationController
 
   def index
     @mods = Internal::ModeratorsQuery.call(
-      User.select(INDEX_ATTRIBUTES), safe_params
+      relation: User.select(INDEX_ATTRIBUTES),
+      options: permitted_params,
     ).page(params[:page]).per(50)
   end
 
@@ -26,7 +27,7 @@ class Internal::ModsController < Internal::ApplicationController
 
   private
 
-  def safe_params
+  def permitted_params
     params.permit(:state, :search, :page)
   end
 end

--- a/app/queries/internal/moderators_query.rb
+++ b/app/queries/internal/moderators_query.rb
@@ -1,0 +1,36 @@
+module Internal
+  class ModeratorsQuery
+    DEFAULT_OPTIONS = {
+      state: :trusted
+    }.with_indifferent_access.freeze
+
+    def self.call(relation = User.all, options = {})
+      options = DEFAULT_OPTIONS.merge(options)
+      state, search = options.values_at(:state, :search)
+
+      relation = if state == "potential"
+                   relation.where(
+                     "id not in (select user_id from users_roles where role_id = ?)",
+                     role_id_for(:trusted),
+                   ).order("users.comments_count DESC")
+                 else
+                   relation.joins(:users_roles).where(users_roles: { role_id: role_id_for(state) })
+                 end
+
+      relation = search_relation(relation, search) if search.presence
+
+      relation
+    end
+
+    def self.role_id_for(role)
+      Role.find_by(name: role)&.id
+    end
+
+    def self.search_relation(relation, search)
+      relation.where(
+        "users.username ILIKE :search OR users.name ILIKE :search",
+        search: "%#{search}%",
+      )
+    end
+  end
+end

--- a/app/views/internal/mods/index.html.erb
+++ b/app/views/internal/mods/index.html.erb
@@ -2,13 +2,13 @@
   <div class="col">
     <ul class="nav nav-pills">
       <li class="nav-item">
-        <a href="/internal/mods" class="nav-link <%= "active" if params[:state].blank? %>">General Community</a>
+        <%= link_to "General Community", internal_mods_path, class: "nav-link #{'active' if params[:state].blank?}" %>
       </li>
       <li class="nav-item">
-        <a href="/internal/mods?state=tag_moderator" class="nav-link <%= "active" if params[:state] == "tag_moderator" %>">Tag Mods</a>
+        <%= link_to "Tag Mods", internal_mods_path(state: :tag_moderator), class: "nav-link #{'active' if params[:state] == 'tag_moderator'}" %>
       </li>
       <li class="nav-item">
-        <a href="/internal/mods?state=potential" class="nav-link <%= "active" if params[:state] == "potential" %>">Potential Mods</a>
+        <%= link_to "Potential Mods", internal_mods_path(state: :potential), class: "nav-link #{'active' if params[:state] == 'potential'}" %>
       </li>
     </ul>
   </div>

--- a/app/views/internal/mods/index.html.erb
+++ b/app/views/internal/mods/index.html.erb
@@ -1,11 +1,11 @@
-<div class="row m-3">
+<div class="row my-3">
   <div class="col">
     <ul class="nav nav-pills">
       <li class="nav-item">
         <a href="/internal/mods" class="nav-link <%= "active" if params[:state].blank? %>">General Community</a>
       </li>
       <li class="nav-item">
-        <a href="/internal/mods?state=tag" class="nav-link <%= "active" if params[:state] == "tag" %>">Tag Mods</a>
+        <a href="/internal/mods?state=tag_moderator" class="nav-link <%= "active" if params[:state] == "tag_moderator" %>">Tag Mods</a>
       </li>
       <li class="nav-item">
         <a href="/internal/mods?state=potential" class="nav-link <%= "active" if params[:state] == "potential" %>">Potential Mods</a>
@@ -13,21 +13,17 @@
     </ul>
   </div>
   <div class="col">
-    <%= form_tag(internal_mods_path, method: "get") do %>
-      <div class="form-row justify-content-end">
-        <div class="form-group">
-          <%= text_field_tag(:search, params[:search]) %>
-          <% if params[:state].present? %>
-            <%= hidden_field_tag(:state, params[:state]) %>
-          <% end %>
-          <%= submit_tag("Search") %>
-        </div>
+    <%= form_with url: internal_mods_path, method: :get, local: true, class: "form-inline justify-content-end" do |f| %>
+      <div class="form-group mx-sm-3">
+        <%= f.text_field :search, value: params[:search], class: "form-control" %>
+        <%= f.hidden_field :state, value: params[:state] if params[:state].present? %>
       </div>
+      <%= f.submit "Search", class: "btn btn-light" %>
     <% end %>
   </div>
 </div>
 
-<%= paginate @mods %>
+<%= paginate @mods, theme: "internal" %>
 
 <table class="table">
   <thead>
@@ -52,8 +48,8 @@
       <td><%= time_ago_in_words mod.last_comment_at %> ago</td>
       <% if params[:state] == "potential" %>
         <td>
-          <%= form_for([:internal, mod], url: internal_mod_path(mod.id), method: :patch) do |f| %>
-            <%= f.submit "Make Trusted Mod" %>
+          <%= form_with model: [:internal, mod], url: internal_mod_path(mod.id), method: :patch, local: true do |f| %>
+            <%= f.submit "Make Trusted Mod", class: "btn btn-light" %>
           <% end %>
         </td>
       <% end %>
@@ -62,4 +58,4 @@
   </tbody>
 </table>
 
-<%= paginate @mods %>
+<%= paginate @mods, theme: "internal" %>

--- a/app/views/kaminari/internal/_first_page.html.erb
+++ b/app/views/kaminari/internal/_first_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t("views.pagination.first")), url, remote: remote, class: "page-link" %>
+</li>

--- a/app/views/kaminari/internal/_gap.html.erb
+++ b/app/views/kaminari/internal/_gap.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item disabled">
+  <%= link_to raw(t("views.pagination.truncate")), "#", class: "page-link" %>
+</li>

--- a/app/views/kaminari/internal/_last_page.html.erb
+++ b/app/views/kaminari/internal/_last_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t("views.pagination.last")), url, remote: remote, class: "page-link" %>
+</li>

--- a/app/views/kaminari/internal/_next_page.html.erb
+++ b/app/views/kaminari/internal/_next_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t("views.pagination.next")), url, rel: "next", remote: remote, class: "page-link" %>
+</li>

--- a/app/views/kaminari/internal/_page.html.erb
+++ b/app/views/kaminari/internal/_page.html.erb
@@ -1,0 +1,9 @@
+<% if page.current? %>
+  <li class="page-item active">
+    <%= content_tag :a, page, data: { remote: remote }, rel: page.rel, class: "page-link" %>
+  </li>
+<% else %>
+  <li class="page-item">
+    <%= link_to page, url, remote: remote, rel: page.rel, class: "page-link" %>
+  </li>
+<% end %>

--- a/app/views/kaminari/internal/_paginator.html.erb
+++ b/app/views/kaminari/internal/_paginator.html.erb
@@ -1,0 +1,17 @@
+<%= paginator.render do %>
+  <nav>
+    <ul class="pagination">
+      <%= first_page_tag unless current_page.first? %>
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| %>
+        <% if page.left_outer? || page.right_outer? || page.inside_window? %>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? -%>
+          <%= gap_tag %>
+        <% end %>
+      <% end %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    </ul>
+  </nav>
+<% end %>

--- a/app/views/kaminari/internal/_prev_page.html.erb
+++ b/app/views/kaminari/internal/_prev_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t("views.pagination.previous")), url, rel: "prev", remote: remote, class: "page-link" %>
+</li>

--- a/spec/queries/internal/moderators_query_spec.rb
+++ b/spec/queries/internal/moderators_query_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe Internal::ModeratorsQuery, type: :query do
+  let!(:user)  { create(:user, :trusted, name: "Greg") }
+  let!(:user2) { create(:user, :trusted, name: "Gregory") }
+  let!(:user3) { create(:user, :tag_moderator, name: "Paul", comments_count: 4) }
+  let!(:user4) { create(:user, :admin, name: "Susi", comments_count: 10) }
+  let!(:user5) { create(:user, :trusted, :admin, name: "Beth") }
+  let!(:user6) { create(:user, :admin, name: "Jean", comments_count: 5) }
+
+  describe ".call" do
+    context "when no arguments are given" do
+      it "returns all moderators" do
+        expect(described_class.call).to eq([user, user2, user5])
+      end
+    end
+
+    context "when search is set" do
+      let(:options) { { search: "greg" } }
+
+      it "returns the users with correct name" do
+        expect(described_class.call(User.all, options)).to eq([user, user2])
+      end
+    end
+
+    context "when state is tag_moderator" do
+      let(:options) { { state: "tag_moderator" } }
+
+      it "returns all tag moderators" do
+        expect(described_class.call(User.all, options)).to eq([user3])
+      end
+    end
+
+    context "when state is potential" do
+      let(:options) { { state: "potential" } }
+
+      it "returns all non moderators ordered by comments_count" do
+        expect(described_class.call(User.all, options)).to eq([user4, user6, user3])
+      end
+    end
+
+    context "when state does not exist" do
+      let(:options) { { state: "non_existent_role" } }
+
+      it "returns all non moderators ordered by comments_count" do
+        expect(described_class.call(User.all, options)).to be_empty
+      end
+    end
+  end
+end

--- a/spec/queries/internal/moderators_query_spec.rb
+++ b/spec/queries/internal/moderators_query_spec.rb
@@ -1,12 +1,14 @@
 require "rails_helper"
 
 RSpec.describe Internal::ModeratorsQuery, type: :query do
-  let!(:user)  { create(:user, :trusted, name: "Greg") }
-  let!(:user2) { create(:user, :trusted, name: "Gregory") }
-  let!(:user3) { create(:user, :tag_moderator, name: "Paul", comments_count: 4) }
-  let!(:user4) { create(:user, :admin, name: "Susi", comments_count: 10) }
-  let!(:user5) { create(:user, :trusted, :admin, name: "Beth") }
-  let!(:user6) { create(:user, :admin, name: "Jean", comments_count: 5) }
+  subject { described_class.call(options: options) }
+
+  let_it_be_readonly(:user)  { create(:user, :trusted, name: "Greg") }
+  let_it_be_readonly(:user2) { create(:user, :trusted, name: "Gregory") }
+  let_it_be_readonly(:user3) { create(:user, :tag_moderator, name: "Paul", comments_count: 4) }
+  let_it_be_readonly(:user4) { create(:user, :admin, name: "Susi", comments_count: 10) }
+  let_it_be_readonly(:user5) { create(:user, :trusted, :admin, name: "Beth") }
+  let_it_be_readonly(:user6) { create(:user, :admin, name: "Jean", comments_count: 5) }
 
   describe ".call" do
     context "when no arguments are given" do
@@ -18,33 +20,25 @@ RSpec.describe Internal::ModeratorsQuery, type: :query do
     context "when search is set" do
       let(:options) { { search: "greg" } }
 
-      it "returns the users with correct name" do
-        expect(described_class.call(User.all, options)).to eq([user, user2])
-      end
+      it { is_expected.to eq([user, user2]) }
     end
 
     context "when state is tag_moderator" do
       let(:options) { { state: "tag_moderator" } }
 
-      it "returns all tag moderators" do
-        expect(described_class.call(User.all, options)).to eq([user3])
-      end
+      it { is_expected.to eq([user3]) }
     end
 
     context "when state is potential" do
       let(:options) { { state: "potential" } }
 
-      it "returns all non moderators ordered by comments_count" do
-        expect(described_class.call(User.all, options)).to eq([user4, user6, user3])
-      end
+      it { is_expected.to eq([user4, user6, user3]) }
     end
 
     context "when state does not exist" do
       let(:options) { { state: "non_existent_role" } }
 
-      it "returns all non moderators ordered by comments_count" do
-        expect(described_class.call(User.all, options)).to be_empty
-      end
+      it { within_block_is_expected.to raise_error(ActiveRecord::RecordNotFound) }
     end
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

This PR address performance issues on Internal Mods page and add minor UI improvements.

- Create `Internal::ModeratorsQuery` with specs.
- Controller
  - Refactor index action to use new query class.
  - Fix rediretion and flash message on update action.
  - Require only the necessary user fields.
  - Change to 50 moderators per page.
- Index.html.erb
  - Refactor forms to use the new `form_with` syntax.
  - Pull Kaminari bootstrap theme into internal pages.
  - Add missing buttons and form styles.

**Previous Query Plan with 1k users:**
```ruby
User.without_role(:trusted).order("comments_count DESC").explain

 Sort  (cost=439.78..441.83 rows=819 width=1924)
   Sort Key: comments_count DESC
   ->  Index Scan using users_pkey on users  (cost=0.28..400.15 rows=819 width=1924)
         Index Cond: (id = ANY ('{6,10,2,11,9,20,306,103,56,15,37,51,55,28,26,22,27,19,44,32,34,31,42,35,40,50,45,41,46,47,39,49,52,54,69,155,109,57,62,105,80,67,77,423,58,71,65,72,64,63,106,73,84,112,111,115,107,123,74,79,85,113,116,945,24,81,68,43,92,87,90,93,89,98,94,643,18,96,16,102,100,82,101,99,117,118,119,121,124,125,126,143,424,315,316,128,145,308,341,344,356,129,134,147,311,319,326,131,149,310,318,331,314,135,136,139,140,141,150,151,152,154,156,159,160,169,170,171,197,221,162,164,166,168,172,175,181,207,219,176,192,235,256,278,289,425,321,178,182,198,209,245,248,426,184,186,187,188,189,190,194,195,196,210,305,324,325,320,200,202,203,204,206,211,215,216,217,218,323,327,328,223,224,225,226,228,229,230,232,233,234,644,238,239,240,241,242,243,250,268,290,293,303,304,428,330,333,251,252,253,255,266,267,281,332,257,277,280,292,302,645,334,335,337,336,258,259,260,261,263,264,265,338,269,270,272,273,274,275,276,283,284,285,286,288,339,295,296,297,298,299,301,343,370,375,376,380,382,345,371,372,386,432,430,347,348,350,351,352,354,346,368,374,385,416,440,441,447,355,357,373,415,434,438,439,442,647,358,359,360,361,363,366,367,377,383,384,394,407,648,649,387,388,390,391,392,393,396,397,398,402,403,404,405,650,409,410,411,412,413,417,651,420,419,435,443,444,445,652,452,453,454,455,458,448,653,654,661,450,481,946,655,657,658,659,457,468,471,473,491,492,500,660,662,461,463,464,465,466,467,469,470,503,525,526,527,663,675,677,472,514,523,528,664,665,669,666,474,475,477,478,479,482,483,667,485,486,487,488,490,668,497,499,502,504,505,670,507,508,509,510,511,512,513,671,515,517,518,520,522,672,674,529,680,690,532,533,534,588,621,676,682,535,536,538,539,540,547,589,598,541,542,543,544,545,548,549,551,552,553,555,558,557,560,561,562,563,567,568,577,566,570,572,573,574,587,576,586,622,623,627,637,688,689,578,579,581,583,584,948,590,591,592,595,596,597,638,684,685,686,687,702,601,610,611,639,692,693,603,604,605,606,607,609,608,612,602,697,698,699,700,701,694,613,615,616,617,618,620,628,629,630,631,632,635,705,706,747,749,750,751,753,754,755,709,710,711,712,713,715,716,745,756,769,949,950,958,963,717,718,720,721,722,723,725,758,953,966,974,994,1001,1007,727,728,729,730,731,733,734,736,735,746,778,779,782,737,738,739,740,741,742,744,748,752,759,780,795,957,757,783,954,956,972,973,978,761,763,764,766,768,955,771,772,774,775,776,777,784,960,787,789,790,791,792,793,794,798,799,800,801,823,833,961,804,805,806,807,810,811,812,813,814,834,867,880,908,921,962,815,817,818,824,826,827,830,831,832,845,829,858,871,882,899,964,965,979,836,837,838,839,840,841,846,843,844,848,866,910,922,890,967,969,971,849,850,853,854,855,856,857,859,860,861,862,863,870,873,874,875,876,877,878,879,881,976,884,885,886,888,891,892,894,895,897,900,902,904,906,907,909,914,916,917,918,919,920,923,924,925,927,926,928,929,930,933,981,982,984,985,932,986,987,989,934,936,939,940,942,943,996,997,998,999,1003,1004,1027,1054,1005,1008,1060,1006,1039,1049,1053,1009,1011,1015,1016,1020,1021,1022,1023,1025,1024,1026,1028,1030,1031,1032,1033,1034,1036,1042,1043,1044,1046,1047,1048,1029,1050,1051,1052,1061,1055,1056,1057,1059,1065,1066,1067,1068,1070,1072,1071,1073,1075,1076,1077,1078,1079,1013,1080,1082,1084,1081,1085,1089,1098,1104,1106,1087,1109,1090,1091,1092,1093,1094,1095,1096,1099,1100,1101,1102,1103,1105,1108,1110,1112,1113}'::integer[]))
(4 rows)
```
**Current previous explain with 1k users:**
```ruby
Internal::ModeratorsQuery.call(User.all, {state: 'potential'}).explain

Sort  (cost=186.04..187.45 rows=565 width=1924)
   Sort Key: users.comments_count DESC
   ->  Seq Scan on users  (cost=15.09..160.21 rows=565 width=1924)
         Filter: (NOT (hashed SubPlan 1))
         SubPlan 1
           ->  Seq Scan on users_roles  (cost=0.00..14.38 rows=284 width=4)
                 Filter: (role_id = 2)
(7 rows)
```

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/issues/6674

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![Screen Shot 2020-04-01 at 14 56 37](https://user-images.githubusercontent.com/141650/78143298-5f098b00-742e-11ea-8463-6774d7f8a611.png)

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![nice](https://big.assets.huffingtonpost.com/tumblr_lso8qzN7g61qetdw6o1_500.gif)
