### PR TITLE
Silence Ruby 2.7 warnings in Travis

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,5 +1,5 @@
 # Silence all Ruby 2.7 deprecation warnings
-$VERBOSE = nil unless ENV["CI"]
+$VERBOSE = nil
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Well, apparently `RUBYOPT=-W0` doesn't work with Rails, so we're going the other route for Travis too. 

This PR silences the warnings (they are already silenced in development mode and local testing mode)

## Related Tickets & Documents

#5281 

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
