### PR TITLE
Suppress unused eager loading warning for comment -> user

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -127,7 +127,9 @@ Rails.application.configure do
     Bullet.add_whitelist(type: :unused_eager_loading, class_name: "ApiSecret", association: :user)
     # acts-as-taggable-on has super weird eager loading problems: <https://github.com/mbleigh/acts-as-taggable-on/issues/91>
     Bullet.add_whitelist(type: :n_plus_one_query, class_name: "ActsAsTaggableOn::Tagging", association: :tag)
+    # Supress incorrect warnings from Bullet due to included columns: https://github.com/flyerhzm/bullet/issues/147
     Bullet.add_whitelist(type: :unused_eager_loading, class_name: "Article", association: :top_comments)
+    Bullet.add_whitelist(type: :unused_eager_loading, class_name: "Comment", association: :user)
 
     # Check if there are any data update scripts to run during startup
     if %w[c console runner s server].include?(ENV["COMMAND"])

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -68,7 +68,9 @@ Rails.application.configure do
     Bullet.add_whitelist(type: :unused_eager_loading, class_name: "ApiSecret", association: :user)
     # acts-as-taggable-on has super weird eager loading problems: <https://github.com/mbleigh/acts-as-taggable-on/issues/91>
     Bullet.add_whitelist(type: :n_plus_one_query, class_name: "ActsAsTaggableOn::Tagging", association: :tag)
+    # Supress incorrect warnings from Bullet due to included columns: https://github.com/flyerhzm/bullet/issues/147
     Bullet.add_whitelist(type: :unused_eager_loading, class_name: "Article", association: :top_comments)
+    Bullet.add_whitelist(type: :unused_eager_loading, class_name: "Comment", association: :user)
   end
 end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Adding users to the eagerly loaded classes while assembling the feed has lead the the same erroneous "unused eager loading" warning from Bullet as was whitelisted for the `Article.top_comments` association in https://github.com/thepracticaldev/dev.to/pull/7261. This PR added `Comments.user` to Bullet's whitelist. This prevents a warning from showing in log messages and on screen in the `development` and `test` environments: there's no impact to production operation.

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/pull/7261

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/2ytsL1dE93zKRwEqAS/giphy.gif)
