### PR TITLE
Revert refactor of increment back to read/write

### DIFF
--- a/app/labor/rate_limit_checker.rb
+++ b/app/labor/rate_limit_checker.rb
@@ -21,11 +21,15 @@ class RateLimitChecker
   end
 
   def track_image_uploads
-    Rails.cache.increment("#{@user.id}_image_upload", expires_in: 30.seconds)
+    count = Rails.cache.read("#{@user.id}_image_upload").to_i
+    count += 1
+    Rails.cache.write("#{@user.id}_image_upload", count, expires_in: 30.seconds)
   end
 
   def track_article_updates
-    Rails.cache.increment("#{@user.id}_article_update", expires_in: 1.day)
+    count = Rails.cache.read("#{@user.id}_article_update").to_i
+    count += 1
+    Rails.cache.write("#{@user.id}_article_update", count, expires_in: 1.day)
   end
 
   def limit_by_email_recipient_address(address)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Reverts a refactor of `Rails.cache.increment` back to `Rails.cache.read` and `Rails.cache.write` since it seemed to have issues initializing a write of the first cache key.