### PR TITLE
Make the site config togglable

### DIFF
--- a/app/views/internal/configs/_card_header.html.erb
+++ b/app/views/internal/configs/_card_header.html.erb
@@ -1,0 +1,12 @@
+<div class="card-header">
+  <span><%= header %></span>
+  <button
+    class="btn btn-secondary float-right"
+    type="button"
+    data-toggle="<%= state %>"
+    data-target="#<%= target %>"
+    aria-expanded="<%= expanded %>"
+    aria-controls="<%= target %>">
+    Toggle
+  </button>
+</div>

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -17,15 +17,21 @@
       <h2 class="d-inline">Site Configuration</h2>
       <button class="btn btn-secondary float-right" type="button" data-toggle="collapse"
         data-target="#siteConfigBodyContainer" aria-expanded="true" aria-controls="siteConfigBodyContainer">
-        Toggle
+        Toggle Site Configuration
       </button>
     </div>
     <div id="siteConfigBodyContainer" class="collapse show hide p-3" aria-labelledby="siteConfigHeader">
       <%= form_for(SiteConfig.new, url: internal_config_path) do |f| %>
 
         <div class="card mt-3">
-          <div class="card-header">Content</div>
-          <div class="card-body">
+          <%= render partial: "card_header",
+            locals: {
+              header: "Community Content",
+              state: "collapse",
+              target: "contentBodyContainer",
+              expanded: "false"
+          } %>
+          <div id="contentBodyContainer" class="card-body collapse hide" aria-labelledby="contentBodyContainer">
             <div class="form-group">
               <%= f.label :community_description, "Community description" %>
               <%= f.text_field :community_description,
@@ -34,30 +40,46 @@
                                placeholder: "A fabulous community of kind and welcoming people." %>
               <div class="alert alert-info">Used in meta description tags etc.</div>
             </div>
+
+            <div class="form-group">
+              <%= f.label :community_member_description, "Community member description" %>
+              <%= f.text_field :community_member_description,
+                               class: "form-control",
+                               value: SiteConfig.community_member_description,
+                               placeholder: "amazing humans who code." %>
+              <div class="alert alert-info">Used in pre-login banners.</div>
+            </div>
+
+            <div class="form-group">
+              <%= f.label :tagline, "Tagline" %>
+              <%= f.text_field :tagline,
+                               class: "form-control",
+                               value: SiteConfig.tagline,
+                               placeholder: "We're a place where coders share, stay up-to-date and grow their careers." %>
+              <div class="alert alert-info">Used in signup modal.</div>
+            </div>
+
+            <div class="form-group">
+              <%= f.label :mascot_user_id, "Mascot user ID" %>
+              <%= f.text_field :mascot_user_id,
+                               class: "form-control",
+                               value: SiteConfig.mascot_user_id,
+                               min: 1,
+                               placeholder: "1" %>
+              <div class="alert alert-info">User ID of the Mascot account</div>
+            </div>
           </div>
         </div>
 
-        <div class="form-group">
-          <%= f.label :community_member_description, "Community member description" %>
-          <%= f.text_field :community_member_description,
-                           class: "form-control",
-                           value: SiteConfig.community_member_description,
-                           placeholder: "amazing humans who code." %>
-          <div class="alert alert-info">Used in pre-login banners.</div>
-        </div>
-
-        <div class="form-group">
-          <%= f.label :tagline, "Tagline" %>
-          <%= f.text_field :tagline,
-                           class: "form-control",
-                           value: SiteConfig.tagline,
-                           placeholder: "We're a place where coders share, stay up-to-date and grow their careers." %>
-          <div class="alert alert-info">Used in signup modal.</div>
-        </div>
-
         <div class="card mt-3">
-          <div class="card-header">Staff</div>
-          <div class="card-body">
+          <%= render partial: "card_header",
+            locals: {
+              header: "Social Media and Email",
+              state: "collapse",
+              target: "socialMediaBodyContainer",
+              expanded: "false"
+          } %>
+          <div id="socialMediaBodyContainer" class="card-body collapse hide" aria-labelledby="socialMediaBodyContainer">
             <div class="form-group">
               <%= f.label :default_site_email %>
               <%= f.email_field :default_site_email,
@@ -79,23 +101,14 @@
         </div>
 
         <div class="card mt-3">
