### PR TITLE
Bypass serviceworkers for /checkin

### DIFF
--- a/app/views/service_worker/index.js.erb
+++ b/app/views/service_worker/index.js.erb
@@ -115,6 +115,7 @@
         !url.href.includes('/enter') && // Don't run on registration.
         !url.href.includes('/sitemap-') && // Don't run on registration.
         !url.href.includes('/welcome') && // Don't run on welcome reroutes.
+        !url.href.includes('/checkin') && // Don't run on checkin reroutes.
 
         // Don't run on search endpoints
         !url.href.includes('/search/tags') &&


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Serviceworkers do not currently behave super well with redirect routes. Since we added the hardcoded `/checkin` url we should also bypass serviceworkers here. Eventually we should figure out how to do this without having to hardcode, to work for redirects in general.