### PR TITLE
Add ARIA checked attribute to article reaction buttons

### DIFF
--- a/app/assets/javascripts/initializers/initializeArticleReactions.js
+++ b/app/assets/javascripts/initializers/initializeArticleReactions.js
@@ -18,15 +18,19 @@ function setReactionCount(reactionName, newCount) {
 }
 
 function showUserReaction(reactionName, animatedClass) {
-  document
-    .getElementById('reaction-butt-' + reactionName)
-    .classList.add('user-activated', animatedClass);
+  const reactionButton = document.getElementById(
+    'reaction-butt-' + reactionName,
+  );
+  reactionButton.classList.add('user-activated', animatedClass);
+  reactionButton.setAttribute('aria-checked', 'true');
 }
 
 function hideUserReaction(reactionName) {
-  document
-    .getElementById('reaction-butt-' + reactionName)
-    .classList.remove('user-activated', 'user-animated');
+  const reactionButton = document.getElementById(
+    'reaction-butt-' + reactionName,
+  );
+  reactionButton.classList.remove('user-activated', 'user-animated');
+  reactionButton.setAttribute('aria-checked', 'false');
 }
 
 function hasUserReacted(reactionName) {

--- a/app/views/articles/_actions.html.erb
+++ b/app/views/articles/_actions.html.erb
@@ -1,14 +1,23 @@
 <div class="article-actions" id="article-reaction-actions">
   <% if @article.published? %>
-    <button id="reaction-butt-like" class="article-reaction-butt like-reaction-button" data-category="like" alt="heart-emoji" title="heart">
-      <img alt="heart" src="<%= asset_path("emoji/emoji-one-heart.png") %>" /><span class="reaction-number" id="reaction-number-like"></span>
-    </button>
-    <button id="reaction-butt-unicorn" class="article-reaction-butt unicorn-reaction-button" data-category="unicorn" alt="unicorn-emoji" title="unicorn">
-      <img alt="unicorn" src="<%= asset_path("emoji/emoji-one-unicorn.png") %>" /><span class="reaction-number" id="reaction-number-unicorn"></span>
-    </button>
-    <button id="reaction-butt-readinglist" class="article-reaction-butt readinglist-reaction-button" data-category="readinglist" alt="unicorn-emoji" title="reading list">
-      <img alt="reading list" src="<%= asset_path("emoji/emoji-one-bookmark.png") %>" /><span class="reaction-number" id="reaction-number-readinglist"></span>
-    </button>
+    <%= render partial: "articles/reaction_button",
+               locals: {
+                 category: :like,
+                 description: "heart",
+                 image_path: "emoji/emoji-one-heart.png"
+               } %>
+    <%= render partial: "articles/reaction_button",
+               locals: {
+                 category: :unicorn,
+                 description: "unicorn",
+                 image_path: "emoji/emoji-one-unicorn.png"
+               } %>
+    <%= render partial: "articles/reaction_button",
+               locals: {
+                 category: :readinglist,
+                 description: "reading list",
+                 image_path: "emoji/emoji-one-bookmark.png"
+               } %>
 
     <% display_name = @article.user.twitter_username ? "@" + @article.user.twitter_username : @article.user.name %>
     <a

--- a/app/views/articles/_reaction_button.html.erb
+++ b/app/views/articles/_reaction_button.html.erb
@@ -1,0 +1,11 @@
+<button
+  id="reaction-butt-<%= category %>"
+  class="article-reaction-butt <%= category %>-reaction-button"
+  data-category="<%= category %>"
+  alt="<%= description %>"
+  title="<%= description %>">
+  <img
+    alt="<%= description %>"
+    src="<%= asset_path(image_path) %>" />
+  <span class="reaction-number" id="reaction-number-<%= category %>" alt="count"></span>
+</button>

--- a/app/views/articles/_reaction_button.html.erb
+++ b/app/views/articles/_reaction_button.html.erb
@@ -1,4 +1,5 @@
 <button
+  role="checkbox"
   id="reaction-butt-<%= category %>"
   class="article-reaction-butt <%= category %>-reaction-button"
   data-category="<%= category %>"


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

As noted in https://github.com/thepracticaldev/dev.to/issues/7058 our article reaction buttons don't communicate their checked status. 

This PR fixes that. I also refactored the article reaction buttons in a partial as they are identical save from the category and the emoji

I didn't add tests as they are quite complicated to setup, let me know if you think we shall add them at all costs and if you have suggestions :D

ps. I think the same happens to all the other reaction buttons (in comments and notifications) but I'd rather investigate each in a separate PR

## Related Tickets & Documents

- https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/checkbox_role
- https://accessibility.oit.ncsu.edu/it-accessibility-at-nc-state/developers/accessibility-handbook/aria-checkbox/

Closes 7058

## Added tests?

- [ ] yes
- [ ] no, because they aren't needed
- [x] no, because I need help
