### PR TITLE
Add community_member_description, tagline and mascot_image_url to SiteConfig. Enable Cloudinary for primary_sticker_image

### DIFF
--- a/app/assets/stylesheets/articles.scss
+++ b/app/assets/stylesheets/articles.scss
@@ -176,7 +176,7 @@
     margin-right: 9px;
     padding-right: 9px;
   }
-  img.rainbowdevimage {
+  img.primary-sticker-image {
     width: 190px;
     height: 190px;
     margin: 18px auto 35px;

--- a/app/assets/stylesheets/signup-modal.scss
+++ b/app/assets/stylesheets/signup-modal.scss
@@ -68,7 +68,7 @@
         vertical-align: calc(-0.1em - 2px);
       }
     }
-    .sloan {
+    .mascot-image {
       height: calc(7vw + 80px);
       margin-top: calc(6vh - 10px);
     }

--- a/app/controllers/internal/configs_controller.rb
+++ b/app/controllers/internal/configs_controller.rb
@@ -23,7 +23,7 @@ class Internal::ConfigsController < Internal::ApplicationController
       default_site_email social_networks_handle mascot_user_id
       campaign_hero_html_variant_name campaign_sidebar_enabled campaign_featured_tags
       campaign_sidebar_image
-      main_social_image favicon_url logo_svg logo_png primary_sticker_image_url 
+      main_social_image favicon_url logo_svg logo_png primary_sticker_image_url
       mascot_image_url
       rate_limit_follow_count_daily
       ga_view_id ga_fetch_rate community_description authentication_providers

--- a/app/controllers/internal/configs_controller.rb
+++ b/app/controllers/internal/configs_controller.rb
@@ -24,7 +24,7 @@ class Internal::ConfigsController < Internal::ApplicationController
       campaign_hero_html_variant_name campaign_sidebar_enabled campaign_featured_tags
       campaign_sidebar_image
       main_social_image favicon_url logo_svg logo_png primary_sticker_image_url
-      mascot_image_url
+      mascot_image_url mascot_image_description
       rate_limit_follow_count_daily
       ga_view_id ga_fetch_rate community_description authentication_providers
       community_member_description tagline

--- a/app/controllers/internal/configs_controller.rb
+++ b/app/controllers/internal/configs_controller.rb
@@ -23,9 +23,11 @@ class Internal::ConfigsController < Internal::ApplicationController
       default_site_email social_networks_handle mascot_user_id
       campaign_hero_html_variant_name campaign_sidebar_enabled campaign_featured_tags
       campaign_sidebar_image
-      main_social_image favicon_url logo_svg logo_png primary_sticker_image_url
+      main_social_image favicon_url logo_svg logo_png primary_sticker_image_url 
+      mascot_image_url
       rate_limit_follow_count_daily
       ga_view_id ga_fetch_rate community_description authentication_providers
+      community_member_description tagline
       mailchimp_newsletter_id mailchimp_sustaining_members_id
       mailchimp_tag_moderators_id mailchimp_community_moderators_id
       periodic_email_digest_max periodic_email_digest_min suggested_tags

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -13,6 +13,8 @@ class SiteConfig < RailsSettings::Base
 
   # site content
   field :community_description, type: :string, default: "A constructive and inclusive social network. Open source and radically transparent."
+  field :community_member_description, type: :string, default: "amazing humans who code."
+  field :tagline, type: :string, default: "We're a place where coders share, stay up-to-date and grow their careers."
 
   # staff account
   field :staff_user_id, type: :integer, default: 1
@@ -40,6 +42,7 @@ class SiteConfig < RailsSettings::Base
   field :logo_png, type: :string, default: "https://practicaldev-herokuapp-com.freetls.fastly.net/assets/devlogo-pwa-512.png"
   field :logo_svg, type: :string, default: ""
   field :primary_sticker_image_url, type: :string, default: "https://practicaldev-herokuapp-com.freetls.fastly.net/assets/rainbowdev.svg"
+  field :mascot_image_url, type: :string, default: "https://practicaldev-herokuapp-com.freetls.fastly.net/assets/sloan.png"
 
   # rate limits
   field :rate_limit_follow_count_daily, type: :integer, default: 500

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -43,6 +43,7 @@ class SiteConfig < RailsSettings::Base
   field :logo_svg, type: :string, default: ""
   field :primary_sticker_image_url, type: :string, default: "https://practicaldev-herokuapp-com.freetls.fastly.net/assets/rainbowdev.svg"
   field :mascot_image_url, type: :string, default: "https://practicaldev-herokuapp-com.freetls.fastly.net/assets/sloan.png"
+  field :mascot_image_description, type: :string, default: "Sloan, the sloth mascot"
 
   # rate limits
   field :rate_limit_follow_count_daily, type: :integer, default: 500

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -40,18 +40,18 @@
         <div class="form-group">
           <%= f.label :community_member_description, "Community member description" %>
           <%= f.text_field :community_member_description,
-                            class: "form-control",
-                            value: SiteConfig.community_member_description,
-                            placeholder: "amazing humans who code." %>
+                           class: "form-control",
+                           value: SiteConfig.community_member_description,
+                           placeholder: "amazing humans who code." %>
           <div class="alert alert-info">Used in pre-login banners.</div>
         </div>
 
         <div class="form-group">
           <%= f.label :tagline, "Tagline" %>
           <%= f.text_field :tagline,
-                            class: "form-control",
-                            value: SiteConfig.tagline,
-                            placeholder: "We're a place where coders share, stay up-to-date and grow their careers." %>
+                           class: "form-control",
+                           value: SiteConfig.tagline,
+                           placeholder: "We're a place where coders share, stay up-to-date and grow their careers." %>
           <div class="alert alert-info">Used in signup modal.</div>
         </div>
 
@@ -211,27 +211,29 @@
                   <img alt="main social image" class="img-fluid" src="<%= SiteConfig.primary_sticker_image_url %>" />
                 </div>
                 <div class="col-12">
-                  <div class="alert alert-info">
-                    <h5>Used as the primary sticker image</h5>
-                  </div>
+                  <div class="alert alert-info"> Used as the primary sticker image </div>
                 </div>
               </div>
-            </div>
-          </div>
-        </div>
 
-        <%= f.label :mascot_image_url %>
-        <%= f.text_field :mascot_image_url,
-                          class: "form-control",
-                          value: SiteConfig.mascot_image_url,
-                          placeholder: "https://image.url" %>
-        <div class="row mt-2">
-          <div class="col-12">
-            <img alt="main social image" class="img-fluid" src="<%= SiteConfig.mascot_image_url %>" />
-          </div>
-          <div class="col-12">
-            <div class="alert alert-info">
-              <h5>Used as the mascot image.</h5>
+              <%= f.label :mascot_image_url %>
+              <%= f.text_field :mascot_image_url,
+                               class: "form-control",
+                               value: SiteConfig.mascot_image_url,
+                               placeholder: "https://image.url" %>
+              <div class="row mt-2">
+                <div class="col-12">
+                  <img alt="<%= SiteConfig.mascot_image_description %>" class="img-fluid" src="<%= SiteConfig.mascot_image_url %>" />
+                </div>
+                <div class="col-12">
+                  <div class="alert alert-info"> Used as the mascot image. </div>
+                </div>
+              </div>
+
+              <%= f.label :mascot_image_description %>
+              <%= f.text_field :mascot_image_description,
+                               class: "form-control",
+                               value: SiteConfig.mascot_image_description %>
+              <div class="alert alert-info">Used as the alt text for the mascot image </div>
             </div>
           </div>
         </div>

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -37,6 +37,24 @@
           </div>
         </div>
 
+        <div class="form-group">
+          <%= f.label :community_member_description, "Community member description" %>
+          <%= f.text_field :community_member_description,
+                            class: "form-control",
+                            value: SiteConfig.community_member_description,
+                            placeholder: "amazing humans who code." %>
+          <div class="alert alert-info">Used in pre-login banners.</div>
+        </div>
+
+        <div class="form-group">
+          <%= f.label :tagline, "Tagline" %>
+          <%= f.text_field :tagline,
+                            class: "form-control",
+                            value: SiteConfig.tagline,
+                            placeholder: "We're a place where coders share, stay up-to-date and grow their careers." %>
+          <div class="alert alert-info">Used in signup modal.</div>
+        </div>
+
         <div class="card mt-3">
           <div class="card-header">Staff</div>
           <div class="card-body">
@@ -198,6 +216,22 @@
                   </div>
                 </div>
               </div>
+            </div>
+          </div>
+        </div>
+
+        <%= f.label :mascot_image_url %>
+        <%= f.text_field :mascot_image_url,
+                          class: "form-control",
+                          value: SiteConfig.mascot_image_url,
+                          placeholder: "https://image.url" %>
+        <div class="row mt-2">
+          <div class="col-12">
+            <img alt="main social image" class="img-fluid" src="<%= SiteConfig.mascot_image_url %>" />
+          </div>
+          <div class="col-12">
+            <div class="alert alert-info">
+              <h5>Used as the mascot image.</h5>
             </div>
           </div>
         </div>

--- a/app/views/layouts/_signup_modal.html.erb
+++ b/app/views/layouts/_signup_modal.html.erb
@@ -5,17 +5,10 @@
     </button>
   </div>
   <div class="global-signup-modal--inner-a">
-    <%= image_tag(cl_image_path(asset_path("/assets/sloan.png"),
-                                type: "fetch",
-                                width: 300,
-                                crop: "imagga_scale",
-                                quality: "auto",
-                                flags: "progressive",
-                                fetch_format: "auto",
-                                sign_url: true), class: "sloan", alt: "Sloan, the sloth mascot", loading: "lazy") %>
+    <%= image_tag(cloudinary(SiteConfig.mascot_image_url, 300), class: "mascot-image", alt: "Sloan, the sloth mascot", loading: "lazy") %>
     <h1>Join our <%= community_qualified_name %> :)</h1>
     <p>
