### PR TITLE
Add text-decoration: none back in for anchor

### DIFF
--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -65,6 +65,10 @@ body {
   font-size: 18px;
 }
 
+a {
+  text-decoration: none;
+}
+
 div {
   &.field,
   &.actions {

--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -66,6 +66,7 @@ body {
 }
 
 a {
+  color: var(--link-branded-color);
   text-decoration: none;
 }
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This was taken out from #6987. Not yet sure precisely intent, but is causing most links on the site to revert to the default "underlines" styling.

<img width="395" alt="Screen Shot 2020-04-03 at 12 50 41 PM" src="https://user-images.githubusercontent.com/3102842/78385621-28587f80-75aa-11ea-9228-95035614dc91.png">

<img width="705" alt="Screen Shot 2020-04-03 at 12 54 44 PM" src="https://user-images.githubusercontent.com/3102842/78385710-50e07980-75aa-11ea-8e5c-3e007f8c6b29.png">

I feel like removing the color defaults and the hover default is good to go, but we still need the `text-decoration: none` for now eh?