### PR TITLE
Fix erb output on sitemaps

### DIFF
--- a/app/views/sitemaps/show.xml.erb
+++ b/app/views/sitemaps/show.xml.erb
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <%= @articles.each do |path, last_comment_at| %>
+  <% @articles.each do |path, last_comment_at| %>
     <url>
         <loc><%= ApplicationConfig['APP_PROTOCOL'] %><%= ApplicationConfig['APP_DOMAIN'] %><%= path %></loc>
         <lastmod><%= last_comment_at.strftime("%F") %></lastmod>


### PR DESCRIPTION

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
I notice we are _outputting_ the result of this loop at the end. Seems to have not affected the validity of the sitemap, but definitely worth fixing!

This should fix performance for crawlers by radically reducing the number of bytes going over the wire.

<img width="943" alt="Screen Shot 2020-04-01 at 1 44 42 PM" src="https://user-images.githubusercontent.com/3102842/78169135-f49d1e80-741e-11ea-9eaf-12b137fcefae.png">