### PR TITLE
Make sure there is no empty <p> in the badge email

### DIFF
--- a/app/views/mailers/notify_mailer/new_badge_email.html.erb
+++ b/app/views/mailers/notify_mailer/new_badge_email.html.erb
@@ -9,7 +9,7 @@
     <%= @badge.description %>
   </p>
 
-  <% if @badge_achievement.rewarding_context_message %>
+  <% if @badge_achievement.rewarding_context_message.present? %>
     <p>
       <em>
         <%= @badge_achievement.rewarding_context_message.html_safe %>

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -206,8 +206,15 @@ RSpec.describe NotifyMailer, type: :mailer do
         expect(email.html_part.body).to include(CGI.escape(URL.url("/hey")))
       end
 
-      it "does not include the rewarding_context_message in the email" do
+      it "does not include the nil rewarding_context_message in the email" do
         allow(badge_achievement).to receive(:rewarding_context_message).and_return(nil)
+
+        expect(email.html_part.body).not_to include("Hello <a")
+        expect(email.html_part.body).not_to include(CGI.escape(URL.url("/hey")))
+      end
+
+      it "does not include the empty rewarding_context_message in the email" do
+        allow(badge_achievement).to receive(:rewarding_context_message).and_return("")
 
         expect(email.html_part.body).not_to include("Hello <a")
         expect(email.html_part.body).not_to include(CGI.escape(URL.url("/hey")))
@@ -234,8 +241,15 @@ RSpec.describe NotifyMailer, type: :mailer do
         expect(email.text_part.body).not_to include(URL.url("/hey"))
       end
 
-      it "does not include the rewarding_context_message in the email" do
+      it "does not include the nil rewarding_context_message in the email" do
         allow(badge_achievement).to receive(:rewarding_context_message).and_return(nil)
+
+        expect(email.text_part.body).not_to include("Hello Yoho")
+        expect(email.text_part.body).not_to include(URL.url("/hey"))
+      end
+
+      it "does not include the empty rewarding_context_message in the email" do
+        allow(badge_achievement).to receive(:rewarding_context_message).and_return("")
 
         expect(email.text_part.body).not_to include("Hello Yoho")
         expect(email.text_part.body).not_to include(URL.url("/hey"))


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

If the message is empty string instead of nil it will render a superflous empty paragraph in the badge email

Thanks @lightalloy for your eagle eye 🦅 

## Related Tickets & Documents

#7000 

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
