### PR TITLE
Split up content of EmailListTermsConditionsForm within onboarding

### DIFF
--- a/app/assets/stylesheets/preact/onboarding-modal.scss
+++ b/app/assets/stylesheets/preact/onboarding-modal.scss
@@ -109,10 +109,18 @@
   width: 100%;
   border-bottom: 2px solid var(--box-darker);
 
+  &.intro-slide {
+    border-bottom: none;
+  }
+
   .navigation-content {
     display: flex;
     justify-content: space-between;
     padding: $su-4;
+
+    &.intro-slide {
+      padding: 0;
+    }
 
     button {
       @extend .crayons-btn;
@@ -336,6 +344,10 @@
   .navigation-content {
     padding: $su-7;
     justify-content: center;
+
+    &.intro-slide {
+      padding: 0;
+    }
 
     button {
       @extend .crayons-btn;
@@ -583,6 +595,14 @@ $onboarding-user-selected-hover: rgba(71, 85, 235, 0.2);
 
     &:last-child {
       margin-bottom: 0;
+    }
+  }
+
+  .checkbox-form-wrapper {
+    padding: 32px;
+
+    .checkbox-form {
+      padding-bottom: 24px;
     }
   }
 

--- a/app/assets/stylesheets/preact/onboarding-modal.scss
+++ b/app/assets/stylesheets/preact/onboarding-modal.scss
@@ -599,10 +599,10 @@ $onboarding-user-selected-hover: rgba(71, 85, 235, 0.2);
   }
 
   .checkbox-form-wrapper {
-    padding: 32px;
+    padding: $su-7;
 
     .checkbox-form {
-      padding-bottom: 24px;
+      padding-bottom: $su-6;
     }
   }
 
@@ -645,5 +645,5 @@ $onboarding-user-selected-hover: rgba(71, 85, 235, 0.2);
     .onboarding-form-input--last {
       margin-bottom: 25px;
     }
-  }  
+  }
 }

--- a/app/javascript/onboarding/Onboarding.jsx
+++ b/app/javascript/onboarding/Onboarding.jsx
@@ -2,7 +2,7 @@ import 'preact/devtools';
 import { h, Component } from 'preact';
 
 import IntroSlide from './components/IntroSlide';
-import EmailListTermsConditionsForm from './components/EmailListTermsConditionsForm';
+import EmailPreferencesForm from './components/EmailPreferencesForm';
 import ClosingSlide from './components/ClosingSlide';
 import FollowTags from './components/FollowTags';
 import FollowUsers from './components/FollowUsers';