-          <div class="card-header">Mascot</div>
-          <div class="card-body">
-            <div class="form-group">
-              <%= f.label :mascot_user_id, "Mascot user ID" %>
-              <%= f.text_field :mascot_user_id,
-                               class: "form-control",
-                               value: SiteConfig.mascot_user_id,
-                               min: 1,
-                               placeholder: "1" %>
-              <div class="alert alert-info">User ID of the Mascot account</div>
-            </div>
-          </div>
-        </div>
-
-        <div class="card mt-3">
-          <div class="card-header">Authentication</div>
-          <div class="card-body">
+          <%= render partial: "card_header",
+            locals: {
+              header: "Authentication",
+              state: "collapse",
+              target: "authenticationBodyContainer",
+              expanded: "false"
+          } %>
+          <div id="authenticationBodyContainer" class="card-body collapse hide" aria-labelledby="authenticationBodyContainer">
             <div class="form-group">
               <%= f.label :authentication_providers, "Authentication providers" %>
               <%= f.text_field :authentication_providers,
@@ -108,8 +121,14 @@
         </div>
 
         <div class="card mt-3">
-          <div class="card-header">Campaign</div>
-          <div class="card-body">
+          <%= render partial: "card_header",
+            locals: {
+              header: "Campaign",
+              state: "collapse",
+              target: "campaignBodyContainer",
+              expanded: "false"
+          } %>
+          <div id="campaignBodyContainer" class="card-body collapse hide" aria-labelledby="campaignBodyContainer">
             <div class="form-group">
               <%= f.label :campaign_hero_html_variant_name %>
               <%= f.text_field :campaign_hero_html_variant_name,
@@ -153,8 +172,14 @@
         </div>
 
         <div class="card mt-3">
-          <div class="card-header">Images</div>
-          <div class="card-body">
+          <%= render partial: "card_header",
+            locals: {
+              header: "Images",
+              state: "collapse",
+              target: "imagesBodyContainer",
+              expanded: "false"
+          } %>
+          <div id="imagesBodyContainer" class="card-body collapse hide" aria-labelledby="imagesBodyContainer">
             <div class="form-group">
               <%= f.label :main_social_image %>
               <%= f.text_field :main_social_image,
@@ -239,8 +264,14 @@
         </div>
 
         <div class="card mt-3">
-          <div class="card-header">Rate limits</div>
-          <div class="card-body">
+          <%= render partial: "card_header",
+            locals: {
+              header: "Rate limits",
+              state: "collapse",
+              target: "rateLimitsBodyContainer",
+              expanded: "false"
+          } %>
+          <div id="rateLimitsBodyContainer" class="card-body collapse hide" aria-labelledby="rateLimitsBodyContainer">
             <div class="form-group">
               <%= f.label :rate_limit_follow_count_daily %>
               <%= f.number_field :rate_limit_follow_count_daily,
@@ -250,8 +281,7 @@
                                  placeholder: 500 %>
               <div class="alert alert-info">Used to limit the amount of users a person can follow daily</div>
             </div>
-          </div>
-          <div class="card-body">
+
             <div class="form-group">
               <%= f.label :rate_limit_comment_creation %>
               <%= f.number_field :rate_limit_comment_creation,
@@ -261,8 +291,7 @@
                                  placeholder: 9 %>
               <div class="alert alert-info">Used to limit the amount of comments a user can create within 30 seconds</div>
             </div>
-          </div>
-          <div class="card-body">
+
             <div class="form-group">
               <%= f.label :rate_limit_published_article_creation %>
               <%= f.number_field :rate_limit_published_article_creation,
@@ -272,8 +301,7 @@
                                  placeholder: 9 %>
               <div class="alert alert-info">Used to limit the amount of articles a user can create within 30 seconds</div>
             </div>
-          </div>
-          <div class="card-body">
+
             <div class="form-group">
               <%= f.label :rate_limit_image_upload %>
               <%= f.number_field :rate_limit_image_upload,
@@ -283,8 +311,7 @@
                                  placeholder: 9 %>
               <div class="alert alert-info">Used to limit the amount of images a user can upload within 30 seconds</div>
             </div>
-          </div>
-          <div class="card-body">
+
             <div class="form-group">
               <%= f.label :rate_limit_email_recipient %>
               <%= f.number_field :rate_limit_email_recipient,
@@ -298,8 +325,14 @@
         </div>
 
         <div class="card mt-3">
