### PR TITLE
Record DB counts with `count`, Fallback on estimated_count

### DIFF
--- a/app/workers/metrics/record_data_counts_worker.rb
+++ b/app/workers/metrics/record_data_counts_worker.rb
@@ -6,9 +6,14 @@ module Metrics
     def perform
       models = [User, Article, Organization, Comment, Podcast, PodcastEpisode, ClassifiedListing, PageView, Notification]
       models.each do |model|
-        estimate = model.estimated_count
-        Rails.logger.info("db_table_size", table_info: { table_name: model.table_name, table_size: estimate })
-        DatadogStatsClient.gauge("postgres.db_table_size", estimate, tags: { table_name: model.table_name })
+        db_count = begin
+                     model.count
+                   rescue ActiveRecord::QueryCanceled
+                     model.estimated_count
+                   end
+
+        Rails.logger.info("db_table_size", table_info: { table_name: model.table_name, table_size: db_count })
+        DatadogStatsClient.gauge("postgres.db_table_size", db_count, tags: { table_name: model.table_name })
 
         next unless model.const_defined?(:SEARCH_CLASS)
 

--- a/spec/workers/metrics/record_data_counts_worker_spec.rb
+++ b/spec/workers/metrics/record_data_counts_worker_spec.rb
@@ -16,8 +16,10 @@ RSpec.describe Metrics::RecordDataCountsWorker, type: :worker do
 
     it "calls count on each model" do
       allow(User).to receive(:count)
+      allow(User).to receive(:estimated_count)
       described_class.new.perform
       expect(User).to have_received(:count)
+      expect(User).not_to have_received(:estimated_count)
     end
 
     it "calls estimated_count if count times out" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
We are tracking these counts in Datadog in order to catch and bugs that might appear in our indexing flows. These numbers need to be as close to accurate as possible and since most of our tables are small I decided to attempt to use `count` on each one first. If that timeout then we can fallback on the estimation.

## Added tests?
- [x] yes

![alt_text](https://media2.giphy.com/media/xUNd9DLukkavmhybAs/giphy.gif?cid=ecf05e47d119ab6e30c266a805423ac97b33049b653c970a&rid=giphy.gif)
