### PR TITLE
Update Ruby version for Gitpod

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -1,7 +1,7 @@
 FROM gitpod/workspace-postgres
 
 # Install Ruby
-ENV RUBY_VERSION=2.6.5
+ENV RUBY_VERSION=2.7.0
 RUN bash -lc "rvm install ruby-$RUBY_VERSION && rvm use ruby-$RUBY_VERSION --default"
 
 # Install Redis.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Developer experience

## Description

While working on #7060 I realized that the recent update to Ruby 2.7.0 did not take `.gitpod.dockerfile` into account. This PR fixes that. 

## Related Tickets & Documents

n/a

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [X] no, because they aren't needed

## Added to documentation?

- [X] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![Docker all the things](https://user-images.githubusercontent.com/47985/78521213-60063800-77f3-11ea-9a0e-e037634daa4a.png)

