### PR TITLE
Move create PodcastEpisode callbacks to create Podcast Service

### DIFF
--- a/app/models/podcast_episode.rb
+++ b/app/models/podcast_episode.rb
@@ -30,12 +30,13 @@ class PodcastEpisode < ApplicationRecord
   validates :media_url, presence: true, uniqueness: true
   validates :guid, presence: true, uniqueness: true
 
+  # NOTE: Any create callbacks will not be run since we use activerecord-import to create episodes
+  # https://github.com/zdennis/activerecord-import#callbacks
   after_update :purge
-  after_create :purge_all
   after_destroy :purge, :purge_all
-  after_save    :bust_cache
+  after_save :bust_cache
 
-  after_commit :index_to_elasticsearch, on: %i[create update]
+  after_commit :index_to_elasticsearch, on: %i[update]
   after_commit :remove_from_elasticsearch, on: [:destroy]
 
   before_validation :process_html_and_prefix_all_images

--- a/app/services/podcasts/create_episode.rb
+++ b/app/services/podcasts/create_episode.rb
@@ -29,7 +29,9 @@ module Podcasts
         conflict_target: %i[media_url],
         columns: %i[title slug subtitle summary website_url published_at reachable media_url https body]
       }
-      PodcastEpisode.find(import_result.ids.first)
+      episode = PodcastEpisode.find(import_result.ids.first)
+      finalize(episode)
+      episode
     end
 
     private
@@ -41,6 +43,11 @@ module Podcasts
       episode.reachable = result.reachable
       episode.media_url = result.url
       episode.https = result.https
+    end
+
+    def finalize(episode)
+      episode.purge_all
+      episode.index_to_elasticsearch
     end
   end
 end

--- a/spec/services/podcasts/create_episode_spec.rb
+++ b/spec/services/podcasts/create_episode_spec.rb
@@ -19,6 +19,11 @@ RSpec.describe Podcasts::CreateEpisode, type: :service do
       end.to change(PodcastEpisode, :count).by(1)
     end
 
+    it "indexes the episode" do
+      sidekiq_perform_enqueued_jobs { described_class.call(podcast.id, item) }
+      expect { podcast.podcast_episodes.each(&:elasticsearch_doc) }.not_to raise_error
+    end
+
     it "creates an episode with correct data" do
       episode = described_class.call(podcast.id, item)
       expect(episode.title).to eq("Individual Contributor Career Growth w/ Matt Klein (part 1)")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Bug Fix

## Description
Who wants to remove callbacks?! 🤚 In https://github.com/thepracticaldev/dev.to/pull/4967 we began to use [activerecord-import](https://github.com/zdennis/activerecord-import#callbacks) to create podcast episodes which means we are NOT triggering any callbacks that create should fire. This became noticeable to me when I realized new episodes were not in Elasticsearch. Rather than manually saving the podcast to fire some of the callbacks I moved the create callbacks to the create podcast episode service since that is the only place we make episodes. (+1 for a single path!!!!) 

In addition, I added a comment warning people not to add after_create callbacks to the PodcastEpisode model since they will never fire. Hopefully we can get a single update path set and then we could remove all callbacks completely! Easier said than done I know 😅 but a girl can dream! 

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-35707406

## Added tests?
- [x] yes

![alt_text](https://25.media.tumblr.com/tumblr_lu11mtd85b1qazzwdo1_400.gif)
