### PR TITLE
Refactor search_documents Method Into Search Base.rb Class

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -38,7 +38,7 @@ class SearchController < ApplicationController
 
   def chat_channels
     ccm_docs = Search::ChatChannelMembership.search_documents(
-      params: chat_channel_params.to_h, user_id: current_user.id,
+      params: chat_channel_params.merge(user_id: current_user.id).to_h,
     )
 
     render json: { result: ccm_docs }

--- a/app/services/search/base.rb
+++ b/app/services/search/base.rb
@@ -43,7 +43,7 @@ module Search
 
       def search_documents(params:)
         set_query_size(params)
-        query_hash = "Search::QueryBuilders::#{name.gsub('Search::', '')}".safe_constantize.new(params: params).as_hash
+        query_hash = "Search::QueryBuilders::#{name.demodulize}".safe_constantize.new(params: params).as_hash
 
         results = search(body: query_hash)
         hits = results.dig("hits", "hits").map { |hit| prepare_doc(hit) }

--- a/app/services/search/base.rb
+++ b/app/services/search/base.rb
@@ -41,7 +41,20 @@ module Search
         Search::Client.count(index: self::INDEX_ALIAS).dig("count")
       end
 
+      def search_documents(params:)
+        set_query_size(params)
+        query_hash = "Search::QueryBuilders::#{name.gsub('Search::', '')}".safe_constantize.new(params: params).as_hash
+
+        results = search(body: query_hash)
+        hits = results.dig("hits", "hits").map { |hit| prepare_doc(hit) }
+        paginate_hits(hits, params)
+      end
+
       private
+
+      def prepare_doc(hit)
+        hit.dig("_source")
+      end
 
       def search(body:)
         Search::Client.search(index: self::INDEX_ALIAS, body: body)

--- a/app/services/search/chat_channel_membership.rb
+++ b/app/services/search/chat_channel_membership.rb
@@ -7,15 +7,6 @@ module Search
     DEFAULT_PER_PAGE = 30
 
     class << self
-      def search_documents(params:, user_id:)
-        set_query_size(params)
-        query_hash = Search::QueryBuilders::ChatChannelMembership.new(params, user_id).as_hash
-
-        results = search(body: query_hash)
-        hits = results.dig("hits", "hits").map { |ccm_doc| ccm_doc.dig("_source") }
-        paginate_hits(hits, params)
-      end
-
       private
 
       def index_settings

--- a/app/services/search/classified_listing.rb
+++ b/app/services/search/classified_listing.rb
@@ -7,15 +7,6 @@ module Search
     DEFAULT_PER_PAGE = 75
 
     class << self
-      def search_documents(params:)
-        set_query_size(params)
-        query_hash = Search::QueryBuilders::ClassifiedListing.new(params).as_hash
-
-        results = search(body: query_hash)
-        hits = results.dig("hits", "hits").map { |cl_doc| cl_doc.dig("_source") }
-        paginate_hits(hits, params)
-      end
-
       private
 
       def index_settings

--- a/app/services/search/feed_content.rb
+++ b/app/services/search/feed_content.rb
@@ -9,17 +9,6 @@ module Search
     INCLUDED_CLASS_NAMES = %w[Article Comment PodcastEpisode].freeze
 
     class << self
-      def search_documents(params:)
-        set_query_size(params)
-        query_hash = Search::QueryBuilders::FeedContent.new(params).as_hash
-
-        results = search(body: query_hash)
-        hits = results.dig("hits", "hits").map do |feed_doc|
-          prepare_doc(feed_doc)
-        end
-        paginate_hits(hits, params)
-      end
-
       INCLUDED_CLASS_NAMES.each do |class_name|
         define_method("#{class_name.underscore.pluralize}_document_count") do
           Search::Client.count(

--- a/app/services/search/query_builders/chat_channel_membership.rb
+++ b/app/services/search/query_builders/chat_channel_membership.rb
@@ -18,9 +18,9 @@ module Search
         size: 0
       }.freeze
 
-      def initialize(params, user_id)
+      def initialize(params:)
         @params = params.deep_symbolize_keys
-        @params[:viewable_by] = user_id
+        @params[:viewable_by] = params[:user_id]
 
         # TODO: @mstruve: When we want to allow people like admins to
         # search ALL memberships this will need to change

--- a/app/services/search/query_builders/classified_listing.rb
+++ b/app/services/search/query_builders/classified_listing.rb
@@ -28,7 +28,7 @@ module Search
         size: 0
       }.freeze
 
-      def initialize(params)
+      def initialize(params:)
         @params = params.deep_symbolize_keys
 
         # For now, we're not allowing searches for ClassifiedListings that are

--- a/app/services/search/query_builders/feed_content.rb
+++ b/app/services/search/query_builders/feed_content.rb
@@ -62,7 +62,7 @@ module Search
 
       attr_accessor :params, :body
 
-      def initialize(params)
+      def initialize(params:)
         @params = params.deep_symbolize_keys
 
         # Default to only showing published articles to start

--- a/app/services/search/query_builders/user.rb
+++ b/app/services/search/query_builders/user.rb
@@ -16,7 +16,7 @@ module Search
         size: 0
       }.freeze
 
-      def initialize(params)
+      def initialize(params:)
         @params = params.deep_symbolize_keys
 
         # default to excluding users who are banned

--- a/app/services/search/user.rb
+++ b/app/services/search/user.rb
@@ -7,35 +7,25 @@ module Search
     DEFAULT_PER_PAGE = 20
 
     class << self
-      def search_documents(params:)
-        set_query_size(params)
-        query_hash = Search::QueryBuilders::User.new(params).as_hash
-
-        results = search(body: query_hash)
-        hits = results.dig("hits", "hits").map do |user_doc|
-          prepare_doc(user_doc.dig("_source"))
-        end
-        paginate_hits(hits, params)
-      end
-
       private
 
       def prepare_doc(hit)
+        source = hit.dig("_source")
         {
           "user" => {
-            "username" => hit["username"],
-            "name" => hit["username"],
-            "profile_image_90" => hit["profile_image_90"]
+            "username" => source["username"],
+            "name" => source["username"],
+            "profile_image_90" => source["profile_image_90"]
           },
-          "title" => hit["name"],
-          "path" => hit["path"],
-          "id" => hit["id"],
+          "title" => source["name"],
+          "path" => source["path"],
+          "id" => source["id"],
           "class_name" => "User",
-          "positive_reactions_count" => hit["positive_reactions_count"],
-          "comments_count" => hit["comments_count"],
-          "badge_achievements_count" => hit["badge_achievements_count"],
-          "last_comment_at" => hit["last_comment_at"],
-          "roles" => hit["roles"]
+          "positive_reactions_count" => source["positive_reactions_count"],
+          "comments_count" => source["comments_count"],
+          "badge_achievements_count" => source["badge_achievements_count"],
+          "last_comment_at" => source["last_comment_at"],
+          "roles" => source["roles"]
         }
       end
 

--- a/spec/services/search/chat_channel_membership_spec.rb
+++ b/spec/services/search/chat_channel_membership_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Search::ChatChannelMembership, type: :service, elasticsearch: tru
     it "parses chat_channel_membership document hits from search response" do
       mock_search_response = { "hits" => { "hits" => {} } }
       allow(described_class).to receive(:search) { mock_search_response }
-      described_class.search_documents(params: {}, user_id: 1)
+      described_class.search_documents(params: { user_id: 1 })
       expect(described_class).to have_received(:search).with(body: a_kind_of(Hash))
     end
 
@@ -18,9 +18,9 @@ RSpec.describe Search::ChatChannelMembership, type: :service, elasticsearch: tru
         allow(chat_channel_membership1).to receive(:channel_text).and_return("a name")
         allow(chat_channel_membership2).to receive(:channel_text).and_return("another name and slug")
         index_documents([chat_channel_membership1, chat_channel_membership2])
