### PR TITLE
Remove onboarding type broadcasts

### DIFF
--- a/app/models/broadcast.rb
+++ b/app/models/broadcast.rb
@@ -4,8 +4,7 @@ class Broadcast < ApplicationRecord
   has_many :notifications, as: :notifiable, inverse_of: :notifiable
 
   validates :title, :type_of, :processed_html, presence: true
-  # TODO: [@thepracticaldev/delightful] Remove Onboarding type once we have launched welcome notifications.
-  validates :type_of, inclusion: { in: %w[Announcement Onboarding Welcome] }
+  validates :type_of, inclusion: { in: %w[Announcement Welcome] }
 
   scope :active, -> { where(active: true) }
 

--- a/app/services/broadcasts/welcome_notification/generator.rb
+++ b/app/services/broadcasts/welcome_notification/generator.rb
@@ -11,7 +11,6 @@ module Broadcasts
       end
 
       def call
-        # TODO: [@thepracticaldev/delightful] Move this check into the rake task logic once it has been implemented.
         return unless user.subscribed_to_welcome_notifications?
 
         send_welcome_notification unless notification_enqueued

--- a/spec/factories/broadcasts.rb
+++ b/spec/factories/broadcasts.rb
@@ -55,12 +55,5 @@ FactoryBot.define do
       type_of        { "Welcome" }
       processed_html { "Sloan here! 👋 I noticed that you haven't <a href='https://dev.to/t/explainlikeimfive'>asked a question</a> or <a href='https://dev.to/t/discuss'>started a discussion</a> yet. It's easy to do both of these; just click on 'Write a Post' in the sidebar of the tag page to get started!" }
     end
-
-    # TODO: [@thepracticaldev/delightful] Remove onboarding factory once welcome notifications are live.
-    factory :onboarding_broadcast do
-      title          { "Welcome Notification" }
-      type_of        { "Onboarding" }
-      processed_html { "Welcome! Introduce yourself in our <a href='/welcome'>welcome thread!</a>" }
-    end
   end
 end

--- a/spec/requests/internal/broadcasts_spec.rb
+++ b/spec/requests/internal/broadcasts_spec.rb
@@ -3,7 +3,7 @@ require "requests/shared_examples/internal_policy_dependant_request"
 
 RSpec.describe "/internal/broadcasts", type: :request do
   let(:get_resource) { get "/internal/broadcasts" }
-  let(:params) { { title: "Hello!", processed_html: "<pHello!</p>", type_of: "Onboarding", sent: true } }
+  let(:params) { { title: "Hello!", processed_html: "<pHello!</p>", type_of: "Welcome", sent: true } }
   let(:post_resource) { post "/internal/broadcasts", params: params }
 
   it_behaves_like "an InternalPolicy dependant request", Broadcast do

--- a/spec/services/notifications/welcome_notification/send_spec.rb
+++ b/spec/services/notifications/welcome_notification/send_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe Notifications::WelcomeNotification::Send, type: :service do
     end
 
     it "creates a new welcome notification", :aggregate_failures do
-      welcome_broadcast = create(:onboarding_broadcast)
+      welcome_broadcast = create(:set_up_profile_broadcast)
       welcome_notification = described_class.call(create(:user).id, welcome_broadcast)
 
       expect(welcome_notification).to be_kind_of(Notification)
       expect(welcome_notification.notifiable_type).to eq "Broadcast"
-      expect(welcome_notification.action).to eq "Onboarding"
+      expect(welcome_notification.action).to eq "Welcome"
       expect(welcome_notification.json_data["broadcast"]["processed_html"]).to eq welcome_broadcast.processed_html
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Removes the "Onboarding" type of broadcast, since we aren't using that to send any notifications anymore. Closes #6709.

## Related Tickets & Documents
#6709

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
