### PR TITLE
Disable service worker on remaining hardcoded redirects

### DIFF
--- a/app/views/service_worker/index.js.erb
+++ b/app/views/service_worker/index.js.erb
@@ -126,10 +126,11 @@
         !url.href.includes('/search/users') &&
 
         // Don't run on redirects
-        !url.href.includes('/workshops') &&
         !url.href.includes('/%F0%9F%92%B8') && // 💸 (hiring)
-        !url.href.includes('/podcasts') &&
         !url.href.includes('/p/rlyweb') &&
+        !url.href.includes('/podcasts') &&
+        !url.href.includes('/shop') &&
+        !url.href.includes('/workshops') &&
 
         caches.match('/shell_top') && // Ensure shell_top is in the cache.
         caches.match('/shell_bottom')) { // Ensure shell_bottom is in the cache.

--- a/app/views/service_worker/index.js.erb
+++ b/app/views/service_worker/index.js.erb
@@ -125,11 +125,14 @@
         !url.href.includes('/search/feed_content') &&
         !url.href.includes('/search/users') &&
 
-        // Don't run on redirects
+        // Don't run on harcoded redirects (see config/routes.rb for the list)
         !url.href.includes('/%F0%9F%92%B8') && // 💸 (hiring)
+        !url.href.includes('/api') &&
+        !url.href.includes('/future') &&
         !url.href.includes('/p/rlyweb') &&
         !url.href.includes('/podcasts') &&
         !url.href.includes('/shop') &&
+        !url.href.includes('/survey') &&
         !url.href.includes('/workshops') &&
 
         caches.match('/shell_top') && // Ensure shell_top is in the cache.


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The service worker doesn't play well with redirects - see #7156 - this disables it in the `/shop` redirect as well.

**update**: I also added all the remaining redirects in `config/routes.rb`

## Related Tickets & Documents

Closes https://github.com/thepracticaldev/dev.to/issues/7339

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
