### PR TITLE
Use article.update instead of update_columns in a couple places

### DIFF
--- a/app/workers/articles/update_main_image_background_hex_worker.rb
+++ b/app/workers/articles/update_main_image_background_hex_worker.rb
@@ -9,7 +9,7 @@ module Articles
 
       return unless article
 
-      article.update_column(:main_image_background_hex_color, ColorFromImage.new(article.main_image).main)
+      article.update(main_image_background_hex_color: ColorFromImage.new(article.main_image).main)
     end
   end
 end

--- a/app/workers/rating_votes/assign_rating_worker.rb
+++ b/app/workers/rating_votes/assign_rating_worker.rb
@@ -11,7 +11,7 @@ module RatingVotes
       ratings = article.rating_votes.where(group: group).pluck(:rating)
       average = ratings.sum / ratings.size
 
-      article.update_columns(
+      article.update(
         experience_level_rating: average,
         experience_level_rating_distribution: ratings.max - ratings.min,
         last_experience_level_rating_at: Time.current,

--- a/spec/workers/rating_votes/assign_rating_worker_spec.rb
+++ b/spec/workers/rating_votes/assign_rating_worker_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe RatingVotes::AssignRatingWorker, type: :worker do
 
   before do
     allow(CacheBuster).to receive(:bust_podcast)
+    user.add_role(:trusted)
   end
 
   describe "#perform" do
     it "assigns explicit score" do
-      user.add_role(:trusted)
       second_user.add_role(:trusted)
       create(:rating_vote, article_id: article.id, user_id: user.id, rating: 3.0)
       create(:rating_vote, article_id: article.id, user_id: second_user.id, rating: 2.0)
@@ -22,7 +22,6 @@ RSpec.describe RatingVotes::AssignRatingWorker, type: :worker do
     end
 
     it "assigns implicit readinglist_reaction score" do
-      user.add_role(:trusted)
       create(:rating_vote, article_id: article.id, user_id: user.id, rating: 4.0)
       create(:rating_vote, article_id: article.id, user_id: second_user.id, rating: 2.0, context: "readinglist_reaction")
       worker.perform(article.id)
@@ -31,12 +30,19 @@ RSpec.describe RatingVotes::AssignRatingWorker, type: :worker do
     end
 
     it "assigns implicit comment score" do
-      user.add_role(:trusted)
       create(:rating_vote, article_id: article.id, user_id: user.id, rating: 4.0)
       create(:rating_vote, article_id: article.id, user_id: second_user.id, rating: 1.0, context: "comment")
       worker.perform(article.id)
       expect(article.reload.experience_level_rating).to eq(2.5)
       expect(article.reload.experience_level_rating_distribution).to eq(3.0)
+    end
+
+    it "updates article in Elasticsearch" do
+      create(:rating_vote, article_id: article.id, user_id: user.id, rating: 4.0)
+      create(:rating_vote, article_id: article.id, user_id: second_user.id, rating: 1.0, context: "comment")
+      worker.perform(article.id)
+      sidekiq_perform_enqueued_jobs
+      expect(article.elasticsearch_doc.dig("_source", "experience_level_rating")).to eq(2.5)
     end
   end
 end


### PR DESCRIPTION


## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Here are two places where we are updating articles in background workers and likely don't need to be using update_columns but can use update instead and ensure our callbacks all run. We have a lot of callbacks on articles and every time we use update_column we risk introducing a bug by not running them all. 

This change is aimed at making sure articles remain synced in Elasticsearch, but in general, we should be looking to move away from these callbacks if we want to make things more efficient by using update columns in many places. Using both callbacks and update_columns randomly in places is inviting bugs to show up in our code and syncing issues. 

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-35630533

## Added tests?
- [x] yes

![alt_text](https://media1.tenor.com/images/b0d340996fd5942caf4367c41e7c03a5/tenor.gif?itemid=7190096)
