### PR TITLE
Introduce URL.sanitized_referer helper

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -36,7 +36,7 @@ class PagesController < ApplicationController
   end
 
   def report_abuse
-    referer = URI(request.referer || "").path == "/serviceworker.js" ? nil : request.referer
+    referer = URL.sanitized_referer(request.referer)
     reported_url = params[:reported_url] || params[:url] || referer
     @feedback_message = FeedbackMessage.new(
       reported_url: reported_url&.chomp("?i=i"),

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -201,4 +201,8 @@ module ApplicationHelper
   def user_url(user)
     URL.user(user)
   end
+
+  def sanitized_referer(referer)
+    URL.sanitized_referer(referer)
+  end
 end

--- a/app/lib/url.rb
+++ b/app/lib/url.rb
@@ -1,5 +1,7 @@
 # Utilities methods to safely build app wide URLs
 module URL
+  SERVICE_WORKER = "/serviceworker.js".freeze
+
   def self.protocol
     ApplicationConfig["APP_PROTOCOL"]
   end
@@ -70,8 +72,7 @@ module URL
   # @example An empty string
   #  sanitized_referer("") #=> nil
   def self.sanitized_referer(referer)
-    return if referer.blank?
-    return if URI(referer).path == "/serviceworker.js"
+    return if referer.blank? || URI(referer).path == SERVICE_WORKER
 
     referer
   end

--- a/app/lib/url.rb
+++ b/app/lib/url.rb
@@ -59,4 +59,20 @@ module URL
   def self.user(user)
     url(user.username)
   end
+
+  # Ensures we don't consider serviceworker.js as referer
+  #
+  # @param referer [String] the unsanitized referer
+  # @example A safe referer
+  #  sanitized_referer("/some/path") #=> "/some/path"
+  # @example serviceworker.js as referer
+  #  sanitized_referer("serviceworker.js") #=> nil
+  # @example An empty string
+  #  sanitized_referer("") #=> nil
+  def self.sanitized_referer(referer)
+    return if referer.blank?
+    return if URI(referer).path == "/serviceworker.js"
+
+    referer
+  end
 end

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -55,7 +55,8 @@
     <input class="uploaded-image" id="uploaded-image-main" />
   </div>
   <div class="actions" id="submit-wrapper">
-    <%= link_to((:back if request.referer.present?) || (commentable.path if commentable) || @comment.path, "aria-label": "Cancel action") do %>
+    <%# See https://github.com/thepracticaldev/dev.to/issues/7081 %>
+    <%= link_to((:back if URL.sanitized_referer(request.referer)) || (commentable.path if commentable) || @comment.path, "aria-label": "Cancel action") do %>
       <button id="cancel-button" class="comment-action-button comment-action-cancel">CANCEL</button>
     <% end %>
     <button id="preview-button" class="comment-action-button comment-action-preview">PREVIEW</button>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -56,7 +56,7 @@
   </div>
   <div class="actions" id="submit-wrapper">
     <%# See https://github.com/thepracticaldev/dev.to/issues/7081 %>
-    <%= link_to((:back if URL.sanitized_referer(request.referer)) || (commentable.path if commentable) || @comment.path, "aria-label": "Cancel action") do %>
+    <%= link_to((:back if URL.sanitized_referer(request.referer)) || commentable&.path || @comment.path, "aria-label": "Cancel action") do %>
       <button id="cancel-button" class="comment-action-button comment-action-cancel">CANCEL</button>
     <% end %>
     <button id="preview-button" class="comment-action-button comment-action-preview">PREVIEW</button>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -56,7 +56,7 @@
   </div>
   <div class="actions" id="submit-wrapper">
     <%# See https://github.com/thepracticaldev/dev.to/issues/7081 %>
-    <%= link_to((:back if URL.sanitized_referer(request.referer)) || commentable&.path || @comment.path, "aria-label": "Cancel action") do %>
+    <%= link_to((:back if sanitized_referer(request.referer)) || commentable&.path || @comment.path, "aria-label": "Cancel action") do %>
       <button id="cancel-button" class="comment-action-button comment-action-cancel">CANCEL</button>
     <% end %>
     <button id="preview-button" class="comment-action-button comment-action-preview">PREVIEW</button>

--- a/foo
+++ b/foo
@@ -1,0 +1,2 @@
+
+dasfsdaf

--- a/foo
+++ b/foo
@@ -1,2 +1,0 @@
-
-dasfsdaf

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -93,4 +93,18 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(app_url(uri)).to eq("https://dev.to/internal#test")
     end
   end
+
+  describe "#sanitized_referer" do
+    it "returns a safe referrer unmodified" do
+      expect(sanitized_referer("/some/path")).to eq("/some/path")
+    end
+
+    it "returns nil if the referer is the service worker" do
+      expect(sanitized_referer("/serviceworker.js")).to be nil
+    end
+
+    it "returns nil if the referer is empty" do
+      expect(sanitized_referer("")).to be nil
+    end
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Description

Under certain circumstances, we were redirecting back to the service worker when canceling a comment edit. This PR fixes that. 

After I did a quick & dirty fix, I noticed that there's at least one other place that could use the same logic, so I added a method to our `URL` helper module and a helper wrapper in `ApplicationHelper`. 

I deliberated a bit on whether `URL` is really the best place for it, but I didn't want to introduce a new module for a single method and it seems to still mostly be on topic, as it's related to URL-based navigation within our app.

## Related Tickets & Documents)

Closes #7081

## Added tests?

- [X] yes

## Added to documentation?

- [X] YARD docs

