### PR TITLE
Add set_up_profile notification, check for active broadcasts

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -531,9 +531,9 @@ class User < ApplicationRecord
   end
 
   def send_welcome_notification
-    return unless (welcome_broadcast = Broadcast.find_by(title: "Welcome Notification"))
+    return unless (set_up_profile_broadcast = Broadcast.active.find_by(title: "Welcome Notification: set_up_profile"))
 
-    Notification.send_welcome_notification(id, welcome_broadcast.id)
+    Notification.send_welcome_notification(id, set_up_profile_broadcast.id)
   end
 
   def verify_twitter_username

--- a/app/services/broadcasts/welcome_notification/generator.rb
+++ b/app/services/broadcasts/welcome_notification/generator.rb
@@ -19,6 +19,8 @@ module Broadcasts
         send_feed_customization_notification unless notification_enqueued
         send_ux_customization_notification unless notification_enqueued
         send_discuss_and_ask_notification unless notification_enqueued
+      rescue ActiveRecord::RecordNotFound => e
+        Rails.logger.error(e)
       end
 
       private
@@ -77,15 +79,15 @@ module Broadcasts
       end
 
       def welcome_broadcast
-        @welcome_broadcast ||= Broadcast.find_by(title: "Welcome Notification: welcome_thread")
+        @welcome_broadcast ||= Broadcast.active.find_by!(title: "Welcome Notification: welcome_thread")
       end
 
       def customize_ux_broadcast
-        @customize_ux_broadcast ||= Broadcast.find_by(title: "Welcome Notification: customize_experience")
+        @customize_ux_broadcast ||= Broadcast.active.find_by!(title: "Welcome Notification: customize_experience")
       end
 
       def customize_feed_broadcast
-        @customize_feed_broadcast ||= Broadcast.find_by(title: "Welcome Notification: customize_feed")
+        @customize_feed_broadcast ||= Broadcast.active.find_by!(title: "Welcome Notification: customize_feed")
       end
 
       def authentication_broadcast
@@ -104,7 +106,7 @@ module Broadcasts
         missing_identities = SiteConfig.authentication_providers.map do |provider|
           identities.exists?(provider: provider) ? nil : "#{provider}_connect"
         end.compact
-        Broadcast.find_by(title: "Welcome Notification: #{missing_identities.first}")
+        Broadcast.active.find_by!(title: "Welcome Notification: #{missing_identities.first}")
       end
 
       def find_discuss_ask_broadcast
@@ -115,7 +117,7 @@ module Broadcasts
                else
                  "discuss_and_ask"
                end
-        Broadcast.find_by(title: "Welcome Notification: #{type}")
+        Broadcast.active.find_by!(title: "Welcome Notification: #{type}")
       end
 
       def asked_a_question

--- a/app/services/broadcasts/welcome_notification/generator.rb
+++ b/app/services/broadcasts/welcome_notification/generator.rb
@@ -20,7 +20,7 @@ module Broadcasts
         send_ux_customization_notification unless notification_enqueued
         send_discuss_and_ask_notification unless notification_enqueued
       rescue ActiveRecord::RecordNotFound => e
-        Rails.logger.error(e)
+        Honeybadger.notify(e)
       end
 
       private

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -239,14 +239,6 @@ end
 counter += 1
 Rails.logger.info "#{counter}. Creating Broadcasts and Welcome Thread"
 
