### PR TITLE
Revert "Serialize search_score for Articles For Sorting"

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -427,16 +427,16 @@ class Article < ApplicationRecord
                    spaminess_rating: BlackBox.calculate_spaminess(self))
   end
 
-  def search_score
-    calculated_score = hotness_score.to_i + ((comments_count * 3).to_i + positive_reactions_count.to_i * 300 * user.reputation_modifier * score.to_i)
-    calculated_score.to_i
-  end
-
   private
 
   def delete_related_objects
     Search::RemoveFromIndexWorker.new.perform("searchables_#{Rails.env}", index_id)
     Search::RemoveFromIndexWorker.new.perform("ordered_articles_#{Rails.env}", index_id)
+  end
+
+  def search_score
+    calculated_score = hotness_score.to_i + ((comments_count * 3).to_i + positive_reactions_count.to_i * 300 * user.reputation_modifier * score.to_i)
+    calculated_score.to_i
   end
 
   def tag_keywords_for_search

--- a/app/serializers/search/article_serializer.rb
+++ b/app/serializers/search/article_serializer.rb
@@ -8,7 +8,7 @@ module Search
                :comments_count, :experience_level_rating, :experience_level_rating_distribution,
                :featured, :featured_number, :hotness_score, :language,
                :main_image, :path, :positive_reactions_count, :published,
-               :published_at, :reactions_count, :reading_time, :search_score, :score, :title
+               :published_at, :reactions_count, :reading_time, :score, :title
 
     # video_duration_in_minutes in Elasticsearch is mapped as an integer
     # however, it really is a string in the format 00:00 which is why we

--- a/spec/serializers/search/article_serializer_spec.rb
+++ b/spec/serializers/search/article_serializer_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Search::ArticleSerializer do
     expect(data_hash[:user]).to eq(user_data)
     expect(data_hash.dig(:organization, :id)).to eq(organization.id)
     expect(data_hash.dig(:flare_tag_hash, :name)).to eq(tag.name)
-    expect(data_hash.keys).to include(:id, :body_text, :hotness_score, :search_score)
+    expect(data_hash.keys).to include(:id, :body_text, :hotness_score)
   end
 
   it "creates valid json for Elasticsearch", elasticsearch: true do


### PR DESCRIPTION
Reverts thepracticaldev/dev.to#7053

some search_scores are in the billions which doesn't fit in the integer field type and is causing errors