### PR TITLE
Record Identity Creation Metrics

### DIFF
--- a/app/services/authentication/authenticator.rb
+++ b/app/services/authentication/authenticator.rb
@@ -110,7 +110,9 @@ module Authentication
 
     def save_identity(identity, user)
       identity.user = user if identity.user_id.blank?
+      new_record = identity.new_record?
       identity.save!
+      record_identity_creation(identity) if new_record
     end
 
     def account_less_than_a_week_old?(user, logged_in_identity)
@@ -125,6 +127,10 @@ module Authentication
 
     def flag_spam_user(user)
       Slack::Messengers::PotentialSpammer.call(user: user)
+    end
+
+    def record_identity_creation(identity)
+      DatadogStatsClient.increment("identity.created", tags: [provider: identity.provider])
     end
   end
 end

--- a/spec/services/authentication/authenticator_spec.rb
+++ b/spec/services/authentication/authenticator_spec.rb
@@ -78,6 +78,15 @@ RSpec.describe Authentication::Authenticator, type: :service do
           described_class.call(auth_payload)
         end
       end
+
+      it "records successful identity creation metric" do
+        allow(DatadogStatsClient).to receive(:increment)
+        service.call
+
+        expect(DatadogStatsClient).to have_received(:increment).with(
+          "identity.created", tags: [provider: "github"]
+        )
+      end
     end
 
     describe "existing user" do
@@ -107,6 +116,13 @@ RSpec.describe Authentication::Authenticator, type: :service do
         expect do
           service.call
         end.not_to change(Identity, :count)
+      end
+
+      it "does not record an identity creation metric" do
+        allow(DatadogStatsClient).to receive(:increment)
+        service.call
+
+        expect(DatadogStatsClient).not_to have_received(:increment)
       end
 
       it "sets remember_me for the existing user" do
@@ -242,6 +258,15 @@ RSpec.describe Authentication::Authenticator, type: :service do
           described_class.call(auth_payload)
         end
       end
+
+      it "records successful identity creation metric" do
+        allow(DatadogStatsClient).to receive(:increment)
+        service.call
+
+        expect(DatadogStatsClient).to have_received(:increment).with(
+          "identity.created", tags: [provider: "twitter"]
+        )
+      end
     end
 
     describe "existing user" do
@@ -271,6 +296,13 @@ RSpec.describe Authentication::Authenticator, type: :service do
         expect do
           service.call
         end.not_to change(Identity, :count)
+      end
+
+      it "does not record an identity creation metric" do
+        allow(DatadogStatsClient).to receive(:increment)
+        service.call
+
+        expect(DatadogStatsClient).not_to have_received(:increment)
       end
 
       it "updates the proper data from the auth payload" do


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Feature

## Description
In order to alert us of problems with our authentication user creation flow lets record every time we create a new identity and if none are created for an extended period of time alert so we can look into it. 

## Added tests?
- [x] yes

![alt_text](https://media3.giphy.com/media/arjtv5JPsgpgs/giphy.gif)
