### PR TITLE
Use Model IDs for Indexing Worker

### DIFF
--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -4,7 +4,7 @@ module Searchable
   end
 
   def index_to_elasticsearch
-    Search::IndexToElasticsearchWorker.perform_async(self.class.name, search_id)
+    Search::IndexToElasticsearchWorker.perform_async(self.class.name, id)
   end
 
   def index_to_elasticsearch_inline

--- a/app/workers/search/index_to_elasticsearch_worker.rb
+++ b/app/workers/search/index_to_elasticsearch_worker.rb
@@ -5,10 +5,7 @@ module Search
     sidekiq_options queue: :high_priority, lock: :until_executing
 
     def perform(object_class, id)
-      # PodcastEpisodes and Articles share an index so their IDs are prepended with their class names
-      # article_ID and podcast_episode_ID
-      object_int_id = id.is_a?(Integer) ? id : id.split("_").last.to_i
-      object = object_class.constantize.find(object_int_id)
+      object = object_class.constantize.find(id)
       object.index_to_elasticsearch_inline
     rescue ActiveRecord::RecordNotFound => e
       return if object_class == "Reaction"

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Article, type: :model do
     describe "#after_commit" do
       it "on update enqueues job to index article to elasticsearch" do
         article.save
-        sidekiq_assert_enqueued_with(job: Search::IndexToElasticsearchWorker, args: [described_class.to_s, article.search_id]) do
+        sidekiq_assert_enqueued_with(job: Search::IndexToElasticsearchWorker, args: [described_class.to_s, article.id]) do
           article.save
         end
       end
@@ -83,7 +83,7 @@ RSpec.describe Article, type: :model do
         allow(article).to receive(:index_to_elasticsearch)
         allow(article.user).to receive(:index_to_elasticsearch)
 
-        sidekiq_assert_enqueued_with(job: Search::IndexToElasticsearchWorker, args: ["Reaction", reaction.search_id]) do
+        sidekiq_assert_enqueued_with(job: Search::IndexToElasticsearchWorker, args: ["Reaction", reaction.id]) do
           article.update(body_markdown: "---\ntitle: NEW TITLE#{rand(1000)}\n")
         end
       end
@@ -887,7 +887,7 @@ RSpec.describe Article, type: :model do
 
   describe "#touch_by_reaction" do
     it "reindexes elasticsearch doc" do
-      sidekiq_assert_enqueued_with(job: Search::IndexToElasticsearchWorker, args: [described_class.to_s, article.search_id]) do
+      sidekiq_assert_enqueued_with(job: Search::IndexToElasticsearchWorker, args: [described_class.to_s, article.id]) do
         article.touch_by_reaction
       end
     end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Comment, type: :model do
 
     describe "#after_commit" do
       it "on update enqueues job to index comment to elasticsearch" do
-        sidekiq_assert_enqueued_with(job: Search::IndexToElasticsearchWorker, args: [described_class.to_s, comment.search_id]) do
+        sidekiq_assert_enqueued_with(job: Search::IndexToElasticsearchWorker, args: [described_class.to_s, comment.id]) do
           comment.save
         end
       end

--- a/spec/models/concerns/searchable_spec.rb
+++ b/spec/models/concerns/searchable_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Searchable do
 
   describe "#index_to_elasticsearch" do
     it "enqueues job to index document to elasticsearch" do
-      sidekiq_assert_enqueued_with(job: Search::IndexToElasticsearchWorker, args: ["SearchableModel", searchable_model.search_id]) do
+      sidekiq_assert_enqueued_with(job: Search::IndexToElasticsearchWorker, args: ["SearchableModel", searchable_model.id]) do
         searchable_model.index_to_elasticsearch
       end
     end

--- a/spec/models/podcast_episode_spec.rb
+++ b/spec/models/podcast_episode_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe PodcastEpisode, type: :model do
   describe "#after_commit" do
     it "on update enqueues job to index podcast_episode to elasticsearch" do
       podcast_episode.save
-      sidekiq_assert_enqueued_with(job: Search::IndexToElasticsearchWorker, args: [described_class.to_s, podcast_episode.search_id]) do
+      sidekiq_assert_enqueued_with(job: Search::IndexToElasticsearchWorker, args: [described_class.to_s, podcast_episode.id]) do
         podcast_episode.save
       end
     end

--- a/spec/workers/search/index_to_elasticsearch_worker_spec.rb
+++ b/spec/workers/search/index_to_elasticsearch_worker_spec.rb
@@ -17,14 +17,6 @@ RSpec.describe Search::IndexToElasticsearchWorker, type: :worker, elasticsearch:
     expect(tag.elasticsearch_doc.dig("_source", "id")).to eql(tag.id)
   end
 
-  it "handles a string search id" do
-    tag = FactoryBot.create(:tag)
-    expect { tag.elasticsearch_doc }.to raise_error(Search::Errors::Transport::NotFound)
-    worker.perform(tag.class.name, "tag_#{tag.id}")
-
-    expect(tag.elasticsearch_doc.dig("_source", "id")).to eql(tag.id)
-  end
-
   it "does not raise an error if Reaction record is not found" do
     expect { worker.perform("Reaction", 1234) }.not_to raise_error(ActiveRecord::RecordNotFound)
   end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [x] Refactor

## Description
When I was making the [search_id change](https://github.com/thepracticaldev/dev.to/pull/6729) I got a little carried away and started passing it everywhere. Turns out we don't need to pass it to the indexing worker since that nearly looks up the model and calls the index inline method which will correctly use the search_id

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-36219698

## Added tests?
- [x] updated

![alt_text](https://media.giphy.com/media/26gYERtrrzIEg6oKI/giphy.gif)
