### PR TITLE
Update Elasticsearch recommended version to 7.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,8 @@ before_install:
   - date --rfc-3339=seconds
   - nvm install
   - pkill -9 -f elasticsearch || true
-  - curl -s -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.5.2-amd64.deb
-  - sudo dpkg -i --force-confnew elasticsearch-7.5.2-amd64.deb
+  - curl -s -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.6.2-amd64.deb
+  - sudo dpkg -i --force-confnew elasticsearch-7.6.2-amd64.deb
   - sudo sed -i.old 's/-Xms1g/-Xms128m/' /etc/elasticsearch/jvm.options
   - sudo sed -i.old 's/-Xmx1g/-Xmx128m/' /etc/elasticsearch/jvm.options
   - echo -e '-XX:+DisableExplicitGC\n-Djdk.io.permissionsUseCanonicalPath=true\n-Dlog4j.skipJansi=true\n-server\n' | sudo tee -a /etc/elasticsearch/jvm.options

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
     ports:
       - "6379:6379"
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.5.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.6.2
     container_name: elasticsearch
     environment:
       - cluster.name=docker-cluster

--- a/docs/installation/linux.md
+++ b/docs/installation/linux.md
@@ -67,16 +67,15 @@ We recommend following Digital Ocean's extensive
 
 ### Elasticsearch
 
-DEV requires a version of Elasticsearch between 7.1 and 7.5. Version 7.6 is not
-supported. We recommend version 7.5.2.
+DEV requires Elasticsearch 7+. We recommend version 7.6.
 
 We recommend following
