### PR TITLE
Add rate limit for article updates

### DIFF
--- a/app/labor/rate_limit_checker.rb
+++ b/app/labor/rate_limit_checker.rb
@@ -21,15 +21,11 @@ class RateLimitChecker
   end
 
   def track_image_uploads
-    count = Rails.cache.read("#{@user.id}_image_upload").to_i
-    count += 1
-    Rails.cache.write("#{@user.id}_image_upload", count, expires_in: 30.seconds)
+    Rails.cache.increment("#{@user.id}_image_upload", count, expires_in: 30.seconds)
   end
 
   def track_article_updates
-    count = Rails.cache.read("#{@user.id}_article_update").to_i
-    count += 1
-    Rails.cache.write("#{@user.id}_article_update", count, expires_in: 1.day)
+    Rails.cache.increment("#{@user.id}_article_update", count, expires_in: 1.day)
   end
 
   def limit_by_email_recipient_address(address)

--- a/app/labor/rate_limit_checker.rb
+++ b/app/labor/rate_limit_checker.rb
@@ -26,6 +26,12 @@ class RateLimitChecker
     Rails.cache.write("#{@user.id}_image_upload", count, expires_in: 30.seconds)
   end
 
+  def track_article_updates
+    count = Rails.cache.read("#{@user.id}_article_update").to_i
+    count += 1
+    Rails.cache.write("#{@user.id}_article_update", count, expires_in: 1.day)
+  end
+
   def limit_by_email_recipient_address(address)
     # This is related to the recipient, not the "user" initiator, like in action.
     EmailMessage.where(to: address).where("sent_at > ?", 2.minutes.ago).size >
@@ -47,6 +53,11 @@ class RateLimitChecker
   def check_image_upload_limit
     Rails.cache.read("#{user.id}_image_upload").to_i >
       SiteConfig.rate_limit_image_upload
+  end
+
+  def check_article_update_limit
+    Rails.cache.read("#{user.id}_article_update").to_i >
+      SiteConfig.rate_limit_article_update
   end
 
   def check_follow_account_limit

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -51,6 +51,7 @@ class SiteConfig < RailsSettings::Base
   field :rate_limit_published_article_creation, type: :integer, default: 9
   field :rate_limit_image_upload, type: :integer, default: 9
   field :rate_limit_email_recipient, type: :integer, default: 5
+  field :rate_limit_article_update, type: :integer, default: 50
 
   # Google Analytics Reporting API v4
   # <https://developers.google.com/analytics/devguides/reporting/core/v4>

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -51,7 +51,7 @@ class SiteConfig < RailsSettings::Base
   field :rate_limit_published_article_creation, type: :integer, default: 9
   field :rate_limit_image_upload, type: :integer, default: 9
   field :rate_limit_email_recipient, type: :integer, default: 5
-  field :rate_limit_article_update, type: :integer, default: 50
+  field :rate_limit_article_update, type: :integer, default: 150
 
   # Google Analytics Reporting API v4
   # <https://developers.google.com/analytics/devguides/reporting/core/v4>

--- a/app/services/articles/updater.rb
+++ b/app/services/articles/updater.rb
@@ -12,6 +12,9 @@ module Articles
     end
 
     def call
+      rate_limiter = RateLimitChecker.new(user)
+      raise if rate_limiter.limit_by_action("article_update")
+
       article = load_article
       was_published = article.published
 
@@ -34,6 +37,7 @@ module Articles
       article_params[:edited_at] = Time.current if update_edited_at
 
       article.update!(article_params)
+      rate_limiter.track_article_updates
 
       # send notification only the first time an article is published
       send_notification = article.published && article.saved_change_to_published_at.present?


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature
- [x] Bug Fix

## Description
We currently don't have a rate limit for article update; this adds one. The default is 50 per day.