-      We're a place where coders share, stay up-to-date and grow their careers.
+      <%= SiteConfig.tagline %>
     </p>
     <% if SiteConfig.auth_allowed?("twitter") %>
       <a href="/users/auth/twitter?callback_url=<%= app_url %>/users/auth/twitter/callback" class="sign-up-link cta" data-no-instant>

--- a/app/views/layouts/_signup_modal.html.erb
+++ b/app/views/layouts/_signup_modal.html.erb
@@ -5,7 +5,8 @@
     </button>
   </div>
   <div class="global-signup-modal--inner-a">
-    <%= image_tag(cloudinary(SiteConfig.mascot_image_url, 300), class: "mascot-image", alt: "Sloan, the sloth mascot", loading: "lazy") %>
+    <%= image_tag(cloudinary(SiteConfig.mascot_image_url, 300),
+                  class: "mascot-image", alt: SiteConfig.mascot_image_description, loading: "lazy") %>
     <h1>Join our <%= community_qualified_name %> :)</h1>
     <p>
       <%= SiteConfig.tagline %>

--- a/app/views/stories/_sign_in_invitation.html.erb
+++ b/app/views/stories/_sign_in_invitation.html.erb
@@ -1,9 +1,11 @@
 <div class="single-article single-article-small-pic feed-cta" id="in-feed-cta">
   <div class="cta-container" id="cta-content">
