### PR TITLE
Rescue file too long error from podcasts and organizations

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -77,7 +77,12 @@ class ApplicationController < ActionController::Base
   end
 
   def log_image_data_to_datadog
-    images = Array.wrap(params.dig("user", "profile_image") || params["image"])
+    images = Array.wrap(
+      params.dig("user", "profile_image") ||
+      params.dig("podcast", "image") ||
+      params.dig("organization", "profile_image") ||
+      params["image"],
+    )
 
     raise if images.empty?
 

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,5 +1,6 @@
 class OrganizationsController < ApplicationController
   after_action :verify_authorized
+  rescue_from Errno::ENAMETOOLONG, with: :log_image_data_to_datadog
 
   def create
     @tab = "organization"

--- a/app/controllers/podcasts_controller.rb
+++ b/app/controllers/podcasts_controller.rb
@@ -5,6 +5,8 @@ class PodcastsController < ApplicationController
   # method "current_user.add_role()" we have no control of
   around_action :skip_bullet, only: %i[create], if: -> { defined?(Bullet) }
 
+  rescue_from Errno::ENAMETOOLONG, with: :log_image_data_to_datadog
+
   def new
     @podcast = Podcast.new
     @podcasts = Podcast.available.order("title asc")

--- a/spec/requests/organizations_update_spec.rb
+++ b/spec/requests/organizations_update_spec.rb
@@ -42,4 +42,19 @@ RSpec.describe "OrganizationsUpdate", type: :request do
       put "/organizations/#{invalid_id}", params: { organization: { id: invalid_id, text_color_hex: "#111111" } }
     end.to raise_error(ActiveRecord::RecordNotFound)
   end
+
+  it "catches error if image file name is too long" do
+    organization = user.organizations.first
+    allow(Organization).to receive(:find_by).and_return(organization)
+    allow(organization).to receive(:update).and_raise(Errno::ENAMETOOLONG)
+    allow(DatadogStatsClient).to receive(:increment)
+
+    expect do
+      put "/organizations/#{org_id}", params: { organization: { id: org_id, profile_image: fixture_file_upload("files/800x600.png", "image/png") } }
+    end.to raise_error(Errno::ENAMETOOLONG)
+
+    tags = hash_including(tags: instance_of(Array))
+
+    expect(DatadogStatsClient).to have_received(:increment).with("image_upload_error", tags)
+  end
 end

--- a/spec/requests/podcasts/podcast_create_spec.rb
+++ b/spec/requests/podcasts/podcast_create_spec.rb
@@ -74,5 +74,20 @@ RSpec.describe "Podcast Create", type: :request do
       post podcasts_path, params: { podcast: valid_attributes }
       expect(response.body).to include("Suggest a Podcast")
     end
+
+    it "catches error if image file name is too long" do
+      podcast = create(:podcast)
+      allow(Podcast).to receive(:new).and_return(podcast)
+      allow(podcast).to receive(:save).and_raise(Errno::ENAMETOOLONG)
+      allow(DatadogStatsClient).to receive(:increment)
+
+      expect do
+        post podcasts_path, params: { podcast: valid_attributes }
+      end.to raise_error(Errno::ENAMETOOLONG)
+
+      tags = hash_including(tags: instance_of(Array))
+
+      expect(DatadogStatsClient).to have_received(:increment).with("image_upload_error", tags)
+    end
   end
 end

--- a/spec/requests/user/user_organization_spec.rb
+++ b/spec/requests/user/user_organization_spec.rb
@@ -49,6 +49,23 @@ RSpec.describe "UserOrganization", type: :request do
     end
   end
 
+  it "catches error if image file name is too long" do
+    sign_in user
+    org_params = build(:organization).attributes
+    org_params["profile_image"] = fixture_file_upload("files/800x600.png", "image/png")
+    allow(Organization).to receive(:new).and_return(organization)
+    allow(organization).to receive(:save).and_raise(Errno::ENAMETOOLONG)
+    allow(DatadogStatsClient).to receive(:increment)
+
+    expect do
+      post "/organizations", params: { organization: org_params }
+    end.to raise_error(Errno::ENAMETOOLONG)
+
+    tags = hash_including(tags: instance_of(Array))
+
+    expect(DatadogStatsClient).to have_received(:increment).with("image_upload_error", tags)
+  end
+
   context "when leaving an org" do
     let(:org_member) { create(:user, :org_member) }
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
In #7200 I added logic to log image data to Datadog to help with debugging. I didn't add that logic to organizations and podcasts and the error came up again in organizations.

https://app.honeybadger.io/projects/66984/faults/62863589

This PR adds the same logic to organizations and podcasts.

## Related Tickets & Documents
https://app.honeybadger.io/projects/66984/faults/62863589

## Added tests?
- [x] yes

## Added to documentation?
- [x] no documentation needed

![face_palm_gif](https://media.giphy.com/media/6yRVg0HWzgS88/giphy.gif)