### PR TITLE
Remove Comment and Article docs From Elasticsearch During User Delete

### DIFF
--- a/app/services/users/delete_articles.rb
+++ b/app/services/users/delete_articles.rb
@@ -13,9 +13,11 @@ module Users
           comment.reactions.delete_all
           cache_buster.bust_comment(comment.commentable)
           cache_buster.bust_user(comment.user)
+          comment.remove_from_elasticsearch
           comment.delete
         end
         article.remove_algolia_index
+        article.remove_from_elasticsearch
         article.delete
         article.purge
       end

--- a/app/services/users/delete_comments.rb
+++ b/app/services/users/delete_comments.rb
@@ -9,6 +9,7 @@ module Users
         comment.reactions.delete_all
         cache_buster.bust_comment(comment.commentable)
         comment.remove_notifications
+        comment.remove_from_elasticsearch
         comment.delete
       end
       cache_buster.bust_user(user)

--- a/spec/services/moderator/banish_user_spec.rb
+++ b/spec/services/moderator/banish_user_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe Moderator::BanishUser, type: :service do
 
   it "removes all their articles" do
     create(:article, user: user, published: true)
+    sidekiq_perform_enqueued_jobs
+
     sidekiq_perform_enqueued_jobs do
       described_class.call(user: user, admin: admin)
     end
@@ -23,6 +25,8 @@ RSpec.describe Moderator::BanishUser, type: :service do
   it "removes all their comments" do
     article = create(:article, user: user, published: true)
     create(:comment, user: user, commentable: article)
+    sidekiq_perform_enqueued_jobs
+
     sidekiq_perform_enqueued_jobs(except: Search::IndexToElasticsearchWorker) do
       described_class.call(user: user, admin: admin)
     end

--- a/spec/services/users/delete_articles_spec.rb
+++ b/spec/services/users/delete_articles_spec.rb
@@ -14,6 +14,14 @@ RSpec.describe Users::DeleteArticles, type: :service do
     expect(Article.find(article3.id)).to be_present
   end
 
+  it "removes article from Elasticsearch" do
+    sidekiq_perform_enqueued_jobs
+    expect(article.elasticsearch_doc).not_to be_nil
+
+    sidekiq_perform_enqueued_jobs { described_class.call(user) }
+    expect { article.elasticsearch_doc }.to raise_error(Search::Errors::Transport::NotFound)
+  end
+
   context "with comments" do
     let(:buster) { double }
 
@@ -43,6 +51,19 @@ RSpec.describe Users::DeleteArticles, type: :service do
       expect(buster).to have_received(:bust_comment).with(article).twice
       expect(buster).to have_received(:bust_user).with(user2).at_least(:once)
       expect(buster).to have_received(:bust_article).with(article)
+    end
+
+    it "removes comments from Elasticsearch", :aggregate_failures do
+      sidekiq_perform_enqueued_jobs
+      comments = article.comments
+      comments.each { |comment| expect(comment.elasticsearch_doc).not_to be_nil }
+      sidekiq_perform_enqueued_jobs(only: Search::RemoveFromElasticsearchIndexWorker) do
+        described_class.call(user)
+      end
+
+      comments.each do |comment|
+        expect { comment.elasticsearch_doc }.to raise_error(Search::Errors::Transport::NotFound)
+      end
     end
   end
 end

--- a/spec/services/users/delete_comments_spec.rb
+++ b/spec/services/users/delete_comments_spec.rb
@@ -20,6 +20,14 @@ RSpec.describe Users::DeleteComments, type: :service do
     expect(Comment.where(user_id: user.id).any?).to be false
   end
 
+  it "removes comments from Elasticsearch" do
+    comment
+    sidekiq_perform_enqueued_jobs
+    expect(comment.elasticsearch_doc).not_to be_nil
+    sidekiq_perform_enqueued_jobs { described_class.call(user, buster) }
+    expect { comment.elasticsearch_doc }.to raise_error(Search::Errors::Transport::NotFound)
+  end
+
   it "busts cache" do
     described_class.call(user, buster)
     expect(buster).to have_received(:bust_comment).with(article).at_least(:once)


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Remove Comments and Articles from Elasticsearch when we delete them and no callbacks are triggered. 

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-35563612

## Added tests?
- [x] yes

![alt_text](https://media2.giphy.com/media/3osxYs3Z4T2eNssLFm/giphy.gif)
