### PR TITLE
Tweak comments in feed

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -30,7 +30,7 @@ class Article < ApplicationRecord
 
   has_many :comments, as: :commentable, inverse_of: :commentable
   has_many :top_comments,
-           -> { where("comments.score > ? AND ancestry IS NULL", 10).order("comments.score DESC") },
+           -> { where("comments.score > ? AND ancestry IS NULL and hidden_by_commentable_user is FALSE and deleted is FALSE", 10).order("comments.score DESC") },
            as: :commentable,
            inverse_of: :commentable,
            class_name: "Comment"

--- a/app/services/articles/feed.rb
+++ b/app/services/articles/feed.rb
@@ -27,7 +27,7 @@ module Articles
     end
 
     def published_articles_by_tag
-      articles = Article.published.limited_column_select.includes(:top_comments).page(@page).per(@number_of_articles)
+      articles = Article.published.limited_column_select.includes(top_comments: :user).page(@page).per(@number_of_articles)
       articles = articles.cached_tagged_with(@tag) if @tag.present? # More efficient than tagged_with
       articles
     end
@@ -213,7 +213,7 @@ module Articles
         hot_stories = hot_stories.offset(offset)
         new_stories = Article.published.
           where("score > ?", -15).
-          limited_column_select.includes(:top_comments).order("published_at DESC").limit(rand(15..80))
+          limited_column_select.includes(top_comments: :user).order("published_at DESC").limit(rand(15..80))
         hot_stories = hot_stories.to_a + new_stories.to_a
       end
       [featured_story, hot_stories.to_a]

--- a/app/views/stories/feeds/show.json.jbuilder
+++ b/app/views/stories/feeds/show.json.jbuilder
@@ -26,7 +26,7 @@ json.array!(@stories) do |article|
   json.tag_list article.cached_tag_list_array
   json.extract! article, *article_methods_to_include
 
-  json.top_comments article.top_comments do |comment|
+  json.top_comments article.top_comments.select(:id, :body_markdown, :updated_at, :user_id) do |comment|
     json.comment_id comment.id
     json.extract! comment, :body_markdown, :updated_at, :user_id
     json.extract! comment.user, :username, :name

--- a/app/views/stories/feeds/show.json.jbuilder
+++ b/app/views/stories/feeds/show.json.jbuilder
@@ -29,6 +29,6 @@ json.array!(@stories) do |article|
   json.top_comments article.top_comments do |comment|
     json.comment_id comment.id
     json.extract! comment, :body_markdown, :updated_at, :user_id
-    json.extract! comment.user, :username, :name
+    json.extract! comment.user, :username, :name, :profile_image_90
   end
 end

--- a/app/views/stories/feeds/show.json.jbuilder
+++ b/app/views/stories/feeds/show.json.jbuilder
@@ -26,7 +26,7 @@ json.array!(@stories) do |article|
   json.tag_list article.cached_tag_list_array
   json.extract! article, *article_methods_to_include
 
-  json.top_comments article.top_comments.select(:id, :body_markdown, :updated_at, :user_id) do |comment|
+  json.top_comments article.top_comments do |comment|
     json.comment_id comment.id
     json.extract! comment, :body_markdown, :updated_at, :user_id
     json.extract! comment.user, :username, :name

--- a/app/views/stories/feeds/show.json.jbuilder
+++ b/app/views/stories/feeds/show.json.jbuilder
@@ -24,6 +24,11 @@ json.array!(@stories) do |article|
   end
 
   json.tag_list article.cached_tag_list_array
-  json.top_comments article.top_comments
   json.extract! article, *article_methods_to_include
+
+  json.top_comments article.top_comments do |comment|
+    json.comment_id comment.id
+    json.extract! comment, :body_markdown, :updated_at, :user_id
+    json.extract! comment.user, :username, :name
+  end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -849,10 +849,14 @@ RSpec.describe Article, type: :model do
     context "when article has comments" do
       let(:root_comment) { create(:comment, commentable: article, score: 20) }
       let(:child_comment) { create(:comment, commentable: article, score: 20, parent: root_comment) }
+      let(:hidden_comment) { create(:comment, commentable: article, score: 20, hidden_by_commentable_user: true) }
+      let(:deleted_comment) { create(:comment, commentable: article, score: 20, deleted: true) }
 
       before do
         root_comment
         child_comment
+        hidden_comment
+        deleted_comment
         create_list(:comment, 2, commentable: article, score: 20)
         article.reload
       end
@@ -863,6 +867,14 @@ RSpec.describe Article, type: :model do
 
       it "only includes root comments" do
         expect(article.top_comments).not_to include(child_comment)
+      end
+
+      it "doesn't include hidden comments" do
+        expect(article.top_comments).not_to include(hidden_comment)
+      end
+
+      it "doesn't include deleted comments" do
+        expect(article.top_comments).not_to include(deleted_comment)
       end
     end
 

--- a/spec/requests/stories/feeds_spec.rb
+++ b/spec/requests/stories/feeds_spec.rb
@@ -115,13 +115,14 @@ RSpec.describe "Stories::Feeds", type: :request do
     end
 
     context "when there are highly rated comments" do
-      let(:comment) { create(:comment, score: 20) }
+      let(:comment) { create(:comment, score: 20, user: user) }
       let(:article) { comment.commentable }
 
       it "renders top comments for the article" do
         get "/stories/feed/infinity", headers: headers
 
         expect(response_article["top_comments"]).not_to be_nil
+        expect(response_article["top_comments"].first["username"]).not_to be_nil
       end
     end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Adjusts the fields included in the home page feed json to only include fields from the `comments` model necessary to render comments on the home page. Also tweaks the way comments to fetched via `article.top_comments` to omit hidden and deleted comments.

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/QmKAToUMrbcikgQmiz/giphy.gif)
