### PR TITLE
Adds number_with_delimiter for friendlier visualization in /parternships

### DIFF
--- a/app/views/partnerships/index.html.erb
+++ b/app/views/partnerships/index.html.erb
@@ -10,7 +10,7 @@
   <h1>Partner With <img src="<%= asset_path "rainbowdev.svg" %>" /> </h1>
   <h3>🚀 Reach</h3>
   <p>
-    DEV serves millions of unique visitors per month.  This highly-targeted developer audience is comprised of registered members (<%= User.estimated_count %>) and visitors from the open web — many of whom visit DEV as part of their daily routine.  You may be interested in the <a href="https://www.similarweb.com/website/dev.to">public analytics available on SimilarWeb</a>.
+    DEV serves millions of unique visitors per month.  This highly-targeted developer audience is comprised of registered members (<%= number_with_delimiter(User.estimated_count) %>) and visitors from the open web — many of whom visit DEV as part of their daily routine.  You may be interested in the <a href="https://www.similarweb.com/website/dev.to">public analytics available on SimilarWeb</a>.
   </p>
   <h3>❤️ Community</h3>
   <p>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Saw that [https://dev.to/partnerships](https://dev.to/partnerships) shows the current number of registered users. This is a tiny enhancement to make the number a bit more pleasant to the eye.

From [the docs](https://api.rubyonrails.org/classes/ActionView/Helpers/NumberHelper.html#method-i-number_with_delimiter) I believe `number_with_delimiter` uses the current locale, although I'm not too sure of the current state of how we manage I18n. This may or may not be useful, so it can be discarded if it's an unwanted change.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

**Before:**

<img width="1296" alt="Screen Shot 2020-04-08 at 12 58 09 " src="https://user-images.githubusercontent.com/6045239/78822822-f3c53900-7998-11ea-95a3-57d8489610fa.png">

**After:**

<img width="1252" alt="Screen Shot 2020-04-08 at 12 51 32" src="https://user-images.githubusercontent.com/6045239/78822828-f4f66600-7998-11ea-893f-e3e395b2da8f.png">

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![tiny adjustment](https://media.giphy.com/media/OlfmxuWHCmw2Q/giphy.gif)