### PR TITLE
Enhance Site Config Togglability

### DIFF
--- a/app/assets/stylesheets/internal/layout.scss
+++ b/app/assets/stylesheets/internal/layout.scss
@@ -4,6 +4,15 @@
   padding: 20px;
 }
 
+#siteConfig .card-header {
+  cursor: pointer;
+}
+
+#siteConfig .card-header__toggle {
+  font-size: 12px;
+  color: var(--secondary);
+}
+
 .pagination {
   justify-content: right;
 

--- a/app/views/internal/configs/_card_header.html.erb
+++ b/app/views/internal/configs/_card_header.html.erb
@@ -1,12 +1,11 @@
-<div class="card-header">
+<div
+  class="card-header"
+  data-toggle="<%= state %>"
+  data-target="#<%= target %>"
+  aria-expanded="<%= expanded %>"
+  aria-controls="<%= target %>">
   <span><%= header %></span>
-  <button
-    class="btn btn-secondary float-right"
-    type="button"
-    data-toggle="<%= state %>"
-    data-target="#<%= target %>"
-    aria-expanded="<%= expanded %>"
-    aria-controls="<%= target %>">
+  <div class="card-header__toggle float-right">
     Toggle
-  </button>
+  </div>
 </div>

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -13,10 +13,10 @@
 
 <div class="row my-3" id="siteConfig">
   <div class="card w-100">
-    <div class="card-header" id="siteConfigHeader">
+    <div class="card-header" id="siteConfigHeader" data-toggle="collapse"
+      data-target="#siteConfigBodyContainer" aria-expanded="true" aria-controls="siteConfigBodyContainer">
       <h2 class="d-inline">Site Configuration</h2>
-      <button class="btn btn-secondary float-right" type="button" data-toggle="collapse"
-        data-target="#siteConfigBodyContainer" aria-expanded="true" aria-controls="siteConfigBodyContainer">
+      <button class="btn btn-secondary float-right" type="button">
         Toggle Site Configuration
       </button>
     </div>
@@ -474,10 +474,10 @@
 <% if current_user.has_role?(:single_resource_admin, Config) && current_user.has_role?(:super_admin) %>
   <div class="row my-3" id="siteConfig">
     <div class="card w-100">
-      <div class="card-header" id="appConfigHeader">
+      <div class="card-header" id="appConfigHeader" data-toggle="collapse"
+        data-target="#appConfigBodyContainer" aria-expanded="false" aria-controls="appConfigBodyContainer">
         <h2 class="d-inline">Environment variables / AppConfig (readonly)</h2>
-        <button class="btn btn-secondary float-right" type="button" data-toggle="collapse"
-          data-target="#appConfigBodyContainer" aria-expanded="false" aria-controls="appConfigBodyContainer">
+        <button class="btn btn-secondary float-right" type="button">
           Toggle Environment Variables
         </button>
       </div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
It was a real pain to click on the button each time the card needed to be expanded or collapsed on the Site Config Page. 

I’ve now made all the cards  collapsable and expandable by clicking anywhere on the card header. Keeping the buttons on the inner cards felt overwhelming and so I replaced it with text just to indicate that its togglable.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/2786819/78916757-416f9d80-7a8e-11ea-8172-8c9e94690718.gif)


## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/1jl0Xuj9wEptDaNTjT/giphy.gif)