@@ -20,7 +20,7 @@ export default class Onboarding extends Component {
 
     const slides = [
       IntroSlide,
-      EmailListTermsConditionsForm,
+      EmailPreferencesForm,
       ProfileForm,
       FollowTags,
       FollowUsers,

--- a/app/javascript/onboarding/Onboarding.jsx
+++ b/app/javascript/onboarding/Onboarding.jsx
@@ -20,10 +20,10 @@ export default class Onboarding extends Component {
 
     const slides = [
       IntroSlide,
-      EmailPreferencesForm,
       ProfileForm,
       FollowTags,
       FollowUsers,
+      EmailPreferencesForm,
       ClosingSlide,
     ];
 

--- a/app/javascript/onboarding/__tests__/Onboarding.test.jsx
+++ b/app/javascript/onboarding/__tests__/Onboarding.test.jsx
@@ -106,43 +106,17 @@ describe('<Onboarding />', () => {
     };
 
     beforeEach(() => {
-      onboardingSlides = initializeSlides(1, getUserData());
+      onboardingSlides = initializeSlides(0, getUserData());
     });
 
     test('renders properly', () => {
       expect(onboardingSlides).toMatchSnapshot();
     });
 
-    beforeEach(() => {
-      onboardingSlides = initializeSlides(0, getUserData());
-    });
-
-    test('should not advance if terms and conditions are not checked', () => {
-      // When none of the boxes are checked.
-      onboardingSlides.find('.next-button').simulate('click');
-      expect(onboardingSlides.state().currentSlide).toBe(0);
-
-      // When only the code of conduct is checked.
-      updateCodeOfConduct();
-      onboardingSlides.find('.next-button').simulate('click');
-      expect(onboardingSlides.state().currentSlide).toBe(0);
-    });
-
-    test('should not advance if code of conduct is not checked', () => {
-      // When none of the boxes are checked
-      onboardingSlides.find('.next-button').simulate('click');
-      expect(onboardingSlides.state().currentSlide).toBe(0);
-
-      // When only the terms and conditions are checked.
-      updateTermsAndConditions();
-      onboardingSlides.find('.next-button').simulate('click');
-      expect(onboardingSlides.state().currentSlide).toBe(0);
-    });
-
     test('should advance if required boxes are checked', async () => {
       fetch.once({});
+      expect(onboardingSlides.state().currentSlide).toBe(0);
 
-      // When both the code of conduct and terms and conditions are checked.
       updateCodeOfConduct();
       updateTermsAndConditions();
 
@@ -158,23 +132,6 @@ describe('<Onboarding />', () => {
     });
   });
 
-  describe('EmailPreferencesForm', () => {
-    let onboardingSlides;
-
-    beforeEach(() => {
-      onboardingSlides = initializeSlides(1, getUserData());
-    });
-
-    test('renders properly', () => {
-      expect(onboardingSlides).toMatchSnapshot();
-    });
-
-    it('should step backward', () => {
-      onboardingSlides.find('.back-button').simulate('click');
-      expect(onboardingSlides.state().currentSlide).toBe(0);
-    });
-  });
-
   describe('ProfileForm', () => {
     let onboardingSlides;
     const meta = document.createElement('meta');
@@ -183,7 +140,7 @@ describe('<Onboarding />', () => {
     document.body.appendChild(meta);
 
     beforeEach(() => {
-      onboardingSlides = initializeSlides(2, getUserData());
+      onboardingSlides = initializeSlides(1, getUserData());
     });
 
     test('renders properly', () => {
@@ -221,12 +178,12 @@ describe('<Onboarding />', () => {
       profileForm.find('.next-button').simulate('click');
       fetch.once(fakeTagsResponse);
       await flushPromises();
-      expect(onboardingSlides.state().currentSlide).toBe(3);
+      expect(onboardingSlides.state().currentSlide).toBe(2);
     });
 
     it('should step backward', () => {
       onboardingSlides.find('.back-button').simulate('click');
-      expect(onboardingSlides.state().currentSlide).toBe(1);
+      expect(onboardingSlides.state().currentSlide).toBe(0);
     });
   });
 
@@ -234,7 +191,7 @@ describe('<Onboarding />', () => {
     let onboardingSlides;
 
     beforeEach(async () => {
-      onboardingSlides = initializeSlides(3, getUserData(), fakeTagsResponse);
+      onboardingSlides = initializeSlides(2, getUserData(), fakeTagsResponse);
       await flushPromises();
     });
 
@@ -246,7 +203,7 @@ describe('<Onboarding />', () => {
       expect(onboardingSlides.find('.onboarding-tags__item').length).toBe(3);
     });
 
-    test('should allow a user to add a tag', async () => {
+    test('should allow a user to add a tag and advance', async () => {
       fetch.once({});
       const followTags = onboardingSlides.find(<FollowTags />);
       const firstButton = onboardingSlides
@@ -259,12 +216,12 @@ describe('<Onboarding />', () => {
       onboardingSlides.find('.next-button').simulate('click');
       fetch.once(fakeUsersResponse);
       await flushPromises();
-      expect(onboardingSlides.state().currentSlide).toBe(4);
+      expect(onboardingSlides.state().currentSlide).toBe(3);
     });
 
     it('should step backward', () => {
       onboardingSlides.find('.back-button').simulate('click');
-      expect(onboardingSlides.state().currentSlide).toBe(2);
+      expect(onboardingSlides.state().currentSlide).toBe(1);
     });
   });
 
@@ -272,7 +229,7 @@ describe('<Onboarding />', () => {
     let onboardingSlides;
 
     beforeEach(async () => {
-      onboardingSlides = initializeSlides(4, getUserData(), fakeUsersResponse);
+      onboardingSlides = initializeSlides(3, getUserData(), fakeUsersResponse);
       await flushPromises();
     });
 
@@ -299,7 +256,7 @@ describe('<Onboarding />', () => {
       expect(followUsers.state('selectedUsers').length).toBe(2);
       onboardingSlides.find('.next-button').simulate('click');
       await flushPromises();
-      expect(onboardingSlides.state().currentSlide).toBe(5);
+      expect(onboardingSlides.state().currentSlide).toBe(4);
     });
 
     test('should have a functioning select-all toggle', async () => {
@@ -320,6 +277,31 @@ describe('<Onboarding />', () => {
       fetch.once(fakeTagsResponse);
       onboardingSlides.find('.back-button').simulate('click');
       await flushPromises();
+      expect(onboardingSlides.state().currentSlide).toBe(2);
+    });
+  });
+
+  describe('EmailPreferencesForm', () => {
+    let onboardingSlides;
+
+    beforeEach(() => {
+      onboardingSlides = initializeSlides(4, getUserData());
+    });
+
+    test('renders properly', () => {
+      expect(onboardingSlides).toMatchSnapshot();
+    });
+
+    test('should allow user to advance', async () => {
+      fetch.once({});
+
+      onboardingSlides.find('.next-button').simulate('click');
+      await flushPromises();
+      expect(onboardingSlides.state().currentSlide).toBe(5);
+    });
+
+    it('should step backward', () => {
+      onboardingSlides.find('.back-button').simulate('click');
       expect(onboardingSlides.state().currentSlide).toBe(3);
     });
   });

--- a/app/javascript/onboarding/__tests__/Onboarding.test.jsx
+++ b/app/javascript/onboarding/__tests__/Onboarding.test.jsx
@@ -158,7 +158,7 @@ describe('<Onboarding />', () => {
     });
   });
 
-  describe('EmailTermsConditionsForm', () => {
+  describe('EmailPreferencesForm', () => {
     let onboardingSlides;
 
     beforeEach(() => {

--- a/app/javascript/onboarding/__tests__/Onboarding.test.jsx
+++ b/app/javascript/onboarding/__tests__/Onboarding.test.jsx
@@ -324,7 +324,7 @@ describe('<Onboarding />', () => {
     });
   });
 
-  describe('CloseSlide', () => {
+  describe('ClosingSlide', () => {
     let onboardingSlides;
 
     beforeEach(() => {

--- a/app/javascript/onboarding/__tests__/Onboarding.test.jsx
+++ b/app/javascript/onboarding/__tests__/Onboarding.test.jsx
@@ -5,7 +5,6 @@ import { axe, toHaveNoViolations } from 'jest-axe';
 
 import Onboarding from '../Onboarding';
 import ProfileForm from '../components/ProfileForm';
-import EmailTermsConditionsForm from '../components/EmailListTermsConditionsForm';
 import FollowTags from '../components/FollowTags';
 import FollowUsers from '../components/FollowUsers';
 
@@ -82,29 +81,6 @@ describe('<Onboarding />', () => {
 
   describe('IntroSlide', () => {
     let onboardingSlides;
-
-    beforeEach(() => {
-      onboardingSlides = initializeSlides(0, getUserData());
-    });
-
-    test('renders properly', () => {
-      expect(onboardingSlides).toMatchSnapshot();
-    });
-
-    test('should not have basic a11y violations', async () => {
-      const results = await axe(onboardingSlides.toString());
-
-      expect(results).toHaveNoViolations();
-    });
-
-    test('should advance', () => {
-      onboardingSlides.find('.next-button').simulate('click');
-      expect(onboardingSlides.state().currentSlide).toBe(1);
-    });
-  });
-
-  describe('EmailTermsConditionsForm', () => {
-    let onboardingSlides;
     const codeOfConductCheckEvent = {
       target: {
         value: 'checked_code_of_conduct',
@@ -117,6 +93,7 @@ describe('<Onboarding />', () => {
         name: 'checked_terms_and_conditions',
       },
     };
+
     const updateCodeOfConduct = () => {
       onboardingSlides
         .find('#checked_code_of_conduct')
@@ -136,47 +113,60 @@ describe('<Onboarding />', () => {
       expect(onboardingSlides).toMatchSnapshot();
     });
 
-    // Arguably this test is actually just testing the Preact framework
-    // but for the sake of detecting a regression I am refactoring it instead
-    // of removing it (@jacobherrington)
-    test('should track state changes', () => {
-      const emailTerms = onboardingSlides.find(<EmailTermsConditionsForm />);
-
-      expect(emailTerms.state('checked_code_of_conduct')).toBe(false);
-      expect(emailTerms.state('checked_terms_and_conditions')).toBe(false);
-
-      updateCodeOfConduct();
-      updateTermsAndConditions();
-
-      expect(emailTerms.state('checked_code_of_conduct')).toBe(true);
-      expect(emailTerms.state('checked_terms_and_conditions')).toBe(true);
+    beforeEach(() => {
+      onboardingSlides = initializeSlides(0, getUserData());
     });
 
-    test('should not advance if required boxes are not checked', () => {
+    test('should not advance if terms and conditions are not checked', () => {
+      // When none of the boxes are checked.
+      onboardingSlides.find('.next-button').simulate('click');
+      expect(onboardingSlides.state().currentSlide).toBe(0);
+
+      // When only the code of conduct is checked.
+      updateCodeOfConduct();
+      onboardingSlides.find('.next-button').simulate('click');
+      expect(onboardingSlides.state().currentSlide).toBe(0);
+    });
+
+    test('should not advance if code of conduct is not checked', () => {
       // When none of the boxes are checked
       onboardingSlides.find('.next-button').simulate('click');
-      expect(onboardingSlides.state().currentSlide).toBe(1);
+      expect(onboardingSlides.state().currentSlide).toBe(0);
 
-      // When only the code of conduct is checked
-      updateCodeOfConduct();
-      expect(onboardingSlides.state().currentSlide).toBe(1);
-
-      // When only the terms and conditions are checked
-      updateCodeOfConduct();
+      // When only the terms and conditions are checked.
       updateTermsAndConditions();
       onboardingSlides.find('.next-button').simulate('click');
-      expect(onboardingSlides.state().currentSlide).toBe(1);
+      expect(onboardingSlides.state().currentSlide).toBe(0);
     });
 
     test('should advance if required boxes are checked', async () => {
       fetch.once({});
 
+      // When both the code of conduct and terms and conditions are checked.
       updateCodeOfConduct();
       updateTermsAndConditions();
 
       onboardingSlides.find('.next-button').simulate('click');
       await flushPromises();
-      expect(onboardingSlides.state().currentSlide).toBe(2);
+      expect(onboardingSlides.state().currentSlide).toBe(1);
+    });
+
+    test('should not have basic a11y violations', async () => {
+      const results = await axe(onboardingSlides.toString());
+
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  describe('EmailTermsConditionsForm', () => {
+    let onboardingSlides;
+
+    beforeEach(() => {
+      onboardingSlides = initializeSlides(1, getUserData());
+    });
+
+    test('renders properly', () => {
+      expect(onboardingSlides).toMatchSnapshot();
     });
 
     it('should step backward', () => {

--- a/app/javascript/onboarding/__tests__/__snapshots__/Onboarding.test.jsx.snap
+++ b/app/javascript/onboarding/__tests__/__snapshots__/Onboarding.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Onboarding /> CloseSlide renders properly 1`] = `
+exports[`<Onboarding /> ClosingSlide renders properly 1`] = `
 preact-render-spy (1 nodes)
 -------
 <main class="onboarding-body">

--- a/app/javascript/onboarding/__tests__/__snapshots__/Onboarding.test.jsx.snap
+++ b/app/javascript/onboarding/__tests__/__snapshots__/Onboarding.test.jsx.snap
@@ -107,49 +107,6 @@ preact-render-spy (1 nodes)
       </header>
       <form>
         <fieldset>
-          <legend>Some things to check off</legend>
-          <ul>
-            <li class="checkbox-item">
-              <label htmlFor="checked_code_of_conduct">
-                <input
-                  type="checkbox"
-                  id="checked_code_of_conduct"
-                  name="checked_code_of_conduct"
-                  checked={false}
-                  onChange={[Function bound handleChange]}
-                 />
-                I agree to uphold the 
-                <a
-                  href="/code-of-conduct"
-                  data-no-instant={true}
-                  onClick={[Function onClick]}
-                >
-                  Code of Conduct
-                </a>
-              </label>
-            </li>
-            <li class="checkbox-item">
-              <label htmlFor="checked_terms_and_conditions">
-                <input
-                  type="checkbox"
-                  id="checked_terms_and_conditions"
-                  name="checked_terms_and_conditions"
-                  checked={false}
-                  onChange={[Function bound handleChange]}
-                 />
-                I agree to our 
-                <a
-                  href="/terms"
-                  data-no-instant={true}
-                  onClick={[Function onClick]}
-                >
-                  Terms and Conditions
-                </a>
-              </label>
-            </li>
-          </ul>
-        </fieldset>
-        <fieldset>
           <legend>Email preferences</legend>
           <ul>
             <li class="checkbox-item">
@@ -413,17 +370,66 @@ preact-render-spy (1 nodes)
         DEV is where programmers share ideas and help each other grow.
       </h2>
     </div>
-    <nav class="onboarding-navigation">
-      <div class="navigation-content">
-        <button
-          onClick={[Function bound onSubmit]}
-          class="next-button"
-          type="button"
-        >
-          Continue
-        </button>
-      </div>
-    </nav>
+    <div class="checkbox-form-wrapper">
+      <form class="checkbox-form">
+        <fieldset>
+          <ul>
+            <li class="checkbox-item">
+              <label htmlFor="checked_code_of_conduct">
+                <input
+                  type="checkbox"
+                  id="checked_code_of_conduct"
+                  name="checked_code_of_conduct"
+                  checked={false}
+                  onChange={[Function bound handleChange]}
+                 />
+                You agree to uphold our 
+                <a
+                  href="/code-of-conduct"
+                  data-no-instant={true}
+                  onClick={[Function onClick]}
+                >
+                  Code of Conduct
+                </a>
+                .
+              </label>
+            </li>
+            <li class="checkbox-item">
+              <label htmlFor="checked_terms_and_conditions">
+                <input
+                  type="checkbox"
+                  id="checked_terms_and_conditions"
+                  name="checked_terms_and_conditions"
+                  checked={false}
+                  onChange={[Function bound handleChange]}
+                 />
+                You agree to our 
+                <a
+                  href="/terms"
+                  data-no-instant={true}
+                  onClick={[Function onClick]}
+                >
+                  Terms and Conditions
+                </a>
+                .
+              </label>
+            </li>
+          </ul>
+        </fieldset>
+      </form>
+      <nav class="onboarding-navigation intro-slide">
+        <div class="navigation-content intro-slide">
+          <button
+            disabled={true}
+            onClick={[Function bound onSubmit]}
+            class="next-button"
+            type="button"
+          >
+            Continue
+          </button>
+        </div>
+      </nav>
+    </div>
   </div>
 </main>
 

--- a/app/javascript/onboarding/__tests__/__snapshots__/Onboarding.test.jsx.snap
+++ b/app/javascript/onboarding/__tests__/__snapshots__/Onboarding.test.jsx.snap
@@ -77,7 +77,7 @@ preact-render-spy (1 nodes)
 
 `;
 
-exports[`<Onboarding /> EmailTermsConditionsForm renders properly 1`] = `
+exports[`<Onboarding /> EmailPreferencesForm renders properly 1`] = `
 preact-render-spy (1 nodes)
 -------
 <main class="onboarding-body">
@@ -102,8 +102,10 @@ preact-render-spy (1 nodes)
     </nav>
     <div class="onboarding-content terms-and-conditions-wrapper">
       <header class="onboarding-content-header">
-        <h1 class="title">Getting started</h1>
-        <h2 class="subtitle">Let's review a few things first</h2>
+        <h1 class="title">Almost there!</h1>
+        <h2 class="subtitle">
+          Review your email preferences before we continue.
+        </h2>
       </header>
       <form>
         <fieldset>
@@ -130,7 +132,7 @@ preact-render-spy (1 nodes)
                   checked={true}
                   onChange={[Function bound handleChange]}
                  />
-                I want to receive a periodic digest with some of the top posts from your tags.
+                I want to receive a periodic digest of top posts from my tags.
               </label>
             </li>
           </ul>

--- a/app/javascript/onboarding/components/EmailListTermsConditionsForm.jsx
+++ b/app/javascript/onboarding/components/EmailListTermsConditionsForm.jsx
@@ -1,5 +1,3 @@
-/* eslint camelcase: "off" */
-
 import { h, Component } from 'preact';
 import PropTypes from 'prop-types';
 
@@ -7,31 +5,24 @@ import Navigation from './Navigation';
 import { getContentOfToken, updateOnboarding } from '../utilities';
 
 /* eslint-disable camelcase */
-
 class EmailTermsConditionsForm extends Component {
   constructor(props) {
     super(props);
 
     this.handleChange = this.handleChange.bind(this);
     this.onSubmit = this.onSubmit.bind(this);
-    this.checkRequirements = this.checkRequirements.bind(this);
 
     this.state = {
-      checked_code_of_conduct: false,
-      checked_terms_and_conditions: false,
       email_newsletter: true,
       email_digest_periodic: true,
-      message: '',
-      textShowing: null,
     };
   }
 
   componentDidMount() {
-    updateOnboarding('emails, COC and T&C form');
+    updateOnboarding('v2: email preferences');
   }
 
   onSubmit() {
-    if (!this.checkRequirements()) return;
     const csrfToken = getContentOfToken('csrf-token');
 
     fetch('/onboarding_checkbox_update', {
@@ -51,27 +42,6 @@ class EmailTermsConditionsForm extends Component {
     });
   }
 
-  checkRequirements() {
-    const {
-      checked_code_of_conduct,
-      checked_terms_and_conditions,
-    } = this.state;
-    if (!checked_code_of_conduct) {
-      this.setState({
-        message: 'You must agree to our Code of Conduct before continuing.',
-      });
-      return false;
-    }
-    if (!checked_terms_and_conditions) {
-      this.setState({
-        message:
-          'You must agree to our Terms and Conditions before continuing.',
-      });
-      return false;
-    }
-    return true;
-  }
-
   handleChange(event) {
     const { name } = event.target;
     this.setState((currentState) => ({
@@ -79,42 +49,9 @@ class EmailTermsConditionsForm extends Component {
     }));
   }
 
-  handleShowText(event, id) {
-    event.preventDefault();
-    this.setState({ textShowing: document.getElementById(id).innerHTML });
-  }
-
-  backToSlide() {
-    this.setState({ textShowing: null });
-  }
-
   render() {
-    const {
-      message,
-      checked_code_of_conduct,
-      checked_terms_and_conditions,
-      email_newsletter,
-      email_digest_periodic,
-      textShowing,
-    } = this.state;
+    const { email_newsletter, email_digest_periodic } = this.state;
     const { prev } = this.props;
-    if (textShowing) {
-      return (
-        <div className="onboarding-main">
-          <div className="onboarding-content terms-and-conditions-wrapper">
-            <button type="button" onClick={() => this.backToSlide()}>
-              Back
-            </button>
-            <div
-              className="terms-and-conditions-content"
-              /* eslint-disable react/no-danger */
-              dangerouslySetInnerHTML={{ __html: textShowing }}
-              /* eslint-enable react/no-danger */
-            />
-          </div>
-        </div>
-      );
-    }
     return (
       <div className="onboarding-main">
         <Navigation prev={prev} next={this.onSubmit} />
@@ -124,60 +61,7 @@ class EmailTermsConditionsForm extends Component {
             <h2 className="subtitle">Let&apos;s review a few things first</h2>
           </header>
 
-          {message && (
-            <span className="crayons-notice crayons-notice--danger">
-              {message}
-            </span>
-          )}
-
           <form>
-            <fieldset>
-              <legend>Some things to check off</legend>
-              <ul>
-                <li className="checkbox-item">
-                  <label htmlFor="checked_code_of_conduct">
-                    <input
-                      type="checkbox"
-                      id="checked_code_of_conduct"
-                      name="checked_code_of_conduct"
-                      checked={checked_code_of_conduct}
-                      onChange={this.handleChange}
-                    />
-                    I agree to uphold the
-                    {' '}
-                    <a
-                      href="/code-of-conduct"
-                      data-no-instant
-                      onClick={(e) => this.handleShowText(e, 'coc')}
-                    >
-                      Code of Conduct
-                    </a>
-                  </label>
-                </li>
-
-                <li className="checkbox-item">
-                  <label htmlFor="checked_terms_and_conditions">
-                    <input
-                      type="checkbox"
-                      id="checked_terms_and_conditions"
-                      name="checked_terms_and_conditions"
-                      checked={checked_terms_and_conditions}
-                      onChange={this.handleChange}
-                    />
-                    I agree to our
-                    {' '}
-                    <a
-                      href="/terms"
-                      data-no-instant
-                      onClick={(e) => this.handleShowText(e, 'terms')}
-                    >
-                      Terms and Conditions
-                    </a>
-                  </label>
-                </li>
-              </ul>
-            </fieldset>
-
             <fieldset>
               <legend>Email preferences</legend>
               <ul>
@@ -221,3 +105,5 @@ EmailTermsConditionsForm.propTypes = {
 };
 
 export default EmailTermsConditionsForm;
+
+/* eslint-enable camelcase */

--- a/app/javascript/onboarding/components/EmailPreferencesForm.jsx
+++ b/app/javascript/onboarding/components/EmailPreferencesForm.jsx
@@ -5,7 +5,7 @@ import Navigation from './Navigation';
 import { getContentOfToken, updateOnboarding } from '../utilities';
 
 /* eslint-disable camelcase */
-class EmailTermsConditionsForm extends Component {
+class EmailPreferencesForm extends Component {
   constructor(props) {
     super(props);
 
@@ -19,7 +19,7 @@ class EmailTermsConditionsForm extends Component {
   }
 
   componentDidMount() {
-    updateOnboarding('v2: email preferences');
+    updateOnboarding('v2: email preferences form');
   }
 
   onSubmit() {
@@ -57,8 +57,10 @@ class EmailTermsConditionsForm extends Component {
         <Navigation prev={prev} next={this.onSubmit} />
         <div className="onboarding-content terms-and-conditions-wrapper">
           <header className="onboarding-content-header">
-            <h1 className="title">Getting started</h1>
-            <h2 className="subtitle">Let&apos;s review a few things first</h2>
+            <h1 className="title">Almost there!</h1>
+            <h2 className="subtitle">
+              Review your email preferences before we continue.
+            </h2>
           </header>
 
           <form>
@@ -86,8 +88,8 @@ class EmailTermsConditionsForm extends Component {
                       checked={email_digest_periodic}
                       onChange={this.handleChange}
                     />
-                    I want to receive a periodic digest with some of the top
-                    posts from your tags.
+                    I want to receive a periodic digest of top posts from my
+                    tags.
                   </label>
                 </li>
               </ul>
@@ -99,11 +101,11 @@ class EmailTermsConditionsForm extends Component {
   }
 }
 
-EmailTermsConditionsForm.propTypes = {
+EmailPreferencesForm.propTypes = {
   prev: PropTypes.func.isRequired,
   next: PropTypes.string.isRequired,
 };
 
-export default EmailTermsConditionsForm;
+export default EmailPreferencesForm;
 
 /* eslint-enable camelcase */

--- a/app/javascript/onboarding/components/FollowTags.jsx
+++ b/app/javascript/onboarding/components/FollowTags.jsx
@@ -32,7 +32,7 @@ class FollowTags extends Component {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        user: { last_onboarding_page: 'follow tags page' },
+        user: { last_onboarding_page: 'v2: follow tags page' },
       }),
       credentials: 'same-origin',
     });

--- a/app/javascript/onboarding/components/FollowUsers.jsx
+++ b/app/javascript/onboarding/components/FollowUsers.jsx
@@ -38,7 +38,7 @@ class FollowUsers extends Component {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        user: { last_onboarding_page: 'follow users page' },
+        user: { last_onboarding_page: 'v2: follow users page' },
       }),
       credentials: 'same-origin',
     });

--- a/app/javascript/onboarding/components/IntroSlide.jsx
+++ b/app/javascript/onboarding/components/IntroSlide.jsx
@@ -56,17 +56,13 @@ class IntroSlide extends Component {
     this.setState({ text: document.getElementById(id).innerHTML });
   }
 
-  buttonIsDisabled() {
+  isButtonDisabled() {
     const {
       checked_code_of_conduct,
       checked_terms_and_conditions,
     } = this.state;
 
     return !checked_code_of_conduct || !checked_terms_and_conditions;
-  }
-
-  backToSlide() {
-    this.setState({ text: false });
   }
 
   render() {
@@ -81,7 +77,7 @@ class IntroSlide extends Component {
       return (
         <div className="onboarding-main">
           <div className="onboarding-content terms-and-conditions-wrapper">
-            <button type="button" onClick={() => this.backToSlide()}>
+            <button type="button" onClick={() => this.setState({ text: null })}>
               Back
             </button>
             <div
@@ -166,7 +162,7 @@ class IntroSlide extends Component {
             </fieldset>
           </form>
           <Navigation
-            disabled={this.buttonIsDisabled()}
+            disabled={this.isButtonDisabled()}
             className="intro-slide"
             prev={prev}
             next={this.onSubmit}

--- a/app/javascript/onboarding/components/Navigation.jsx
+++ b/app/javascript/onboarding/components/Navigation.jsx
@@ -1,16 +1,36 @@
 import { h } from 'preact';
 import PropTypes from 'prop-types';
 
-const Navigation = ({ next, prev, hideNext, hidePrev }) => (
-  <nav className="onboarding-navigation">
-    <div className="navigation-content">
+const Navigation = ({
+  next,
+  prev,
+  hideNext,
+  hidePrev,
+  disabled,
+  className,
+}) => (
+  <nav
+    className={`onboarding-navigation${
+      className && className.length > 0 ? ` ${className}` : ''
+    }`}
+  >
+    <div
+      className={`navigation-content${
+        className && className.length > 0 ? ` ${className}` : ''
+      }`}
+    >
       {!hidePrev && (
         <button onClick={prev} className="back-button" type="button">
           Back
         </button>
       )}
       {!hideNext && (
-        <button onClick={next} className="next-button" type="button">
+        <button
+          disabled={disabled}
+          onClick={next}
+          className="next-button"
+          type="button"
+        >
           Continue
         </button>
       )}
@@ -19,6 +39,8 @@ const Navigation = ({ next, prev, hideNext, hidePrev }) => (
 );
 
 Navigation.propTypes = {
+  disabled: PropTypes.bool,
+  className: PropTypes.string,
   prev: PropTypes.func.isRequired,
   next: PropTypes.string.isRequired,
   hideNext: PropTypes.bool,
@@ -26,8 +48,10 @@ Navigation.propTypes = {
 };
 
 Navigation.defaultProps = {
+  disabled: false,
   hideNext: false,
   hidePrev: false,
+  className: '',
 };
 
 export default Navigation;

--- a/app/javascript/onboarding/components/ProfileForm.jsx
+++ b/app/javascript/onboarding/components/ProfileForm.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import Navigation from './Navigation';
 import { userData, getContentOfToken, updateOnboarding } from '../utilities';
 
+/* eslint-disable camelcase */
 class ProfileForm extends Component {
   constructor(props) {
     super(props);
@@ -40,7 +41,7 @@ class ProfileForm extends Component {
         const { next } = this.props;
         next();
       }
-    })
+    });
   }
 
   handleChange(e) {
@@ -68,7 +69,11 @@ class ProfileForm extends Component {
           </header>
           <div className="current-user-info">
             <figure className="current-user-avatar-container">
-              <img className="current-user-avatar" alt="profile" src={profile_image_90} />
+              <img
+                className="current-user-avatar"
+                alt="profile"
+                src={profile_image_90}
+              />
             </figure>
             <h3>{name}</h3>
             <p>{username}</p>
@@ -131,3 +136,5 @@ ProfileForm.propTypes = {
 };
 
 export default ProfileForm;
+
+/* eslint-enable camelcase */


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

This PR makes two major changes to the onboarding flow:
1) It moves the terms and conditions/code of conduct into the intro slide.
2) It moves the email preferences into the last slide (before the closing slide, which [will ultimately disappear](https://github.com/thepracticaldev/dev.to/issues/6552)).

It also prepends `v2:` to some of the `updateOnboarding()` functions and some lines to ignore linters where necessary. Also reorganizes the tests.

## Related Tickets & Documents
Closes https://github.com/thepracticaldev/dev.to/issues/6545.
Closes https://github.com/thepracticaldev/dev.to/issues/6550.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Before this change, our intro slide didn't have much going on inside of it...
<img width="598" alt="Screen Shot 2020-04-14 at 4 55 50 PM" src="https://user-images.githubusercontent.com/6921610/79285027-2bd4ec00-7e71-11ea-8313-6fd50071581c.png">

...and all of the "preference" checkboxes lived in the second slide:
<img width="823" alt="Screen Shot 2020-04-14 at 4 55 58 PM" src="https://user-images.githubusercontent.com/6921610/79285049-3beccb80-7e71-11ea-9c34-e3844162afbe.png">

With this PR, this is now split up into different slides. The terms and conditions and code of conduct appear on the intro slide, and the button is disabled unless both boxes are checked:
<img width="621" alt="Screen_Shot_2020-04-14_at_4_52_31_PM" src="https://user-images.githubusercontent.com/6921610/79285167-9f76f900-7e71-11ea-9378-c38f879ffd9b.png">
<img width="606" alt="Screen Shot 2020-04-14 at 4 52 44 PM" src="https://user-images.githubusercontent.com/6921610/79285186-a7cf3400-7e71-11ea-9108-30417ff7e294.png">

The email preferences are now the second-to-last slide, appearing just before the closing slide:
<img width="828" alt="Screen Shot 2020-04-14 at 4 53 06 PM" src="https://user-images.githubusercontent.com/6921610/79285192-ad2c7e80-7e71-11ea-89a1-2774e9d0a9b0.png">

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed