### PR TITLE
Index Articles after Ratings are Updated

### DIFF
--- a/app/workers/rating_votes/assign_rating_worker.rb
+++ b/app/workers/rating_votes/assign_rating_worker.rb
@@ -16,6 +16,7 @@ module RatingVotes
         experience_level_rating_distribution: ratings.max - ratings.min,
         last_experience_level_rating_at: Time.current,
       )
+      article.index_to_elasticsearch_inline
     end
   end
 end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Ensure that articles are indexes after their ratings are updated since we store those in our Elasticsearch docs and I believe they will likely be something we want to search on in the future. 

## Added tests?
- [x] yes

![alt_text](https://media.giphy.com/media/1jX7arHdf8epR44LNg/giphy.gif)
