### PR TITLE
Add user_id presence validation for Identity

### DIFF
--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -4,7 +4,9 @@ class Identity < ApplicationRecord
 
   validates :uid, :provider, presence: true
   validates :uid, uniqueness: { scope: :provider }, if: proc { |identity| identity.uid_changed? || identity.provider_changed? }
+  validates :user_id, presence: true
   validates :user_id, uniqueness: { scope: :provider }, if: proc { |identity| identity.user_id_changed? || identity.provider_changed? }
+
   # TODO: [thepracticaldev/oss] put the providers somewhere else
   validates :provider, inclusion: { in: %w[github twitter] }
 

--- a/app/services/authentication/authenticator.rb
+++ b/app/services/authentication/authenticator.rb
@@ -82,7 +82,7 @@ module Authentication
 
         user.set_remember_fields
 
-        # save_identity() requires uses to have been saved in the DB prior
+        # save_identity() requires users to have been saved in the DB prior
         # to its execution, thus we need to make sure the new user is saved
         # before that
         user.save!

--- a/app/services/authentication/authenticator.rb
+++ b/app/services/authentication/authenticator.rb
@@ -81,6 +81,11 @@ module Authentication
         user.assign_attributes(default_user_fields)
 
         user.set_remember_fields
+
+        # save_identity() requires uses to have been saved in the DB prior
+        # to its execution, thus we need to make sure the new user is saved
+        # before that
+        user.save!
       end
     end
 

--- a/spec/models/identity_spec.rb
+++ b/spec/models/identity_spec.rb
@@ -1,20 +1,33 @@
 require "rails_helper"
 
 RSpec.describe Identity, type: :model do
-  it { is_expected.to belong_to(:user) }
-  it { is_expected.to validate_presence_of(:uid) }
-  it { is_expected.to validate_presence_of(:provider) }
-  it { is_expected.to validate_uniqueness_of(:uid).scoped_to(:provider) }
+  let(:identity) { create(:identity, user: create(:user), uid: SecureRandom.hex) }
 
-  it do
-    # rubocop:disable RSpec/NamedSubject
-    subject.user = build(:user)
-    expect(subject).to validate_uniqueness_of(:user_id).scoped_to(:provider)
-    # rubocop:enable RSpec/NamedSubject
+  describe "validations" do
+    describe "builtin validations" do
+      subject { identity }
+
+      it { is_expected.to belong_to(:user) }
+
+      it { is_expected.to have_many(:backup_data).class_name("BackupData").dependent(:destroy) }
+
+      it { is_expected.to validate_presence_of(:provider) }
+      it { is_expected.to validate_presence_of(:uid) }
+      it { is_expected.to validate_presence_of(:user_id) }
+      it { is_expected.to validate_uniqueness_of(:uid).scoped_to(:provider) }
+      it { is_expected.to validate_uniqueness_of(:user_id).scoped_to(:provider) }
+
+      it do
+        # rubocop:disable RSpec/NamedSubject
+        subject.user = build(:user)
+        expect(subject).to validate_uniqueness_of(:user_id).scoped_to(:provider)
+        # rubocop:enable RSpec/NamedSubject
+      end
+
+      it { is_expected.to validate_inclusion_of(:provider).in_array(%w[github twitter]) }
+      it { is_expected.to serialize(:auth_data_dump) }
+    end
   end
-
-  it { is_expected.to validate_inclusion_of(:provider).in_array(%w[github twitter]) }
-  it { is_expected.to serialize(:auth_data_dump) }
 
   describe ".build_build_from_omniauth" do
     let(:user) { create(:user) }

--- a/spec/models/identity_spec.rb
+++ b/spec/models/identity_spec.rb
@@ -17,14 +17,8 @@ RSpec.describe Identity, type: :model do
       it { is_expected.to validate_uniqueness_of(:uid).scoped_to(:provider) }
       it { is_expected.to validate_uniqueness_of(:user_id).scoped_to(:provider) }
 
-      it do
-        # rubocop:disable RSpec/NamedSubject
-        subject.user = build(:user)
-        expect(subject).to validate_uniqueness_of(:user_id).scoped_to(:provider)
-        # rubocop:enable RSpec/NamedSubject
-      end
-
       it { is_expected.to validate_inclusion_of(:provider).in_array(%w[github twitter]) }
+
       it { is_expected.to serialize(:auth_data_dump) }
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -841,7 +841,7 @@ RSpec.describe User, type: :model do
     end
 
     it "does not assign signup_cta_variant to non-new users" do
-      returning_user = build(:user, signup_cta_variant: nil)
+      returning_user = create(:user, signup_cta_variant: nil)
       new_user = user_from_authorization_service(:twitter, returning_user, "hey-hey-hey")
       expect(new_user.signup_cta_variant).to eq(nil)
     end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Added presence validation for `Identity.user_id`

I'm going to address the underlying lack of constraint in a separate PR (as in the DB not having `NOT NULL` on the column) 

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