-        name_params = { size: 5, channel_text: "name" }
+        name_params = { size: 5, channel_text: "name", user_id: user.id }
 
-        chat_channel_membership_docs = described_class.search_documents(params: name_params, user_id: user.id)
+        chat_channel_membership_docs = described_class.search_documents(params: name_params)
         expect(chat_channel_membership_docs.count).to eq(2)
         doc_ids = chat_channel_membership_docs.map { |t| t.dig("id") }
         expect(doc_ids).to include(chat_channel_membership1.id, chat_channel_membership2.id)
@@ -32,9 +32,9 @@ RSpec.describe Search::ChatChannelMembership, type: :service, elasticsearch: tru
         new_user = create(:user)
         chat_channel_membership3 = create(:chat_channel_membership, user_id: new_user.id)
         index_documents([chat_channel_membership1, chat_channel_membership2, chat_channel_membership3])
-        params = { size: 5 }
+        params = { size: 5, user_id: new_user.id }
 
-        chat_channel_membership_docs = described_class.search_documents(params: params, user_id: new_user.id)
+        chat_channel_membership_docs = described_class.search_documents(params: params)
         expect(chat_channel_membership_docs.count).to eq(1)
         expect(chat_channel_membership_docs.first["id"]).to eq(chat_channel_membership3.id)
       end
@@ -42,9 +42,9 @@ RSpec.describe Search::ChatChannelMembership, type: :service, elasticsearch: tru
       it "searches by channel_status" do
         allow(chat_channel_membership1).to receive(:channel_status).and_return("popping")
         index_documents([chat_channel_membership1, chat_channel_membership2])
-        params = { size: 5, channel_status: "popping" }
+        params = { size: 5, channel_status: "popping", user_id: user.id }
 
-        chat_channel_membership_docs = described_class.search_documents(params: params, user_id: user.id)
+        chat_channel_membership_docs = described_class.search_documents(params: params)
         expect(chat_channel_membership_docs.count).to eq(1)
         expect(chat_channel_membership_docs.first["id"]).to eq(chat_channel_membership1.id)
       end
@@ -52,9 +52,9 @@ RSpec.describe Search::ChatChannelMembership, type: :service, elasticsearch: tru
       it "searches by channel_type" do
         allow(chat_channel_membership2).to receive(:channel_type).and_return("invite_only")
         index_documents([chat_channel_membership1, chat_channel_membership2])
-        params = { size: 5, channel_type: "invite_only" }
+        params = { size: 5, channel_type: "invite_only", user_id: user.id }
 
-        chat_channel_membership_docs = described_class.search_documents(params: params, user_id: user.id)
+        chat_channel_membership_docs = described_class.search_documents(params: params)
         expect(chat_channel_membership_docs.count).to eq(1)
         expect(chat_channel_membership_docs.first["id"]).to eq(chat_channel_membership2.id)
       end
@@ -63,9 +63,9 @@ RSpec.describe Search::ChatChannelMembership, type: :service, elasticsearch: tru
         chat_channel_membership1.update(status: "inactive")
         chat_channel_membership2.update(status: "active")
         index_documents([chat_channel_membership1, chat_channel_membership2])
-        params = { size: 5 }
+        params = { size: 5, user_id: user.id }
 
-        chat_channel_membership_docs = described_class.search_documents(params: params, user_id: user.id)
+        chat_channel_membership_docs = described_class.search_documents(params: params)
         expect(chat_channel_membership_docs.count).to eq(1)
         expect(chat_channel_membership_docs.first["id"]).to eq(chat_channel_membership2.id)
       end
@@ -78,9 +78,9 @@ RSpec.describe Search::ChatChannelMembership, type: :service, elasticsearch: tru
         chat_channel_membership1.update(status: "active")
         chat_channel_membership2.update(status: "inactive")
         index_documents([chat_channel_membership1, chat_channel_membership2])
-        name_params = { size: 5, channel_text: "name", status: "active" }
+        name_params = { size: 5, channel_text: "name", status: "active", user_id: user.id }
 
