### PR TITLE
Prevent AR Unique errors with find_or_create for ChatChannelMembership

### DIFF
--- a/app/models/chat_channel.rb
+++ b/app/models/chat_channel.rb
@@ -92,7 +92,7 @@ class ChatChannel < ApplicationRecord
 
   def add_users(users)
     Array(users).each do |user|
-      ChatChannelMembership.create!(user_id: user.id, chat_channel_id: id)
+      ChatChannelMembership.find_or_create_by!(user_id: user.id, chat_channel_id: id)
     end
   end
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Fixes: https://app.honeybadger.io/fault/66984/6fd7e14997f49097942c3ef75b84fd93
```
ActiveRecord::RecordInvalid: Validation failed: User has already been taken, Chat channel has already been taken
 chat_channel.rb  95 block in add_users(...)
[PROJECT_ROOT]/app/models/chat_channel.rb:95:in `block in add_users'
93   def add_users(users)
94     Array(users).each do |user|
95       ChatChannelMembership.create!(user_id: user.id, chat_channel_id: id)
96     end
97   end
```

## Added tests?
- [x] no, because they aren't needed

![alt_text](https://media1.tenor.com/images/d34c6ab21bf12b688493b994b970c36a/tenor.gif?itemid=13481421)
