### PR TITLE
Change window.currentUser to userData()

### DIFF
--- a/app/javascript/src/utils/getUnopenedChannels.jsx
+++ b/app/javascript/src/utils/getUnopenedChannels.jsx
@@ -42,7 +42,7 @@ class UnopenedChannelNotice extends Component {
     const number = document.getElementById('connect-number');
     this.setState({ unopenedChannels });
     if (unopenedChannels.length > 0) {
-      if (unopenedChannels[0].adjusted_slug === "@"+JSON.parse(window.currentUser).username) {
+      if (unopenedChannels[0].adjusted_slug === "@"+userData().username) {
         return;
       }
       number.classList.remove('hidden');


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

For some reason `window.currentUser` is sometimes a string and sometimes an object. This seems to fix it in either case.