### PR TITLE
Unset DATABASE_URL in .gitpod.yml

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -19,6 +19,8 @@ tasks:
   - init: >
       cp config/sample_application.yml config/application.yml &&
       bin/setup 2>/dev/null || true
+    # We explicitly unset DATABASE_URL so bin/setup can do its job.
+    # See: https://github.com/thepracticaldev/dev.to/issues/7040
     command: >
       while [ -z "${ALGOLIASEARCH_APPLICATION_ID:=$(cat config/application.yml | grep ALGOLIASEARCH_APPLICATION_ID | sed 's/.*:\s*//')}" ] ||
             [ -z "${ALGOLIASEARCH_SEARCH_ONLY_KEY:=$(cat config/application.yml | grep ALGOLIASEARCH_SEARCH_ONLY_KEY | sed 's/.*:\s*//')}" ] ||
@@ -28,6 +30,7 @@ tasks:
         printf "❗ To get them, please follow https://docs.dev.to/backend/algolia/#get-api-keys\n\n" &&
         read -p "Add them to config/application.yml, save the file, and press any key to continue... " -n 1 -r
       done ;
+      eval $(gp env -e DATABASE_URL='')
       bin/setup &&
       bin/startup
 github:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -16,9 +16,7 @@ ports:
 tasks:
   - command: redis-server
   - command: /home/gitpod/elasticsearch-7.5.2/bin/elasticsearch
-  - init: >
-      cp config/sample_application.yml config/application.yml &&
-      bin/setup 2>/dev/null || true
+  - init: cp config/sample_application.yml config/application.yml
     # We explicitly unset DATABASE_URL so bin/setup can do its job.
     # See: https://github.com/thepracticaldev/dev.to/issues/7040
     command: >

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -17,8 +17,6 @@ tasks:
   - command: redis-server
   - command: /home/gitpod/elasticsearch-7.5.2/bin/elasticsearch
   - init: cp config/sample_application.yml config/application.yml
-    # We explicitly unset DATABASE_URL so bin/setup can do its job.
-    # See: https://github.com/thepracticaldev/dev.to/issues/7040
     command: >
       while [ -z "${ALGOLIASEARCH_APPLICATION_ID:=$(cat config/application.yml | grep ALGOLIASEARCH_APPLICATION_ID | sed 's/.*:\s*//')}" ] ||
             [ -z "${ALGOLIASEARCH_SEARCH_ONLY_KEY:=$(cat config/application.yml | grep ALGOLIASEARCH_SEARCH_ONLY_KEY | sed 's/.*:\s*//')}" ] ||
@@ -28,7 +26,7 @@ tasks:
         printf "❗ To get them, please follow https://docs.dev.to/backend/algolia/#get-api-keys\n\n" &&
         read -p "Add them to config/application.yml, save the file, and press any key to continue... " -n 1 -r
       done ;
-      DATABASE_URL='' bin/setup &&
+      bin/setup &&
       bin/startup
 github:
   prebuilds:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -28,8 +28,7 @@ tasks:
         printf "❗ To get them, please follow https://docs.dev.to/backend/algolia/#get-api-keys\n\n" &&
         read -p "Add them to config/application.yml, save the file, and press any key to continue... " -n 1 -r
       done ;
-      eval $(gp env -e DATABASE_URL='')
-      bin/setup &&
+      DATABASE_URL='' bin/setup &&
       bin/startup
 github:
   prebuilds:

--- a/bin/setup
+++ b/bin/setup
@@ -1,17 +1,17 @@
 #!/usr/bin/env ruby
-require 'fileutils'
+require "fileutils"
 
 # path to your application root.
-APP_ROOT = File.expand_path('..', __dir__)
+APP_ROOT = File.expand_path("..", __dir__)
 
-db_url = ENV['DATABASE_URL'].to_s
+db_url = ENV["DATABASE_URL"].to_s
 
 # We explicitly unset DATABASE_URL for Gitpod so bin/setup can do its job.
 # See: https://github.com/thepracticaldev/dev.to/issues/7040
