### PR TITLE
Throttle API get and write Endpoints

### DIFF
--- a/config/initializers/rack/attack.rb
+++ b/config/initializers/rack/attack.rb
@@ -4,4 +4,16 @@ class Rack::Attack
       request.env["HTTP_FASTLY_CLIENT_IP"].to_s
     end
   end
+
+  throttle("api_throttle", limit: 3, period: 1) do |request|
+    if request.path.starts_with?("/api/") && request.get? && request.env["HTTP_FASTLY_CLIENT_IP"].present?
+      request.env["HTTP_FASTLY_CLIENT_IP"].to_s
+    end
+  end
+
+  throttle("api_write_throttle", limit: 1, period: 1) do |request|
+    if request.path.starts_with?("/api/") && (request.put? || request.post? || request.delete?)
+      request.env["HTTP_API_KEY"]
+    end
+  end
 end

--- a/spec/initializers/rack/attack_spec.rb
+++ b/spec/initializers/rack/attack_spec.rb
@@ -1,13 +1,13 @@
 require "rails_helper"
 
 describe Rack::Attack, type: :request, throttle: true do
-  describe "search_throttle" do
-    before do
-      redis_url = "redis://localhost:6379"
-      cache_db = ActiveSupport::Cache::RedisStore.new(redis_url)
-      allow(Rails).to receive(:cache) { cache_db }
-    end
+  before do
+    redis_url = "redis://localhost:6379"
+    cache_db = ActiveSupport::Cache::RedisStore.new(redis_url)
+    allow(Rails).to receive(:cache) { cache_db }
+  end
 
+  describe "search_throttle" do
     it "throttles /search endpoints based on IP" do
       Timecop.freeze do
         allow(Search::User).to receive(:search_documents).and_return({})
@@ -20,6 +20,43 @@ describe Rack::Attack, type: :request, throttle: true do
         valid_responses.each { |r| expect(r).not_to eq(429) }
         expect(throttled_response).to eq(429)
         expect(new_ip_response).not_to eq(429)
+      end
+    end
+  end
+
+  describe "api_throttle" do
+    it "throttles api get endpoints based on IP" do
+      Timecop.freeze do
+        valid_responses = Array.new(3).map do
+          get api_articles_path, headers: { "HTTP_FASTLY_CLIENT_IP" => "5.6.7.8" }
+        end
+        throttled_response = get api_articles_path, headers: { "HTTP_FASTLY_CLIENT_IP" => "5.6.7.8" }
+        new_ip_response = get api_articles_path, headers: { "HTTP_FASTLY_CLIENT_IP" => "1.1.1.1" }
+
+        valid_responses.each { |r| expect(r).not_to eq(429) }
+        expect(throttled_response).to eq(429)
+        expect(new_ip_response).not_to eq(429)
+      end
+    end
+  end
+
+  describe "api_write_throttle" do
+    let(:api_secret) { create(:api_secret) }
+    let(:another_api_secret) { create(:api_secret) }
+
+    it "throttles api write endpoints based on api-key" do
+      headers = { "api-key" => api_secret.secret, "content-type" => "application/json" }
+      dif_headers = { "api-key" => another_api_secret.secret, "content-type" => "application/json" }
+      params = { body_markdown: "", title: Faker::Book.title }
+
+      Timecop.freeze do
+        valid_response = post api_articles_path, params: { article: params }.to_json, headers: headers
+        throttled_response = post api_articles_path, params: { article: params }.to_json, headers: headers
+        new_api_response = post api_articles_path, params: { article: params }.to_json, headers: dif_headers
+
+        expect(valid_response).not_to eq(429)
+        expect(throttled_response).to eq(429)
+        expect(new_api_response).not_to eq(429)
       end
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
To prevent users from abusing endpoints and flooding our workers we should limit how often they can hit the API. 
- Limit get requests to 3 requests/second
- Limit PUT/POST/DELETE requests to 1 request/second

## Added tests?
- [x] yes

![alt_text](https://media.giphy.com/media/1X7lzO38mcvAyKTD2m/giphy.gif)