-        chat_channel_membership_docs = described_class.search_documents(params: name_params, user_id: user.id)
+        chat_channel_membership_docs = described_class.search_documents(params: name_params)
         expect(chat_channel_membership_docs.count).to eq(1)
         doc_ids = chat_channel_membership_docs.map { |t| t.dig("id") }
         expect(doc_ids).to include(chat_channel_membership1.id)
@@ -91,9 +91,9 @@ RSpec.describe Search::ChatChannelMembership, type: :service, elasticsearch: tru
       allow(chat_channel_membership1).to receive(:channel_type).and_return("not_direct")
       allow(chat_channel_membership2).to receive(:channel_type).and_return("direct")
       index_documents([chat_channel_membership1, chat_channel_membership2])
-      params = { size: 5, sort_by: "channel_type", sort_direction: "asc" }
+      params = { size: 5, sort_by: "channel_type", sort_direction: "asc", user_id: user.id }
 
-      chat_channel_membership_docs = described_class.search_documents(params: params, user_id: user.id)
+      chat_channel_membership_docs = described_class.search_documents(params: params)
       expect(chat_channel_membership_docs.count).to eq(2)
       expect(chat_channel_membership_docs.first["id"]).to eq(chat_channel_membership2.id)
       expect(chat_channel_membership_docs.last["id"]).to eq(chat_channel_membership1.id)
@@ -103,9 +103,9 @@ RSpec.describe Search::ChatChannelMembership, type: :service, elasticsearch: tru
       allow(chat_channel_membership1).to receive(:channel_last_message_at).and_return(Time.current)
       allow(chat_channel_membership2).to receive(:channel_last_message_at).and_return(1.year.ago)
       index_documents([chat_channel_membership1, chat_channel_membership2])
-      params = { size: 5 }
+      params = { size: 5, user_id: user.id }
 
-      chat_channel_membership_docs = described_class.search_documents(params: params, user_id: user.id)
+      chat_channel_membership_docs = described_class.search_documents(params: params)
       expect(chat_channel_membership_docs.count).to eq(2)
       expect(chat_channel_membership_docs.first["id"]).to eq(chat_channel_membership1.id)
       expect(chat_channel_membership_docs.last["id"]).to eq(chat_channel_membership2.id)
@@ -113,9 +113,9 @@ RSpec.describe Search::ChatChannelMembership, type: :service, elasticsearch: tru
 
     it "will return a set number of docs based on pagination params" do
       index_documents([chat_channel_membership1, chat_channel_membership2])
-      params = { page: 0, per_page: 1 }
+      params = { page: 0, per_page: 1, user_id: user.id }
 
-      chat_channel_membership_docs = described_class.search_documents(params: params, user_id: user.id)
+      chat_channel_membership_docs = described_class.search_documents(params: params)
       expect(chat_channel_membership_docs.count).to eq(1)
     end
 
@@ -123,14 +123,14 @@ RSpec.describe Search::ChatChannelMembership, type: :service, elasticsearch: tru
       allow(chat_channel_membership1).to receive(:channel_last_message_at).and_return(Time.current)
       allow(chat_channel_membership2).to receive(:channel_last_message_at).and_return(1.year.ago)
       index_documents([chat_channel_membership1, chat_channel_membership2])
-      first_page_params = { page: 0, per_page: 1, sort_by: "channel_last_message_at", order: "dsc" }
+      first_page_params = { page: 0, per_page: 1, sort_by: "channel_last_message_at", order: "dsc", user_id: user.id }
 
-      chat_channel_membership_docs = described_class.search_documents(params: first_page_params, user_id: user.id)
+      chat_channel_membership_docs = described_class.search_documents(params: first_page_params)
       expect(chat_channel_membership_docs.first["id"]).to eq(chat_channel_membership1.id)
 
-      second_page_params = { page: 1, per_page: 1, sort_by: "channel_last_message_at", order: "dsc" }
+      second_page_params = { page: 1, per_page: 1, sort_by: "channel_last_message_at", order: "dsc", user_id: user.id }
 
