### PR TITLE
Fix onboarding profile slide for short screens

### DIFF
--- a/app/assets/stylesheets/preact/onboarding-modal.scss
+++ b/app/assets/stylesheets/preact/onboarding-modal.scss
@@ -36,6 +36,8 @@
   flex: 1 0 auto;
   padding: $su-4;
   width: 100%;
+  max-height: calc(100vh - 70px);
+  overflow: scroll;
 
   @media screen and (min-width: $breakpoint-s) {
     justify-content: center;
@@ -592,4 +594,10 @@ $onboarding-user-selected-hover: rgba(71, 85, 235, 0.2);
       }
     }
   }
+
+  @media screen and (max-height: 790px) {
+    .onboarding-form-input--last {
+      margin-bottom: 25px;
+    }
+  }  
 }

--- a/app/assets/stylesheets/preact/onboarding-modal.scss
+++ b/app/assets/stylesheets/preact/onboarding-modal.scss
@@ -37,7 +37,7 @@
   padding: $su-4;
   width: 100%;
   max-height: calc(100vh - 70px);
-  overflow: scroll;
+  overflow: auto;
 
   @media screen and (min-width: $breakpoint-s) {
     justify-content: center;

--- a/app/javascript/onboarding/__tests__/__snapshots__/Onboarding.test.jsx.snap
+++ b/app/javascript/onboarding/__tests__/__snapshots__/Onboarding.test.jsx.snap
@@ -507,6 +507,7 @@ preact-render-spy (1 nodes)
             placeholder="e.g. Company name, self-employed, etc."
             onChange={[Function bound handleChange]}
             maxLength="60"
+            class="onboarding-form-input--last"
            />
         </label>
       </form>

--- a/app/javascript/onboarding/components/ProfileForm.jsx
+++ b/app/javascript/onboarding/components/ProfileForm.jsx
@@ -115,6 +115,7 @@ class ProfileForm extends Component {
                 placeholder="e.g. Company name, self-employed, etc."
                 onChange={this.handleChange}
                 maxLength="60"
+                className="onboarding-form-input--last"
               />
             </label>
           </form>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Currently shorter screens run into problems of scrolling with the tall profile slide. This might not be the most elegant solution but it's a patch.

Current page: You can see that the buttons are starting to get cut off at the top...

<img width="904" alt="Screen Shot 2020-04-13 at 7 28 54 PM" src="https://user-images.githubusercontent.com/3102842/79170334-11d9d180-7dbd-11ea-8690-a2a09fe97c3b.png">

Fixes #7278