### PR TITLE
Add metadata to user search results

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -60,10 +60,10 @@ class SearchController < ApplicationController
     feed_docs = if params[:class_name].blank?
                   # If we are in the main feed and not filtering by type return
                   # all articles, podcast episodes, and users
-                  feed_content_search.concat(user_search.dig(:users))
+                  feed_content_search.concat(user_search)
                 elsif params[:class_name] == "User"
                   # No need to check for articles or podcast episodes if we know we only want users
-                  user_search.dig(:users)
+                  user_search
                 else
                   # if params[:class_name] == PodcastEpisode or Article then skip user lookup
                   feed_content_search

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -60,10 +60,10 @@ class SearchController < ApplicationController
     feed_docs = if params[:class_name].blank?
                   # If we are in the main feed and not filtering by type return
                   # all articles, podcast episodes, and users
-                  feed_content_search.concat(user_search)
+                  feed_content_search.concat(user_search.dig(:users))
                 elsif params[:class_name] == "User"
                   # No need to check for articles or podcast episodes if we know we only want users
-                  user_search
+                  user_search.dig(:users)
                 else
                   # if params[:class_name] == PodcastEpisode or Article then skip user lookup
                   feed_content_search

--- a/app/javascript/listings/listings.jsx
+++ b/app/javascript/listings/listings.jsx
@@ -49,7 +49,7 @@ function resizeAllMasonryItems() {
 function updateListings(classifiedListings) {
   const fullListings = [];
 
-  classifiedListings.forEach(listing => {
+  classifiedListings.forEach((listing) => {
     if (listing.bumped_at) {
       fullListings.push(listing);
     }
@@ -70,7 +70,7 @@ export class Listings extends Component {
     openedListing: null,
     message: '',
     slug: null,
-    page: 0,
+    page: 1,
     showNextPageButt: false,
   };
 
@@ -167,12 +167,12 @@ export class Listings extends Component {
     this.listingSearch(query, tags, cat, null);
   };
 
-  handleKeyDown = e => {
+  handleKeyDown = (e) => {
     // Enable Escape key to close an open listing.
     this.handleCloseModal(e);
   };
 
-  handleCloseModal = e => {
+  handleCloseModal = (e) => {
     const { openedListing } = this.state;
     if (
       (openedListing !== null && e.key === 'Escape') ||
@@ -199,12 +199,12 @@ export class Listings extends Component {
     document.body.classList.add('modal-open');
   };
 
-  handleDraftingMessage = e => {
+  handleDraftingMessage = (e) => {
     e.preventDefault();
     this.setState({ message: e.target.value });
   };
 
-  handleSubmitMessage = e => {
+  handleSubmitMessage = (e) => {
     e.preventDefault();
     const { message, openedListing } = this.state;
     if (message.replace(/\s/g, '').length === 0) {
@@ -231,7 +231,7 @@ export class Listings extends Component {
       });
   };
 
-  handleQuery = e => {
+  handleQuery = (e) => {
     const { tags, category } = this.state;
     this.setState({ query: e.target.value, page: 0 });
     this.listingSearch(e.target.value, tags, category, null);
@@ -326,7 +326,7 @@ export class Listings extends Component {
     };
 
     const responsePromise = fetchSearch('classified_listings', dataHash);
-    return responsePromise.then(response => {
+    return responsePromise.then((response) => {
       const classifiedListings = response.result;
       const fullListings = updateListings(classifiedListings);
       t.setState({
@@ -351,7 +351,7 @@ export class Listings extends Component {
       initialFetch,
       message,
     } = this.state;
-    const allListings = listings.map(listing => (
+    const allListings = listings.map((listing) => (
       <SingleListing
         onAddTag={this.addTag}
         onChangeCategory={this.selectCategory}
@@ -361,21 +361,21 @@ export class Listings extends Component {
         isOpen={false}
       />
     ));
-    const selectedTags = tags.map(tag => (
+    const selectedTags = tags.map((tag) => (
       <span className="classified-tag">
         <a
           href="/listings?tags="
           className="tag-name"
-          onClick={e => this.removeTag(e, tag)}
+          onClick={(e) => this.removeTag(e, tag)}
           data-no-instant
         >
           <span>{tag}</span>
           <span
             className="tag-close"
-            onClick={e => this.removeTag(e, tag)}
+            onClick={(e) => this.removeTag(e, tag)}
             data-no-instant
             role="button"
-            onKeyPress={e => e.key === 'Enter' && this.removeTag(e, tag)}
+            onKeyPress={(e) => e.key === 'Enter' && this.removeTag(e, tag)}
             tabIndex="0"
           >
             ×
@@ -383,11 +383,11 @@ export class Listings extends Component {
         </a>
       </span>
     ));
-    const categoryLinks = allCategories.map(cat => (
+    const categoryLinks = allCategories.map((cat) => (
       <a
         href={`/listings/${cat.slug}`}
         className={cat.slug === category ? 'selected' : ''}
-        onClick={e => this.selectCategory(e, cat.slug)}
+        onClick={(e) => this.selectCategory(e, cat.slug)}
         data-no-instant
       >
         {cat.name}
@@ -397,7 +397,7 @@ export class Listings extends Component {
     if (showNextPageButt) {
       nextPageButt = (
         <div className="classifieds-load-more-button">
-          <button onClick={e => this.loadNextPage(e)} type="button">
+          <button onClick={(e) => this.loadNextPage(e)} type="button">
             Load More Listings
           </button>
         </div>
@@ -530,7 +530,7 @@ export class Listings extends Component {
             <a
               href="/listings"
               className={category === '' ? 'selected' : ''}
-              onClick={e => this.selectCategory(e, '')}
+              onClick={(e) => this.selectCategory(e, '')}
               data-no-instant
             >
               all

--- a/app/services/search/base.rb
+++ b/app/services/search/base.rb
@@ -94,12 +94,12 @@ module Search
         total = results.dig("hits", "total", "value")
 
         {
-          total_count: total,
-          total_pages: (total.to_f / params[:per_page]).ceil,
-          current_page: params[:page],
-          limit_value: params[:per_page],
-          offset_value: params[:offset_value],
-          size: params[:size]
+          "total_count" => total,
+          "total_pages" => (total.to_f / params[:per_page]).ceil,
+          "current_page" => params[:page],
+          "limit_value" => params[:per_page],
+          "offset_value" => params[:offset_value],
+          "size" => params[:size]
         }
       end
 

--- a/app/services/search/chat_channel_membership.rb
+++ b/app/services/search/chat_channel_membership.rb
@@ -3,7 +3,7 @@ module Search
     INDEX_NAME = "chat_channel_memberships_#{Rails.env}".freeze
     INDEX_ALIAS = "chat_channel_memberships_#{Rails.env}_alias".freeze
     MAPPINGS = JSON.parse(File.read("config/elasticsearch/mappings/chat_channel_memberships.json"), symbolize_names: true).freeze
-    DEFAULT_PAGE = 0
+    DEFAULT_PAGE = 1
     DEFAULT_PER_PAGE = 30
 
     class << self

--- a/app/services/search/classified_listing.rb
+++ b/app/services/search/classified_listing.rb
@@ -3,7 +3,7 @@ module Search
     INDEX_NAME = "classified_listings_#{Rails.env}".freeze
     INDEX_ALIAS = "classified_listings_#{Rails.env}_alias".freeze
     MAPPINGS = JSON.parse(File.read("config/elasticsearch/mappings/classified_listings.json"), symbolize_names: true).freeze
-    DEFAULT_PAGE = 0
+    DEFAULT_PAGE = 1
     DEFAULT_PER_PAGE = 75
 
     class << self

--- a/app/services/search/feed_content.rb
+++ b/app/services/search/feed_content.rb
@@ -3,7 +3,7 @@ module Search
     INDEX_NAME = "feed_content_#{Rails.env}".freeze
     INDEX_ALIAS = "feed_content_#{Rails.env}_alias".freeze
     MAPPINGS = JSON.parse(File.read("config/elasticsearch/mappings/feed_content.json"), symbolize_names: true).freeze
-    DEFAULT_PAGE = 0
+    DEFAULT_PAGE = 1
     DEFAULT_PER_PAGE = 60
 
     INCLUDED_CLASS_NAMES = %w[Article Comment PodcastEpisode].freeze

--- a/app/services/search/reaction.rb
+++ b/app/services/search/reaction.rb
@@ -3,7 +3,7 @@ module Search
     INDEX_NAME = "reactions_#{Rails.env}".freeze
     INDEX_ALIAS = "reactions_#{Rails.env}_alias".freeze
     MAPPINGS = JSON.parse(File.read("config/elasticsearch/mappings/reactions.json"), symbolize_names: true).freeze
-    DEFAULT_PAGE = 0
+    DEFAULT_PAGE = 1
     DEFAULT_PER_PAGE = 80
 
     class << self

--- a/app/services/search/user.rb
+++ b/app/services/search/user.rb
@@ -10,27 +10,36 @@ module Search
     class << self
       def search_documents(params:)
         set_query_size(params)
-        query_hash = Search::QueryBuilders::User.new(params).as_hash
+        query_hash = Search::QueryBuilders::User.new(params: params).as_hash
 
         results = search(body: query_hash)
         hits = results.dig("hits", "hits")
         paginated_results = paginate_hits(hits, params)
 
-        hits = paginated_results.map do |user_doc|
-          prepare_doc(user_doc.dig("_source"))
+        paginated_results.map do |user_doc|
+          prepare_doc(user_doc.dig("_source")).merge(metadata(results, params))
         end
-
-        {
-          users: hits
-        }.merge(metadata(results, params)).with_indifferent_access
       end
 
       private
 
-      def prepare_doc(hit)
-        SERIALIZER_CLASS.attributes_to_serialize.keys.reduce({}) do |m, k|
-          m.merge(k.to_s => hit[k.to_s])
-        end
+      def prepare_doc(source)
+        {
+          "user" => {
+            "username" => source["username"],
+            "name" => source["username"],
+            "profile_image_90" => source["profile_image_90"]
+          },
+          "title" => source["name"],
+          "path" => source["path"],
+          "id" => source["id"],
+          "class_name" => "User",
+          "positive_reactions_count" => source["positive_reactions_count"],
+          "comments_count" => source["comments_count"],
+          "badge_achievements_count" => source["badge_achievements_count"],
+          "last_comment_at" => source["last_comment_at"],
+          "roles" => source["roles"]
+        }
       end
 
       def index_settings

--- a/spec/services/search/chat_channel_membership_spec.rb
+++ b/spec/services/search/chat_channel_membership_spec.rb
@@ -123,12 +123,12 @@ RSpec.describe Search::ChatChannelMembership, type: :service, elasticsearch: tru
       allow(chat_channel_membership1).to receive(:channel_last_message_at).and_return(Time.current)
       allow(chat_channel_membership2).to receive(:channel_last_message_at).and_return(1.year.ago)
       index_documents([chat_channel_membership1, chat_channel_membership2])
-      first_page_params = { page: 0, per_page: 1, sort_by: "channel_last_message_at", order: "dsc", user_id: user.id }
+      first_page_params = { page: 1, per_page: 1, sort_by: "channel_last_message_at", order: "dsc" }
 
       chat_channel_membership_docs = described_class.search_documents(params: first_page_params)
       expect(chat_channel_membership_docs.first["id"]).to eq(chat_channel_membership1.id)
 
-      second_page_params = { page: 1, per_page: 1, sort_by: "channel_last_message_at", order: "dsc", user_id: user.id }
+      second_page_params = { page: 2, per_page: 1, sort_by: "channel_last_message_at", order: "dsc" }
 
       chat_channel_membership_docs = described_class.search_documents(params: second_page_params)
       expect(chat_channel_membership_docs.first["id"]).to eq(chat_channel_membership2.id)

--- a/spec/services/search/classified_listing_spec.rb
+++ b/spec/services/search/classified_listing_spec.rb
@@ -148,12 +148,12 @@ RSpec.describe Search::ClassifiedListing, type: :service, elasticsearch: true do
       classified_listing.update(bumped_at: 1.year.ago)
       classified_listing2 = FactoryBot.create(:classified_listing, bumped_at: Time.current)
       index_documents([classified_listing, classified_listing2])
-      first_page_params = { page: 0, per_page: 1, sort_by: "bumped_at", order: "dsc" }
+      first_page_params = { page: 1, per_page: 1, sort_by: "bumped_at", order: "dsc" }
 
       classified_listing_docs = described_class.search_documents(params: first_page_params)
       expect(classified_listing_docs.first["id"]).to eq(classified_listing2.id)
 
-      second_page_params = { page: 1, per_page: 1, sort_by: "bumped_at", order: "dsc" }
+      second_page_params = { page: 2, per_page: 1, sort_by: "bumped_at", order: "dsc" }
 
       classified_listing_docs = described_class.search_documents(params: second_page_params)
       expect(classified_listing_docs.first["id"]).to eq(classified_listing.id)

--- a/spec/services/search/user_spec.rb
+++ b/spec/services/search/user_spec.rb
@@ -1,13 +1,15 @@
 require "rails_helper"
 
 RSpec.describe Search::User, type: :service do
-  it "defines INDEX_NAME, INDEX_ALIAS, and MAPPINGS", :aggregate_failures do
+  it "defines INDEX_NAME, INDEX_ALIAS, MAPPINGS and SERIALIZER_CLASS", :aggregate_failures do
     expect(described_class::INDEX_NAME).not_to be_nil
     expect(described_class::INDEX_ALIAS).not_to be_nil
     expect(described_class::MAPPINGS).not_to be_nil
+    expect(described_class::SERIALIZER_CLASS).not_to be_nil
   end
 
   describe "::search_documents", elasticsearch: true do
+    let(:attributes) { described_class::SERIALIZER_CLASS.attributes_to_serialize.stringify_keys.keys }
     let(:user1) { create(:user) }
     let(:user2) { create(:user) }
 
@@ -15,33 +17,80 @@ RSpec.describe Search::User, type: :service do
       mock_search_response = { "hits" => { "hits" => {} } }
       allow(described_class).to receive(:search) { mock_search_response }
       described_class.search_documents(params: {})
+
       expect(described_class).to have_received(:search).with(body: a_kind_of(Hash))
     end
 
-    context "with a query" do
-      it "searches by search_fields" do
+    it "returns user default attributes" do
+      index_documents([user1])
+      users = described_class.search_documents(params: {}).dig(:users)
+
+      expect(users.first).to include(*attributes)
+    end
+
+    context "when paginating results" do
+      let(:mock_search_response) do
+        {
+          "hits" => {
+            "total" => {
+              "value" => 100
+            },
+            "hits" => Array.new(100, "_source" => {})
+          }
+        }
+      end
+
+      let(:expected_metadata) do
+        {
+          total_count: 100,
+          total_pages: 10,
+          current_page: 2,
+          limit_value: 10,
+          offset_value: 10,
+          size: 20
+        }
+      end
+
+      before do
+        allow(described_class).to receive(:search) { mock_search_response }
+      end
+
+      it "returns the correct metadata" do
+        doc = described_class.search_documents(params: { page: 2, per_page: 10 })
+        expect(doc).to include(expected_metadata)
+      end
+    end
+
+    context "when query by search_fields" do
+      before do
         allow(user1).to receive(:available_for).and_return("ruby")
         allow(user2).to receive(:employer_name).and_return("Ruby Tuesday")
         index_documents([user1, user2])
-        query_params = { size: 5, search_fields: "ruby" }
+      end
 
+      let(:query_params) { { size: 5, search_fields: "ruby" } }
+
+      it "returns the correct users" do
         user_docs = described_class.search_documents(params: query_params)
-        expect(user_docs.count).to eq(2)
-        doc_ids = user_docs.map { |t| t.dig("id") }
+        expect(user_docs.dig("users").size).to eq(2)
+        doc_ids = user_docs.dig("users").map { |t| t.dig("id") }
         expect(doc_ids).to include(user1.id, user2.id)
       end
     end
 
     context "with a filter" do
-      it "searches by excluding roles" do
+      before do
         user1.add_role(:admin)
         user2.add_role(:banned)
         index_documents([user1, user2])
-        query_params = { size: 5, exclude_roles: ["banned"] }
+      end
 
+      let(:query_params) { { size: 5, exclude_roles: ["banned"] } }
+
+      it "searches by excluding roles" do
         user_docs = described_class.search_documents(params: query_params)
-        expect(user_docs.count).to eq(1)
-        doc_ids = user_docs.map { |t| t.dig("id") }
+        expect(user_docs.dig("users").size).to eq(1)
+        doc_ids = user_docs.dig("users").map { |t| t.dig("id") }
         expect(doc_ids).to match_array([user1.id])
       end
     end

--- a/spec/services/search/user_spec.rb
+++ b/spec/services/search/user_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe Search::User, type: :service do
   end
 
   describe "::search_documents", elasticsearch: true do
-    let(:attributes) { described_class::SERIALIZER_CLASS.attributes_to_serialize.stringify_keys.keys }
     let(:user1) { create(:user) }
     let(:user2) { create(:user) }
 
@@ -19,13 +18,6 @@ RSpec.describe Search::User, type: :service do
       described_class.search_documents(params: {})
 
       expect(described_class).to have_received(:search).with(body: a_kind_of(Hash))
-    end
-
-    it "returns user default attributes" do
-      index_documents([user1])
-      users = described_class.search_documents(params: {}).dig(:users)
-
-      expect(users.first).to include(*attributes)
     end
 
     context "when paginating results" do
@@ -42,12 +34,12 @@ RSpec.describe Search::User, type: :service do
 
       let(:expected_metadata) do
         {
-          total_count: 100,
-          total_pages: 10,
-          current_page: 2,
-          limit_value: 10,
-          offset_value: 10,
-          size: 20
+          "total_count" => 100,
+          "total_pages" => 10,
+          "current_page" => 2,
+          "limit_value" => 10,
+          "offset_value" => 10,
+          "size" => 20
         }
       end
 
@@ -57,7 +49,7 @@ RSpec.describe Search::User, type: :service do
 
       it "returns the correct metadata" do
         doc = described_class.search_documents(params: { page: 2, per_page: 10 })
-        expect(doc).to include(expected_metadata)
+        expect(doc.first).to include(expected_metadata)
       end
     end
 
@@ -72,8 +64,8 @@ RSpec.describe Search::User, type: :service do
 
       it "returns the correct users" do
         user_docs = described_class.search_documents(params: query_params)
-        expect(user_docs.dig("users").size).to eq(2)
-        doc_ids = user_docs.dig("users").map { |t| t.dig("id") }
+        expect(user_docs.size).to eq(2)
+        doc_ids = user_docs.map { |t| t.dig("id") }
         expect(doc_ids).to include(user1.id, user2.id)
       end
     end
@@ -89,8 +81,8 @@ RSpec.describe Search::User, type: :service do
 
       it "searches by excluding roles" do
         user_docs = described_class.search_documents(params: query_params)
-        expect(user_docs.dig("users").size).to eq(1)
-        doc_ids = user_docs.dig("users").map { |t| t.dig("id") }
+        expect(user_docs.size).to eq(1)
+        doc_ids = user_docs.map { |t| t.dig("id") }
         expect(doc_ids).to match_array([user1.id])
       end
     end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
On https://github.com/thepracticaldev/dev.to/pull/7093 I suggested adding some metadata attributes to `Search::User` so we could easily paginate the results.

This is a suggestion based on `Kaminari` pagination attributes.

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/pull/7093

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://img.buzzfeed.com/buzzfeed-static/static/2014-10/30/19/enhanced/webdr08/anigif_enhanced-26853-1414711827-6.gif)
