### PR TITLE
Make root_exists Method Public and Use In Other Callbacks

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -152,7 +152,7 @@ class Comment < ApplicationRecord
   end
 
   def adjust_comment_parent_based_on_depth
-    self.parent_id = parent.descendant_ids.last if root_exists? && (parent.depth > 1 && parent.has_children?)
+    self.parent_id = parent.descendant_ids.last if parent_exists? && (parent.depth > 1 && parent.has_children?)
   end
 
   def wrap_timestamps_if_video_present!
@@ -227,7 +227,7 @@ class Comment < ApplicationRecord
   end
 
   def should_send_email_notification?
-    root_exists? &&
+    parent_exists? &&
       parent_user.class.name != "Podcast" &&
       parent_user != user &&
       parent_user.email_comment_notifications &&
@@ -258,5 +258,9 @@ class Comment < ApplicationRecord
 
   def notify_slack_channel_about_warned_users
     Slack::Messengers::CommentUserWarned.call(comment: self)
+  end
+
+  def parent_exists?
+    parent_id && Comment.exists?(id: parent_id)
   end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -119,6 +119,10 @@ class Comment < ApplicationRecord
     processed_html.html_safe
   end
 
+  def root_exists?
+    ancestry && Comment.exists?(id: ancestry)
+  end
+
   private
 
   def update_notifications
@@ -148,7 +152,7 @@ class Comment < ApplicationRecord
   end
 
   def adjust_comment_parent_based_on_depth
-    self.parent_id = parent.descendant_ids.last if parent && (parent.depth > 1 && parent.has_children?)
+    self.parent_id = parent.descendant_ids.last if root_exists? && (parent.depth > 1 && parent.has_children?)
   end
 
   def wrap_timestamps_if_video_present!
@@ -218,16 +222,13 @@ class Comment < ApplicationRecord
     expire_root_fragment
   end
 
-  def root_exists?
-    ancestry && Comment.exists?(id: ancestry)
-  end
-
   def send_email_notification
     Comments::SendEmailNotificationWorker.perform_async(id)
   end
 
   def should_send_email_notification?
-    parent_user.class.name != "Podcast" &&
+    root_exists? &&
+      parent_user.class.name != "Podcast" &&
       parent_user != user &&
       parent_user.email_comment_notifications &&
       parent_user.email &&

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -385,4 +385,18 @@ RSpec.describe Comment, type: :model do
       end
     end
   end
+
+  describe "#root_exists?" do
+    let(:root_comment) { create(:comment) }
+    let(:comment) { create(:comment, ancestry: root_comment.id) }
+
+    it "returns true if root is present" do
+      expect(comment.root_exists?).to eq(true)
+    end
+
+    it "returns false if root has been deleted" do
+      root_comment.destroy
+      expect(comment.reload.root_exists?).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This is a followup to #7080 where we choose to skip updating the root comment if it didn't exist. Once deployed I found that we were incorrectly trying to call a private method so I made it public and added some tests. Upon adding some tests and trying to reload the secondary comment I found a few more places we needed to add the `root_exists?` method to allow a comment to reload.

## Added tests?
- [x] yes

![alt_text](https://media0.giphy.com/media/Zh0koTa7Jka6k/source.gif)
