### PR TITLE
Copy set_cache_control_headers from fastly-rails

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
   include SessionCurrentUser
   include ValidRequest
   include Pundit
+  include FastlyHeaders
 
   rescue_from ActionView::MissingTemplate, with: :routing_error
 
@@ -73,40 +74,5 @@ class ApplicationController < ActionController::Base
 
   def touch_current_user
     current_user.touch
-  end
-
-  # The following is from the now deprecated fastly-rails gem
-  # https://github.com/fastly/fastly-rails/tree/master/lib/fastly-rails/action_controller
-
-  # Sets Cache-Control and Surrogate-Control HTTP headers
-  # Surrogate-Control is stripped at the cache, Cache-Control persists (in case of other caches in front of fastly)
-  # Defaults are:
-  #  Cache-Control: 'public, no-cache'
-  #  Surrogate-Control: 'max-age: 30 days
-  # custom config example:
-  #  {cache_control: 'public, no-cache, maxage=xyz', surrogate_control: 'max-age: blah'}
-  def set_cache_control_headers(max_age = 1.day.to_i, opts = {})
-    request.session_options[:skip] = true # no cookies
-    response.headers["Cache-Control"] = opts[:cache_control] || "public, no-cache"
-    response.headers["Surrogate-Control"] = opts[:surrogate_control] || build_surrogate_control(max_age, opts)
-  end
-
-  # Sets Surrogate-Key HTTP header with one or more keys
-  # strips session data from the request
-  def set_surrogate_key_header(*surrogate_keys)
-    request.session_options[:skip] = true # No Set-Cookie
-    response.headers["Surrogate-Key"] = surrogate_keys.join(" ")
-  end
-
-  private
-
-  def build_surrogate_control(max_age, opts)
-    surrogate_control = "max-age=#{max_age}"
-    stale_while_revalidate = opts[:stale_while_revalidate]
-    stale_if_error = opts[:stale_if_error] || 26_400
-
-    surrogate_control += ", stale-while-revalidate=#{stale_while_revalidate}" if stale_while_revalidate
-    surrogate_control += ", stale-if-error=#{stale_if_error}" if stale_if_error
-    surrogate_control
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -74,4 +74,39 @@ class ApplicationController < ActionController::Base
   def touch_current_user
     current_user.touch
   end
+
+  # The following is from the now deprecated fastly-rails gem
+  # https://github.com/fastly/fastly-rails/tree/master/lib/fastly-rails/action_controller
+
+  # Sets Cache-Control and Surrogate-Control HTTP headers
+  # Surrogate-Control is stripped at the cache, Cache-Control persists (in case of other caches in front of fastly)
+  # Defaults are:
+  #  Cache-Control: 'public, no-cache'
+  #  Surrogate-Control: 'max-age: 30 days
+  # custom config example:
+  #  {cache_control: 'public, no-cache, maxage=xyz', surrogate_control: 'max-age: blah'}
+  def set_cache_control_headers(max_age = 1.day.to_i, opts = {})
+    request.session_options[:skip] = true # no cookies
+    response.headers["Cache-Control"] = opts[:cache_control] || "public, no-cache"
+    response.headers["Surrogate-Control"] = opts[:surrogate_control] || build_surrogate_control(max_age, opts)
+  end
+
+  # Sets Surrogate-Key HTTP header with one or more keys
+  # strips session data from the request
+  def set_surrogate_key_header(*surrogate_keys)
+    request.session_options[:skip] = true # No Set-Cookie
+    response.headers["Surrogate-Key"] = surrogate_keys.join(" ")
+  end
+
+  private
+
+  def build_surrogate_control(max_age, opts)
+    surrogate_control = "max-age=#{max_age}"
+    stale_while_revalidate = opts[:stale_while_revalidate]
+    stale_if_error = opts[:stale_if_error] || 26_400
+
+    surrogate_control += ", stale-while-revalidate=#{stale_while_revalidate}" if stale_while_revalidate
+    surrogate_control += ", stale-if-error=#{stale_if_error}" if stale_if_error
+    surrogate_control
+  end
 end

