### PR TITLE
Remove variants from backend portion of onboarding

### DIFF
--- a/app/controllers/async_info_controller.rb
+++ b/app/controllers/async_info_controller.rb
@@ -61,7 +61,6 @@ class AsyncInfoController < ApplicationController
         experience_level: @user.experience_level,
         preferred_languages_array: @user.preferred_languages_array,
         config_body_class: @user.config_body_class,
-        onboarding_variant_version: @user.onboarding_variant_version,
         pro: @user.pro?
       }
     end

--- a/app/controllers/internal/growth_controller.rb
+++ b/app/controllers/internal/growth_controller.rb
@@ -1,7 +1,3 @@
 class Internal::GrowthController < Internal::ApplicationController
   layout "internal"
-
-  def index
-    @variants = %w[0 1 2 3 4 5 6 7 8 9]
-  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
     onboarding_package_form_submmitted_at
     onboarding_package_fulfilled
     onboarding_package_requested_again
+    onboarding_variant_version
     org_admin
     personal_data_updated_at
     resume_html

--- a/app/services/authorization_service.rb
+++ b/app/services/authorization_service.rb
@@ -63,7 +63,6 @@ class AuthorizationService
       add_social_identity_data(user)
       user.saw_onboarding = false
       user.editor_version = "v2"
-      user.onboarding_variant_version = %w[0 0 0 1 2 3 4 5 6 6 6 7 8 8 8 8 9].sample # 0, 6 and 8 promoted due to success
       user.save!
     end
     user

--- a/app/views/internal/growth/_results.html.erb
+++ b/app/views/internal/growth/_results.html.erb
@@ -19,26 +19,3 @@
     </div>
   </div>
 </div>
-
-<div class="row">
-  <% @variants.each do |var| %>
-    <div class="col-sm-6 mt-3">
-      <div class="card">
-        <div class="card-header">
-          <strong>Variant: <%= var %></strong>
-        </div>
-        <ul class="list-group list-group-flush">
-          <li class="list-group-item">
-            Average comments: <%= User.where("created_at > ?", num_days.day.ago).where(onboarding_variant_version: var).average(:comments_count) %>
-          </li>
-          <li class="list-group-item">
-            Average articles: <%= User.where("created_at > ?", num_days.day.ago).where(onboarding_variant_version: var).average(:articles_count) %>
-          </li>
-          <li class="list-group-item">
-            Average reactions: <%= User.where("created_at > ?", num_days.day.ago).where(onboarding_variant_version: var).average(:reactions_count) %>
-          </li>
-        </ul>
-      </div>
-    </div>
-  <% end %>
-</div>

--- a/app/views/internal/growth/index.html.erb
+++ b/app/views/internal/growth/index.html.erb
@@ -1,18 +1,3 @@
-<h2>Onboarding variants</h2>
+<h2>Onboarding</h2>
 <%= render "results", num_days: 7 %>
 <%= render "results", num_days: 1 %>
-
-<h2 class="m-4">Descriptions of current variants</h2>
-
-<%= simple_format "
-// 0) Original intro slide: three explainer paragraphs, left adjusted.
-// 1) Modified intro slide: Cat gif, let's get started.
-// 2) Modified intro slide: Cat gif, We have a few quick questions to fill out your profile
-// 3) Modified intro slide: Skull gif, The more you get involved in community, the better developer you will be.
-// 4) Modified intro slide: Skull gif, You just made a great choice for your dev career
-// 5) No intro slide.
-// 6) Last slide challenge: Leave three constructive comments today
-// 7) Last slide: Only display cue for welcome thread
-// 8) Last slide: Only display cue for welcome thread, and also the leave three constructive comments challenge
-// 9) Last slide: Only display cue for welcome thread, display challenge right in link body
-" %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
Since we're no longer using variants in onboarding, we don't need this code anymore!

Also ignores the `onboarding_variant_version` column on the user since it is no longer used,
and removes references to "onboarding variants" from the `/internal/growth` pages.

**Please review #7116 first, as that needs to be merged/deployed before this PR!**

## Related Tickets & Documents
Addresses the second half of #6714. Also closes #6714.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
The `internal/growth` page now looks something like this (but with data, lol):
<img width="1338" alt="Screen Shot 2020-04-06 at 2 01 25 PM" src="https://user-images.githubusercontent.com/6921610/78604790-30652900-780f-11ea-9a31-0866dda6daae.png">


## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
