### PR TITLE
Add type_of param to Fastly param list

### DIFF
--- a/config/fastly/whitelisted_params.yml
+++ b/config/fastly/whitelisted_params.yml
@@ -50,6 +50,7 @@
 - tag
 - tag_list
 - top
+- type_of
 - url
 - username
 - ut


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Fastly back at it again. Need to add `type_of` to the list for a `GET /response_templates?type_of` request.

## Related Tickets & Documents
#7068 #7279 

## Added tests?
- [x] no, because they aren't needed

## [optional] Are there any post deployment tasks we need to perform?
No? I think?