### PR TITLE
Make Elasticsearch Data in Honeycomb Distinct

### DIFF
--- a/app/services/search/client.rb
+++ b/app/services/search/client.rb
@@ -33,17 +33,23 @@ module Search
       ].freeze
 
       def request
+        Honeycomb.add_field("app.name", "elasticsearch")
         yield
       rescue *TRANSPORT_EXCEPTIONS => e
         class_name = e.class.name.demodulize
-
-        DatadogStatsClient.increment("elasticsearch.errors", tags: ["error:#{class_name}"], message: e.message)
+        record_error(e.message, class_name)
 
         # raise specific error if known, generic one if unknown
         error_class = "::Search::Errors::Transport::#{class_name}".safe_constantize
         raise error_class, e.message if error_class
 
         raise ::Search::Errors::TransportError, e.message
+      end
+
+      def record_error(error_message, class_name)
+        Honeycomb.add_field("elasticsearch.result", "error")
+        Honeycomb.add_field("elasticsearch.error", class_name)
+        DatadogStatsClient.increment("elasticsearch.errors", tags: ["error:#{class_name}"], message: error_message)
       end
 
       def target


### PR DESCRIPTION


## What type of PR is this? (check all applicable)
- [x] Feature

## Description
When Elasticsearch requests are recorded in Honeycomb we record them under the name "http_client". This changes that to "Elasticsearch" so it is easier to filter for these requests. I also added some more error information to the span.

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-33076459

## Added tests?
- [x] no, because they aren't needed

![alt_text](https://media1.tenor.com/images/66c3a94ed6484eb250bce088a36af5f2/tenor.gif?itemid=13898754)
