### PR TITLE
Return cloudinary url from Elasticsearch to show Videos in Feed

### DIFF
--- a/app/services/search/query_builders/feed_content.rb
+++ b/app/services/search/query_builders/feed_content.rb
@@ -40,6 +40,7 @@ module Search
       SOURCE = %i[
         id
         class_name
+        cloudinary_video_url
         comments_count
         flare_tag_hash
         main_image

--- a/spec/services/search/feed_content_spec.rb
+++ b/spec/services/search/feed_content_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe Search::FeedContent, type: :service do
     it "returns fields necessary for the view" do
       allow(article1).to receive(:flare_tag).and_return(name: "help", bg_color_hex: nil, text_color_hex: nil)
       view_keys = %w[
-        id title path class_name flare_tag tag_list user_id user published_at_int
-        published_timestamp readable_publish_date
+        id title path class_name cloudinary_video_url comments_count flare_tag tag_list user_id user
+        published_at_int published_timestamp readable_publish_date
       ]
       flare_tag_keys = %w[name bg_color_hex text_color_hex]
       user_keys = %w[username name profile_image_90]


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This ensures that we return the cloundinary URL which is required to show a video in the feed view
```
var videoHTML = '';
    if (article.cloudinary_video_url) {
      videoHTML = '<a href="'+article.path+'" class="single-article-video-preview" style="background-image:url('+article.cloudinary_video_url+')"><div class="single-article-video-duration"><img src="<%= asset_path("video-camera.svg") %>" alt="video camera">'+article.video_duration_in_minutes+'</div></a>'
    }
```

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-35622089

## Added tests?
- [x] yes

![alt_text](https://media.giphy.com/media/3orieSQJWJwicVxugw/giphy.gif)
