### PR TITLE
Index all readinglist Reactions into Elasticsearch

### DIFF
--- a/lib/data_update_scripts/20200415200651_index_reading_list_reactions.rb
+++ b/lib/data_update_scripts/20200415200651_index_reading_list_reactions.rb
@@ -1,0 +1,11 @@
+module DataUpdateScripts
+  class IndexReadingListReactions
+    def run
+      Reaction.readinglist.select(:id).in_batches do |batch|
+        Search::BulkIndexToElasticsearchWorker.set(queue: :default).perform_async(
+          "Reaction", batch.map(&:id)
+        )
+      end
+    end
+  end
+end

--- a/lib/data_update_scripts/20200415200651_index_reading_list_reactions.rb
+++ b/lib/data_update_scripts/20200415200651_index_reading_list_reactions.rb
@@ -3,7 +3,7 @@ module DataUpdateScripts
     def run
       Reaction.readinglist.select(:id).in_batches do |batch|
         Search::BulkIndexToElasticsearchWorker.set(queue: :default).perform_async(
-          "Reaction", batch.map(&:id)
+          "Reaction", batch.pluck(:id)
         )
       end
     end

--- a/spec/lib/data_update_scripts/index_reading_list_reactions_spec.rb
+++ b/spec/lib/data_update_scripts/index_reading_list_reactions_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+require Rails.root.join("lib/data_update_scripts/20200415200651_index_reading_list_reactions.rb")
+
+describe DataUpdateScripts::IndexReadingListReactions, elasticsearch: true do
+  it "indexes feed content(articles, comments, podcast episodes) to Elasticsearch" do
+    reactions = Array.new(3).map { create(:reaction, category: "readinglist") }
+    Sidekiq::Worker.clear_all
+
+    reactions.each do |reaction|
+      expect { reaction.elasticsearch_doc }.to raise_error(Search::Errors::Transport::NotFound)
+    end
+
+    sidekiq_perform_enqueued_jobs { described_class.new.run }
+    reactions.each do |reaction|
+      expect(reaction.elasticsearch_doc).not_to be_nil
+    end
+  end
+end

--- a/spec/lib/data_update_scripts/index_reading_list_reactions_spec.rb
+++ b/spec/lib/data_update_scripts/index_reading_list_reactions_spec.rb
@@ -3,7 +3,7 @@ require Rails.root.join("lib/data_update_scripts/20200415200651_index_reading_li
 
 describe DataUpdateScripts::IndexReadingListReactions, elasticsearch: true do
   it "indexes feed content(articles, comments, podcast episodes) to Elasticsearch" do
-    reactions = Array.new(3).map { create(:reaction, category: "readinglist") }
+    reactions = create_list(:reaction, 3, category: "readinglist")
     Sidekiq::Worker.clear_all
 
     reactions.each do |reaction|


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Feature

## Description
Creates a data update script to index all reading list reactions to Elasticsearch. There are 1.2 million of them which is why I put them on the lowest priority queue, `:default` and used the bulk indexing elasticsearch worker. 

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-32289393

## Added tests?
- [x] yes

![alt_text](https://i0.wp.com/www.universeofmemory.com/wp-content/uploads/2017/06/funny-big-bang-theory-sheldon-reads-comic-book-animated-gif.gif?resize=500%2C275)
