### PR TITLE
Copy ActiveRecord methods from fastly-rails

### DIFF
--- a/app/labor/cache_buster.rb
+++ b/app/labor/cache_buster.rb
@@ -7,6 +7,17 @@ module CacheBuster
   ].freeze
 
   def self.bust(path)
+    # TODO: (Alex Smith) - It would be "nice to have" the ability to use the
+    # Fastly gem here instead of custom API calls. We'd want to keep thread
+    # safety in mind. We'll also want to consider making this modular for those
+    # who don't want to use Fastly at all.
+    #
+    # Instead of HTTP calls, we could do:
+    # fastly  = Fastly.new(api_key: ApplicationConfig["FASTLY_API_KEY"])
+    # service = Fastly::Service.new({ id: ApplicationConfig["FASTLY_SERVICE_ID"] }, fastly)
+    # fastly.purge(path)
+    #
+    # https://github.com/fastly/fastly-ruby#efficient-purging
     return unless Rails.env.production?
 
     HTTParty.post("https://api.fastly.com/purge/https://#{ApplicationConfig['APP_DOMAIN']}#{path}",

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,6 +1,8 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
+  include Purgable
+
   QUERY_ESTIMATED_COUNT = <<~SQL.squish.freeze
     SELECT (
       (reltuples / GREATEST(relpages, 1)) *

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,7 +1,7 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
-  include Purgable
+  include Purgeable
 
   QUERY_ESTIMATED_COUNT = <<~SQL.squish.freeze
     SELECT (

--- a/app/models/concerns/purgable.rb
+++ b/app/models/concerns/purgable.rb
@@ -1,0 +1,78 @@
+# Copied from the deprecate fastly-rails gem
+# https://github.com/fastly/fastly-rails/blob/master/lib/fastly-rails/active_record/surrogate_key.rb
+#
+# This concern handles purge and purge_all calls to purge the edge cache (Fastly)
+module Purgable
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def purge_all
+      return unless Rails.env.production?
+
+      service.purge_by_key(table_key)
+    end
+
+    def soft_purge_all
+      return unless Rails.env.production?
+
+      service.purge_by_key(table_key, true)
+    end
+
+    def table_key
+      table_name
+    end
+
+    def fastly_service_identifier
+      return unless Rails.env.production?
+
+      service.service_id
+    end
+  end
+
+  # Instance methods
+  def record_key
+    "#{table_key}/#{id}"
+  end
+
+  def table_key
+    self.class.table_key
+  end
+
+  def purge
+    return unless Rails.env.production?
+
+    service.purge_by_key(record_key)
+  end
+
+  def soft_purge
+    return unless Rails.env.production?
+
+    service.purge_by_key(record_key, true)
+  end
+
+  def purge_all
+    self.class.purge_all
+  end
+
+  def soft_purge_all
+    self.class.soft_purge_all
+  end
+
+  def fastly_service_identifier
+    self.class.fastly_service_identifier
+  end
+
+  private
+
+  def fastly
+    return unless Rails.env.production?
+
+    Fastly.new(api_key: ApplicationConfig["FASTLY_API_KEY"])
+  end
+
+  def service
+    return unless Rails.env.production?
+
+    Fastly::Service.new({ id: ApplicationConfig["FASTLY_SERVICE_ID"] }, fastly)
+  end
+end

--- a/app/models/concerns/purgable.rb
+++ b/app/models/concerns/purgable.rb
@@ -1,4 +1,4 @@
-# Copied from the deprecate fastly-rails gem
+# Copied from the deprecated fastly-rails gem
 # https://github.com/fastly/fastly-rails/blob/master/lib/fastly-rails/active_record/surrogate_key.rb
 #
 # This concern handles purge and purge_all calls to purge the edge cache (Fastly)

--- a/app/models/concerns/purgeable.rb
+++ b/app/models/concerns/purgeable.rb
@@ -2,19 +2,15 @@
 # https://github.com/fastly/fastly-rails/blob/master/lib/fastly-rails/active_record/surrogate_key.rb
 #
 # This concern handles purge and purge_all calls to purge the edge cache (Fastly)
-module Purgable
+module Purgeable
   extend ActiveSupport::Concern
 
   module ClassMethods
     def purge_all
-      return unless Rails.env.production?
-
       service.purge_by_key(table_key)
     end
 
     def soft_purge_all
-      return unless Rails.env.production?
-
       service.purge_by_key(table_key, true)
     end
 
@@ -23,8 +19,6 @@ module Purgable
     end
 
     def fastly_service_identifier
-      return unless Rails.env.production?
-
       service.service_id
     end
   end
@@ -39,14 +33,10 @@ module Purgable
   end
 
   def purge
-    return unless Rails.env.production?
-
     service.purge_by_key(record_key)
   end
 
   def soft_purge
-    return unless Rails.env.production?
-
     service.purge_by_key(record_key, true)
   end
 
@@ -65,14 +55,10 @@ module Purgable
   private
 
   def fastly
-    return unless Rails.env.production?
-
     Fastly.new(api_key: ApplicationConfig["FASTLY_API_KEY"])
   end
 
   def service
-    return unless Rails.env.production?
-
     Fastly::Service.new({ id: ApplicationConfig["FASTLY_SERVICE_ID"] }, fastly)
   end
 end

--- a/app/models/concerns/purgeable.rb
+++ b/app/models/concerns/purgeable.rb
@@ -7,10 +7,14 @@ module Purgeable
 
   module ClassMethods
     def purge_all
+      return if Rails.env.development?
+
       service.purge_by_key(table_key)
     end
 
     def soft_purge_all
+      return if Rails.env.development?
+
       service.purge_by_key(table_key, true)
     end
 
@@ -19,10 +23,14 @@ module Purgeable
     end
 
     def fastly
+      return if Rails.env.development?
+
       Fastly.new(api_key: ApplicationConfig["FASTLY_API_KEY"])
     end
 
     def service
+      return if Rails.env.development?
+
       Fastly::Service.new({ id: ApplicationConfig["FASTLY_SERVICE_ID"] }, fastly)
     end
   end
@@ -37,10 +45,14 @@ module Purgeable
   end
 
   def purge
+    return if Rails.env.development?
+
     service.purge_by_key(record_key)
   end
 
   def soft_purge
+    return if Rails.env.development?
+
     service.purge_by_key(record_key, true)
   end
 

--- a/app/models/concerns/purgeable.rb
+++ b/app/models/concerns/purgeable.rb
@@ -18,10 +18,6 @@ module Purgeable
       table_name
     end
 
-    def fastly_service_identifier
-      service.service_id
-    end
-
     def fastly
       Fastly.new(api_key: ApplicationConfig["FASTLY_API_KEY"])
     end
@@ -54,10 +50,6 @@ module Purgeable
 
   def soft_purge_all
     self.class.soft_purge_all
-  end
-
-  def fastly_service_identifier
-    self.class.fastly_service_identifier
   end
 
   def fastly

--- a/app/models/concerns/purgeable.rb
+++ b/app/models/concerns/purgeable.rb
@@ -21,6 +21,14 @@ module Purgeable
     def fastly_service_identifier
       service.service_id
     end
+
+    def fastly
+      Fastly.new(api_key: ApplicationConfig["FASTLY_API_KEY"])
+    end
+
+    def service
+      Fastly::Service.new({ id: ApplicationConfig["FASTLY_SERVICE_ID"] }, fastly)
+    end
   end
 
   # Instance methods
@@ -52,13 +60,11 @@ module Purgeable
     self.class.fastly_service_identifier
   end
 
-  private
-
   def fastly
-    Fastly.new(api_key: ApplicationConfig["FASTLY_API_KEY"])
+    self.class.fastly
   end
 
   def service
-    Fastly::Service.new({ id: ApplicationConfig["FASTLY_SERVICE_ID"] }, fastly)
+    self.class.service
   end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -40,7 +40,7 @@ class Tag < ActsAsTaggableOn::Tag
   SEARCH_CLASS = Search::Tag
 
   # This model doesn't inherit from ApplicationRecord so this has to be included
-  include Purgable
+  include Purgeable
 
   # possible social previews templates for articles with a particular tag
   def self.social_preview_templates

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -39,6 +39,9 @@ class Tag < ActsAsTaggableOn::Tag
   SEARCH_SERIALIZER = Search::TagSerializer
   SEARCH_CLASS = Search::Tag
 
+  # This model doesn't inherit from ApplicationRecord so this has to be included
+  include Purgable
+
   # possible social previews templates for articles with a particular tag
   def self.social_preview_templates
     Rails.root.join("app/views/social_previews/articles").children.map { |ch| File.basename(ch, ".html.erb") }

--- a/spec/models/concerns/purgeable_spec.rb
+++ b/spec/models/concerns/purgeable_spec.rb
@@ -1,0 +1,101 @@
+require "rails_helper"
+
+class PurgeableModel
+  include Purgeable
+
+  def self.table_name
+    "purgeables"
+  end
+
+  def id
+    1
+  end
+end
+
+RSpec.describe Purgeable do
+  let(:model_class) { PurgeableModel }
+  let(:purgeable_model) { model_class.new }
+  let(:fastly_service) { instance_double(Fastly::Service) }
+
+  before do
+    allow(Fastly::Service).to receive(:new).and_return(fastly_service)
+  end
+
+  describe "class methods" do
+    it "calls .purge_by_key with table_key in purge_all" do
+      allow(fastly_service).to receive(:purge_by_key)
+      model_class.purge_all
+      expect(fastly_service).to have_received(:purge_by_key).with(model_class.table_key)
+    end
+
+    it "calls .purge_by_key with table_key and true in soft_purge_all" do
+      allow(fastly_service).to receive(:purge_by_key)
+      model_class.soft_purge_all
+      expect(fastly_service).to have_received(:purge_by_key).with(model_class.table_key, true)
+    end
+
+    it "returns table_name with table_key" do
+      expect(model_class.table_key).to eq(model_class.table_name)
+    end
+
+    it "returns a Fastly object" do
+      fastly = instance_double(Fastly)
+      allow(Fastly).to receive(:new).and_return(fastly)
+      model_class.fastly
+      expect(Fastly).to have_received(:new)
+    end
+
+    it "returns a Fastly::Service object" do
+      model_class.service
+      expect(Fastly::Service).to have_received(:new)
+    end
+  end
+
+  describe "instance methods" do
+    it "returns a record key" do
+      expect(purgeable_model.record_key).to eq("purgeables/1")
+    end
+
+    it "returns a table_key" do
+      allow(model_class).to receive(:table_key).and_return(model_class.table_name)
+      expect(purgeable_model.table_key).to eq(model_class.table_name)
+      expect(model_class).to have_received(:table_key)
+    end
+
+    it "calls .purge_by_key with record_key in purge" do
+      allow(fastly_service).to receive(:purge_by_key)
+      purgeable_model.purge
+      expect(fastly_service).to have_received(:purge_by_key).with(purgeable_model.record_key)
+    end
+
+    it "calls .purge_by_key with record_key and true in soft_purge" do
+      allow(fastly_service).to receive(:purge_by_key)
+      purgeable_model.soft_purge
+      expect(fastly_service).to have_received(:purge_by_key).with(purgeable_model.record_key, true)
+    end
+
+    it "calls purge_all class method" do
+      allow(model_class).to receive(:purge_all)
+      purgeable_model.purge_all
+      expect(model_class).to have_received(:purge_all)
+    end
+
+    it "calls soft_purge_all class method" do
+      allow(model_class).to receive(:soft_purge_all)
+      purgeable_model.soft_purge_all
+      expect(model_class).to have_received(:soft_purge_all)
+    end
+
+    it "calls the fastly class method" do
+      allow(model_class).to receive(:fastly)
+      purgeable_model.fastly
+      expect(model_class).to have_received(:fastly)
+    end
+
+    it "calls the service class method" do
+      allow(model_class).to receive(:service)
+      purgeable_model.service
+      expect(model_class).to have_received(:service)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -113,7 +113,7 @@ RSpec.configure do |config|
     stub_request(:any, /res.cloudinary.com/).to_rack("dsdsdsds")
 
     stub_request(:post, /api.fastly.com/).
-      to_return(status: 200, body: "", headers: {})
+      to_return(status: 200, body: "".to_json, headers: {})
 
     stub_request(:post, /api.bufferapp.com/).
       to_return(status: 200, body: { fake_text: "so fake" }.to_json, headers: {})


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Feature

## Description
**This PR:**
The [`fastly-rails` gem](https://github.com/fastly/fastly-rails) has been deprecated. I copied over the ActiveRecord methods we need from it to purge cache in Fastly.

---

It's worth noting that the `fastly` gem states in their [documentation](https://github.com/fastly/fastly-ruby#efficient-purging):
> To purge efficiently you do not want to look up the service every time you issue a purge.

I'm intentionally ignoring that here for a couple of reasons.
1) It's less of a change since `fastly-rails` was [doing this](https://github.com/fastly/fastly-rails/blob/6ed13a694b8753d43515079ae667fe6f8c0fcd23/lib/fastly-rails/client.rb#L11-L13) "incorrectly" as well.
2) The `fastly` [documentation](https://github.com/fastly/fastly-ruby#usage-notes) also states:
>If you are performing many purges per second we recommend you use the API directly with an HTTP client of your choice. See Efficient Purging above.
>
> fastly-ruby has not been audited for thread-safety. If you are performing actions that require multiple threads (such as performing many purges) we recommend you use the API directly.

So if we didn't do this the "incorrect" way, we'd have to implement some thread safety on our own. As it turns out, most Ruby HTTP libraries aren't thread-safe either. So it wouldn't be as "straight forward" to just send it with our own HTTP calls as the documentation suggests.

I think that's better done in a separate PR later on down the road. It's more of a "nice to have". AFAIK, there aren't any major drawbacks that would deter us from looking up the service each time for a while. After all, that is the current behavior via `fastly-rails`.

Whenever we go to make the gem usage thread-safe (PR to the gem itself perhaps?) we'd want to keep in mind that we want to shift the `CacheBuster` over from custom HTTP calls to using the `fastly` gem. I left a [comment](https://github.com/thepracticaldev/dev.to/pull/7145/files#diff-6e58540a6172a3c1054d1ede7134dd00R10-R20) about that.

---

I considered trying to break this up into smaller chunks, like implementing only a handful of the methods. I didn't see a path where it would really make a difference, but I'm open to the idea if people have suggestions.

---

Testing - the [`CacheBuster` spec](https://github.com/thepracticaldev/dev.to/blob/master/spec/labor/cache_buster_spec.rb) is still passing with this change. That testing is loose since we return early if the environment isn't production.

---

**UPDATED: Fastly update overview (will be copied to each PR for convenience):**
We are updating Fastly to get rid of the deprecated [`fastly-rails gem`](https://github.com/fastly/fastly-rails). We use the `fastly-rails` gem to set Fastly headers and to purge the cache in Fastly. We'll be implementing the logic for both and then remove the gem. This will result in a few PRs:
- [x] [Copy `set_cache_control_headers` from `fastly-rails`](https://github.com/thepracticaldev/dev.to/projects/9#card-35433259)
- [x] [Copy `set_surrogate_key_header` method from `fastly-rails`](https://github.com/thepracticaldev/dev.to/projects/9#card-35704769)
- [x] [Copy ActiveRecord methods from `fastly-rails`](https://github.com/thepracticaldev/dev.to/projects/9#card-35694968)
- [ ] [Remove the `fastly-rails` gem](https://github.com/thepracticaldev/dev.to/projects/9#card-35695053)
- [ ] [Update `fastly` gem](https://github.com/thepracticaldev/dev.to/projects/9#card-35905624)

We'll want to make sure we review these PRs thoroughly because Fastly touches _a lot_. Overall, the risk should be pretty low. The worst-case scenario (looking at all PRs) is we don't properly cache and that we don't bust the cache resulting in stale content. We should be able to catch those quickly and roll it back if needed. All that is to say, we aren't flying close to the sun (which is the giant purge all button). That's what burned us in the past.

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/9#card-35694968

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed (added and pasted a bunch of comments though 😎)

## Are there any post deployment tasks we need to perform?
We'll want to observe this deployment. Let's deploy this once a few people are around to test and to make sure those with production access to Fastly are online in case anything goes wrong.

![hopeful_gif](https://media.giphy.com/media/l0K4mUcTBtkPrCZXy/giphy.gif)