### PR TITLE
Add Solargraph gem for Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -26,6 +26,7 @@ tasks:
         printf "❗ To get them, please follow https://docs.dev.to/backend/algolia/#get-api-keys\n\n" &&
         read -p "Add them to config/application.yml, save the file, and press any key to continue... " -n 1 -r
       done ;
+      gem install solargraph;
       bin/setup &&
       bin/startup
 github:

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apk update -qq && apk add git nodejs postgresql-client ruby-dev build-base \
 # Install required bundler version
 #
 #------------------------------------------------------------------------------
-RUN gem install bundler:2.0.2
+RUN gem install bundler:2.1.4
 
 #------------------------------------------------------------------------------
 #

--- a/bin/docker-setup
+++ b/bin/docker-setup
@@ -4,7 +4,7 @@ echo "== Building Docker image (this may take a while) =="
 docker-compose build
 
 echo "== Setting up database =="
-docker-compose run web rails db:setup db:migrate search:setup
+docker-compose run web rails db:setup db:migrate search:setup data_updates:run
 
 echo "== Starting app =="
 docker-compose up


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Feature

## Description

When doing some Gitpod work the other day I thought it might be a good idea to add the Solargraph gem by default for the web-based VSCode editor.

## Related Tickets & Documents

n/a

## Added tests?

- [X] no, because they aren't needed 

## Added to documentation?

- [X] no documentation needed
