### PR TITLE
Index User Roles to use to Filter out banned users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,7 +28,8 @@ class User < ApplicationRecord
     :add_credits, :remove_credits, :add_org_credits, :remove_org_credits, :ghostify
   )
 
-  rolify
+  rolify after_add: :index_roles, after_remove: :index_roles
+
   include AlgoliaSearch
   include Storext.model
   include Searchable
@@ -709,5 +710,9 @@ class User < ApplicationRecord
     follower_relationships = Follow.followable_user(id)
     follower_relationships.destroy_all
     follows.destroy_all
+  end
+
+  def index_roles(_role)
+    index_to_elasticsearch_inline
   end
 end

--- a/app/serializers/search/user_serializer.rb
+++ b/app/serializers/search/user_serializer.rb
@@ -14,5 +14,9 @@ module Search
                :profile_image_90,
                :reactions_count,
                :username
+
+    attribute :roles do |user|
+      user.roles.map(&:name)
+    end
   end
 end

--- a/app/services/moderator/banish_user.rb
+++ b/app/services/moderator/banish_user.rb
@@ -21,6 +21,7 @@ module Moderator
       delete_articles
       Users::CleanupChatChannels.call(user)
       user.remove_from_algolia_index
+      user.index_to_elasticsearch
       reassign_and_bust_username
       delete_vomit_reactions
     end

--- a/app/services/moderator/banish_user.rb
+++ b/app/services/moderator/banish_user.rb
@@ -21,7 +21,6 @@ module Moderator
       delete_articles
       Users::CleanupChatChannels.call(user)
       user.remove_from_algolia_index
-      user.index_to_elasticsearch
       reassign_and_bust_username
       delete_vomit_reactions
     end

--- a/config/elasticsearch/mappings/users.json
+++ b/config/elasticsearch/mappings/users.json
@@ -41,6 +41,9 @@
     "reactions_count": {
       "type": "integer"
     },
+    "roles": {
+      "type": "keyword"
+    },
     "search_fields": {
       "type": "text"
     },

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -70,6 +70,10 @@ RSpec.configure do |config|
   config.include SidekiqTestHelpers
   config.include ElasticsearchHelpers, elasticsearch: true
 
+  config.before(:suite) do
+    Search::Cluster.recreate_indexes
+  end
+
   config.before do
     Sidekiq::Worker.clear_all # worker jobs shouldn't linger around between tests
   end

--- a/spec/serializers/search/user_serializer_spec.rb
+++ b/spec/serializers/search/user_serializer_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe Search::UserSerializer do
   end
 
   it "creates valid json for Elasticsearch", elasticsearch: true do
-    user.add_role(:admin)
     data_hash = described_class.new(user).serializable_hash.dig(:data, :attributes)
     result = User::SEARCH_CLASS.index(user.id, data_hash)
     expect(result["result"]).to eq("created")

--- a/spec/serializers/search/user_serializer_spec.rb
+++ b/spec/serializers/search/user_serializer_spec.rb
@@ -5,6 +5,13 @@ RSpec.describe Search::UserSerializer do
 
   it "serializes a user" do
     data_hash = described_class.new(user).serializable_hash.dig(:data, :attributes)
-    expect(data_hash.keys).to include(:id, :name, :path, :username)
+    expect(data_hash.keys).to include(:id, :name, :path, :username, :roles)
+  end
+
+  it "creates valid json for Elasticsearch", elasticsearch: true do
+    user.add_role(:admin)
+    data_hash = described_class.new(user).serializable_hash.dig(:data, :attributes)
+    result = User::SEARCH_CLASS.index(user.id, data_hash)
+    expect(result["result"]).to eq("created")
   end
 end


### PR DESCRIPTION


## What type of PR is this? (check all applicable)
- [x] Feature
- [x] Bug Fix

## Description
In Algolia we remove users when they are banned. In Elasticsearch the goal is to always have all of our data in it but then use filters to ensure we only search for the data we want at any given time. This means we need a way to exclude banned users from our search. I decided rather than having a "user status" adding the roles would likely be more helpful. We could also use these to search for mods and admins in the future. 

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-35575574

## Added tests?
- [x] yes

![alt_text](https://blog.trello.com/hs-fs/hubfs/office-space%20gif.gif?width=649&name=office-space%20gif.gif)