-    <img class="rainbowdevimage" src="<%= SiteConfig.primary_sticker_image_url %>" alt="rainbow DEV logo" />
+    <img class="primary-sticker-image" src="<%= cloudinary(SiteConfig.primary_sticker_image_url, 190) %>" 
+         alt="Primary <%= community_qualified_name %> logo" />
 
     <h2>
-      <a href="/">DEV</a> is a community of <br /><%= number_with_delimiter User.estimated_count %> amazing humans who code.
+      <a href="/"><%= community_name %></a> is a community of <br />
+      <%= number_with_delimiter User.estimated_count %> <%= SiteConfig.community_member_description %>
     </h2>
 
     <h3>

--- a/spec/requests/internal/configs_spec.rb
+++ b/spec/requests/internal/configs_spec.rb
@@ -126,6 +126,12 @@ RSpec.describe "/internal/config", type: :request do
           expect(SiteConfig.mascot_image_url).to eq(expected_image_url)
         end
 
+        it "updates mascot_image_description" do
+          description = "Hey hey #{rand(100)}"
+          post "/internal/config", params: { site_config: { mascot_image_description: description }, confirmation: confirmation_message }
+          expect(SiteConfig.mascot_image_description).to eq(expected_image_url)
+        end
+
         it "rejects update without proper confirmation" do
           expected_image_url = "https://dummyimage.com/300x300"
           expect { post "/internal/config", params: { site_config: { logo_svg: expected_image_url }, confirmation: "Incorrect yo!" } }.to raise_error Pundit::NotAuthorizedError

--- a/spec/requests/internal/configs_spec.rb
+++ b/spec/requests/internal/configs_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe "/internal/config", type: :request do
         it "updates mascot_image_description" do
           description = "Hey hey #{rand(100)}"
           post "/internal/config", params: { site_config: { mascot_image_description: description }, confirmation: confirmation_message }
-          expect(SiteConfig.mascot_image_description).to eq(expected_image_url)
+          expect(SiteConfig.mascot_image_description).to eq(description)
         end
 
         it "rejects update without proper confirmation" do

