### PR TITLE
Send auth failures to Datadog

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -15,19 +15,18 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def failure
     error = request.env["omniauth.error"]
 
-    Honeybadger.notify(
-      "Authentication failure",
-      error_message: error&.message,
-      error_class: error.to_s,
-      context: {
-        error_reason: error&.error_reason,
-        error_type: error&.error,
-        error_uri: error&.error_uri,
-        provider: request.env["omniauth.strategy"].name,
-        origin: request.env["omniauth.strategy.origin"],
-        params: request.env["omniauth.params"],
-        cookie: request.env["rack.request.cookie_hash"]
-      },
+    DatadogStatsClient.increment(
+      "auth.failure",
+      tags: [
+        "class:#{error}",
+        "message:#{error&.message}",
+        "reason:#{error&.error_reason}",
+        "type:#{error&.error}",
+        "uri:#{error&.error_uri}",
+        "provider:#{request.env['omniauth.strategy'].name}",
+        "origin:#{request.env['omniauth.strategy.origin']}",
+        "params:#{request.env['omniauth.params']}",
+      ],
     )
 
     super

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -17,12 +17,12 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
     Honeybadger.notify(
       "Authentication failure",
-      error_message: error.message,
+      error_message: error&.message,
       error_class: error.to_s,
       context: {
-        error_reason: error.error_reason,
-        error_type: error.error,
-        error_uri: error.error_uri,
+        error_reason: error&.error_reason,
+        error_type: error&.error,
+        error_uri: error&.error_uri,
         provider: request.env["omniauth.strategy"].name,
         origin: request.env["omniauth.strategy.origin"],
         params: request.env["omniauth.params"],

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -16,7 +16,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     error = request.env["omniauth.error"]
 
     DatadogStatsClient.increment(
-      "auth.failure",
+      "omniauth.failure",
       tags: [
         "class:#{error}",
         "message:#{error&.message}",

--- a/spec/system/user_logs_in_with_twitter_spec.rb
+++ b/spec/system/user_logs_in_with_twitter_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe "Authenticating with twitter" do
       expect(page).to have_link "All about #{ApplicationConfig['COMMUNITY_NAME']}"
 
       expect(DatadogStatsClient).to have_received(:increment).with(
-        "auth.failure",
+        "omniauth.failure",
         tags: [
           "class:",
           "message:",

--- a/spec/system/user_logs_in_with_twitter_spec.rb
+++ b/spec/system/user_logs_in_with_twitter_spec.rb
@@ -53,6 +53,8 @@ RSpec.describe "Authenticating with twitter" do
     end
 
     it "logging in with twitter using invalid credentials" do
+      allow(DatadogStatsClient).to receive(:increment)
+
       user_do_not_grants_authorization_on_twitter_popup
 
       visit root_path
@@ -62,6 +64,20 @@ RSpec.describe "Authenticating with twitter" do
       expect(page).to have_link "Via Twitter"
       expect(page).to have_link "Via GitHub"
       expect(page).to have_link "All about #{ApplicationConfig['COMMUNITY_NAME']}"
+
+      expect(DatadogStatsClient).to have_received(:increment).with(
+        "auth.failure",
+        tags: [
+          "class:",
+          "message:",
+          "reason:",
+          "type:",
+          "uri:",
+          "provider:twitter",
+          "origin:",
+          "params:{}",
+        ],
+      )
     end
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Thanks to https://github.com/thepracticaldev/dev.to/issues/7134 I found out the failure path for the sign in process is broken as Timber is not enabled in development anymore. As logging the error in production logs might not actually be beneficial, I moved it to Datadog.

I got the options from https://docs.datadoghq.com/developers/metrics/dogstatsd_metrics_submission/

## Related Tickets & Documents

Helping to debug https://github.com/thepracticaldev/dev.to/issues/7134

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
