### PR TITLE
Bug Fix: Rescue Addressable::URI::InvalidURIError and Mark Podcast Episode unreachable

### DIFF
--- a/app/services/podcasts/get_media_url.rb
+++ b/app/services/podcasts/get_media_url.rb
@@ -35,7 +35,7 @@ module Podcasts
     def url_reachable?(url)
       url = Addressable::URI.parse(url).normalize.to_s
       HTTParty.head(url).code == 200
-    rescue Net::OpenTimeout, SystemCallError, URI::InvalidURIError
+    rescue Net::OpenTimeout, SystemCallError, URI::InvalidURIError, Addressable::URI::InvalidURIError
       false
     end
   end

--- a/spec/services/podcasts/get_media_url_spec.rb
+++ b/spec/services/podcasts/get_media_url_spec.rb
@@ -74,4 +74,13 @@ RSpec.describe Podcasts::GetMediaUrl, type: :service do
     expect(result.reachable).to be false
     expect(result.url).to eq(http_url)
   end
+
+  it "marks unreachable with addressable invalid url exception" do
+    allow(HTTParty).to receive(:head).with(https_url).and_raise(Addressable::URI::InvalidURIError)
+    allow(HTTParty).to receive(:head).with(http_url).and_raise(Addressable::URI::InvalidURIError)
+    result = described_class.call(http_url)
+    expect(result.https).to be false
+    expect(result.reachable).to be false
+    expect(result.url).to eq(http_url)
+  end
 end


### PR DESCRIPTION


## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
[A couple weeks ago I fixed a similar error](https://github.com/thepracticaldev/dev.to/pull/7137) but apparently there is another type of invalid error to catch. 
Fixes: https://app.honeybadger.io/fault/66984/51226b47c7edbb2ef566c681bbff2e98
 
## Added tests?
- [x] yes

![alt_text](https://media2.giphy.com/media/xT0BKGvnT5kY58xZG8/giphy.gif)
