### PR TITLE
Create a Bulk Index Elasticsearch Worker

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -172,6 +172,8 @@ class Article < ApplicationRecord
 
   scope :with_video, -> { published.where.not(video: [nil, ""], video_thumbnail_url: [nil, ""]).where("score > ?", -4) }
 
+  scope :eager_load_serialized_data, -> { includes(:user, :organization, :tags) }
+
   algoliasearch per_environment: true, auto_remove: false, enqueue: :trigger_index do
     attribute :title
     add_index "searchables", id: :index_id, per_environment: true, enqueue: :trigger_index do

--- a/app/models/chat_channel_membership.rb
+++ b/app/models/chat_channel_membership.rb
@@ -19,6 +19,8 @@ class ChatChannelMembership < ApplicationRecord
 
   delegate :channel_type, to: :chat_channel
 
+  scope :eager_load_serialized_data, -> { includes(:user, :channel) }
+
   def channel_last_message_at
     chat_channel.last_message_at
   end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -48,6 +48,8 @@ class Comment < ApplicationRecord
   before_validation :evaluate_markdown, if: -> { body_markdown }
   validate :permissions, if: :commentable
 
+  scope :eager_load_serialized_data, -> { includes(:user, :commentable) }
+
   alias touch_by_reaction save
 
   def self.tree_for(commentable, limit = 0)

--- a/app/models/podcast.rb
+++ b/app/models/podcast.rb
@@ -22,6 +22,7 @@ class Podcast < ApplicationRecord
   scope :reachable, -> { where(id: PodcastEpisode.reachable.select(:podcast_id)) }
   scope :published, -> { where(published: true) }
   scope :available, -> { reachable.published }
+  scope :eager_load_serialized_data, -> { includes(:user, :podcast, :tags) }
 
   alias_attribute :path, :slug
   alias_attribute :profile_image_url, :image_url

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -20,6 +20,7 @@ class Reaction < ApplicationRecord
 
   scope :positive, -> { where("points > ?", 0) }
   scope :readinglist, -> { where(category: "readinglist") }
+  scope :eager_load_serialized_data, -> { includes(:reactable, :user) }
 
   validates :category, inclusion: { in: CATEGORIES }
   validates :reactable_type, inclusion: { in: REACTABLE_TYPES }

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -35,6 +35,8 @@ class Tag < ActsAsTaggableOn::Tag
   after_commit :index_to_elasticsearch, on: %i[create update]
   after_commit :remove_from_elasticsearch, on: [:destroy]
 
+  scope :eager_load_serialized_data, -> {}
+
   include Searchable
   SEARCH_SERIALIZER = Search::TagSerializer
   SEARCH_CLASS = Search::Tag

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -159,6 +159,7 @@ class User < ApplicationRecord
   scope :top_commenters, lambda { |number = 10|
     includes(:counters).order(Arel.sql("user_counters.data -> 'comments_these_7_days' DESC")).limit(number)
   }
+  scope :eager_load_serialized_data, -> { includes(:roles) }
 
   after_save :bust_cache
   after_save :subscribe_to_mailchimp_newsletter

--- a/app/services/search/base.rb
+++ b/app/services/search/base.rb
@@ -9,6 +9,22 @@ module Search
         )
       end
 
+      def bulk_index(data_hashes)
+        indexing_hashes = data_hashes.map do |data_hash|
+          model_hash = data_hash.with_indifferent_access
+          model_hash[:last_indexed_at] = Time.current
+          {
+            index: {
+              _index: self::INDEX_ALIAS,
+              _id: model_hash[:id],
+              data: model_hash
+            }
+          }
+        end
+
+        process_hashes(indexing_hashes)
+      end
+
       def find_document(doc_id)
         Search::Client.get(id: doc_id, index: self::INDEX_ALIAS)
       end
@@ -66,6 +82,30 @@ module Search
 
       def index_settings
         raise "Search classes must implement their own index settings"
+      end
+
+      def process_hashes(indexing_hashes)
+        indexing_hashes.in_groups_of(1000, false).flat_map do |hashes|
+          indexing_chunks(hashes).select(&:any?).map { |chunk| Search::Client.bulk(body: chunk) }
+        end
+      end
+
+      def indexing_chunks(hashes)
+        return [] unless hashes.any?
+        return to_enum(__method__, hashes) unless block_given?
+
+        size = 0
+        chunk = []
+        hashes.each do |hash|
+          chunk << hash
+          size += hash.to_s.bytesize
+          next unless size > 5.megabytes
+
+          yield chunk
+          size = 0
+          chunk = []
+        end
+        yield chunk
       end
     end
   end

--- a/app/workers/search/bulk_index_to_elasticsearch_worker.rb
+++ b/app/workers/search/bulk_index_to_elasticsearch_worker.rb
@@ -1,0 +1,16 @@
+module Search
+  class BulkIndexToElasticsearchWorker
+    include Sidekiq::Worker
+
+    sidekiq_options queue: :high_priority, lock: :until_executing
+
+    def perform(object_class, ids)
+      data_hashes = object_class.constantize.
+        eager_load_serialized_data.
+        where(id: ids).
+        find_each.map(&:serialized_search_hash)
+
+      "Search::#{object_class}".constantize.bulk_index(data_hashes)
+    end
+  end
+end

--- a/spec/workers/search/bulk_index_to_elasticsearch_worker_spec.rb
+++ b/spec/workers/search/bulk_index_to_elasticsearch_worker_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe Search::BulkIndexToElasticsearchWorker, type: :worker, elasticsearch: true do
+  let(:worker) { subject }
+  let(:article) { create(:article) }
+
+  include_examples "#enqueues_on_correct_queue", "high_priority", ["Reaction", 1]
+
+  it "indexes documents for a set of given ids and object class" do
+    reactions = [create(:reaction, reactable: article), create(:reaction), create(:reaction)]
+    Sidekiq::Worker.clear_all
+
+    reactions.each do |reaction|
+      expect { reaction.elasticsearch_doc }.to raise_error(Search::Errors::Transport::NotFound)
+    end
+    worker.perform("Reaction", reactions.map(&:id))
+
+    reactions.each do |reaction|
+      expect(reaction.elasticsearch_doc.dig("_source", "id")).to eql(reaction.id)
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
Having a [bulk index](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html) worker like this will allow us to more quickly reindex large amounts of documents when necessary. One of those necessary times will be when indexing Reading List reactions (which will happen in a followup PR). We have 1.2 million reactions that need to be indexed and we don't want to waste lots of resources having to enqueue 1.2 million Sidekiq jobs. In addition, any time we are doing bulk updates in the future we can make use of this worker to improve performance. 

I tried to make this as optimal as possible by adding an eager load scope to each indexable model so each one can execute the bulk indexing data gathering efficiently. 

You will also notice I am chunking the data into 5 MB chunks. Our article doc size tends to average around 4-5KB so we likely won't often need this but it is great to have to keep your indexing performant and prevent surprises. According to Elasticsearch
> There is no "correct" number of actions to perform in a single bulk request. Experiment with different settings to find the optimal size for your particular workload.

In my experience(from trainings and blog posts), they often recommend the size of data to be between 5-15 MB. I choose to go for the lower end of the spectrum to be safe. Trying to index too large amount of data can put unnecessary memory pressure on your cluster. To begin these details are not a huge deal but down the road when we start indexing a ton of data these are going to be the levers we tweak to optimize our indexing speed. 

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-34384750

## Added tests?
- [x] yes

![alt_text](https://media1.giphy.com/media/SsCA7SjPHTaG3eyNXQ/giphy.gif)
