### PR TITLE
Sync Elasticsearch Articles and Reactions if Tag Search Keywords are Updated

### DIFF
--- a/app/lib/acts_as_taggable_on/tag.rb
+++ b/app/lib/acts_as_taggable_on/tag.rb
@@ -1,7 +1,11 @@
 module ActsAsTaggableOn
   class Tag
-    after_commit on: :create do
+    after_commit on: %i[create update] do
       ::Tag.find(id).index_to_elasticsearch
+    end
+
+    after_commit on: :update do
+      DataSync::Elasticsearch::Tag.new(self).call
     end
   end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -33,11 +33,13 @@ class Tag < ActsAsTaggableOn::Tag
 
   after_commit :bust_cache
   after_commit :index_to_elasticsearch, on: %i[create update]
+  after_commit :sync_related_elasticsearch_docs, on: [:update]
   after_commit :remove_from_elasticsearch, on: [:destroy]
 
   include Searchable
   SEARCH_SERIALIZER = Search::TagSerializer
   SEARCH_CLASS = Search::Tag
+  DATA_SYNC_CLASS = DataSync::Elasticsearch::Tag
 
   # possible social previews templates for articles with a particular tag
   def self.social_preview_templates

--- a/app/services/data_sync/elasticsearch/tag.rb
+++ b/app/services/data_sync/elasticsearch/tag.rb
@@ -1,0 +1,31 @@
+module DataSync
+  module Elasticsearch
+    class Tag < Base
+      RELATED_DOCS = %i[
+        articles
+        podcast_episodes
+        reactions
+      ].freeze
+
+      SHARED_FIELDS = %i[
+        keywords_for_search
+      ].freeze
+
+      private
+
+      def articles
+        ::Article.cached_tagged_with(updated_record.name)
+      end
+
+      def reactions
+        ::Reaction.readinglist.where(reactable: articles)
+      end
+
+      def podcast_episodes
+        ::PodcastEpisode.where(
+          id: updated_record.taggings.where(taggable_type: "PodcastEpisode").select(:taggable_id),
+        )
+      end
+    end
+  end
+end

--- a/spec/lib/acts_as_taggable_on/tag_spec.rb
+++ b/spec/lib/acts_as_taggable_on/tag_spec.rb
@@ -9,5 +9,27 @@ RSpec.describe ActsAsTaggableOn::Tag, type: :lib do
       tag = Tag.find_by(name: tag_name)
       expect(tag.elasticsearch_doc).not_to be_nil
     end
+
+    it "syncs related elasticsearch documents" do
+      article = create(:article)
+      podcast_episode = create(:podcast_episode)
+      tag = article.tags.first
+      podcast_episode.tags << tag
+      reaction = create(:reaction, reactable: article, category: "readinglist")
+      new_keywords = "keyword1, keyword2, keyword3"
+      sidekiq_perform_enqueued_jobs
+
+      tag.update(keywords_for_search: new_keywords)
+      sidekiq_perform_enqueued_jobs
+      expect(collect_keywords(article)).to include(new_keywords)
+      expect(
+        reaction.elasticsearch_doc.dig("_source", "reactable", "tags").flat_map { |t| t["keywords_for_search"] },
+      ).to include(new_keywords)
+      expect(collect_keywords(podcast_episode)).to include(new_keywords)
+    end
+  end
+
+  def collect_keywords(record)
+    record.elasticsearch_doc.dig("_source", "tags").flat_map { |t| t["keywords_for_search"] }
   end
 end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -103,5 +103,27 @@ RSpec.describe Tag, type: :model do
         tag.destroy
       end
     end
+
+    it "syncs related elasticsearch documents" do
+      article = create(:article)
+      podcast_episode = create(:podcast_episode)
+      tag = described_class.find(article.tags.first.id)
+      podcast_episode.tags << tag
+      reaction = create(:reaction, reactable: article, category: "readinglist")
+      new_keywords = "keyword1, keyword2, keyword3"
+      sidekiq_perform_enqueued_jobs
+
+      tag.update(keywords_for_search: new_keywords)
+      sidekiq_perform_enqueued_jobs
+      expect(collect_keywords(article)).to include(new_keywords)
+      expect(
+        reaction.elasticsearch_doc.dig("_source", "reactable", "tags").flat_map { |t| t["keywords_for_search"] },
+      ).to include(new_keywords)
+      expect(collect_keywords(podcast_episode)).to include(new_keywords)
+    end
+  end
+
+  def collect_keywords(record)
+    record.elasticsearch_doc.dig("_source", "tags").flat_map { |t| t["keywords_for_search"] }
   end
 end

--- a/spec/services/data_sync/elasticsearch/tag_spec.rb
+++ b/spec/services/data_sync/elasticsearch/tag_spec.rb
@@ -1,0 +1,8 @@
+require "rails_helper"
+
+RSpec.describe DataSync::Elasticsearch::Tag, type: :service do
+  it "defines necessary constants" do
+    expect(described_class::RELATED_DOCS).not_to be_nil
+    expect(described_class::SHARED_FIELDS).not_to be_nil
+  end
+end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
We index keywords_for_search from Tags on Articles, Reactions(articles as reachable) and PodcastEpisodes(well we can, we currently don't use this feature). If they change we need to make sure to update those Elasticsearch documents.

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-35915111

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help


![alt_text](https://media.giphy.com/media/3o6Mb5Cy5tZFkNLLLa/giphy.gif)
