### PR TITLE
Hide the Shop in homepage if not present

### DIFF
--- a/app/views/articles/_sidebar_nav.html.erb
+++ b/app/views/articles/_sidebar_nav.html.erb
@@ -56,10 +56,12 @@
         <%= inline_svg_tag("twemoji/bulb.svg", aria: true, class: "crayons-icon crayons-icon--default", title: "FAQ") %>
         FAQ
       </a>
+      <% if SiteConfig.shop_url.present? %>
       <a href="<%= SiteConfig.shop_url %>" class="crayons-link crayons-link--block">
         <%= inline_svg_tag("twemoji/shopping.svg", aria: true, class: "crayons-icon crayons-icon--default", title: "Shop") %>
         <%= community_name %> Shop
       </a>
+      <% end %>
       <a href="/sponsors" class="crayons-link crayons-link--block">
         <%= inline_svg_tag("twemoji/heart.svg", aria: true, class: "crayons-icon crayons-icon--default", title: "Sponsors") %>
         Sponsors

--- a/spec/system/homepage/user_visits_homepage_spec.rb
+++ b/spec/system/homepage/user_visits_homepage_spec.rb
@@ -84,5 +84,27 @@ RSpec.describe "User visits a homepage", type: :system do
         end
       end
     end
+
+    describe "shop url" do
+      it "shows the link to the shop if present" do
+        SiteConfig.shop_url = "https://example.com"
+
+        visit "/"
+
+        within("#main-nav-more") do
+          expect(page).to have_link(href: SiteConfig.shop_url)
+        end
+      end
+
+      it "does not show the shop if not present" do
+        SiteConfig.shop_url = ""
+
+        visit "/"
+
+        within("#main-nav-more") do
+          expect(page).not_to have_text("Shop")
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Now that the shop URL is an optional configuration parameter, we should hide its like from the homepage. It's already hidden in the other places, just forgot to do it here in #7319 :D

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
