### PR TITLE
Manually create channel and add users for org channels

### DIFF
--- a/app/models/chat_channel.rb
+++ b/app/models/chat_channel.rb
@@ -72,8 +72,6 @@ class ChatChannel < ApplicationRecord
       channel
     end
 
-    private
-
     def find_or_create_chat_channel(channel_type, slug, contrived_name)
       channel = ChatChannel.find_by(slug: slug)
       if channel

--- a/app/models/organization_membership.rb
+++ b/app/models/organization_membership.rb
@@ -27,12 +27,9 @@ class OrganizationMembership < ApplicationRecord
     if channel
       add_chat_channel_membership(user, channel, role)
     else
-      ChatChannel.create_with_users(
-        users: [user],
-        channel_type: "invite_only",
-        contrived_name: name,
-        membership_role: role,
-      )
+       # find_or_create_chat_channel is custom method in class, not generic rails method
+      channel = ChatChannel.find_or_create_chat_channel("invite_only", "#{organization.slug}-private-group-chat", name)
+      add_chat_channel_membership(user, channel, role)
     end
   end
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The `create_with_users` method by default creates an _invitation_ to private groups rather than adding folks, but the other part of this adds folks directly. This means the _first_ user gets invited but everyone else is just added. It's odd behavior and this fixes it.