### PR TITLE
Delete all Users via the DeleteWorker for Consistency and use Destroy in Worker

### DIFF
--- a/app/services/moderator/delete_user.rb
+++ b/app/services/moderator/delete_user.rb
@@ -20,17 +20,14 @@ module Moderator
       @ghost = User.find_by(username: "ghost")
       reassign_articles
       reassign_comments
-      delete_non_content_activity_and_user
+      delete_user
       CacheBuster.bust("/ghost")
     end
 
     private
 
-    def delete_non_content_activity_and_user
-      delete_user_activity
-      user.unsubscribe_from_newsletters
-      CacheBuster.bust("/#{user.username}")
-      user.delete
+    def delete_user
+      Users::DeleteWorker.new.perform(user.id, true)
     end
 
     def reassign_comments

--- a/app/services/users/delete.rb
+++ b/app/services/users/delete.rb
@@ -10,7 +10,7 @@ module Users
       delete_user_activity
       user.unsubscribe_from_newsletters
       CacheBuster.bust("/#{user.username}")
-      user.delete
+      user.destroy
       Rails.cache.delete("user-destroy-token-#{user.id}")
     end
 

--- a/spec/services/moderator/merge_user_spec.rb
+++ b/spec/services/moderator/merge_user_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe Moderator::MergeUser, type: :service do
+  let!(:keep_user) { create(:user) }
+  let!(:delete_user) { create(:user) }
+  let(:delete_user_id) { delete_user.id }
+  let(:admin) { create(:user, :super_admin) }
+
+  describe "#merge" do
+    before { sidekiq_perform_enqueued_jobs }
+
+    it "deletes delete_user_id and keeps keep_user" do
+      sidekiq_perform_enqueued_jobs do
+        described_class.call_merge(admin: admin, keep_user: keep_user, delete_user_id: delete_user.id)
+      end
+      expect(User.find_by(id: delete_user_id)).to be_nil
+      expect(User.find_by(id: keep_user.id)).not_to be_nil
+    end
+  end
+end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Bug Fix

## Description
I found 3 different code paths that we use to delete users and all of them had duplicated code. Rather than continuing to duplicate the code for removing users from Elasticsearch I 
- Updated 2 of the code paths to use the `Users::DeleteWorker`
- Updated the `Users::DeleteWorker` to call destroy on the user rather than delete to trigger all of the callbacks like removing the user from Elasticsearch and, until further notice, Algolia. 

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-35501428

## Added tests?
- [x] yes

![alt_text](https://media0.giphy.com/media/10HKDjMyyBgOWs/giphy.gif)
