### PR TITLE
Flaky Spec Fix: Credits Spec, Compare org updated_at's Properly 

### DIFF
--- a/spec/services/credits/buyer_spec.rb
+++ b/spec/services/credits/buyer_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Credits::Buyer, type: :service do
     it "updates the updated_at of the organization" do
       create_list(:credit, 2, organization: org)
 
-      old_updated_at = user.updated_at
+      old_updated_at = org.updated_at
       Timecop.travel(1.minute.from_now) do
         described_class.call(purchaser: org, purchase: listing, cost: 2)
       end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Looks like a little copy/pasta caused us to be comparing the org updated_at with the user updated_at which led to this spec failing intermittently. 

## Added tests?
- [x] yes

![alt_text](https://media1.tenor.com/images/855b8d393c3be99701ee77053f461002/tenor.gif?itemid=5103774)
