### PR TITLE
Add exceptions to the serviceworker code to fix redirects

### DIFF
--- a/app/views/service_worker/index.js.erb
+++ b/app/views/service_worker/index.js.erb
@@ -7,6 +7,7 @@
 
   self.addEventListener('install', event => {
     self.skipWaiting();
+
     // Populate initial serviceworker cache.
     event.waitUntil(
       caches.open(staticCacheName)
@@ -80,12 +81,10 @@
 
   self.addEventListener('fetch', event => {
     const url = new URL(event.request.url);
-
     if (/iPhone|CriOS|iPad/i.test(navigator.userAgent) && event.request.referrer.includes('t.co')) {
        // Twitter on iOS seems to cause problems
        return;
     }
-
     if (url.origin === location.origin) {
       if (event.clientId === "" && // Not fetched via AJAX after page load.
         event.request.method == "GET" && // Don't fetch on POST, DELETE, etc.

--- a/app/views/service_worker/index.js.erb
+++ b/app/views/service_worker/index.js.erb
@@ -7,7 +7,6 @@
 
   self.addEventListener('install', event => {
     self.skipWaiting();
-
     // Populate initial serviceworker cache.
     event.waitUntil(
       caches.open(staticCacheName)
@@ -81,10 +80,12 @@
 
   self.addEventListener('fetch', event => {
     const url = new URL(event.request.url);
+
     if (/iPhone|CriOS|iPad/i.test(navigator.userAgent) && event.request.referrer.includes('t.co')) {
        // Twitter on iOS seems to cause problems
        return;
     }
+
     if (url.origin === location.origin) {
       if (event.clientId === "" && // Not fetched via AJAX after page load.
         event.request.method == "GET" && // Don't fetch on POST, DELETE, etc.
@@ -121,6 +122,12 @@
         !url.href.includes('/search/chat_channels') &&
         !url.href.includes('/search/classified_listings') &&
         !url.href.includes('/search/users') &&
+
+        // Don't run on redirects
+        !url.href.includes('/workshops') &&
+        !url.href.includes('/%F0%9F%92%B8') && // 💸 (hiring)
+        !url.href.includes('/podcasts') &&
+        !url.href.includes('/p/rlyweb') &&
 
         caches.match('/shell_top') && // Ensure shell_top is in the cache.
         caches.match('/shell_bottom')) { // Ensure shell_bottom is in the cache.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Added exceptions to the serviceworker to the redirect paths, to avoid console errors and double footer rendering. This could also potentially help with an offline page on this paths in production, e.g. https://dev.to/workshops

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
Example of the double footer:
![изображение](https://user-images.githubusercontent.com/30115/78803115-46b5e500-79c7-11ea-8dcc-8ea49232a2de.png)