-[Elasticsearch's guide for installing on Linux](https://www.elastic.co/guide/en/elasticsearch/reference/7.5/targz.html#install-linux).
+[Elasticsearch's guide for installing on Linux](https://www.elastic.co/guide/en/elasticsearch/reference/7.6/targz.html#install-linux).
 
 Elasticsearch is also available as as
-[Debian package](https://www.elastic.co/guide/en/elasticsearch/reference/7.5/deb.html)
+[Debian package](https://www.elastic.co/guide/en/elasticsearch/reference/7.6/deb.html)
 or a
-[RPM package](https://www.elastic.co/guide/en/elasticsearch/reference/7.5/rpm.html).
+[RPM package](https://www.elastic.co/guide/en/elasticsearch/reference/7.6/rpm.html).
 
 NOTE: Make sure to download **the OSS version**, `elasticsearch-oss`.
 

--- a/docs/installation/macos.md
+++ b/docs/installation/macos.md
@@ -60,16 +60,35 @@ redis-cli ping
 
 ### Elasticsearch
 
-DEV requires a version of Elasticsearch between 7.1 and 7.5. Version 7.6 is not
-supported. We recommend version 7.5.2.
+DEV requires Elasticsearch 7+. We recommend version 7.6.
 
 You have the option of installing Elasticsearch with Homebrew or through an
-archive. We recommend installing from archive on Mac.
+archive. We recommend installing from Homebrew as it will be kept up to date
+automatically.
+
+### Installing Elasticsearch with Homebrew
+
+The following directions were
+[taken from the Elasticsearch docs themselves](https://www.elastic.co/guide/en/elasticsearch/reference/7.6/brew.html),
+so check those out if you run into any issues or want further information. Make
+sure to download **the OSS version** of Elasticsearch, `elasticsearch-oss`.
+
+```shell
+brew tap elastic/tap
+brew install elasticsearch-oss
+```
+
+After installation you can manually test if the Elasticsearch server starts by
+issuing the command `elasticsearch` in the shell. You can then start the server
+as a service with `brew services start elasticsearch-oss`.
+
+You can find further info on your local Elasticsearch installation by typing
+`brew info elastic/tap/elasticsearch-oss`.
 
 ### Installing Elasticsearch from the archive
 
 The following directions were
-[taken from the Elasticsearch docs themselves](https://www.elastic.co/guide/en/elasticsearch/reference/7.5/targz.html#install-macos),
+[taken from the Elasticsearch docs themselves](https://www.elastic.co/guide/en/elasticsearch/reference/7.6/targz.html#install-macos),
 so check those out if you run into any issues or want further information. Make
 sure to download **the OSS version** of Elasticsearch, `elasticsearch-oss`.
 
@@ -77,16 +96,16 @@ Please note that you will need `wget` in order to proceed with this installation
 (`brew install wget`).
 
 ```shell
-wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-7.5.2-darwin-x86_64.tar.gz
-wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-7.5.2-darwin-x86_64.tar.gz.sha512
-shasum -a 512 -c elasticsearch-oss-7.5.2-darwin-x86_64.tar.gz.sha512
-tar -xzf elasticsearch-oss-7.5.2-darwin-x86_64.tar.gz
+wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-7.6.2-darwin-x86_64.tar.gz
+wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-7.6.2-darwin-x86_64.tar.gz.sha512
+shasum -a 512 -c elasticsearch-oss-7.6.2-darwin-x86_64.tar.gz.sha512
+tar -xzf elasticsearch-oss-7.6.2-darwin-x86_64.tar.gz
 ```
 
 To start elasticsearch, make sure you are in the correct directory:
 
 ```shell
-cd elasticsearch-7.5.2
+cd elasticsearch-7.6.2
 ```
 
 You can then start it by running:
@@ -100,25 +119,6 @@ To start elasticsearch as a daemonized process:
 ```shell
 ./bin/elasticsearch -d
 ```
-
-### Installing Elasticsearch with Homebrew
-
-As the default version of the Homebrew formula points to Elasticsearch 7.6, we
-need to retrieve the correct revision of the formula to make sure we install the
-latest supported version: 7.5.2.
-
-```shell
-brew tap elastic/tap
-brew install https://raw.githubusercontent.com/elastic/homebrew-tap/bed8bc6b03213c2c1a7df6e4b9f928e7082fae46/Formula/elasticsearch-oss.rb
-brew pin elasticsearch-oss
-```
-
-After installation you can manually test if the Elasticsearch server starts by
-issuing the command `elasticsearch` in the shell. You can then start the server
-as a service with `brew services start elasticsearch-oss`.
-
-You can find further info on your local Elasticsearch installation by typing
-`brew info elastic/tap/elasticsearch-oss`.
 
 #### Troubleshooting startup issues
 
@@ -178,13 +178,13 @@ your local Elasticsearch installation, for example:
   "cluster_name": "elasticsearch_...",
   "cluster_uuid": "...",
   "version": {
-    "number": "7.5.2",
+    "number": "7.6.2",
     "build_flavor": "oss",
     "build_type": "tar",
-    "build_hash": "8bec50e1e0ad29dad5653712cf3bb580cd1afcdf",
-    "build_date": "2020-01-15T12:11:52.313576Z",
+    "build_hash": "ef48eb35cf30adf4db14086e8aabd07ef6fb113f",
+    "build_date": "2020-03-26T06:34:37.794943Z",
     "build_snapshot": false,
-    "lucene_version": "8.3.0",
+    "lucene_version": "8.4.0",
     "minimum_wire_compatibility_version": "6.8.0",
     "minimum_index_compatibility_version": "6.0.0-beta1"
   },

--- a/docs/installation/readme.md
+++ b/docs/installation/readme.md
@@ -1,8 +1,8 @@
 ---
 items:
-  - mac.md
-  - windows.md
+  - macos.md
   - linux.md
+  - windows.md
   - docker.md
   - gitpod.md
   - postgresql.md

--- a/docs/installation/windows.md
+++ b/docs/installation/windows.md
@@ -144,11 +144,10 @@ WSL.
 
 ### Elasticsearch
 
-DEV requires a version of Elasticsearch between 7.1 and 7.5. Version 7.6 is not
-supported. We recommend version 7.5.2.
+DEV requires Elasticsearch 7+. We recommend version 7.6.
 
 We recommend following the install guide
-[in Elasticsearch's docs](https://www.elastic.co/guide/en/elasticsearch/reference/7.5/zip-windows.html)
+[in Elasticsearch's docs](https://www.elastic.co/guide/en/elasticsearch/reference/7.6/zip-windows.html)
 for installing on Windows machines.
 
 NOTE: Make sure to download **the OSS version**, `elasticsearch-oss`.


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [x] Documentation Update

## Description

As we're now safe and sound both in both client and server on ES 7.6, I've updated the recommended version, removed the hack in macOS's instructions and recommended Homebrew and updated the version in Docker and Travis.

## Related Tickets & Documents

#7208 

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [x] docs.dev.to
- [ ] readme
- [ ] no documentation needed
