### PR TITLE
Fix sidebar colors on dark themes

### DIFF
--- a/app/assets/stylesheets/themes/hacker.scss
+++ b/app/assets/stylesheets/themes/hacker.scss
@@ -6,6 +6,7 @@
   --theme-container-box-shadow: none;
   --theme-container-border: 1px solid #22303f;
   --theme-social-icon-invert: invert(100%);
+  --theme-color: #ffffff;
 
   // Base
   --base-100: #ffffff;

--- a/app/assets/stylesheets/themes/night.scss
+++ b/app/assets/stylesheets/themes/night.scss
@@ -6,6 +6,7 @@
   --theme-container-box-shadow: none;
   --theme-container-border: 1px solid #22303f;
   --theme-social-icon-invert: invert(100%);
+  --theme-color: #ffffff;
 
   // Base
   --base-100: #f9fafa;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
When using a dark theme, the sidebar user's name didn't change its color because of the missing `--theme-color` variable. This pull request fixes it by adding the aforesaid variable.

## Related Tickets & Documents
Fixes #7074 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![BEFORE](https://user-images.githubusercontent.com/30203228/78414345-126ead00-75f2-11ea-8645-6e1f0c957e18.png)

![AFTER](https://user-images.githubusercontent.com/30203228/78414354-1a2e5180-75f2-11ea-812a-960bae72a003.png)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed