### PR TITLE
Remove leftover harcoded shop string

### DIFF
--- a/app/views/articles/_sidebar_nav.html.erb
+++ b/app/views/articles/_sidebar_nav.html.erb
@@ -44,9 +44,9 @@
       <%= inline_svg_tag("twemoji/tag.svg", aria: true, class: "crayons-icon crayons-icon--default", title: "Tags") %>
       Tags
     </a>
-    
+
     <a href="javascript:void(0)" class="crayons-link crayons-link--secondary crayons-link--block crayons-link--block--indented fs-s" id="main-nav-more-trigger">More...</a>
-    
+
     <div class="hidden" id="main-nav-more">
       <a href="/code-of-conduct" class="crayons-link crayons-link--block">
         <%= inline_svg_tag("twemoji/thumb-up.svg", aria: true, class: "crayons-icon crayons-icon--default", title: "Code of Conduct") %>
@@ -56,7 +56,7 @@
         <%= inline_svg_tag("twemoji/bulb.svg", aria: true, class: "crayons-icon crayons-icon--default", title: "FAQ") %>
         FAQ
       </a>
-      <a href="https://shop.dev.to/" class="crayons-link crayons-link--block">
+      <a href="<%= SiteConfig.shop_url %>" class="crayons-link crayons-link--block">
         <%= inline_svg_tag("twemoji/shopping.svg", aria: true, class: "crayons-icon crayons-icon--default", title: "Shop") %>
         <%= community_name %> Shop
       </a>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -320,7 +320,11 @@ Rails.application.routes.draw do
   post "articles/preview" => "articles#preview"
   post "comments/preview" => "comments#preview"
   get "/stories/warm_comments/:username/:slug" => "stories#warm_comments"
-  get "/shop", to: redirect("https://shop.dev.to/")
+
+  # NOTE: can't remove the hardcoded URL here as SiteConfig is not available here, we should eventually
+  # setup dynamic redirects, see <https://github.com/thepracticaldev/dev.to/issues/7267>
+  get "/shop", to: redirect("https://shop.dev.to")
+
   get "/mod" => "moderations#index", :as => :mod
   get "/mod/:tag" => "moderations#index"
   get "/page/crayons" => "pages#crayons"

--- a/spec/requests/internal/configs_spec.rb
+++ b/spec/requests/internal/configs_spec.rb
@@ -247,11 +247,13 @@ RSpec.describe "/internal/config", type: :request do
       describe "Shop" do
         it "rejects update to shop_url without proper confirmation" do
           expected_shop_url = "https://qshop.dev.to"
-          expect { post "/internal/config", params: { site_config: { shop_url: expected_shop_url }, confirmation: "Incorrect confirmation" } }.to raise_error Pundit::NotAuthorizedError
+
+          expect do
+            params = { site_config: { shop_url: expected_shop_url }, confirmation: "Incorrect confirmation" }
+            post "/internal/config", params: params
+          end.to raise_error(Pundit::NotAuthorizedError)
+
           expect(SiteConfig.shop_url).not_to eq(expected_shop_url)
-          get "/privacy"
-          expect(response.body).not_to include(expected_shop_url)
-          expect(response.body).to include("#{ApplicationConfig['COMMUNITY_NAME']} Shop")
         end
 
         it "sets shop_url to nil" do

--- a/spec/routing/all_routes_spec.rb
+++ b/spec/routing/all_routes_spec.rb
@@ -32,9 +32,10 @@ RSpec.describe "all routes", type: :routing do
   context "when redirected routes" do
     include RSpec::Rails::RequestExampleGroup
 
-    it "redirects /shop to shop.dev.to" do
-      get "/shop"
-      expect(response).to redirect_to("https://shop.dev.to/")
+    it "redirects /shop to the default shop_url" do
+      get shop_path
+
+      expect(response).to redirect_to(SiteConfig.shop_url)
     end
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Now that #7262 is in, we can remove the last hardcoded shop URL.

I also added a note explaining why we can't remove it from the routes just yet.

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