-          <div class="card-header">Google Analytics Reporting API v4</div>
-          <div class="card-body">
+          <%= render partial: "card_header",
+            locals: {
+              header: "Google Analytics Reporting API v4",
+              state: "collapse",
+              target: "gaBodyContainer",
+              expanded: "false"
+          } %>
+          <div id="gaBodyContainer" class="card-body collapse hide" aria-labelledby="gaBodyContainer">
             <div class="form-group">
               <%= f.label :ga_view_id, "View ID" %>
               <%= f.text_field :ga_view_id,
@@ -321,8 +354,14 @@
         </div>
 
         <div class="card mt-3">
-          <div class="card-header">Mailchimp Lists IDs</div>
-          <div class="card-body">
+          <%= render partial: "card_header",
+            locals: {
+              header: "Mailchimp Lists IDs",
+              state: "collapse",
+              target: "mailchimpListBodyContainer",
+              expanded: "false"
+          } %>
+          <div id="mailchimpListBodyContainer" class="card-body collapse hide" aria-labelledby="mailchimpListBodyContainer">
             <div class="form-group">
               <%= f.label :mailchimp_newsletter_id, "Main Newsletter" %>
               <%= f.text_field :mailchimp_newsletter_id,
@@ -358,8 +397,14 @@
         </div>
 
         <div class="card mt-3">
-          <div class="card-header">Email digest frequency</div>
-          <div class="card-body">
+          <%= render partial: "card_header",
+            locals: {
+              header: "Email digest frequency",
+              state: "collapse",
+              target: "emailDigestBodyContainer",
+              expanded: "false"
+          } %>
+          <div id="emailDigestBodyContainer" class="card-body collapse hide" aria-labelledby="emailDigestBodyContainer">
             <div class="form-group">
               <%= f.label :periodic_email_digest_max %>
               <%= f.number_field :periodic_email_digest_max,
@@ -381,8 +426,14 @@
         </div>
 
         <div class="card mt-3">
-          <div class="card-header">Tags</div>
-          <div class="card-body">
+          <%= render partial: "card_header",
+            locals: {
+              header: "Tags",
+              state: "collapse",
+              target: "tagsBodyContainer",
+              expanded: "false"
+          } %>
+          <div id="tagsBodyContainer" class="card-body collapse hide" aria-labelledby="tagsBodyContainer">
             <div class="form-group">
               <%= f.label :suggested_tags %>
               <%= f.text_field :suggested_tags,
@@ -427,7 +478,7 @@
         <h2 class="d-inline">Environment variables / AppConfig (readonly)</h2>
         <button class="btn btn-secondary float-right" type="button" data-toggle="collapse"
           data-target="#appConfigBodyContainer" aria-expanded="true" aria-controls="appConfigBodyContainer">
-          Toggle
+          Toggle Environment Variables
         </button>
       </div>
       <div id="appConfigBodyContainer" class="collapse show hide" aria-labelledby="appConfigHeader">

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -477,11 +477,11 @@
       <div class="card-header" id="appConfigHeader">
         <h2 class="d-inline">Environment variables / AppConfig (readonly)</h2>
         <button class="btn btn-secondary float-right" type="button" data-toggle="collapse"
-          data-target="#appConfigBodyContainer" aria-expanded="true" aria-controls="appConfigBodyContainer">
+          data-target="#appConfigBodyContainer" aria-expanded="false" aria-controls="appConfigBodyContainer">
           Toggle Environment Variables
         </button>
       </div>
-      <div id="appConfigBodyContainer" class="collapse show hide" aria-labelledby="appConfigHeader">
+      <div id="appConfigBodyContainer" class="collapse hide" aria-labelledby="appConfigHeader">
         <table class="table">
           <thead>
             <tr>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
The site config page has become unmanageable and the submit button has fallen right to the bottom of the page, making it difficult to easily navigate the page and make quick changes.

For now, I have collapsed all the sections by default, until we get around to designing out a tabbed or sidebar format. I've also renamed some section headers to be more reflective of the config that they have in it, since they will be closed by default now. In addition, mascot id has been moved to Community Content.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![screencapture-localhost-3000-internal-config-2020-04-08-14_54_47](https://user-images.githubusercontent.com/2786819/78789332-4c063600-79ad-11ea-8f3b-2966c7e066a5.png)

![screencapture-localhost-3000-internal-config-2020-04-08-14_54_58](https://user-images.githubusercontent.com/2786819/78789356-51fc1700-79ad-11ea-9e2b-76963d2a6b7c.png)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/icaeeT2BbEmwo/giphy.gif)
