### PR TITLE
Fix typo in credits/new

### DIFF
--- a/app/views/credits/new.html.erb
+++ b/app/views/credits/new.html.erb
@@ -37,7 +37,7 @@
     </div>
       <br />
     </div>
-    <p class="bulk-description"><em>Contact <a href="mailto:biz@dev.to">biz@dev.to</a> to for custom bulk pricing and partnerships.</em></p>
+    <p class="bulk-description"><em>Contact <a href="mailto:biz@dev.to">biz@dev.to</a> for custom bulk pricing and partnerships.</em></p>
     <details>
       <summary>
         How many credits does one listing cost?


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
The typo is in this page:

https://dev.to/credits/new



## Related Tickets & Documents

Nope.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

<img width="482" alt="Screenshot 2020-04-08 at 21 07 02" src="https://user-images.githubusercontent.com/645514/78828961-71129d00-79dd-11ea-8ca8-44842a8e23a7.png">


## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://i.giphy.com/media/CRR2Q9ppqx0Eo/giphy.webp)
