### PR TITLE
Skip updating a root comment if it doesnt exist

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -219,7 +219,7 @@ class Comment < ApplicationRecord
   end
 
   def root_exists?
-    ancestry && Comment.find_by(id: ancestry)
+    ancestry && Comment.exists?(id: ancestry)
   end
 
   def send_email_notification

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -185,7 +185,11 @@ class Comment < ApplicationRecord
   end
 
   def expire_root_fragment
-    root.touch
+    if root_exists?
+      root.touch
+    else
+      touch
+    end
   end
 
   def create_first_reaction
@@ -212,6 +216,10 @@ class Comment < ApplicationRecord
     user.touch(:last_comment_at)
     CacheBuster.bust(commentable.path.to_s) if commentable
     expire_root_fragment
+  end
+
+  def root_exists?
+    ancestry && Comment.find_by(id: ancestry)
   end
 
   def send_email_notification

--- a/app/workers/comments/calculate_score_worker.rb
+++ b/app/workers/comments/calculate_score_worker.rb
@@ -12,7 +12,7 @@ module Comments
       spaminess_rating = BlackBox.calculate_spaminess(comment)
 
       comment.update_columns(score: score, spaminess_rating: spaminess_rating)
-      comment.root.save! unless comment.is_root?
+      comment.root.save! if !comment.is_root? && comment.root_exists?
     end
   end
 end

--- a/spec/workers/comments/calculate_score_worker_spec.rb
+++ b/spec/workers/comments/calculate_score_worker_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe Comments::CalculateScoreWorker, type: :worker do
         allow(root_comment).to receive(:save!)
         allow(child_comment).to receive(:update_columns)
         allow(child_comment).to receive(:is_root?).and_return(false)
+        allow(child_comment).to receive(:root_exists?).and_return(true)
         allow(child_comment).to receive(:root).and_return(root_comment)
         allow(Comment).to receive(:find_by).with(id: 1).and_return(child_comment)
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
When you try to save a comment that's parent/root comment has been deleted it will fail with the following error `ActiveRecord::RecordNotFound (Couldn't find Comment with 'id'=123)`. The reason for this is because during the save process we try to touch the parent/root comment. Calling `root` or `parent` on a comment where the parent/root has been deleted raises an AR not found error. Instead, I choose to do the check by hand before calling root to update it.

This will fix the failing `Reactions::UpdateReactableWorker`'s and `Comments::CalculateScoreWorker`'s

## Added tests?
- [x] no, because they aren't needed

![alt_text](https://media.giphy.com/media/xUySTMPTqceh0JkPrW/giphy.gif)
