### PR TITLE
Synchronously render the article editor guide

### DIFF
--- a/app/views/articles/edit.html.erb
+++ b/app/views/articles/edit.html.erb
@@ -28,5 +28,6 @@
 <% end %>
 
 <%= render "shared/webcomponents_loader_script" %>
-<%= javascript_packs_with_chunks_tag "clipboardCopy", "articleForm", defer: true %>
 <%= render "articles/v2_form", article: @article, organizations: @organizations, version: @version %>
+
+<%= javascript_packs_with_chunks_tag "clipboardCopy", "articleForm", defer: true %>

--- a/app/views/articles/new.html.erb
+++ b/app/views/articles/new.html.erb
@@ -2,8 +2,8 @@
 
 <% if user_signed_in? %>
   <%= render "shared/webcomponents_loader_script" %>
-  <%= javascript_packs_with_chunks_tag "clipboardCopy", "articleForm", defer: true %>
   <%= render "articles/v2_form", article: @article, organizations: @organizations, version: @version %>
+  <%= javascript_packs_with_chunks_tag "clipboardCopy", "articleForm", defer: true %>
 <% else %>
   <% @new_article_not_logged_in = true %>
   <%= render "devise/registrations/registration_form" %>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We have a weird and non deterministic bug happening in the article edit page in which it sometimes doesn't render, at all.

Thanks to @caleb15 reporting the console log and @lightalloy's investigation there's strong evidence this is related to the the element whose ID is `editor-help-guide`, which is the editor guide.

Precisely this happens here:

https://github.com/thepracticaldev/dev.to/blob/bca0573a147ceb764ef8d4f2d4acb0f8f587fbc6/app/javascript/article-form/articleForm.jsx#L102

I noticed how we render the JS tag **before** the HTML that contains the editor guide. Even though the script it set to `defer` I guess there might be a situation where the script still starts before the HTML is fully in.

By rendering the HTML before the script runs, at least we're sure the editor guide is in the DOM when the script runs.

I'm not 100% sure this is the whole solution though.

## Related Tickets & Documents

https://github.com/thepracticaldev/dev.to/issues/6927

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
