### PR TITLE
Add canonical url to /new

### DIFF
--- a/app/views/articles/new.html.erb
+++ b/app/views/articles/new.html.erb
@@ -1,4 +1,7 @@
 <% title "New Post" %>
+<%= content_for :page_meta do %>
+    <link rel="canonical" href="<%= app_url("/new") %>" />
+<% end %>
 
 <% if user_signed_in? %>
   <%= render "shared/webcomponents_loader_script" %>

--- a/spec/requests/articles/articles_spec.rb
+++ b/spec/requests/articles/articles_spec.rb
@@ -144,6 +144,16 @@ RSpec.describe "Articles", type: :request do
         expect(response).to have_http_status(:ok)
       end
     end
+
+    it "sets canonical url with base" do
+      get "/new"
+      expect(response.body).to include('<link rel="canonical" href="http://localhost:3000/new" />')
+    end
+
+    it "sets canonical url with prefil" do
+      get "/new?prefill=dsdweewewew"
+      expect(response.body).to include('<link rel="canonical" href="http://localhost:3000/new" />')
+    end
   end
 
   describe "GET /:path/edit" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Because sometimes we link to `/new?prefill=whatever` for article composition page, we need to have a canonical meta tag so that spiders know that these are all the same page regardless of the query params.