### PR TITLE
Use atomic increment for rate limiter counters

### DIFF
--- a/app/labor/rate_limit_checker.rb
+++ b/app/labor/rate_limit_checker.rb
@@ -21,15 +21,11 @@ class RateLimitChecker
   end
 
   def track_image_uploads
-    count = Rails.cache.read("#{@user.id}_image_upload").to_i
-    count += 1
-    Rails.cache.write("#{@user.id}_image_upload", count, expires_in: 30.seconds)
+    Rails.cache.increment("#{@user.id}_image_upload", 1, expires_in: 30.seconds)
   end
 
   def track_article_updates
-    count = Rails.cache.read("#{@user.id}_article_update").to_i
-    count += 1
-    Rails.cache.write("#{@user.id}_article_update", count, expires_in: 1.day)
+    Rails.cache.increment("#{@user.id}_article_update", 1, expires_in: 30.seconds)
   end
 
   def limit_by_email_recipient_address(address)

--- a/spec/requests/image_uploads_spec.rb
+++ b/spec/requests/image_uploads_spec.rb
@@ -85,19 +85,18 @@ RSpec.describe "ImageUploads", type: :request do
     end
 
     context "when uploading rate limiting works" do
-      let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
+      let(:cache_store) { ActiveSupport::Cache.lookup_store(:redis_cache_store) }
       let(:cache) { Rails.cache }
       let(:cache_key) { "#{user.id}_image_upload" }
 
       before do
         sign_in user
-        allow(Rails).to receive(:cache).and_return(memory_store)
-        Rails.cache.write(cache_key, 0)
+        allow(Rails).to receive(:cache).and_return(cache_store)
       end
 
       it "counts number of uploads in cache" do
         post "/image_uploads", headers: headers, params: { image: [image] }
-        expect(cache.read(cache_key)).to eq(1)
+        expect(cache.read(cache_key).to_i).to eq(1)
       end
 
       it "raises error with too many uploads" do

--- a/spec/requests/image_uploads_spec.rb
+++ b/spec/requests/image_uploads_spec.rb
@@ -10,8 +10,6 @@ RSpec.describe "ImageUploads", type: :request do
         "image/jpeg",
       )
     end
-    let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
-    let(:cache) { Rails.cache }
     let(:bad_image) do
       Rack::Test::UploadedFile.new(
         Rails.root.join("spec/support/fixtures/images/bad-image.jpg"),
@@ -87,15 +85,19 @@ RSpec.describe "ImageUploads", type: :request do
     end
 
     context "when uploading rate limiting works" do
+      let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
+      let(:cache) { Rails.cache }
+      let(:cache_key) { "#{user.id}_image_upload" }
+
       before do
         sign_in user
         allow(Rails).to receive(:cache).and_return(memory_store)
-        Rails.cache.clear
+        Rails.cache.write(cache_key, 0)
       end
 
       it "counts number of uploads in cache" do
         post "/image_uploads", headers: headers, params: { image: [image] }
-        expect(cache.read("#{user.id}_image_upload")).to eq(1)
+        expect(cache.read(cache_key)).to eq(1)
       end
 
       it "raises error with too many uploads" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Use [atomic Redis increment](https://redis.io/commands/incr) for counters.

I tested this with:

```ruby
# try this after toggling `rails dev:cache` on and off
# `rails runner cache_test.rb`

key = "key-#{rand(10_000)}"

# this will print nothing with the :null_store
# but it will work with :redis_cache_store

puts "Initial value: #{Rails.cache.read(key)}"
Rails.cache.increment(key, 1)
value = Rails.cache.read(key)
puts "After increment: #{value}, #{value.class}"

# Cache read: key-1639 ({:namespace=>nil, :compress=>true, :compress_threshold=>1024, :expires_in=>3600, :race_condition_ttl=>nil})
# Initial value:
# Cache increment: key-1639 ({:amount=>1})
# Cache read: key-1639 ({:namespace=>nil, :compress=>true, :compress_threshold=>1024, :expires_in=>3600, :race_condition_ttl=>nil})
# After increment: 1, String
```

and verified with:

```shell
➜  devto ✗ redis-cli
127.0.0.1:6379> get key-1639
"1"
127.0.0.1:6379> incrby key-1639 2
(integer) 3
127.0.0.1:6379> get key-1639
"3"
127.0.0.1:6379>

➜  devto ✗ rails runner "puts Rails.cache.read('key-1639')"
Cache read: key-1639 ({:namespace=>nil, :compress=>true, :compress_threshold=>1024, :expires_in=>3600, :race_condition_ttl=>nil})
3
```

The correct way to make it work in testing is to use the [https://api.rubyonrails.org/classes/ActiveSupport/Cache/RedisCacheStore.html](https://api.rubyonrails.org/classes/ActiveSupport/Cache/RedisCacheStore.html):

```ruby
if Rails.env.test?
  Rails.cache = ActiveSupport::Cache::RedisCacheStore.new
end

key = "key-#{rand(10_000)}"

puts "Key: #{key}"
puts "Initial value: #{Rails.cache.read(key)}"
Rails.cache.increment(key, 1)
value = Rails.cache.read(key)
puts "After increment: #{value}, #{value.class}"
```

see:

```shell
➜  devto ✗ rails runner -e test t.rb
Key: key-3825
Initial value:
After increment: 1, String
➜  devto ✗ redis-cli get key-3825
"1"
```

The reason why it didn't work in the tests is because we're using the memory store, [which I believe contains a bug in how it works](https://github.com/rails/rails/blob/4dcc5435e9569e084f6f90fcea6e7c37d7bd2b4d/activesupport/lib/active_support/cache/memory_store.rb#L160-L164):

```ruby
            if num = read(name, options)
              num = num.to_i + amount
              write(name, num, options)
              num
            end
```

As you can see, it will increment the counter, only if it's already initialized to 0 (which in Ruby is a truthy value and will end up in the increment block), otherwise it will fail :(

[Redis cache store on the other side](https://github.com/rails/rails/blob/4dcc5435e9569e084f6f90fcea6e7c37d7bd2b4d/activesupport/lib/active_support/cache/redis_cache_store.rb#L262):

```ruby
            redis.with { |c| c.incrby normalize_key(name, options), amount }
```

uses [Redis INCRBY](https://redis.io/commands/incrby) which has this behavior:

> Increments the number stored at key by increment. If the key does not exist, it is set to 0 before performing the operation.

this is why with Redis works, with MemoryStore doesn't. 

I'll see if I can raise the issue with Rails and see what they tell me about the discrepancy.

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
