### PR TITLE
Log image data to Datadog for file name too long error

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -75,4 +75,23 @@ class ApplicationController < ActionController::Base
   def touch_current_user
     current_user.touch
   end
+
+  def log_image_data_to_datadog
+    images = Array.wrap(params.dig("user", "profile_image") || params["image"])
+
+    images.each do |image|
+      tags = [
+        "controller:#{params['controller']}",
+        "action:#{params['action']}",
+        "content_type:#{image.content_type}",
+        "original_filename:#{image.original_filename}",
+        "tempfile:#{image.tempfile}",
+        "size:#{image.size}",
+      ]
+
+      DatadogStatsClient.increment("image_upload_error", tags: tags)
+    end
+
+    raise
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -79,6 +79,8 @@ class ApplicationController < ActionController::Base
   def log_image_data_to_datadog
     images = Array.wrap(params.dig("user", "profile_image") || params["image"])
 
+    raise if images.empty?
+
     images.each do |image|
       tags = [
         "controller:#{params['controller']}",

--- a/app/controllers/image_uploads_controller.rb
+++ b/app/controllers/image_uploads_controller.rb
@@ -1,6 +1,7 @@
 class ImageUploadsController < ApplicationController
   before_action :authenticate_user!
   after_action :verify_authorized
+  rescue_from Errno::ENAMETOOLONG, with: :log_image_data_to_datadog
 
   def create
     authorize :image_upload

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,6 +4,7 @@ class UsersController < ApplicationController
   before_action :set_user, only: %i[update update_twitch_username update_language_settings confirm_destroy request_destroy full_delete remove_association]
   after_action :verify_authorized, except: %i[index signout_confirm add_org_admin remove_org_admin remove_from_org]
   before_action :authenticate_user!, only: %i[onboarding_update onboarding_checkbox_update]
+  rescue_from Errno::ENAMETOOLONG, with: :log_image_data_to_datadog
 
   DEFAULT_FOLLOW_SUGGESTIONS = %w[ben jess peter maestromac andy liana].freeze
 

--- a/spec/requests/user/user_settings_spec.rb
+++ b/spec/requests/user/user_settings_spec.rb
@@ -131,6 +131,20 @@ RSpec.describe "UserSettings", type: :request do
       expect(response.body).to include("Profile image File size should be less than 2 MB")
     end
 
+    it "catches error if Profile image file name is too long" do
+      allow(user).to receive(:update).and_raise(Errno::ENAMETOOLONG)
+      allow(DatadogStatsClient).to receive(:increment)
+      profile_image = fixture_file_upload("files/800x600.png", "image/png")
+
+      expect do
+        put "/users/#{user.id}", params: { user: { tab: "profile", profile_image: profile_image } }
+      end.to raise_error(Errno::ENAMETOOLONG)
+
+      tags = hash_including(tags: instance_of(Array))
+
+      expect(DatadogStatsClient).to have_received(:increment).with("image_upload_error", tags)
+    end
+
     context "when requesting an export of the articles" do
       def send_request(flag = true)
         put "/users/#{user.id}", params: {


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)
- [x] Feature

## Description
After #6918, we're still getting some file name too long errors:
https://app.honeybadger.io/projects/66984/faults/62329414
https://app.honeybadger.io/projects/66984/faults/62292062

I think what's happening is Carrierwave has logic to assign unique file names that include encoding. And after encoding very specific files, the resulting (temporary) file name is way too long, even if the original filename is valid (less than 250 characters).

This PR catches the error, sends helpful data to Datadog, and then continues to raise the error as normal. This happens very infrequently. Once this happens again, I can make much more progress for a better fix once I get the data I'm logging with this PR.

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/9#card-36038792
https://app.honeybadger.io/projects/66984/faults/62329414
https://app.honeybadger.io/projects/66984/faults/62292062

## Added tests?
- [x] yes

## Added to documentation?
- [x] no documentation needed

![never_ending_chase_gif](https://media.giphy.com/media/2xEzi32w6cLCgmAa6p/giphy.gif)