-      chat_channel_membership_docs = described_class.search_documents(params: second_page_params, user_id: user.id)
+      chat_channel_membership_docs = described_class.search_documents(params: second_page_params)
       expect(chat_channel_membership_docs.first["id"]).to eq(chat_channel_membership2.id)
     end
 
@@ -138,9 +138,9 @@ RSpec.describe Search::ChatChannelMembership, type: :service, elasticsearch: tru
       allow(chat_channel_membership1).to receive(:channel_last_message_at).and_return(Time.current)
       allow(chat_channel_membership2).to receive(:channel_last_message_at).and_return(1.year.ago)
       index_documents([chat_channel_membership1, chat_channel_membership2])
-      params = { page: 3, per_page: 1 }
+      params = { page: 3, per_page: 1, user_id: user.id }
 
-      chat_channel_membership_docs = described_class.search_documents(params: params, user_id: user.id)
+      chat_channel_membership_docs = described_class.search_documents(params: params)
       expect(chat_channel_membership_docs).to eq([])
     end
   end

--- a/spec/services/search/query_builders/chat_channel_membership_spec.rb
+++ b/spec/services/search/query_builders/chat_channel_membership_spec.rb
@@ -4,20 +4,20 @@ RSpec.describe Search::QueryBuilders::ChatChannelMembership, type: :service do
   describe "::initialize" do
     it "sets params" do
       filter_params = { foo: "bar" }
-      filter = described_class.new(filter_params, 1)
+      filter = described_class.new(params: filter_params)
       expect(filter.params).to include(filter_params)
     end
 
     it "builds query body" do
-      filter = described_class.new({}, 1)
+      filter = described_class.new(params: {})
       expect(filter.body).not_to be_nil
     end
   end
 
   describe "#as_hash" do
     it "applies FILTER_KEYS from params" do
