### PR TITLE
Copy set_surrogate_key_header from fastly-rails

### DIFF
--- a/app/controllers/concerns/fastly_headers.rb
+++ b/app/controllers/concerns/fastly_headers.rb
@@ -17,6 +17,13 @@ module FastlyHeaders
     response.headers["Surrogate-Control"] = opts[:surrogate_control] || build_surrogate_control(max_age, opts)
   end
 
+  # Sets Surrogate-Key HTTP header with one or more keys strips session data
+  # from the request
+  def set_surrogate_key_header(*surrogate_keys)
+    request.session_options[:skip] = true # No Set-Cookie
+    response.headers["Surrogate-Key"] = surrogate_keys.join(" ")
+  end
+
   private
 
   def build_surrogate_control(max_age, opts)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Feature

## Description
**This PR:**
The [`fastly-rails` gem](https://github.com/fastly/fastly-rails) has been deprecated. I copied over the `set_surrogate_key_header` controller method we need from it to set the headers for Fastly.

Note: there are some places we set headers manually like this:
https://github.com/thepracticaldev/dev.to/blob/ee594a657f08fecfd22aaffdd03c379ccd1828fe/app/controllers/articles_controller.rb#L27

I'll update those to use the helpers in a separate PR. I'm trying to introduce as little change as possible on each PR so it's easier to debug if it goes off the rails.

**Fastly update overview (will be copied to each PR for convenience):**
We are updating Fastly to get rid of the deprecated [`fastly-rails gem`](https://github.com/fastly/fastly-rails). We use the `fastly-rails` gem to set Fastly headers and to purge the cache in Fastly. We'll be implementing the logic for both and then remove the gem. This will result in a few PRs:
- [x] [Copy `set_cache_control_headers` from `fastly-rails`](https://github.com/thepracticaldev/dev.to/projects/9#card-35433259)
- [x] [Copy `set_surrogate_key_header` method from `fastly-rails`](https://github.com/thepracticaldev/dev.to/projects/9#card-35704769)
- [ ] [Update manual header updates to use helpers](https://github.com/thepracticaldev/dev.to/projects/9#card-35704965)
- [ ] [Create Fastly API wrapper and add a call for `purge`](https://github.com/thepracticaldev/dev.to/projects/9#card-35694968)
- [ ] [Add `purge_all` call to Fastly API wrapper](https://github.com/thepracticaldev/dev.to/projects/9#card-35695066)
- [ ] [Update `CacheBuster` to use new Fastly API wrapper](https://github.com/thepracticaldev/dev.to/projects/9#card-35695066)
- [ ] [Remove the `fastly-rails` and `fastly-ruby` gems](https://github.com/thepracticaldev/dev.to/projects/9#card-35695053)

We'll want to make sure we review these PRs thoroughly because Fastly touches _a lot_. Overall, the risk should be pretty low. The worst-case scenario (looking at all PRs) is we don't properly cache and that we don't bust the cache resulting in stale content. We should be able to catch those quickly and roll it back if needed. All that is to say, we aren't flying close to the sun (which is the giant purge all button). That's what burned us in the past.

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/9#card-35704769

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed (added and pasted a bunch of comments though 😎)

## Are there any post deployment tasks we need to perform?
We'll want to observe this deployment. Let's deploy this once a few people are around to test and to make sure those with production access to Fastly are online in case anything goes wrong.

![netflix_you_gif](https://media.giphy.com/media/28I5KEqbxUEafaeNtV/giphy.gif)