### PR TITLE
Revert generalization of meta content in offline.html

### DIFF
--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -6,7 +6,7 @@
   <meta name="keywords" content="software development,engineering,rails,javascript,ruby">
 
   <meta property="og:type" content="article" />
-  <meta property="og:url" content="(<%= app_url("/about") %>" />
+  <meta property="og:url" content="<%= app_url("/about") %>" />
   <meta property="og:title" content="Tags to follow on dev.to" />
   <meta property="og:image" content="<%= SiteConfig.main_social_image %>" />
   <meta property="og:description" content="<%= community_qualified_name %> is great!" />

--- a/public/offline.html
+++ b/public/offline.html
@@ -2,11 +2,11 @@
 <html>
 <head>
   <title>You are not connected to the Internet</title>
-  <meta property="og:url" content="<%= app_url("/offline.html") %>" />
+  <meta property="og:url" content="https://dev.to/offline.html" />
   <meta property="og:title" content="Looks like you've lost your Internet connection" />
   <meta property="og:image" content="https://thepracticaldev.s3.amazonaws.com/i/aio6nc08tpcqavej512d.png" />
   <meta property="og:description" content="Maybe you could go outside and get some fresh air." />
-  <meta property="og:site_name" content="<%= community_qualified_name %>" />
+  <meta property="og:site_name" content="The DEV Community" />
 
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@ThePracticalDev">


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

An `html` file was among many of the other files that were refactored during the meta generalization process, but unfortunately, unlike the other files that were `html.erb`, this one was just `html`, causing the `erb` tags to render none of the meta content (shown while inspecting the content in the browser), as well as causing a closing tag to render on the offline page. 

The best solution I could come up with was to revert the meta content back to what it was prior to the changes because the offline page is merely an `html` file, but I am very open to ideas on how to better resolve this tiny issue!

While hunting this change down, I also noticed that there was an extra open parenthesis, so I removed that as well.

## Related Tickets & Documents

The PR containing the work I am reverting can be found [here](https://github.com/thepracticaldev/dev.to/pull/6887/files#diff-fc2517ec0f60625d8d0d203cec4b520bR5).

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Before:
<img width="916" alt="Screen Shot 2020-04-10 at 1 51 53 PM" src="https://user-images.githubusercontent.com/32834804/79023968-d631d400-7b3e-11ea-9762-d3fcc87c7fe4.png">

After:
<img width="916" alt="Screen Shot 2020-04-10 at 3 21 17 PM" src="https://user-images.githubusercontent.com/32834804/79024012-f3ff3900-7b3e-11ea-880a-ea7471974cbe.png">

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