-      params = { channel_status: "active", channel_type: "direct" }
-      filter = described_class.new(params, 1)
+      params = { channel_status: "active", channel_type: "direct", user_id: 1 }
+      filter = described_class.new(params: params)
       expected_filters = [
         { "term" => { "channel_status" => "active" } },
         { "term" => { "channel_type" => "direct" } },
@@ -29,7 +29,7 @@ RSpec.describe Search::QueryBuilders::ChatChannelMembership, type: :service do
 
     it "applies QUERY_KEYS from params" do
       params = { channel_text: "a_name" }
-      query = described_class.new(params, 1)
+      query = described_class.new(params: params)
       expected_query = [{
         "simple_query_string" => {
           "query" => "a_name*", "fields" => [:channel_text], "lenient" => true, "analyze_wildcard" => true
@@ -39,8 +39,8 @@ RSpec.describe Search::QueryBuilders::ChatChannelMembership, type: :service do
     end
 
     it "applies QUERY_KEYS and FILTER_KEYS from params" do
-      params = { channel_text: "a_name", channel_status: "active" }
-      query = described_class.new(params, 1)
+      params = { channel_text: "a_name", channel_status: "active", user_id: 1 }
+      query = described_class.new(params: params)
       expected_query = [{
         "simple_query_string" => {
           "query" => "a_name*", "fields" => [:channel_text], "lenient" => true, "analyze_wildcard" => true
@@ -52,8 +52,8 @@ RSpec.describe Search::QueryBuilders::ChatChannelMembership, type: :service do
     end
 
     it "always applies viewable_by and status params" do
-      params = {}
-      filter = described_class.new(params, 1)
+      params = { user_id: 1 }
+      filter = described_class.new(params: params)
       expected_filters = [
         { "term" => { "status" => "active" } },
         { "term" => { "viewable_by" => 1 } },
@@ -62,8 +62,8 @@ RSpec.describe Search::QueryBuilders::ChatChannelMembership, type: :service do
     end
 
     it "ignores params we dont support" do
-      params = { not_supported: "direct" }
-      filter = described_class.new(params, 1)
+      params = { not_supported: "direct", user_id: 1 }
+      filter = described_class.new(params: params)
       expected_filters = [
         { "term" => { "status" => "active" } },
         { "term" => { "viewable_by" => 1 } },
@@ -72,14 +72,14 @@ RSpec.describe Search::QueryBuilders::ChatChannelMembership, type: :service do
     end
 
     it "sets default params when not present" do
-      filter = described_class.new({}, 1)
+      filter = described_class.new(params: {})
       expect(filter.as_hash.dig("sort")).to eq("channel_last_message_at" => "desc")
       expect(filter.as_hash.dig("size")).to eq(0)
     end
 
     it "allows default params to be overriden" do
       params = { sort_by: "status", sort_direction: "asc", size: 20 }
-      filter = described_class.new(params, 1)
+      filter = described_class.new(params: params)
       expect(filter.as_hash.dig("sort")).to eq("status" => "asc")
       expect(filter.as_hash.dig("size")).to eq(20)
     end

--- a/spec/services/search/query_builders/classified_listing_spec.rb
+++ b/spec/services/search/query_builders/classified_listing_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe Search::QueryBuilders::ClassifiedListing, type: :service do
   describe "::intialize" do
     it "sets params" do
       filter_params = { foo: "bar" }
-      filter = described_class.new(filter_params)
+      filter = described_class.new(params: filter_params)
       expect(filter.params).to include(filter_params)
     end
 
     it "builds query body" do
-      filter = described_class.new({})
+      filter = described_class.new(params: {})
       expect(filter.body).not_to be_nil
     end
   end
@@ -17,7 +17,7 @@ RSpec.describe Search::QueryBuilders::ClassifiedListing, type: :service do
   describe "#as_hash" do
     it "applies TERM_KEYS from params" do
       params = { category: "cfp", tags: ["beginner"], contact_via_connect: false }
-      filter = described_class.new(params)
+      filter = described_class.new(params: params)
       exepcted_filters = [
         { "term" => { "category" => "cfp" } },
         { "term" => { "tags" => ["beginner"] } },
@@ -30,7 +30,7 @@ RSpec.describe Search::QueryBuilders::ClassifiedListing, type: :service do
     it "applies RANGE_KEYS from params" do
       Timecop.freeze(Time.current) do
         params = { bumped_at: Time.current, expires_at: 1.day.from_now }
-        filter = described_class.new(params)
+        filter = described_class.new(params: params)
         exepcted_filters = [
           { "range" => { "bumped_at" => Time.current } },
           { "range" => { "expires_at" => 1.day.from_now } },
@@ -42,7 +42,7 @@ RSpec.describe Search::QueryBuilders::ClassifiedListing, type: :service do
 
     it "applies QUERY_KEYS from params" do
       params = { classified_listing_search: "test" }
-      filter = described_class.new(params)
+      filter = described_class.new(params: params)
       exepcted_query = [{
         "simple_query_string" => {
           "query" => "test*", "fields" => [:classified_listing_search], "lenient" => true, "analyze_wildcard" => true
@@ -54,7 +54,7 @@ RSpec.describe Search::QueryBuilders::ClassifiedListing, type: :service do
     it "applies QUERY_KEYS, TERM_KEYS, and RANGE_KEYS from params" do
       Timecop.freeze(Time.current) do
         params = { classified_listing_search: "test", bumped_at: Time.current, category: "cfp" }
-        filter = described_class.new(params)
+        filter = described_class.new(params: params)
         exepcted_query = [{
           "simple_query_string" => { "query" => "test*", "fields" => [:classified_listing_search], "lenient" => true, "analyze_wildcard" => true }
         }]
@@ -70,7 +70,7 @@ RSpec.describe Search::QueryBuilders::ClassifiedListing, type: :service do
 
     it "ignores params we don't support" do
       params = { not_supported: "trash", category: "cfp" }
-      filter = described_class.new(params)
+      filter = described_class.new(params: params)
       exepcted_filters = [
         { "term" => { "category" => "cfp" } },
         { "term" => { "published" => true } },
@@ -79,7 +79,7 @@ RSpec.describe Search::QueryBuilders::ClassifiedListing, type: :service do
     end
 
     it "sets default params when not present" do
-      filter = described_class.new({}).as_hash
+      filter = described_class.new(params: {}).as_hash
       expect(filter.dig("sort")).to eq("bumped_at" => "desc")
       expect(filter.dig("size")).to eq(0)
       expect(filter.dig("query", "bool", "filter")).to match_array([{ "term" => { "published" => true } }])
@@ -87,7 +87,7 @@ RSpec.describe Search::QueryBuilders::ClassifiedListing, type: :service do
 
     it "allows default params to be overriden" do
       params = { sort_by: "category", sort_direction: "asc", size: 20 }
-      filter = described_class.new(params).as_hash
+      filter = described_class.new(params: params).as_hash
       expect(filter.dig("sort")).to eq("category" => "asc")
       expect(filter.dig("size")).to eq(20)
     end

--- a/spec/services/search/query_builders/feed_content_spec.rb
+++ b/spec/services/search/query_builders/feed_content_spec.rb
@@ -4,17 +4,17 @@ RSpec.describe Search::QueryBuilders::FeedContent, type: :service do
   describe "::intialize" do
     it "sets params" do
       filter_params = { foo: "bar" }
-      filter = described_class.new(filter_params)
+      filter = described_class.new(params: filter_params)
       expect(filter.params).to include(filter_params)
     end
 
     it "builds query body" do
-      filter = described_class.new({})
+      filter = described_class.new(params: {})
       expect(filter.body).not_to be_nil
     end
 
     it "sets published to true" do
-      filter = described_class.new({})
+      filter = described_class.new(params: {})
       expect(filter.params).to include(published: true)
     end
   end
@@ -24,7 +24,7 @@ RSpec.describe Search::QueryBuilders::FeedContent, type: :service do
 
     it "applies QUERY_KEYS from params" do
       params = { search_fields: "test" }
-      filter = described_class.new(params)
+      filter = described_class.new(params: params)
       exepcted_query = [{
         "simple_query_string" => {
           "query" => "test",
@@ -39,7 +39,7 @@ RSpec.describe Search::QueryBuilders::FeedContent, type: :service do
 
     it "applies TERM_KEYS from params" do
       params = { approved: true, tag_names: "beginner", user_id: 777, class_name: "Article" }
-      filter = described_class.new(params)
+      filter = described_class.new(params: params)
       exepcted_filters = [
         { "terms" => { "approved" => [true] } },
         { "terms" => { "tags.name" => ["beginner"] } },
@@ -53,7 +53,7 @@ RSpec.describe Search::QueryBuilders::FeedContent, type: :service do
     it "applies RANGE_KEYS from params" do
       Timecop.freeze(Time.current) do
         params = { published_at: { lte: Time.current } }
-        filter = described_class.new(params)
+        filter = described_class.new(params: params)
         exepcted_filters = [
           { "range" => { "published_at" => { lte: Time.current } } },
           { "terms" => { "published" => [true] } },
@@ -65,7 +65,7 @@ RSpec.describe Search::QueryBuilders::FeedContent, type: :service do
     it "applies QUERY_KEYS, TERM_KEYS, and RANGE_KEYS from params" do
       Timecop.freeze(Time.current) do
         params = { search_fields: "ruby", published_at: { lte: Time.current }, tag_names: "cfp" }
-        filter = described_class.new(params)
+        filter = described_class.new(params: params)
         exepcted_query = [{
           "simple_query_string" => { "query" => "ruby", "fields" => query_fields, "lenient" => true, "analyze_wildcard" => true, "minimum_should_match" => 2 }
         }]
@@ -81,7 +81,7 @@ RSpec.describe Search::QueryBuilders::FeedContent, type: :service do
 
     it "ignores params we don't support" do
       params = { not_supported: "trash", search_fields: "cfp" }
-      filter = described_class.new(params)
+      filter = described_class.new(params: params)
       exepcted_query = [{
         "simple_query_string" => {
           "query" => "cfp", "fields" => query_fields, "lenient" => true, "analyze_wildcard" => true, "minimum_should_match" => 2
@@ -92,13 +92,13 @@ RSpec.describe Search::QueryBuilders::FeedContent, type: :service do
 
     it "allows default params to be overriden" do
       params = { sort_by: "published_at", sort_direction: "asc", size: 20 }
-      filter = described_class.new(params).as_hash
+      filter = described_class.new(params: params).as_hash
       expect(filter.dig("sort")).to eq("published_at" => "asc")
       expect(filter.dig("size")).to eq(20)
     end
 
     it "correctly sets default sort" do
-      filter = described_class.new({}).as_hash
+      filter = described_class.new(params: {}).as_hash
       expect(filter.dig("sort")).to eq(described_class::DEFAULT_PARAMS[:sort])
     end
   end

--- a/spec/services/search/query_builders/user_spec.rb
+++ b/spec/services/search/query_builders/user_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe Search::QueryBuilders::User, type: :service do
   describe "::intialize" do
     it "sets params" do
       filter_params = { foo: "bar" }
-      filter = described_class.new(filter_params)
+      filter = described_class.new(params: filter_params)
       expect(filter.params).to include(filter_params)
     end
 
     it "builds query body" do
-      filter = described_class.new({})
+      filter = described_class.new(params: {})
       expect(filter.body).not_to be_nil
     end
   end
@@ -17,7 +17,7 @@ RSpec.describe Search::QueryBuilders::User, type: :service do
   describe "#as_hash" do
     it "applies QUERY_KEYS from params" do
       params = { search_fields: "test" }
-      filter = described_class.new(params)
+      filter = described_class.new(params: params)
       exepcted_query = [{
         "simple_query_string" => {
           "query" => "test*", "fields" => [:search_fields], "lenient" => true, "analyze_wildcard" => true
@@ -27,7 +27,7 @@ RSpec.describe Search::QueryBuilders::User, type: :service do
     end
 
     it "applies EXCLUDED_TERM_KEYS by default" do
-      filter = described_class.new({})
+      filter = described_class.new(params: {})
       expected_filters = [
         { "terms" => { "roles" => ["banned"] } },
       ]
@@ -36,7 +36,7 @@ RSpec.describe Search::QueryBuilders::User, type: :service do
 
     it "applies EXCLUDED_TERM_KEYS and QUERY_KEYS" do
       params = { search_fields: "test" }
-      filter = described_class.new(params)
+      filter = described_class.new(params: params)
       expected_query = [{
         "simple_query_string" => {
           "query" => "test*", "fields" => [:search_fields], "lenient" => true, "analyze_wildcard" => true
@@ -51,7 +51,7 @@ RSpec.describe Search::QueryBuilders::User, type: :service do
 
     it "ignores params we don't support" do
       params = { not_supported: "trash", search_fields: "cfp" }
-      filter = described_class.new(params)
+      filter = described_class.new(params: params)
       exepcted_query = [{
         "simple_query_string" => {
           "query" => "cfp*", "fields" => [:search_fields], "lenient" => true, "analyze_wildcard" => true
@@ -62,7 +62,7 @@ RSpec.describe Search::QueryBuilders::User, type: :service do
 
     it "allows default params to be overriden" do
       params = { sort_by: "name", sort_direction: "asc", size: 20 }
-      filter = described_class.new(params).as_hash
+      filter = described_class.new(params: params).as_hash
       expect(filter.dig("sort")).to eq("name" => "asc")
       expect(filter.dig("size")).to eq(20)
     end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
- Move search_documents method into `Search::Base` class
- Update all query builders to use keyword arguments for params
- Remove user_id argument from ChatChannelMembership query builder and add to params
- Choosing to ignore the leftover duplicate code for now. You can't have it all CodeClimate, that's not how this works. 

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-36211320

## ~Added~ Updated tests?
- [x] yes

![alt_text](https://media0.giphy.com/media/26n6WywJyh39n1pBu/giphy.gif)
