### PR TITLE
Update manual Fastly header assignments

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -24,7 +24,10 @@ class ArticlesController < ApplicationController
     end
 
     set_surrogate_key_header "feed"
-    response.headers["Surrogate-Control"] = "max-age=600, stale-while-revalidate=30, stale-if-error=86400"
+
+    set_cache_control_headers(600,
+                              stale_while_revalidate: 30,
+                              stale_if_error: 86_400)
 
     render layout: false
   end

--- a/app/controllers/sitemaps_controller.rb
+++ b/app/controllers/sitemaps_controller.rb
@@ -13,7 +13,9 @@ class SitemapsController < ApplicationController
     end
     @articles = Article.published.where("published_at > ? AND published_at < ? AND score > ?", date, date.end_of_month, 3).pluck(:path, :last_comment_at)
     set_surrogate_controls(date)
-    response.headers["Surrogate-Control"] = "max-age=#{@max_age}, stale-while-revalidate=#{@stale_while_revalidate}, stale-if-error=#{@stale_if_error}"
+    set_cache_control_headers(@max_age,
+                              stale_while_revalidate: @stale_while_revalidate,
+                              stale_if_error: @stale_if_error)
     render layout: false
   end
 

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -60,7 +60,7 @@ class StoriesController < ApplicationController
   def assign_hero_html
     return if SiteConfig.campaign_hero_html_variant_name.blank?
 
-    @hero_area =  HtmlVariant.relevant.select(:name, :html).
+    @hero_area = HtmlVariant.relevant.select(:name, :html).
       find_by(group: "campaign", name: SiteConfig.campaign_hero_html_variant_name)
     @hero_html = @hero_area&.html
   end
@@ -138,7 +138,9 @@ class StoriesController < ApplicationController
     @stories = @stories.decorate
 
     set_surrogate_key_header "articles-#{@tag}"
-    response.headers["Surrogate-Control"] = "max-age=600, stale-while-revalidate=30, stale-if-error=86400"
+    set_cache_control_headers(600,
+                              stale_while_revalidate: 30,
+                              stale_if_error: 86_400)
     render template: "articles/tag_index"
   end
 
@@ -159,7 +161,9 @@ class StoriesController < ApplicationController
     @featured_story = (featured_story || Article.new)&.decorate
     @stories = ArticleDecorator.decorate_collection(@stories)
     set_surrogate_key_header "main_app_home_page"
-    response.headers["Surrogate-Control"] = "max-age=600, stale-while-revalidate=30, stale-if-error=86400"
+    set_cache_control_headers(600,
+                              stale_while_revalidate: 30,
+                              stale_if_error: 86_400)
 
     render template: "articles/index"
   end

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -81,6 +81,14 @@ RSpec.describe "StoriesIndex", type: :request do
       expect(response.body).to include(CGI.escapeHTML(listing.title))
     end
 
+    it "sets Fastly Surrogate-Key headers" do
+      get "/"
+      expect(response.status).to eq(200)
+
+      expected_surrogate_key_headers = %w[main_app_home_page]
+      expect(response.headers["Surrogate-Key"].split(", ")).to match_array(expected_surrogate_key_headers)
+    end
+
     context "with campaign hero" do
       let_it_be_readonly(:hero_html) do
         create(
@@ -181,6 +189,30 @@ RSpec.describe "StoriesIndex", type: :request do
     it "renders page with proper header" do
       get "/t/#{tag.name}"
       expect(response.body).to include(tag.name)
+    end
+
+    it "sets Fastly Cache-Control headers" do
+      get "/t/#{tag.name}"
+      expect(response.status).to eq(200)
+
+      expected_cache_control_headers = %w[public no-cache]
+      expect(response.headers["Cache-Control"].split(", ")).to match_array(expected_cache_control_headers)
+    end
+
+    it "sets Fastly Surrogate-Control headers" do
+      get "/t/#{tag.name}"
+      expect(response.status).to eq(200)
+
+      expected_surrogate_control_headers = %w[max-age=600 stale-while-revalidate=30 stale-if-error=86400]
+      expect(response.headers["Surrogate-Control"].split(", ")).to match_array(expected_surrogate_control_headers)
+    end
+
+    it "sets Fastly Surrogate-Key headers" do
+      get "/t/#{tag.name}"
+      expect(response.status).to eq(200)
+
+      expected_surrogate_key_headers = %W[articles-#{tag}]
+      expect(response.headers["Surrogate-Key"].split(", ")).to match_array(expected_surrogate_key_headers)
     end
 
     it "renders page with top/week etc." do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
**This PR:**
The [`fastly-rails` gem](https://github.com/fastly/fastly-rails) has been deprecated. This a clean up PR on the heels of #7108 to clean up places where we set headers manually like this:
https://github.com/thepracticaldev/dev.to/blob/ee594a657f08fecfd22aaffdd03c379ccd1828fe/app/controllers/articles_controller.rb#L27

I've also added tests (overkill) for the headers in each spot I updated.

**Note:** #7108 doesn't have to be merged first since the method name, `set_cache_control_headers`,  is the same.

**Fastly update overview (will be copied to each PR for convenience):**
We are updating Fastly to get rid of the deprecated [`fastly-rails gem`](https://github.com/fastly/fastly-rails). We use the `fastly-rails` gem to set Fastly headers and to purge the cache in Fastly. We'll be implementing the logic for both and then remove the gem. This will result in a few PRs:
- [x] [Copy `set_cache_control_headers` from `fastly-rails`](https://github.com/thepracticaldev/dev.to/projects/9#card-35433259)
- [x] [Copy `set_surrogate_key_header` method from `fastly-rails`](https://github.com/thepracticaldev/dev.to/projects/9#card-35704769)
- [x] [Update manual header updates to use helpers](https://github.com/thepracticaldev/dev.to/projects/9#card-35704965)
- [ ] [Create Fastly API wrapper and add a call for `purge`](https://github.com/thepracticaldev/dev.to/projects/9#card-35694968)
- [ ] [Add `purge_all` call to Fastly API wrapper](https://github.com/thepracticaldev/dev.to/projects/9#card-35695066)
- [ ] [Update `CacheBuster` to use new Fastly API wrapper](https://github.com/thepracticaldev/dev.to/projects/9#card-35695066)
- [ ] [Remove the `fastly-rails` and `fastly-ruby` gems](https://github.com/thepracticaldev/dev.to/projects/9#card-35695053)

We'll want to make sure we review these PRs thoroughly because Fastly touches _a lot_. Overall, the risk should be pretty low. The worst-case scenario (looking at all PRs) is we don't properly cache and that we don't bust the cache resulting in stale content. We should be able to catch those quickly and roll it back if needed. All that is to say, we aren't flying close to the sun (which is the giant purge all button). That's what burned us in the past.

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/9#card-35704965

## Added tests?
- [x] yes

## Added to documentation?
- [x] no documentation needed

## Are there any post deployment tasks we need to perform?
We'll want to observe this deployment. Let's deploy this once a few people are around to test and to make sure those with production access to Fastly are online in case anything goes wrong.

![clean_up_on_aisle_5_gif](https://media.giphy.com/media/OTszKBXzfG5e8/giphy.gif)