--- a/spec/requests/internal/configs_spec.rb
+++ b/spec/requests/internal/configs_spec.rb
@@ -45,6 +45,18 @@ RSpec.describe "/internal/config", type: :request do
           post "/internal/config", params: { site_config: { community_description: description }, confirmation: confirmation_message }
           expect(SiteConfig.community_description).to eq(description)
         end
+
+        it "updates the community_member_description" do
+          description = "Hey hey #{rand(100)}"
+          post "/internal/config", params: { site_config: { community_member_description: description }, confirmation: confirmation_message }
+          expect(SiteConfig.community_member_description).to eq(description)
+        end
+
+        it "updates the tagline" do
+          description = "Hey hey #{rand(100)}"
+          post "/internal/config", params: { site_config: { tagline: description }, confirmation: confirmation_message }
+          expect(SiteConfig.tagline).to eq(description)
+        end
       end
 
       describe "staff" do
@@ -106,6 +118,12 @@ RSpec.describe "/internal/config", type: :request do
           expected_image_url = "https://dummyimage.com/300x300"
           post "/internal/config", params: { site_config: { primary_sticker_image_url: expected_image_url }, confirmation: confirmation_message }
           expect(SiteConfig.primary_sticker_image_url).to eq(expected_image_url)
+        end
+
+        it "updates mascot_image_url" do
+          expected_image_url = "https://dummyimage.com/300x300"
+          post "/internal/config", params: { site_config: { mascot_image_url: expected_image_url }, confirmation: confirmation_message }
+          expect(SiteConfig.mascot_image_url).to eq(expected_image_url)
         end
 
         it "rejects update without proper confirmation" do

--- a/spec/views/layouts/signup_modal.html.erb_spec.rb
+++ b/spec/views/layouts/signup_modal.html.erb_spec.rb
@@ -1,0 +1,8 @@
+require "rails_helper"
+
+RSpec.describe "layouts/_signup_modal.html.erb", type: :view do
+  it "has the tagline" do
+    render
+    expect(rendered).to have_text(SiteConfig.tagline)
+  end
+end

--- a/spec/views/stories/sign_in_invitation.html.erb_spec.rb
+++ b/spec/views/stories/sign_in_invitation.html.erb_spec.rb
@@ -1,0 +1,8 @@
+require "rails_helper"
+
+RSpec.describe "stories/_sign_in_invitation.html.erb", type: :view do
+  it "has the community member description" do
+    render
+    expect(rendered).to have_text(SiteConfig.community_member_description)
+  end
+end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Adding `community_member_description`, `tagline` and `mascot_image_url` to SiteConfig. Also enabling cloudinary for `primary_sticker_url` which was created by #6746. 

The only thing missing in order to complete issue https://github.com/thepracticaldev/dev.to/issues/5477 is implementing `secondary_sticker_image_url`. However, that purple logo is implemented in jsx. I am not really sure how to push SiteConfig details into javascript.

## Related Tickets & Documents
#5477

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)


### community_member_description

<img width="1114" alt="Screen Shot 2020-03-23 at 8 18 09 AM" src="https://user-images.githubusercontent.com/14208431/77320636-f0665800-6cde-11ea-8292-ae7bd47393ce.png">

<img width="546" alt="Screen Shot 2020-03-23 at 8 35 07 AM" src="https://user-images.githubusercontent.com/14208431/77322118-3ae8d400-6ce1-11ea-8b74-e58ea250d640.png">

### tagline

<img width="1079" alt="Screen Shot 2020-03-23 at 8 31 00 AM" src="https://user-images.githubusercontent.com/14208431/77321894-dd548780-6ce0-11ea-9e72-e35e7113f1c0.png">

<img width="769" alt="Screen Shot 2020-03-23 at 8 31 19 AM" src="https://user-images.githubusercontent.com/14208431/77321908-e180a500-6ce0-11ea-8912-6a823a875f90.png">

### mascot_image_url

<img width="1087" alt="Screen Shot 2020-03-23 at 9 06 11 AM" src="https://user-images.githubusercontent.com/14208431/77357324-f0357f00-6d15-11ea-949d-fbf5cbd4fb13.png">

<img width="1070" alt="Screen Shot 2020-03-23 at 9 06 03 AM" src="https://user-images.githubusercontent.com/14208431/77357316-edd32500-6d15-11ea-8f15-1fb5672b8cbf.png">

## Added tests?

- [X] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed

