### PR TITLE
Allow img to use data-src in RSS

### DIFF
--- a/app/services/rss_reader/assembler.rb
+++ b/app/services/rss_reader/assembler.rb
@@ -124,7 +124,9 @@ class RssReader
 
     def clean_relative_path!(html_doc, url)
       html_doc.css("img").each do |img_tag|
-        path = img_tag.attributes["src"].value
+        path = (img_tag.attributes["src"] || img_tag.attributes["data-src"])&.value
+        next unless path
+
         img_tag.attributes["src"].value = URI.join(url, path).to_s if path.start_with? "/"
       end
     end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
An RSS item's `img` tag could be using `data-src` instead of `src`. This account for that instead of silently failing.
## Related Tickets & Documents
n/a
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
n/a
## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a