### PR TITLE
Move fragment cache to more efficient location

### DIFF
--- a/app/views/shell/_top.html.erb
+++ b/app/views/shell/_top.html.erb
@@ -44,20 +44,20 @@
     <% end %>
   </head>
   <% unless internal_navigation? %>
-    <body data-user-status="<%= user_logged_in_status %>" data-pusher-key="<%= ApplicationConfig["PUSHER_KEY"] %>">
-      <div id="body-styles"></div>
-      <% if user_signed_in? %>
-        <%= render "layouts/user_config" %>
-      <% end %>
+    <% cache_key_heroku_slug("top-html-and-config--#{user_signed_in?}") %>
+      <body data-user-status="<%= user_logged_in_status %>" data-pusher-key="<%= ApplicationConfig["PUSHER_KEY"] %>">
+        <div id="body-styles"></div>
+        <% if user_signed_in? %>
+          <%= render "layouts/user_config" %>
+        <% end %>
         <div id="audiocontent" data-podcast="">
           <%= yield(:audio) %>
         </div>
-      <% cache("application-top-bar--#{user_signed_in?}", expires_in: 100.hours) do %>
         <%= render "layouts/top_bar" %>
-      <% end %>
-      <div id="message-notice"></div>
-      <div class="app-shell-loader">
-        loading...
-      </div>
+        <div id="message-notice"></div>
+        <div class="app-shell-loader">
+          loading...
+        </div>
+    <% end %>
     <!-- End Top Shell -->
   <% end %>

--- a/app/views/shell/_top.html.erb
+++ b/app/views/shell/_top.html.erb
@@ -44,7 +44,7 @@
     <% end %>
   </head>
   <% unless internal_navigation? %>
-    <% cache_key_heroku_slug("top-html-and-config--#{user_signed_in?}") %>
+    <% cache(cache_key_heroku_slug("top-html-and-config--#{user_signed_in?}")) do %>
       <body data-user-status="<%= user_logged_in_status %>" data-pusher-key="<%= ApplicationConfig["PUSHER_KEY"] %>">
         <div id="body-styles"></div>
         <% if user_signed_in? %>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

The content of `layouts/user_config` contains some inline fetched style like this...

`<%= Rails.application.assets["themes/night.css"].to_s.squish.html_safe %>` which I believe is pretty inefficient in fetching the assets in runtime in production, all else equal.

We had another fragment cache wrapping `top_bar` for no _great_ reason. So removed that and replaced with this fragment cache which wraps the whole area.