### PR TITLE
Rescue invalid URL errors and Mark as Unreachable for Podcast Episodes

### DIFF
--- a/app/services/podcasts/get_media_url.rb
+++ b/app/services/podcasts/get_media_url.rb
@@ -35,7 +35,7 @@ module Podcasts
     def url_reachable?(url)
       url = Addressable::URI.parse(url).normalize.to_s
       HTTParty.head(url).code == 200
-    rescue Net::OpenTimeout, SystemCallError
+    rescue Net::OpenTimeout, SystemCallError, URI::InvalidURIError
       false
     end
   end

--- a/spec/services/podcasts/get_media_url_spec.rb
+++ b/spec/services/podcasts/get_media_url_spec.rb
@@ -65,4 +65,13 @@ RSpec.describe Podcasts::GetMediaUrl, type: :service do
     expect(result.reachable).to be false
     expect(result.url).to eq(http_url)
   end
+
+  it "http, https unreachable with invalid url exception" do
+    allow(HTTParty).to receive(:head).with(https_url).and_raise(URI::InvalidURIError)
+    allow(HTTParty).to receive(:head).with(http_url).and_raise(URI::InvalidURIError)
+    result = described_class.call(http_url)
+    expect(result.https).to be false
+    expect(result.reachable).to be false
+    expect(result.url).to eq(http_url)
+  end
 end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Currently have a collection of failing workers trying to make podcast episodes with invalid URLs. This allows us to make the podcast episode but then mark the URL as unreachable. 
Fixes: https://app.honeybadger.io/fault/66984/c325e105109b2312cfcaf55fb904c254
```
URI::InvalidURIError: URI must be ascii only "https://codestammtis.ch/podcast/CST048_K%C3%A4ferverfolgung.mp3?ptm_source=feed&ptm_context=mp3&ptm_request
```
## Added tests?
- [x] yes

![alt_text](https://media.giphy.com/media/ukqwi7Shna63K/giphy.gif)
