### PR TITLE
Fix UI for settings - API secrets

### DIFF
--- a/app/assets/stylesheets/settings.scss
+++ b/app/assets/stylesheets/settings.scss
@@ -758,20 +758,15 @@ ul.delete__account {
 .api__secret {
   &__container {
     background-color: $white;
-    height: 6.5rem;
+    display: flex;
+    height: auto;
     margin: 0.5rem 0;
     padding: 0.5rem;
     border-radius: 3px;
     border: 1px solid $light-medium-gray;
-    @media screen and (min-width: 600px) {
-      height: 5rem;
-    }
   }
 
   &__desc {
-    width: 70%;
-    float: left;
-
     .title {
       color: $dark-gray;
       font-weight: bold;
@@ -795,13 +790,10 @@ ul.delete__account {
   }
 
   &__revoke {
-    text-align: right;
-    margin: 1.6rem auto 0;
+    text-align: left;
+    margin: 1rem auto 0;
     display: block;
-    @media screen and (min-width: 600px) {
-      float: left;
-      width: 30%;
-    }
+    width: 100%;
   }
 }
 

--- a/app/views/users/_account.html.erb
+++ b/app/views/users/_account.html.erb
@@ -26,14 +26,13 @@
       <details>
         <summary class="title"><%= api_secret.description %></summary>
         <p class="content"><%= api_secret.secret %></p>
+        <p class="subtitle">
+          Created: <time datetime="<%= api_secret.created_at.rfc3339 %>"><%= api_secret.created_at.to_s %></time>
+        </p>
+        <%= form_tag users_api_secret_path(api_secret.id), class: "api__secret__revoke", method: :delete do %>
+          <%= button_tag "Revoke", class: "big-action danger-button" %>
+        <% end %>
       </details>
-      <p class="subtitle">Created <%= api_secret.created_at.to_date.to_s %></p>
-    </div>
-
-    <div class="api__secret__revoke">
-      <%= form_tag users_api_secret_path(api_secret.id), method: :delete do %>
-        <%= button_tag "Revoke", class: "big-action danger-button" %>
-      <% end %>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

While testing for https://github.com/thepracticaldev/dev.to/issues/7242 I noticed how the UI for API secrets was a bit off when the `<details>` is opened:

![before_opened](https://user-images.githubusercontent.com/146201/79080741-d33e0b80-7d17-11ea-8d43-85d56881c094.png)

This is how it currently looks like closed:

![before_closed](https://user-images.githubusercontent.com/146201/79080758-eea91680-7d17-11ea-9bac-1e3063a5ba48.png)

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![after_closed](https://user-images.githubusercontent.com/146201/79080761-f49ef780-7d17-11ea-86da-49835155ff78.png)

![after_opened](https://user-images.githubusercontent.com/146201/79080762-f8327e80-7d17-11ea-87ec-09c864104ac4.png)

![after_mobile](https://user-images.githubusercontent.com/146201/79080766-fcf73280-7d17-11ea-8377-4d8959b4909e.png)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
