### PR TITLE
Keep Articles Updated in Elasticsearch when Organization is Updated

### DIFF
--- a/app/services/data_sync/elasticsearch/organization.rb
+++ b/app/services/data_sync/elasticsearch/organization.rb
@@ -1,0 +1,38 @@
+module DataSync
+  module Elasticsearch
+    class Organization
+      RELATED_DOCS = %i[
+        articles
+      ].freeze
+
+      SHARED_TAG_FIELDS = %i[
+        slug
+        name
+        profile_image
+      ].freeze
+
+      attr_accessor :organization, :updated_fields
+
+      delegate :articles, to: :@organization
+
+      def initialize(organization, updated_fields)
+        @organization = organization
+        @updated_fields = updated_fields.deep_symbolize_keys
+      end
+
+      def call
+        return unless sync_needed?
+
+        RELATED_DOCS.each do |relation_name|
+          send(relation_name).find_each(&:index_to_elasticsearch)
+        end
+      end
+
+      private
+
+      def sync_needed?
+        updated_fields.slice(*SHARED_TAG_FIELDS).any?
+      end
+    end
+  end
+end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -6,6 +6,26 @@ RSpec.describe Organization, type: :model do
   it { is_expected.to have_many(:sponsorships) }
   it { is_expected.to have_many(:organization_memberships).dependent(:delete_all) }
 
+  describe "#after_commit" do
+    it "on update syncs elasticsearch data" do
+      article = create(:article, organization: organization)
+      sidekiq_perform_enqueued_jobs
+      new_org_name = "#{organization.name}+NEW"
+      organization.update(name: new_org_name)
+      sidekiq_perform_enqueued_jobs
+      expect(article.elasticsearch_doc.dig("_source", "organization", "name")).to eq(new_org_name)
+    end
+
+    it "on destroy removes data from elasticsearch" do
+      article = create(:article, organization: organization)
+      sidekiq_perform_enqueued_jobs
+      expect(article.elasticsearch_doc.dig("_source", "organization", "id")).to eq(organization.id)
+      organization.destroy
+      sidekiq_perform_enqueued_jobs
+      expect(article.elasticsearch_doc.dig("_source", "organization")).to be_nil
+    end
+  end
+
   describe "#name" do
     it "rejects names with over 50 characters" do
       organization.name = "x" * 51

--- a/spec/services/data_sync/elasticsearch/organization_spec.rb
+++ b/spec/services/data_sync/elasticsearch/organization_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe DataSync::Elasticsearch::Organization, type: :service do
+  let!(:organization) { create(:organization) }
+
+  describe "#call" do
+    it "reindexes RELATED_DOCS when sync is needed " do
+      syncer = described_class.new(organization, name: %w[name1 name2])
+      described_class::RELATED_DOCS.each do |method_name|
+        allow(syncer).to receive(method_name).and_call_original
+      end
+      syncer.call
+      described_class::RELATED_DOCS.each do |method_name|
+        expect(syncer).to have_received(method_name)
+      end
+    end
+
+    it "does not reindex when sync is not needed" do
+      syncer = described_class.new(organization, articles_count: [0, 1])
+      described_class::RELATED_DOCS.each { |method_name| allow(syncer).to receive(method_name) }
+      syncer.call
+      described_class::RELATED_DOCS.each do |method_name|
+        expect(syncer).not_to have_received(method_name)
+      end
+    end
+  end
+end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Since organization data is indexed on articles we need to ensure that data is updated when an organization is updated. This adds a DataSync class for organizations which is the first model to get a sync class but it is not an indexed model itself which is why I implemented the method for it in the model class itself. 

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-35915671

## Added tests?
- [x] yes

![alt_text](https://media1.giphy.com/media/U2RhNiWPNyhc8dtCeZ/giphy.gif)