-# TODO: [@thepracticaldev/delightful] Remove this once we have launched welcome notifications.
-Broadcast.create!(
-  title: "Welcome Notification",
-  processed_html: "Welcome to dev.to! Start by introducing yourself in <a href='/welcome' data-no-instant>the welcome thread</a>.",
-  type_of: "Onboarding",
-  active: true,
-)
-
 broadcast_messages = {
   set_up_profile: "Welcome to DEV! 👋 I'm Sloan, the community mascot and I'm here to help get you started. Let's begin by <a href='/settings'>setting up your profile</a>!",
   welcome_thread: "Sloan here again! 👋 DEV is a friendly community. Why not introduce yourself by leaving a comment in <a href='/welcome'>the welcome thread</a>!",

--- a/spec/factories/broadcasts.rb
+++ b/spec/factories/broadcasts.rb
@@ -2,6 +2,12 @@ FactoryBot.define do
   factory :broadcast do
     active { true }
 
+    factory :set_up_profile_broadcast do
+      title          { "Welcome Notification: set_up_profile" }
+      type_of        { "Welcome" }
+      processed_html { "Welcome to DEV! 👋 I'm <a href='https://dev.to/sloan'>Sloan</a>, the community mascot and I'm here to help get you started. Let's begin by <a href='https://dev.to/settings'>setting up your profile</a>!" }
+    end
+
     factory :welcome_broadcast do
       title          { "Welcome Notification: welcome_thread" }
       type_of        { "Welcome" }

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -592,9 +592,8 @@ RSpec.describe "NotificationsIndex", type: :request do
     end
 
     context "when a user has a new welcome notification" do
-      # TODO: [@thepracticaldev/delightful] Only test against type_of Welcome once Onbarding notifications have been removed.
-      let(:active_broadcast) { create(:onboarding_broadcast) }
-      let(:inactive_broadcast) { create(:onboarding_broadcast, active: false) }
+      let(:active_broadcast) { create(:set_up_profile_broadcast) }
+      let(:inactive_broadcast) { create(:set_up_profile_broadcast, active: false) }
 
       before { sign_in user }
 

--- a/spec/services/broadcasts/welcome_notification/generator_spec.rb
+++ b/spec/services/broadcasts/welcome_notification/generator_spec.rb
@@ -44,13 +44,7 @@ RSpec.describe Broadcasts::WelcomeNotification::Generator, type: :service do
       end.to change(user.notifications, :count).by(0)
     end
 
-    it "sends only 1 notification at a time" do
-      expect do
-        sidekiq_perform_enqueued_jobs { described_class.call(user.id) }
-      end.to change(user.notifications, :count).by(1)
-    end
-
-    it "sends notifications in the correct order" do # rubocop:disable RSpec/MultipleExpectations, RSpec/ExampleLength
+    it "sends only 1 notification at a time, in the correct order" do # rubocop:disable RSpec/MultipleExpectations, RSpec/ExampleLength
       user.update!(created_at: 1.day.ago)
 
       expect { sidekiq_perform_enqueued_jobs { described_class.call(user.id) } }.to change(user.notifications, :count).by(1)

--- a/spec/services/broadcasts/welcome_notification/generator_spec.rb
+++ b/spec/services/broadcasts/welcome_notification/generator_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe Broadcasts::WelcomeNotification::Generator, type: :service do
   let(:mascot_account)  { create(:user) }
   let!(:welcome_thread) { create(:article, user: mascot_account, published: true, tags: "welcome") }
 
-  let_it_be_readonly(:welcome_broadcast)         { create(:welcome_broadcast) }
+  # welcome_broadcast is explicitly not readonly so that we can test against an inactive broadcast
+  let_it_be(:welcome_broadcast)                  { create(:welcome_broadcast) }
   let_it_be_readonly(:twitter_connect_broadcast) { create(:twitter_connect_broadcast) }
   let_it_be_readonly(:github_connect_broadcast)  { create(:github_connect_broadcast) }
   let_it_be_readonly(:customize_feed_broadcast)  { create(:customize_feed_broadcast) }

--- a/spec/workers/notifications/welcome_notification_worker_spec.rb
+++ b/spec/workers/notifications/welcome_notification_worker_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 RSpec.describe Notifications::WelcomeNotificationWorker, type: :worker do
   describe "#perform" do
-    let(:broadcast) { create(:onboarding_broadcast) }
-    let(:inactive_broadcast) { create(:onboarding_broadcast, active: false) }
+    let(:broadcast) { create(:set_up_profile_broadcast) }
+    let(:inactive_broadcast) { create(:set_up_profile_broadcast, active: false) }
     let(:user) { create(:user) }
     let(:service) { Notifications::WelcomeNotification::Send }
     let(:worker) { subject }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Currently, users get an "onboarding" notification immediately after they are sign up (via an `after_create_commit`). However, as we are planning to launch "welcome notifications" today, we want the initial notification to be slightly different:
* It should introduce Sloan, who is the "author" of all the welcome notifications
* It should prompt users to set up their profile.

I have already added the `Welcome Notification: set_up_profile` broadcast to production (and set it to `active`), so once this is deployed, we'll begin sending out the new, "Sloan-authored" welcome notifications!

Additionally, this PR also ensures that we only look for `Broadcast`s that are explicitly set to `active`. We already have [this check](https://github.com/thepracticaldev/dev.to/blob/3bc0f49861be99c437a840c5cfd1ad69bf53c259/app/workers/notifications/welcome_notification_worker.rb#L7) in the worker itself, but we don't need to unnecessarily enqueue a bunch of jobs that are going to do nothing! So, I'm also adding this check to the generator, which will `rescue` if an active Broadcast isn't found, and log it out so that we know about it and can fix it accordingly.

## Related Tickets & Documents
* Addresses [this ticket](https://github.com/thepracticaldev/dev.to/projects/7#card-34793243).
* I have added the new broadcast (and set it to `active`) on the internal broadcast page: https://dev.to/internal/broadcasts

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Here's the new notification in action on my local machine:
<img width="1154" alt="Screen Shot 2020-04-02 at 10 27 33 AM" src="https://user-images.githubusercontent.com/6921610/78296165-190dff00-74e2-11ea-95bc-82acdda74719.png">


## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed