### PR TITLE
Onboarding intro slide tweaks

### DIFF
--- a/app/assets/stylesheets/preact/onboarding-modal.scss
+++ b/app/assets/stylesheets/preact/onboarding-modal.scss
@@ -43,6 +43,20 @@
   }
 }
 
+// terms and conditions view
+.terms-and-conditions-wrapper {
+  $content-height: 358px;
+
+  button {
+    @extend .crayons-btn;
+  }
+  .terms-and-conditions-content {
+    height: $content-height;
+    overflow-y: scroll;
+    margin-top: 10px;
+  }
+}
+
 // window background
 .onboarding-body {
   -moz-background-size: cover;
@@ -369,7 +383,7 @@ $onboarding-user-selected-hover: rgba(71, 85, 235, 0.2);
   .user-name {
     font-size: $fs-base;
   }
-  
+
   .user-info {
     width: 100%;
   }

--- a/app/javascript/onboarding/__tests__/Onboarding.test.jsx
+++ b/app/javascript/onboarding/__tests__/Onboarding.test.jsx
@@ -16,8 +16,8 @@ function flushPromises() {
   return new Promise((resolve) => setImmediate(resolve));
 }
 
-function initializeSlides(currentSlide, dataUser = null, mockData = null) {
-  document.body.setAttribute('data-user', dataUser);
+function initializeSlides(currentSlide, userData = null, mockData = null) {
+  document.body.setAttribute('data-user', userData);
   const onboardingSlides = deep(<Onboarding />);
 
   if (mockData) {
@@ -74,18 +74,19 @@ describe('<Onboarding />', () => {
       profile_image_url: 'dev.jpg',
     },
   ]);
-  const dataUser = JSON.stringify({
-    followed_tag_names: ['javascript'],
-    profile_image_90: 'mock_url_link',
-    name: 'firstname lastname',
-    username: 'username',
-  });
+  const getUserData = () =>
+    JSON.stringify({
+      followed_tag_names: ['javascript'],
+      profile_image_90: 'mock_url_link',
+      name: 'firstname lastname',
+      username: 'username',
+    });
 
   describe('IntroSlide', () => {
     let onboardingSlides;
 
     beforeEach(() => {
-      onboardingSlides = initializeSlides(0, dataUser);
+      onboardingSlides = initializeSlides(0, getUserData());
     });
 
     test('renders properly', () => {
@@ -130,7 +131,7 @@ describe('<Onboarding />', () => {
     };
 
     beforeEach(() => {
-      onboardingSlides = initializeSlides(1, dataUser);
+      onboardingSlides = initializeSlides(1, getUserData());
     });
 
     test('renders properly', () => {
@@ -194,7 +195,7 @@ describe('<Onboarding />', () => {
     document.body.appendChild(meta);
 
     beforeEach(() => {
-      onboardingSlides = initializeSlides(2, dataUser);
+      onboardingSlides = initializeSlides(2, getUserData());
     });
 
     test('renders properly', () => {
@@ -227,7 +228,7 @@ describe('<Onboarding />', () => {
     document.body.appendChild(meta);
 
     beforeEach(() => {
-      onboardingSlides = initializeSlides(3, dataUser);
+      onboardingSlides = initializeSlides(3, getUserData());
     });
 
     test('renders properly', () => {
@@ -278,7 +279,7 @@ describe('<Onboarding />', () => {
     let onboardingSlides;
 
     beforeEach(async () => {
-      onboardingSlides = initializeSlides(4, dataUser, fakeTagsResponse);
+      onboardingSlides = initializeSlides(4, getUserData(), fakeTagsResponse);
       await flushPromises();
     });
 
@@ -316,7 +317,7 @@ describe('<Onboarding />', () => {
     let onboardingSlides;
 
     beforeEach(async () => {
-      onboardingSlides = initializeSlides(5, dataUser, fakeUsersResponse);
+      onboardingSlides = initializeSlides(5, getUserData(), fakeUsersResponse);
       await flushPromises();
     });
 
@@ -351,7 +352,7 @@ describe('<Onboarding />', () => {
     let onboardingSlides;
 
     beforeEach(() => {
-      onboardingSlides = initializeSlides(6);
+      onboardingSlides = initializeSlides(6, getUserData());
     });
 
     test('renders properly', () => {

--- a/app/javascript/onboarding/__tests__/Onboarding.test.jsx
+++ b/app/javascript/onboarding/__tests__/Onboarding.test.jsx
@@ -76,16 +76,21 @@ describe('<Onboarding />', () => {
   ]);
   const dataUser = JSON.stringify({
     followed_tag_names: ['javascript'],
+    profile_image_90: 'mock_url_link',
+    name: 'firstname lastname',
+    username: 'username',
   });
 
   describe('IntroSlide', () => {
     let onboardingSlides;
 
     beforeEach(() => {
-      onboardingSlides = initializeSlides(0);
+      onboardingSlides = initializeSlides(0, dataUser);
     });
 
     test('renders properly', () => {
+      // For some reason, this snapshot does not ever pick up on the dataUser properties
+      // so the snapshots do not render the user's name and render the fallback greeting instead.
       expect(onboardingSlides).toMatchSnapshot();
     });
 

--- a/app/javascript/onboarding/__tests__/Onboarding.test.jsx
+++ b/app/javascript/onboarding/__tests__/Onboarding.test.jsx
@@ -17,13 +17,13 @@ function flushPromises() {
 }
 
 function initializeSlides(currentSlide, dataUser = null, mockData = null) {
+  document.body.setAttribute('data-user', dataUser);
   const onboardingSlides = deep(<Onboarding />);
 
   if (mockData) {
     fetch.once(mockData);
   }
 
-  document.body.setAttribute('data-user', dataUser);
   onboardingSlides.setState({ currentSlide });
 
   return onboardingSlides;
@@ -89,8 +89,6 @@ describe('<Onboarding />', () => {
     });
 
     test('renders properly', () => {
-      // For some reason, this snapshot does not ever pick up on the dataUser properties
-      // so the snapshots do not render the user's name and render the fallback greeting instead.
       expect(onboardingSlides).toMatchSnapshot();
     });
 

--- a/app/javascript/onboarding/__tests__/__snapshots__/Onboarding.test.jsx.snap
+++ b/app/javascript/onboarding/__tests__/__snapshots__/Onboarding.test.jsx.snap
@@ -148,7 +148,7 @@ preact-render-spy (1 nodes)
         </button>
       </div>
     </nav>
-    <div class="onboarding-content checkbox-slide">
+    <div class="onboarding-content terms-and-conditions-wrapper">
       <header class="onboarding-content-header">
         <h1 class="title">Getting started</h1>
         <h2 class="subtitle">Let's review a few things first</h2>

--- a/app/javascript/onboarding/__tests__/__snapshots__/Onboarding.test.jsx.snap
+++ b/app/javascript/onboarding/__tests__/__snapshots__/Onboarding.test.jsx.snap
@@ -450,7 +450,7 @@ preact-render-spy (1 nodes)
           alt="DEV"
          />
       </figure>
-      <h1 class="introduction-title">Welcome to DEV!</h1>
+      <h1 class="introduction-title">firstname lastname — welcome to DEV!</h1>
       <h2 class="introduction-subtitle">
         DEV is where programmers share ideas and help each other grow.
       </h2>

--- a/app/javascript/onboarding/components/EmailListTermsConditionsForm.jsx
+++ b/app/javascript/onboarding/components/EmailListTermsConditionsForm.jsx
@@ -42,7 +42,7 @@ class EmailTermsConditionsForm extends Component {
       },
       body: JSON.stringify({ user: this.state }),
       credentials: 'same-origin',
-    }).then(response => {
+    }).then((response) => {
       if (response.ok) {
         localStorage.setItem('shouldRedirectToOnboarding', false);
         const { next } = this.props;
@@ -74,7 +74,7 @@ class EmailTermsConditionsForm extends Component {
 
   handleChange(event) {
     const { name } = event.target;
-    this.setState(currentState => ({
+    this.setState((currentState) => ({
       [name]: !currentState[name],
     }));
   }
@@ -101,14 +101,14 @@ class EmailTermsConditionsForm extends Component {
     if (textShowing) {
       return (
         <div className="onboarding-main">
-          <div className="onboarding-content checkbox-slide">
+          <div className="onboarding-content terms-and-conditions-wrapper">
             <button type="button" onClick={() => this.backToSlide()}>
               Back
             </button>
             <div
+              className="terms-and-conditions-content"
               /* eslint-disable react/no-danger */
               dangerouslySetInnerHTML={{ __html: textShowing }}
-              style={{ height: '360px', overflow: 'scroll' }}
               /* eslint-enable react/no-danger */
             />
           </div>
@@ -118,7 +118,7 @@ class EmailTermsConditionsForm extends Component {
     return (
       <div className="onboarding-main">
         <Navigation prev={prev} next={this.onSubmit} />
-        <div className="onboarding-content checkbox-slide">
+        <div className="onboarding-content terms-and-conditions-wrapper">
           <header className="onboarding-content-header">
             <h1 className="title">Getting started</h1>
             <h2 className="subtitle">Let&apos;s review a few things first</h2>
@@ -148,7 +148,7 @@ class EmailTermsConditionsForm extends Component {
                     <a
                       href="/code-of-conduct"
                       data-no-instant
-                      onClick={e => this.handleShowText(e, 'coc')}
+                      onClick={(e) => this.handleShowText(e, 'coc')}
                     >
                       Code of Conduct
                     </a>
@@ -169,7 +169,7 @@ class EmailTermsConditionsForm extends Component {
                     <a
                       href="/terms"
                       data-no-instant
-                      onClick={e => this.handleShowText(e, 'terms')}
+                      onClick={(e) => this.handleShowText(e, 'terms')}
                     >
                       Terms and Conditions
                     </a>

--- a/app/javascript/onboarding/components/IntroSlide.jsx
+++ b/app/javascript/onboarding/components/IntroSlide.jsx
@@ -2,16 +2,14 @@ import { h, Component } from 'preact';
 import PropTypes from 'prop-types';
 
 import Navigation from './Navigation';
-import { updateOnboarding } from '../utilities';
+import { userData, updateOnboarding } from '../utilities';
 
 class IntroSlide extends Component {
   constructor(props) {
     super(props);
 
-    const user = window.userData();
-    this.name = user.name;
-
     this.onSubmit = this.onSubmit.bind(this);
+    this.user = userData();
   }
 
   componentDidMount() {
@@ -25,6 +23,9 @@ class IntroSlide extends Component {
 
   render() {
     const { prev } = this.props;
+    const greeting = this.user
+      ? `${this.user.name} — welcome to DEV!`
+      : 'Welcome to DEV!';
 
     return (
       <div className="onboarding-main introduction">
@@ -36,11 +37,7 @@ class IntroSlide extends Component {
               alt="DEV"
             />
           </figure>
-          <h1 className="introduction-title">
-            {this.name}
-            {' '}
-            &mdash; welcome to DEV!
-          </h1>
+          <h1 className="introduction-title">{greeting}</h1>
           <h2 className="introduction-subtitle">
             DEV is where programmers share ideas and help each other grow.
           </h2>

--- a/app/javascript/onboarding/components/IntroSlide.jsx
+++ b/app/javascript/onboarding/components/IntroSlide.jsx
@@ -23,9 +23,6 @@ class IntroSlide extends Component {
 
   render() {
     const { prev } = this.props;
-    const greeting = this.user
-      ? `${this.user.name} — welcome to DEV!`
-      : 'Welcome to DEV!';
 
     return (
       <div className="onboarding-main introduction">
@@ -37,7 +34,11 @@ class IntroSlide extends Component {
               alt="DEV"
             />
           </figure>
-          <h1 className="introduction-title">{greeting}</h1>
+          <h1 className="introduction-title">
+            {this.user.name}
+            {' '}
+            &mdash; welcome to DEV!
+          </h1>
           <h2 className="introduction-subtitle">
             DEV is where programmers share ideas and help each other grow.
           </h2>

--- a/app/javascript/onboarding/components/IntroSlide.jsx
+++ b/app/javascript/onboarding/components/IntroSlide.jsx
@@ -8,6 +8,9 @@ class IntroSlide extends Component {
   constructor(props) {
     super(props);
 
+    const user = window.userData();
+    this.name = user.name;
+
     this.onSubmit = this.onSubmit.bind(this);
   }
 
@@ -33,7 +36,11 @@ class IntroSlide extends Component {
               alt="DEV"
             />
           </figure>
-          <h1 className="introduction-title">Welcome to DEV!</h1>
+          <h1 className="introduction-title">
+            {this.name}
+            {' '}
+            &mdash; welcome to DEV!
+          </h1>
           <h2 className="introduction-subtitle">
             DEV is where programmers share ideas and help each other grow.
           </h2>

--- a/app/javascript/onboarding/utilities.js
+++ b/app/javascript/onboarding/utilities.js
@@ -1,13 +1,13 @@
-export const jsonToForm = data => {
+export const jsonToForm = (data) => {
   const form = new FormData();
-  data.forEach(item => form.append(item.key, item.value));
+  data.forEach((item) => form.append(item.key, item.value));
   return form;
 };
 
-export const getContentOfToken = token =>
+export const getContentOfToken = (token) =>
   document.querySelector(`meta[name='${token}']`).content;
 
-export const updateOnboarding = lastPage => {
+export const updateOnboarding = (lastPage) => {
   const csrfToken = getContentOfToken('csrf-token');
   fetch('/onboarding_update', {
     method: 'PATCH',
@@ -18,4 +18,15 @@ export const updateOnboarding = lastPage => {
     body: JSON.stringify({ user: { last_onboarding_page: lastPage } }),
     credentials: 'same-origin',
   });
+};
+
+/**
+ * A util function to fetch the user's data from off of the document's body.
+ *
+ *
+ * @returns {Object} A JSON object with the parsed user data.
+ */
+export const userData = () => {
+  const { user = null } = document.body.dataset;
+  return JSON.parse(user);
 };


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
Quite a few optimizations here:

* Render the user's name on the intro slide for onboarding.
* Style the back button using crayons design system.
* Remove redundant scroll styles in the "terms and conditions" view.
* Ensure that ToC is readable, and that the back button doesn't conflict with ToC content.
* Ensure size of ToC content is same size as "intro slide".
* Remove unnecessary inline styles, use CSS classes instead.

## Related Tickets & Documents
Part of the task list described in #6545, and some minor refactors that seemed like they should happen before the major refactor required by #6545.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Before this PR, the intro slide looked like:
<img width="622" alt="Screen Shot 2020-04-08 at 3 40 59 PM" src="https://user-images.githubusercontent.com/6921610/78840738-70afdd00-79b0-11ea-8ee2-3c4d4227e1f2.png">

After this PR,  the intro slide will look like:
<img width="683" alt="Screen Shot 2020-04-08 at 3 40 06 PM" src="https://user-images.githubusercontent.com/6921610/78840752-77d6eb00-79b0-11ea-89cc-ad23936db6dc.png">

Before this PR, the ToC view looked like:
<img width="821" alt="Screen_Shot_2020-04-08_at_3_41_16_PM" src="https://user-images.githubusercontent.com/6921610/78840825-a654c600-79b0-11ea-8eda-242e3fa3a72b.png">

After this PR,  the ToC view will look like:
<img width="841" alt="Screen_Shot_2020-04-08_at_3_40_39_PM" src="https://user-images.githubusercontent.com/6921610/78840835-ad7bd400-79b0-11ea-9623-16bdee8970f4.png">


## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed