### PR TITLE
Add some keyboard shortcuts for /connect active content

### DIFF
--- a/app/javascript/chat/__tests__/__snapshots__/article.test.jsx.snap
+++ b/app/javascript/chat/__tests__/__snapshots__/article.test.jsx.snap
@@ -5,6 +5,7 @@ exports[`<Article /> should load article 1`] = `
   class="activechatchannel__activeArticle"
 >
   <iframe
+    id="activecontent-iframe"
     src="/princesscarolyn/your-approval-means-nothing-to-me-42640"
   />
 </div>

--- a/app/javascript/chat/article.jsx
+++ b/app/javascript/chat/article.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 const Article = ({ resource: article }) => (
   <div className="activechatchannel__activeArticle">
-    <iframe src={article.path} title={article.title} />
+    <iframe id="activecontent-iframe" src={article.path} title={article.title} />
   </div>
 );
 

--- a/app/javascript/chat/chat.jsx
+++ b/app/javascript/chat/chat.jsx
@@ -543,6 +543,9 @@ export default class Chat extends Component {
     if (rightPressed && !activeContent[activeChannelId] && e.target.value === '') {
       e.preventDefault();
       const richLinks = document.querySelectorAll(".chatchannels__richlink");
+      if (richLinks.length === 0) {
+        return;
+      }
       this.setActiveContentState(activeChannelId, {
         type_of: 'loading-post',
       });

--- a/app/javascript/chat/chat.jsx
+++ b/app/javascript/chat/chat.jsx
@@ -505,8 +505,11 @@ export default class Chat extends Component {
   };
 
   handleKeyDown = (e) => {
-    const { showMemberlist } = this.state;
+    const { showMemberlist, activeContent, activeChannelId } = this.state;
     const enterPressed = e.keyCode === 13;
+    const leftPressed = e.keyCode === 37;
+    const rightPressed = e.keyCode === 39;
+    const escPressed = e.keyCode === 27;
     const targetValue = e.target.value;
     const messageIsEmpty = targetValue.length === 0;
     const shiftPressed = e.shiftKey;
@@ -529,6 +532,30 @@ export default class Chat extends Component {
         e.preventDefault();
       }
     }
+    if (leftPressed && activeContent[activeChannelId] && e.target.value === '' && document.getElementById('activecontent-iframe')) {
+      e.preventDefault();
+      try {
+        e.target.value = document.getElementById('activecontent-iframe').contentWindow.location.href
+      } catch(err){
+        e.target.value = activeContent[activeChannelId].path
+      }
+    }
+    if (rightPressed && !activeContent[activeChannelId] && e.target.value === '') {
+      e.preventDefault();
+      const richLinks = document.querySelectorAll(".chatchannels__richlink");
+      this.setActiveContentState(activeChannelId, {
+        type_of: 'loading-post',
+      });
+      this.setActiveContent({
+        path: richLinks[richLinks.length - 1].href,
+        type_of: 'article',
+      });
+    }
+    if (escPressed && activeContent[activeChannelId]) {
+      this.setActiveContentState(activeChannelId, null);
+      this.setState({fullscreenContent: null});
+    }
+
   };
 
   handleKeyDownEdit = (e) => {
@@ -760,12 +787,13 @@ export default class Chat extends Component {
         });
       } else if (target.dataset.content === 'exit') {
         this.setActiveContentState(activeChannelId, null);
-        this.setState({fullscreenContent: null})
+        this.setState({fullscreenContent: null});
       } else if (target.dataset.content === 'fullscreen') {
         const mode = this.state.fullscreenContent === 'sidecar' ? null : 'sidecar'
         this.setState({fullscreenContent: mode})
       }
     }
+    document.getElementById('messageform').focus();
     return false;
   };
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Add a few extra keyboard shortcuts to `/connect`.

... `esc` hides active sidecar content
... `right arrow` shows most recent "rich link" in convo when no other text in textbox
... `left arrow` pulls current page from sidecar into body of message when no other text in textbox.