### PR TITLE
Add character limits for reported_url and message

### DIFF
--- a/app/models/feedback_message.rb
+++ b/app/models/feedback_message.rb
@@ -7,8 +7,8 @@ class FeedbackMessage < ApplicationRecord
   has_many :notes, as: :noteable, inverse_of: :noteable, dependent: :destroy
 
   validates :feedback_type, :message, presence: true
-  validates :reported_url, :category, presence: { if: :abuse_report? }, length: { maximum: 50 }
-  validates :message, length: { maximum: 500 }
+  validates :reported_url, :category, presence: { if: :abuse_report? }, length: { maximum: 250 }
+  validates :message, length: { maximum: 2500 }
   validates :category,
             inclusion: {
               in: ["spam", "other", "rude or vulgar", "harassment", "bug", "listings"]

--- a/app/models/feedback_message.rb
+++ b/app/models/feedback_message.rb
@@ -7,8 +7,7 @@ class FeedbackMessage < ApplicationRecord
   has_many :notes, as: :noteable, inverse_of: :noteable, dependent: :destroy
 
   validates :feedback_type, :message, presence: true
-  validates :reported_url, :category, presence: { if: :abuse_report? }
-  validates :reported_url, length: { maximum: 50 }
+  validates :reported_url, :category, presence: { if: :abuse_report? }, length: { maximum: 50 }
   validates :message, length: { maximum: 500 }
   validates :category,
             inclusion: {

--- a/app/models/feedback_message.rb
+++ b/app/models/feedback_message.rb
@@ -8,6 +8,8 @@ class FeedbackMessage < ApplicationRecord
 
   validates :feedback_type, :message, presence: true
   validates :reported_url, :category, presence: { if: :abuse_report? }
+  validates :reported_url, length: { maximum: 50 }
+  validates :message, length: { maximum: 500 }
   validates :category,
             inclusion: {
               in: ["spam", "other", "rude or vulgar", "harassment", "bug", "listings"]

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -307,7 +307,6 @@ ActiveRecord::Schema.define(version: 2020_04_09_050122) do
     t.string "slug"
     t.string "status", default: "active"
     t.datetime "updated_at", null: false
-    t.index ["slug"], name: "index_chat_channels_on_slug", unique: true
   end
 
   create_table "classified_listing_categories", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -307,6 +307,7 @@ ActiveRecord::Schema.define(version: 2020_04_09_050122) do
     t.string "slug"
     t.string "status", default: "active"
     t.datetime "updated_at", null: false
+    t.index ["slug"], name: "index_chat_channels_on_slug", unique: true
   end
 
   create_table "classified_listing_categories", force: :cascade do |t|

--- a/spec/models/feedback_message_spec.rb
+++ b/spec/models/feedback_message_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe FeedbackMessage, type: :model do
     it { is_expected.to validate_presence_of(:feedback_type) }
     it { is_expected.to validate_presence_of(:reported_url) }
     it { is_expected.to validate_presence_of(:message) }
+    it { is_expected.to validate_length_of(:reported_url).is_at_most(50) }
+    it { is_expected.to validate_length_of(:message).is_at_most(500) }
 
     it do
       expect(feedback_message).to validate_inclusion_of(:category).

--- a/spec/models/feedback_message_spec.rb
+++ b/spec/models/feedback_message_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe FeedbackMessage, type: :model do
     it { is_expected.to validate_presence_of(:feedback_type) }
     it { is_expected.to validate_presence_of(:reported_url) }
     it { is_expected.to validate_presence_of(:message) }
-    it { is_expected.to validate_length_of(:reported_url).is_at_most(50) }
-    it { is_expected.to validate_length_of(:message).is_at_most(500) }
+    it { is_expected.to validate_length_of(:reported_url).is_at_most(250) }
+    it { is_expected.to validate_length_of(:message).is_at_most(2500) }
 
     it do
       expect(feedback_message).to validate_inclusion_of(:category).


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This adds character limits for the public `reported_url` and `message` fields of an abuse report.

## Added tests?
- [x] yes