### PR TITLE
Removed unused pages routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -326,13 +326,14 @@ Rails.application.routes.draw do
   get "/mod/:tag" => "moderations#index"
   get "/page/crayons" => "pages#crayons"
 
+  get "/p/rlyweb", to: redirect("/rlyweb")
+
   post "/fallback_activity_recorder" => "ga_events#create"
 
   get "/page/:slug" => "pages#show"
 
   scope "p" do
-    pages_actions = %w[rly rlyweb welcome twitter_moniter editor_guide publishing_from_rss_guide information
-                       markdown_basics scholarships wall_of_patrons badges]
+    pages_actions = %w[welcome editor_guide publishing_from_rss_guide information markdown_basics badges].freeze
     pages_actions.each do |action|
       get action, action: action, controller: "pages"
     end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
- removed  `/p/rly`, `/p/scholarships`, `/p/wall_of_patrons` and `/p/twitter_moniter` routes because the corresponding actions were missing in the `PagesController` and these pages are 404 anyway
- added a redirect from `/p/rlyweb` from `/rlyweb` because there is no point in rendering the same action for the 2 urls in this case

## Related Tickets & Documents
#7021 

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed