### PR TITLE
Generalize Fastly rake task

### DIFF
--- a/Envfile
+++ b/Envfile
@@ -114,7 +114,7 @@ variable :HCTI_API_KEY, :String, default: "Optional"
 # (https://docs.fastly.com/api/)
 variable :FASTLY_API_KEY, :String, default: ""
 variable :FASTLY_SERVICE_ID, :String, default: ""
-variable :WHITELIST_PARAMS_SNIPPET_NAME, :String, default: ""
+variable :FASTLY_WHITELIST_PARAMS_SNIPPET_NAME, :String, default: ""
 
 # Honeycomb for monitoring and observability
 # (https://www.honeycomb.io/)

--- a/Envfile
+++ b/Envfile
@@ -112,8 +112,8 @@ variable :HCTI_API_KEY, :String, default: "Optional"
 
 # Fastly for edge caching
 # (https://docs.fastly.com/api/)
-variable :FASTLY_API_KEY, :String, default: "Optional"
-variable :FASTLY_SERVICE_ID, :String, default: "Optional"
+variable :FASTLY_API_KEY, :String, default: ""
+variable :FASTLY_SERVICE_ID, :String, default: ""
 
 # Honeycomb for monitoring and observability
 # (https://www.honeycomb.io/)

--- a/Envfile
+++ b/Envfile
@@ -114,6 +114,7 @@ variable :HCTI_API_KEY, :String, default: "Optional"
 # (https://docs.fastly.com/api/)
 variable :FASTLY_API_KEY, :String, default: ""
 variable :FASTLY_SERVICE_ID, :String, default: ""
+variable :WHITELIST_PARAMS_SNIPPET_NAME, :String, default: ""
 
 # Honeycomb for monitoring and observability
 # (https://www.honeycomb.io/)

--- a/app/services/fastly_vcl/whitelisted_params.rb
+++ b/app/services/fastly_vcl/whitelisted_params.rb
@@ -3,7 +3,7 @@ module FastlyVCL
   class WhitelistedParams
     VCL_DELIMITER_START = "^(".freeze
     VCL_DELIMITER_END = ")$".freeze
-    SNIPPET_NAME = "Whitelist certain querystring parameters".freeze
+    SNIPPET_NAME = ApplicationConfig["WHITELIST_PARAMS_SNIPPET_NAME"].freeze
     FILE_PARAMS = YAML.load_file("config/fastly/whitelisted_params.yml").freeze
 
     class << self

--- a/app/services/fastly_vcl/whitelisted_params.rb
+++ b/app/services/fastly_vcl/whitelisted_params.rb
@@ -3,7 +3,7 @@ module FastlyVCL
   class WhitelistedParams
     VCL_DELIMITER_START = "^(".freeze
     VCL_DELIMITER_END = ")$".freeze
-    SNIPPET_NAME = ApplicationConfig["WHITELIST_PARAMS_SNIPPET_NAME"].freeze
+    SNIPPET_NAME = ApplicationConfig["FASTLY_WHITELIST_PARAMS_SNIPPET_NAME"].freeze
     FILE_PARAMS = YAML.load_file("config/fastly/whitelisted_params.yml").freeze
 
     class << self

--- a/docs/backend/fastly.md
+++ b/docs/backend/fastly.md
@@ -42,12 +42,14 @@ _Fastly is not setup for development._
 
 ## In production
 
-Whitelisted params on Fastly are updated automatically when a production deploy
-goes out.
+If you have Fastly configured in Production and have a similar custom VCL script
+to whitelist query string params, make sure you've set the
+`FASTLY_WHITELIST_PARAMS_SNIPPET_NAME` ENV variable with the name of the VCL
+snippet you have configured in Fastly.
 
-Make sure you've set the `FASTLY_WHITELIST_PARAMS_SNIPPET_NAME` ENV variable
-with the name of the VCL snippet you have configured in Fastly. If this key is
-not set, this update will be skipped on deployments.
+Whitelisted params on Fastly are updated automatically when a production deploy
+goes out unless this key is not set (i.e. you don't have a similar custom VCL
+setup).
 
 We do this by executing `bin/rails fastly:update_whitelisted_params` in our
 `release-tasks.sh` script.

--- a/docs/backend/fastly.md
+++ b/docs/backend/fastly.md
@@ -45,5 +45,9 @@ _Fastly is not setup for development._
 Whitelisted params on Fastly are updated automatically when a production deploy
 goes out.
 
+Make sure you've set the `FASTLY_WHITELIST_PARAMS_SNIPPET_NAME` ENV variable
+with the name of the VCL snippet you have configured in Fastly. If this key is
+not set, this update will be skipped on deployments.
+
 We do this by executing `bin/rails fastly:update_whitelisted_params` in our
 `release-tasks.sh` script.

--- a/lib/tasks/fastly.rake
+++ b/lib/tasks/fastly.rake
@@ -1,6 +1,11 @@
 namespace :fastly do
   desc "Update VCL for whitelisted params on Fastly"
   task update_whitelisted_params: :environment do
+    if ApplicationConfig["FASTLY_API_KEY"].blank? || ApplicationConfig["FASTLY_SERVICE_ID"].blank?
+      puts "Fastly not configured. Please set FASTLY_API_KEY and FAASTLY_SERVICE_ID in your environment."
+      exit
+    end
+
     FastlyVCL::WhitelistedParams.update
   end
 end

--- a/lib/tasks/fastly.rake
+++ b/lib/tasks/fastly.rake
@@ -4,7 +4,7 @@ namespace :fastly do
     fastly_credentials = %w[
       FASTLY_API_KEY
       FASTLY_SERVICE_ID
-      WHITELIST_PARAMS_SNIPPET_NAME
+      FASTLY_WHITELIST_PARAMS_SNIPPET_NAME
     ]
 
     if fastly_credentials.any? { |cred| ApplicationConfig[cred].blank? }

--- a/lib/tasks/fastly.rake
+++ b/lib/tasks/fastly.rake
@@ -8,7 +8,7 @@ namespace :fastly do
     ]
 
     if fastly_credentials.any? { |cred| ApplicationConfig[cred].blank? }
-      puts "Fastly not configured. Please set FASTLY_API_KEY, FASTLY_SERVICE_ID, WHITELIST_PARAMS_SNIPPET_NAME in your environment."
+      puts "Fastly not configured. Please set #{fastly_credentials.join(", ")} in your environment."
       exit
     end
 

--- a/lib/tasks/fastly.rake
+++ b/lib/tasks/fastly.rake
@@ -1,8 +1,14 @@
 namespace :fastly do
   desc "Update VCL for whitelisted params on Fastly"
   task update_whitelisted_params: :environment do
-    if ApplicationConfig["FASTLY_API_KEY"].blank? || ApplicationConfig["FASTLY_SERVICE_ID"].blank?
-      puts "Fastly not configured. Please set FASTLY_API_KEY and FAASTLY_SERVICE_ID in your environment."
+    fastly_credentials = %w[
+      FASTLY_API_KEY
+      FASTLY_SERVICE_ID
+      WHITELIST_PARAMS_SNIPPET_NAME
+    ]
+
+    if fastly_credentials.any? { |cred| ApplicationConfig[cred].blank? }
+      puts "Fastly not configured. Please set FASTLY_API_KEY, FASTLY_SERVICE_ID, WHITELIST_PARAMS_SNIPPET_NAME in your environment."
       exit
     end
 

--- a/spec/tasks/fastly_spec.rb
+++ b/spec/tasks/fastly_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe "Fastly tasks", type: :task do
+  before do
+    Rake::Task.clear
+    PracticalDeveloper::Application.load_tasks
+  end
+
+  describe "#update_whitelisted_params" do
+    it "doesn't run if Fastly isn't configured" do
+      allow(ApplicationConfig).to receive(:[]).with("FASTLY_API_KEY").and_return(nil)
+      allow(ApplicationConfig).to receive(:[]).with("FASTLY_SERVICE_ID").and_return(nil)
+      allow(FastlyVCL::WhitelistedParams).to receive(:update)
+      Rake::Task["fastly:update_whitelisted_params"].invoke
+      expect(FastlyVCL::WhitelistedParams).not_to have_received(:update)
+    end
+  end
+end

--- a/spec/tasks/fastly_spec.rb
+++ b/spec/tasks/fastly_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe "Fastly tasks", type: :task do
     it "doesn't run if Fastly isn't configured" do
       allow(ApplicationConfig).to receive(:[]).with("FASTLY_API_KEY").and_return(nil)
       allow(ApplicationConfig).to receive(:[]).with("FASTLY_SERVICE_ID").and_return(nil)
+      allow(ApplicationConfig).to receive(:[]).with("WHITELIST_PARAMS_SNIPPET_NAME").and_return(nil)
       allow(FastlyVCL::WhitelistedParams).to receive(:update)
       Rake::Task["fastly:update_whitelisted_params"].invoke
       expect(FastlyVCL::WhitelistedParams).not_to have_received(:update)

--- a/spec/tasks/fastly_spec.rb
+++ b/spec/tasks/fastly_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Fastly tasks", type: :task do
     it "doesn't run if Fastly isn't configured" do
       allow(ApplicationConfig).to receive(:[]).with("FASTLY_API_KEY").and_return(nil)
       allow(ApplicationConfig).to receive(:[]).with("FASTLY_SERVICE_ID").and_return(nil)
-      allow(ApplicationConfig).to receive(:[]).with("WHITELIST_PARAMS_SNIPPET_NAME").and_return(nil)
+      allow(ApplicationConfig).to receive(:[]).with("FASTLY_WHITELIST_PARAMS_SNIPPET_NAME").and_return(nil)
       allow(FastlyVCL::WhitelistedParams).to receive(:update)
       Rake::Task["fastly:update_whitelisted_params"].invoke
       expect(FastlyVCL::WhitelistedParams).not_to have_received(:update)


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
In #7279 we added the `fastly:update_whitelisted_params` task to `release-script.sh`. This will fail for other communities who don't have Fastly configured. This PR adds a guard to not run the task if Fastly isn't configured so deployments don't fail.

There's still work to be done to generalize Fastly altogether.

**P.S.**
I updated Rubocop to ignore spec names for rake tasks. It was complaining:
```
 RSpec/DescribeClass: The first argument to describe should be the class or module being tested.
```

## Related Tickets & Documents
#7279
https://github.com/thepracticaldev/dev.to/pull/7279#issuecomment-614879618
https://github.com/thepracticaldev/dev.to/projects/9#card-36459306

## Added tests?
- [x] yes

## Added to documentation?
- [x] no documentation needed

## Post deploy
@mstruve can you add the ENV variable `FASTLY_WHITELIST_PARAMS_SNIPPET_NAME`?

![welcome_gif](https://media.giphy.com/media/l46Cpz0A0dB1jMxG0/giphy.gif)