### PR TITLE
Use force redirects for docs to follow legacy functionality

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -10,42 +10,54 @@
   command = "node deploy-script.js"
 
 [[redirects]]
+  force = true
   from = "http://docs.dev.to"
   to = "https://docs.dev.to"
 [[redirects]]
+  force = true
   from = "http://docs.dev.to/ruby-doc"
   to = "https://docs.dev.to/ruby-doc/index.html"
 [[redirects]]
+  force = true
   from = "http://docs.dev.to/ruby-doc/"
   to = "https://docs.dev.to/ruby-doc/index.html"
 [[redirects]]
+  force = true
   from = "http://docs.dev.to/api"
   to = "https://docs.dev.to/api/index.html"
 [[redirects]]
+  force = true
   from = "http://docs.dev.to/api/"
   to = "https://docs.dev.to/api/index.html"
 [[redirects]]
+  force = true
   from = "http://docs.dev.to/*"
   to = "https://docs.dev.to/:splat"
   status = 301
 [[redirects]]
+  force = true
   from = "docs.dev.to"
   to = "https://docs.dev.to"
 [[redirects]]
+  force = true
   from = "docs.dev.to/*"
   to = "https://docs.dev.to/:splat"
   status = 301
 [[redirects]]
+  force = true
   from = "http://devto.netlify.com"
   to = "https://docs.dev.to"
 [[redirects]]
+  force = true
   from = "http://devto.netlify.com/*"
   to = "https://docs.dev.to/:splat"
   status = 301
 [[redirects]]
+  force = true
   from = "https://devto.netlify.com"
   to = "https://docs.dev.to"
 [[redirects]]
+  force = true
   from = "https://devto.netlify.com/*"
   to = "https://docs.dev.to/:splat"
   status = 301


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
[Netlify will be updating their redirect logic tomorrow](https://community.netlify.com/t/changed-behavior-in-redirects/10084/4), and I think this is the only thing we need to do to keep consistent functionality. I'm not entirely sure if this is the right move; if it's not, we can revert this.

As I understand from the above link, the current behavior of redirects is already a "forced rule", and by adding this, we'll keep behavior consistent with what we've been previously doing.

I think to observe if anything changes, we can either:
1. merge today, see if anything changes, and see if anything changes tomorrow after their logic.
2. see if anything changes tomorrow after their logic, and if it does, merge this and see if it works.

I think the worst thing that would happen is our routes that happen to have specific files (`/index.html` for example) will fail.