--- a/app/controllers/concerns/fastly_headers.rb
+++ b/app/controllers/concerns/fastly_headers.rb
@@ -1,0 +1,31 @@
+module FastlyHeaders
+  extend ActiveSupport::Concern
+
+  # The following is from the now deprecated fastly-rails gem
+  # https://github.com/fastly/fastly-rails/tree/master/lib/fastly-rails/action_controller
+
+  # Sets Cache-Control and Surrogate-Control HTTP headers
+  # Surrogate-Control is stripped at the cache, Cache-Control persists (in case of other caches in front of fastly)
+  # Defaults are:
+  #  Cache-Control: 'public, no-cache'
+  #  Surrogate-Control: 'max-age: 30 days
+  # custom config example:
+  #  {cache_control: 'public, no-cache, maxage=xyz', surrogate_control: 'max-age: blah'}
+  def set_cache_control_headers(max_age = 1.day.to_i, opts = {})
+    request.session_options[:skip] = true # no cookies
+    response.headers["Cache-Control"] = opts[:cache_control] || "public, no-cache"
+    response.headers["Surrogate-Control"] = opts[:surrogate_control] || build_surrogate_control(max_age, opts)
+  end
+
+  private
+
+  def build_surrogate_control(max_age, opts)
+    surrogate_control = "max-age=#{max_age}"
+    stale_while_revalidate = opts[:stale_while_revalidate]
+    stale_if_error = opts[:stale_if_error] || 26_400
+
+    surrogate_control += ", stale-while-revalidate=#{stale_while_revalidate}" if stale_while_revalidate
+    surrogate_control += ", stale-if-error=#{stale_if_error}" if stale_if_error
+    surrogate_control
+  end
+end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Feature

## Description
**This PR:**
The [`fastly-rails` gem](https://github.com/fastly/fastly-rails) has been deprecated. I copied over the controller methods we need from it to set the headers for Fastly.

Note: there are some places we set headers manually like this:
https://github.com/thepracticaldev/dev.to/blob/ee594a657f08fecfd22aaffdd03c379ccd1828fe/app/controllers/articles_controller.rb#L27

I'll update those to use the helpers in a separate PR. I'm trying to introduce as little change as possible on each PR so it's easier to debug if it goes off the rails.

**Fastly update overview (will be copied to each PR for convenience):**
We are updating Fastly to get rid of the deprecated [`fastly-rails gem`](https://github.com/fastly/fastly-rails). We use the `fastly-rails` gem to set Fastly headers and to purge the cache in Fastly. We'll be implementing the logic for both and then remove the gem. This will result in a few PRs:
- [x] [Copy `set_cache_control_headers` from `fastly-rails`](https://github.com/thepracticaldev/dev.to/projects/9#card-35433259)
- [ ] [Copy `set_surrogate_key_header` method from `fastly-rails`](https://github.com/thepracticaldev/dev.to/projects/9#card-35704769)
- [ ] [Update manual header updates to use helpers](https://github.com/thepracticaldev/dev.to/projects/9#card-35704965)
- [ ] [Create Fastly API wrapper and add a call for `purge`](https://github.com/thepracticaldev/dev.to/projects/9#card-35694968)
- [ ] [Add `purge_all` call to Fastly API wrapper](https://github.com/thepracticaldev/dev.to/projects/9#card-35695066)
- [ ] [Update `CacheBuster` to use new Fastly API wrapper](https://github.com/thepracticaldev/dev.to/projects/9#card-35695066)
- [ ] [Remove the `fastly-rails` and `fastly-ruby` gems](https://github.com/thepracticaldev/dev.to/projects/9#card-35695053)

We'll want to make sure we review these PRs thoroughly because Fastly touches _a lot_. Overall, the risk should be pretty low. The worst-case scenario (looking at all 3 PRs) is we don't properly cache and that we don't bust the cache resulting in stale content. We should be able to catch those quickly and roll it back if needed. All that is to say, we aren't flying close to the sun (which is the giant purge all button). That's what burned us in the past.

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/9#card-35433259

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed (added and pasted a bunch of comments though 😎)

## Are there any post deployment tasks we need to perform?
We'll want to observe this deployment. Let's deploy this once a few people are around to test and to make sure those with production access to Fastly are online in case anything goes wrong.

![copy_paste_gif](https://media.giphy.com/media/1UTnNZF2vvykzdxEo9/giphy.gif)
~EVOLUTION!~ _**REVOLUTION!**_ :trollface: