### PR TITLE
Ignore Reaction Not Found During Indexing

### DIFF
--- a/app/workers/search/index_to_elasticsearch_worker.rb
+++ b/app/workers/search/index_to_elasticsearch_worker.rb
@@ -10,6 +10,10 @@ module Search
       object_int_id = id.is_a?(Integer) ? id : id.split("_").last.to_i
       object = object_class.constantize.find(object_int_id)
       object.index_to_elasticsearch_inline
+    rescue ActiveRecord::RecordNotFound => e
+      return if object_class == "Reaction"
+
+      raise e
     end
   end
 end

--- a/spec/workers/search/index_to_elasticsearch_worker_spec.rb
+++ b/spec/workers/search/index_to_elasticsearch_worker_spec.rb
@@ -24,4 +24,8 @@ RSpec.describe Search::IndexToElasticsearchWorker, type: :worker, elasticsearch:
 
     expect(tag.elasticsearch_doc.dig("_source", "id")).to eql(tag.id)
   end
+
+  it "does not raise an error if Reaction record is not found" do
+    expect { worker.perform("Reaction", 1234) }.not_to raise_error(ActiveRecord::RecordNotFound)
+  end
 end


### PR DESCRIPTION


## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Reactions are one of those records that can be created and deleted very quickly. For this reason it is not uncommon for us to see Sidekiq Indexing worker failing with a ActiveRecord::NotFound error. To prevent this since it is common I choose to ignore AR NotFound errors when they are raise for Reactions. I don't want to ignore all model types bc other models should never find themselves in this situation and if they do it is likely a bug.

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-36207568

## Added tests?
- [x] yes

![alt_text](https://media2.giphy.com/media/xT0xeBa0xeUjvORGNy/giphy.gif)
