### PR TITLE
Avoid clobbering user attributes with empty params during onboarding

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -143,6 +143,7 @@ class UsersController < ApplicationController
 
   def onboarding_update
     if params[:user]
+      sanitize_user_params
       permitted_params = %i[summary location employment_title employer_name last_onboarding_page]
       current_user.assign_attributes(params[:user].permit(permitted_params))
       current_user.profile_updated_at = Time.current
@@ -250,6 +251,10 @@ class UsersController < ApplicationController
   end
 
   private
+
+  def sanitize_user_params
+    params[:user].delete_if { |_k, v| v.blank? }
+  end
 
   def render_update_response
     if current_user.save

--- a/spec/requests/users_onboarding_spec.rb
+++ b/spec/requests/users_onboarding_spec.rb
@@ -1,31 +1,56 @@
 require "rails_helper"
 
 RSpec.describe "UsersOnboarding", type: :request do
-  let(:user) { create(:user, saw_onboarding: false) }
+  let(:user) { create(:user, saw_onboarding: false, location: "Llama Town") }
 
   describe "PATCH /onboarding_update" do
-    it "updates saw_onboarding boolean" do
-      sign_in user
-      patch "/onboarding_update.json", params: {}
-      expect(user.saw_onboarding).to eq(true)
+    context "when signed in" do
+      before { sign_in user }
+
+      it "updates saw_onboarding boolean" do
+        sign_in user
+        patch "/onboarding_update.json", params: {}
+        expect(user.saw_onboarding).to eq(true)
+      end
+
+      it "updates the attributes on the user" do
+        params = { user: { location: "Alpaca Town" } }
+        expect do
+          patch "/onboarding_update.json", params: params
+        end.to change(user, :location)
+      end
+
+      it "does not update attributes if params are empty" do
+        params = { user: { location: "" } }
+        expect do
+          patch "/onboarding_update.json", params: params
+        end.not_to change(user, :location)
+      end
     end
 
-    it "returns a not found error if user is not signed in" do
-      patch "/onboarding_update.json", params: {}
-      expect(response.parsed_body["error"]).to include("Please sign in")
+    context "when signed out" do
+      it "returns a not found error if user is not signed in" do
+        patch "/onboarding_update.json", params: {}
+        expect(response.parsed_body["error"]).to include("Please sign in")
+      end
     end
   end
 
   describe "PATCH /onboarding_checkbox_update" do
-    it "updates saw_onboarding boolean" do
-      sign_in user
-      patch "/onboarding_checkbox_update.json", params: {}
-      expect(user.saw_onboarding).to eq(true)
+    context "when signed in" do
+      before { sign_in user }
+
+      it "updates saw_onboarding boolean" do
+        patch "/onboarding_checkbox_update.json", params: {}
+        expect(user.saw_onboarding).to eq(true)
+      end
     end
 
-    it "returns a not found error if user is not signed in" do
-      patch "/onboarding_checkbox_update.json", params: {}
-      expect(response.parsed_body["error"]).to include("Please sign in")
+    context "when signed out" do
+      it "returns a not found error if user is not signed in" do
+        patch "/onboarding_checkbox_update.json", params: {}
+        expect(response.parsed_body["error"]).to include("Please sign in")
+      end
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Ensures that we don't `assign_attributes` on a user blindly. Sanitizes the user params to ignore any blank attributes, and only updates attributes on a user that have a value/are not blank.

## Related Tickets & Documents
Closes #6985.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
