### PR TITLE
Index Articles to Elasticsearch when adding Comments and Syncing Scores

### DIFF
--- a/app/services/edge_cache/commentable/bust.rb
+++ b/app/services/edge_cache/commentable/bust.rb
@@ -14,6 +14,7 @@ module EdgeCache
         cache_buster.bust_comment(commentable)
         cache_buster.bust("#{commentable.path}/comments")
         commentable.index!
+        commentable.index_to_elasticsearch_inline
       end
 
       private

--- a/app/services/moderator/delete_user.rb
+++ b/app/services/moderator/delete_user.rb
@@ -46,10 +46,11 @@ module Moderator
       return unless user.articles.any?
 
       # preload associations that are going to be used during indexing
-      user.articles.preload(:taggings, :organization).find_each do |article|
+      user.articles.preload(:taggings, :organization, :tag_taggings, :tags).find_each do |article|
         path = "/#{@ghost.username}/#{article.slug}"
         article.update_columns(user_id: @ghost.id, path: path)
         article.index!
+        article.index_to_elasticsearch_inline
       end
     end
   end

--- a/app/workers/articles/score_calc_worker.rb
+++ b/app/workers/articles/score_calc_worker.rb
@@ -10,6 +10,7 @@ module Articles
 
       article.update_score
       article.index!
+      article.index_to_elasticsearch_inline
     end
   end
 end

--- a/spec/requests/internal/users_manage_spec.rb
+++ b/spec/requests/internal/users_manage_spec.rb
@@ -152,10 +152,12 @@ RSpec.describe "Internal::Users", type: :request do
     it "reassigns comment and article content to ghost account" do
       create(:article, user: user)
       call_ghost
-      expect(ghost.articles.count).to eq(2)
+      articles = ghost.articles
+      expect(articles.count).to eq(2)
       expect(ghost.comments.count).to eq(1)
       expect(ghost.comments.last.path).to include("ghost")
-      expect(ghost.articles.last.path).to include("ghost")
+      expect(articles.last.path).to include("ghost")
+      expect(articles.last.elasticsearch_doc.dig("_source", "path")).to include("ghost")
     end
   end
 

--- a/spec/services/edge_cache/commentable/bust_spec.rb
+++ b/spec/services/edge_cache/commentable/bust_spec.rb
@@ -20,4 +20,10 @@ RSpec.describe EdgeCache::Commentable::Bust, type: :service do
     described_class.call(commentable, cache_buster)
     expect(commentable).to have_received(:index!).once
   end
+
+  it "indexes commentable to Elasticsearch" do
+    allow(commentable).to receive(:index_to_elasticsearch_inline)
+    described_class.call(commentable, cache_buster)
+    expect(commentable).to have_received(:index_to_elasticsearch_inline).once
+  end
 end

--- a/spec/services/moderator/delete_user_spec.rb
+++ b/spec/services/moderator/delete_user_spec.rb
@@ -31,4 +31,25 @@ RSpec.describe Moderator::DeleteUser, type: :service do
       expect(Article.find_by(id: article.id)).to be_nil
     end
   end
+
+  describe "#ghostify" do
+    let(:deleter) { described_class.new(user: user, admin: admin, user_params: { ghostify: true }) }
+
+    before do
+      user.update(username: "ghost")
+      create(:article, user: user)
+    end
+
+    it "reassigns articles" do
+      allow(deleter).to receive(:reassign_articles)
+      deleter.ghostify
+      expect(deleter).to have_received(:reassign_articles)
+    end
+
+    it "reassigns comments" do
+      allow(deleter).to receive(:reassign_comments)
+      deleter.ghostify
+      expect(deleter).to have_received(:reassign_comments)
+    end
+  end
 end

--- a/spec/workers/articles/score_calc_worker_spec.rb
+++ b/spec/workers/articles/score_calc_worker_spec.rb
@@ -29,6 +29,13 @@ RSpec.describe Articles::ScoreCalcWorker, type: :worker do
         expect(article.hotness_score).to be(373)
         expect(article.spaminess_rating).to be(2)
       end
+
+      it "indexes the article to Elasticsearch" do
+        allow(Article).to receive(:find_by).and_return(article)
+        allow(article).to receive(:index_to_elasticsearch_inline)
+        worker.perform(article.id)
+        expect(article).to have_received(:index_to_elasticsearch_inline).once
+      end
     end
 
     context "without article" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Few more places we are indexing Articles to Algolia manually and need to also be indexing them to Elasticsearch. In one instance we are not actually updating the article and only updating a relation. In the other instance, we are using update_column which will not trigger the indexing callback.

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-35556485

## Added tests?
- [x] yes

![alt_text](https://media.giphy.com/media/l2QE7lME4znz6M8BG/giphy.gif)
