### PR TITLE
Serialize search_score for Articles For Sorting

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -427,16 +427,16 @@ class Article < ApplicationRecord
                    spaminess_rating: BlackBox.calculate_spaminess(self))
   end
 
+  def search_score
+    calculated_score = hotness_score.to_i + ((comments_count * 3).to_i + positive_reactions_count.to_i * 300 * user.reputation_modifier * score.to_i)
+    calculated_score.to_i
+  end
+
   private
 
   def delete_related_objects
     Search::RemoveFromIndexWorker.new.perform("searchables_#{Rails.env}", index_id)
     Search::RemoveFromIndexWorker.new.perform("ordered_articles_#{Rails.env}", index_id)
-  end
-
-  def search_score
-    calculated_score = hotness_score.to_i + ((comments_count * 3).to_i + positive_reactions_count.to_i * 300 * user.reputation_modifier * score.to_i)
-    calculated_score.to_i
   end
 
   def tag_keywords_for_search

--- a/app/serializers/search/article_serializer.rb
+++ b/app/serializers/search/article_serializer.rb
@@ -8,7 +8,7 @@ module Search
                :comments_count, :experience_level_rating, :experience_level_rating_distribution,
                :featured, :featured_number, :hotness_score, :language,
                :main_image, :path, :positive_reactions_count, :published,
-               :published_at, :reactions_count, :reading_time, :score, :title
+               :published_at, :reactions_count, :reading_time, :search_score, :score, :title
 
     # video_duration_in_minutes in Elasticsearch is mapped as an integer
     # however, it really is a string in the format 00:00 which is why we

--- a/spec/serializers/search/article_serializer_spec.rb
+++ b/spec/serializers/search/article_serializer_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Search::ArticleSerializer do
     expect(data_hash[:user]).to eq(user_data)
     expect(data_hash.dig(:organization, :id)).to eq(organization.id)
     expect(data_hash.dig(:flare_tag_hash, :name)).to eq(tag.name)
-    expect(data_hash.keys).to include(:id, :body_text, :hotness_score)
+    expect(data_hash.keys).to include(:id, :body_text, :hotness_score, :search_score)
   end
 
   it "creates valid json for Elasticsearch", elasticsearch: true do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
Currently in [Algolia we sort one of our indexes by hotness and search score](https://github.com/thepracticaldev/dev.to/blob/master/app/models/article.rb#L198). In order to try and mimic that as best as possible in Elasticsearch, we need to be indexing that field. 

Once again, there is not sync script in here bc I am in bug fixing and finding mode still. That will be added once all the bugs have been squashed. At least all the important ones. 😉 

NOTE: Travis failure due to github issues

## Added tests?
- [x] yes

![alt_text](https://media1.giphy.com/media/UlYq4cSAJDdKg/giphy.gif)
