### PR TITLE
By Default Search for Users that are not Banned

### DIFF
--- a/app/services/search/query_builders/user.rb
+++ b/app/services/search/query_builders/user.rb
@@ -5,6 +5,11 @@ module Search
         search_fields
       ].freeze
 
+      # In the event we want to search for documents that do NOT contain certain values
+      EXCLUDED_TERM_KEYS = {
+        exclude_roles: "roles"
+      }.freeze
+
       DEFAULT_PARAMS = {
         sort_by: "hotness_score",
         sort_direction: "desc",
@@ -13,6 +18,10 @@ module Search
 
       def initialize(params)
         @params = params.deep_symbolize_keys
+
+        # default to excluding users who are banned
+        @params[:exclude_roles] = ["banned"]
+
         build_body
       end
 
@@ -21,6 +30,19 @@ module Search
       def build_queries
         @body[:query] = { bool: {} }
         @body[:query][:bool][:must] = query_conditions if query_keys_present?
+        @body[:query][:bool][:must_not] = excluded_term_keys if excluded_term_keys_present?
+      end
+
+      def excluded_term_keys_present?
+        self.class::EXCLUDED_TERM_KEYS.detect { |key, _| @params[key].present? }
+      end
+
+      def excluded_term_keys
+        EXCLUDED_TERM_KEYS.map do |term_key, search_key|
+          next unless @params.key? term_key
+
+          { terms: { search_key => Array.wrap(@params[term_key]) } }
+        end.compact
       end
     end
   end

--- a/spec/services/search/query_builders/user_spec.rb
+++ b/spec/services/search/query_builders/user_spec.rb
@@ -26,6 +26,29 @@ RSpec.describe Search::QueryBuilders::User, type: :service do
       expect(filter.as_hash.dig("query", "bool", "must")).to match_array(exepcted_query)
     end
 
+    it "applies EXCLUDED_TERM_KEYS by default" do
+      filter = described_class.new({})
+      exepcted_filters = [
+        { "terms" => { "roles" => ["banned"] } },
+      ]
+      expect(filter.as_hash.dig("query", "bool", "must_not")).to match_array(exepcted_filters)
+    end
+
+    it "applies EXCLUDED_TERM_KEYS and QUERY_KEYS" do
+      params = { search_fields: "test" }
+      filter = described_class.new(params)
+      exepcted_query = [{
+        "simple_query_string" => {
+          "query" => "test*", "fields" => [:search_fields], "lenient" => true, "analyze_wildcard" => true
+        }
+      }]
+      exepcted_filters = [
+        { "terms" => { "roles" => ["banned"] } },
+      ]
+      expect(filter.as_hash.dig("query", "bool", "must_not")).to match_array(exepcted_filters)
+      expect(filter.as_hash.dig("query", "bool", "must")).to match_array(exepcted_query)
+    end
+
     it "ignores params we don't support" do
       params = { not_supported: "trash", search_fields: "cfp" }
       filter = described_class.new(params)

--- a/spec/services/search/query_builders/user_spec.rb
+++ b/spec/services/search/query_builders/user_spec.rb
@@ -28,25 +28,25 @@ RSpec.describe Search::QueryBuilders::User, type: :service do
 
     it "applies EXCLUDED_TERM_KEYS by default" do
       filter = described_class.new({})
-      exepcted_filters = [
+      expected_filters = [
         { "terms" => { "roles" => ["banned"] } },
       ]
-      expect(filter.as_hash.dig("query", "bool", "must_not")).to match_array(exepcted_filters)
+      expect(filter.as_hash.dig("query", "bool", "must_not")).to match_array(expected_filters)
     end
 
     it "applies EXCLUDED_TERM_KEYS and QUERY_KEYS" do
       params = { search_fields: "test" }
       filter = described_class.new(params)
-      exepcted_query = [{
+      expected_query = [{
         "simple_query_string" => {
           "query" => "test*", "fields" => [:search_fields], "lenient" => true, "analyze_wildcard" => true
         }
       }]
-      exepcted_filters = [
+      expected_filters = [
         { "terms" => { "roles" => ["banned"] } },
       ]
-      expect(filter.as_hash.dig("query", "bool", "must_not")).to match_array(exepcted_filters)
-      expect(filter.as_hash.dig("query", "bool", "must")).to match_array(exepcted_query)
+      expect(filter.as_hash.dig("query", "bool", "must_not")).to match_array(expected_filters)
+      expect(filter.as_hash.dig("query", "bool", "must")).to match_array(expected_query)
     end
 
     it "ignores params we don't support" do

--- a/spec/services/search/user_spec.rb
+++ b/spec/services/search/user_spec.rb
@@ -31,5 +31,19 @@ RSpec.describe Search::User, type: :service do
         expect(doc_ids).to include(user1.id, user2.id)
       end
     end
+
+    context "with a filter" do
+      it "searches by excluding roles" do
+        user1.add_role(:admin)
+        user2.add_role(:banned)
+        index_documents([user1, user2])
+        query_params = { size: 5, exclude_roles: ["banned"] }
+
+        user_docs = described_class.search_documents(params: query_params)
+        expect(user_docs.count).to eq(1)
+        doc_ids = user_docs.map { |t| t.dig("id") }
+        expect(doc_ids).to match_array([user1.id])
+      end
+    end
   end
 end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
When users are banned we remove them from Algolia. However, in Elasticsearch we simply apply the banned role to them. This ensures that none of those banned users are returned in search results. Eventually we will not want to make this hardcoded but for now I think it is fine. 

Per @rhymes in a [previous PR comment](https://github.com/thepracticaldev/dev.to/pull/7014#issuecomment-607663389)
> Adding a note for the implementation in the following PRs: there are users whose role is banned, but there also users whose role comment_bannished, not sure if they shall be filtered out as well. There are also "banished users", see the model BanishedUser and the method User.banished?. There's also warned as a role, but not sure if those should be displayed anyway.

Right now the only time we remove users from Algolia is if they are banned, nothing for warned or banned_comment so I am sticking with that behavior for Elasticsearch to start. We can definitely expand on it in the future.

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-35572518

## Added tests?
- [x] yes

![alt_text](https://media.giphy.com/media/Vh2c84FAPVyvvjZJNM/giphy.gif)
