### PR TITLE
Exempt new search endpoints from the service worker

### DIFF
--- a/app/views/service_worker/index.js.erb
+++ b/app/views/service_worker/index.js.erb
@@ -121,6 +121,8 @@
         !url.href.includes('/search/tags') &&
         !url.href.includes('/search/chat_channels') &&
         !url.href.includes('/search/classified_listings') &&
+        !url.href.includes('/search/reactions') &&
+        !url.href.includes('/search/feed_content') &&
         !url.href.includes('/search/users') &&
 
         // Don't run on redirects


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Feature

## Description
Before starting to use these new endpoints we should make sure they are exempt from the service worker.

## Added tests?
- [x] no, because they aren't needed

![alt_text](https://media1.giphy.com/media/fGR0wfrAFhkfgV5r7M/giphy.gif?cid=ecf05e4799c947c69d196d8d88477ad8df8810e57dcfbaa0&rid=giphy.gif)
