### PR TITLE
Fix comment hiding

### DIFF
--- a/app/assets/javascripts/initializers/initializeBaseUserData.js
+++ b/app/assets/javascripts/initializers/initializeBaseUserData.js
@@ -76,16 +76,13 @@ function addRelevantButtonsToComments(user) {
       if (parseInt(userId, 10) === user.id) {
         butt.style.display = 'inline-block';
       }
+
       if (
         action === 'hide-button' &&
         parseInt(commentableUserId, 10) === user.id
       ) {
         butt.style.display = 'inline-block';
-      } else if (
-        action === 'hide-button' &&
-        parseInt(commentableUserId, 10) !== user.id
-      ) {
-        butt.style.display = 'none';
+        butt.classList.remove('hidden');
       }
     }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Description

At one point we lost the ability for post authors to hide comments for their posts. This PR fixes this. While we did set the display attribute correctly, we did not remove the `hidden` CSS class, which caused this issue.

![Screen Shot 2020-04-06 at 15 36 21](https://user-images.githubusercontent.com/47985/78540614-9d33ef80-781e-11ea-9f76-6f4ae4b536a7.png)

I also refactored the relevant method a little bit, I think the current version is functionally equivalent (sans bug) but easier to read.

## Related Tickets & Documents

https://github.com/thepracticaldev/tech-private/issues/418

## Added tests?

- [X] no, because I need help

I didn't add them yet because I figured we didn't have any, otherwise we'd have caught this somehow. As I'm not super up to date on our frontend testing I may need help. Though we also may choose to get the fix out first.

## Added to documentation?

- [X] no documentation needed