-DB = if db_url.to_s.empty? || db_url = 'postgresql://gitpod@localhost'
-       'PracticalDeveloper_development'
+DB = if db_url.to_s.empty? || db_url = "postgresql://gitpod@localhost"
+       "PracticalDeveloper_development"
      else
-       ENV['DATABASE_URL']
+       db_url
      end
 
 def system!(*args)
@@ -23,39 +23,39 @@ FileUtils.chdir APP_ROOT do
   # This script is idempotent, so that you can run it at anytime and get an expectable outcome.
   # Add necessary setup steps to this file.
 
-  puts '== Installing dependencies =='
-  system! 'gem install bundler --conservative'
-  system('bundle check') || system!('bundle install')
+  puts "== Installing dependencies =="
+  system! "gem install bundler --conservative"
+  system("bundle check") || system!("bundle install")
 
-  system! 'gem install foreman'
+  system! "gem install foreman"
 
   # Install JavaScript dependencies if using Yarn
-  system('bin/yarn')
+  system("bin/yarn")
 
   puts "\n== Copying sample files =="
-  unless File.exist?('config/database.yml')
-    FileUtils.cp 'config/database.yml.sample', 'config/database.yml'
+  unless File.exist?("config/database.yml")
+    FileUtils.cp "config/database.yml.sample", "config/database.yml"
   end
 
   puts "\n== Preparing database =="
   command = "psql -o /dev/null -q -n -c 'select 1' #{DB}"
   db_exists = system(command)
   if db_exists
-    system! 'bin/rails db:migrate'
+    system! "bin/rails db:migrate"
   else
-    system! 'bin/rails db:setup'
+    system! "bin/rails db:setup"
   end
 
   puts "\n== Preparing Elasticsearch =="
-  system! 'bin/rails search:setup'
+  system! "bin/rails search:setup"
   system! 'RAILS_ENV="test" bin/rails search:setup'
 
   puts "\n== Updating Data =="
-  system! 'bin/rails data_updates:run'
+  system! "bin/rails data_updates:run"
 
   puts "\n== Removing old logs and tempfiles =="
-  system! 'bin/rails log:clear tmp:clear'
+  system! "bin/rails log:clear tmp:clear"
 
   puts "\n== Restarting application server =="
-  system! 'bin/rails restart'
+  system! "bin/rails restart"
 end

--- a/bin/setup
+++ b/bin/setup
@@ -8,7 +8,7 @@ db_url = ENV["DATABASE_URL"].to_s
 
 # We explicitly unset DATABASE_URL for Gitpod so bin/setup can do its job.
 # See: https://github.com/thepracticaldev/dev.to/issues/7040
-DB = if db_url.to_s.empty? || db_url = "postgresql://gitpod@localhost"
+DB = if db_url.to_s.empty? || db_url == "postgresql://gitpod@localhost"
        "PracticalDeveloper_development"
      else
        db_url

--- a/bin/setup
+++ b/bin/setup
@@ -4,7 +4,11 @@ require 'fileutils'
 # path to your application root.
 APP_ROOT = File.expand_path('..', __dir__)
 
-DB = if ENV['DATABASE_URL'].to_s.empty?
+db_url = ENV['DATABASE_URL'].to_s
+
+# We explicitly unset DATABASE_URL for Gitpod so bin/setup can do its job.
+# See: https://github.com/thepracticaldev/dev.to/issues/7040
+DB = if db_url.to_s.empty? || db_url = 'postgresql://gitpod@localhost'
        'PracticalDeveloper_development'
      else
        ENV['DATABASE_URL']


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Description

Gitpod sets a `DATABASE_URL` environment variable which defaults to `postgresql://gitpod@localhost`. This doesn't play well with our `bin/setup` script, which won't attempt to create the DB before running migrations because of this. 

I also updated `.gitpod.yml` to only run `bin/setup` once, it was running twice before, once during `init:` and once during `command:`.

## Related Tickets & Documents

Closes #7040 

## Added tests?

- [X] no, because they aren't needed

If you want to confirm that this works, start a Gitpod instance from the link below:

<img width="800" alt="gitpod" src="https://user-images.githubusercontent.com/47985/78326473-b5003f00-75a4-11ea-8666-e1ac20c6b75e.png">

## Added to documentation?

- [X] no documentation needed
