### PR TITLE
Wrap user/identity coupled logic in a transaction

### DIFF
--- a/app/services/authentication/authenticator.rb
+++ b/app/services/authentication/authenticator.rb
@@ -64,8 +64,10 @@ module Authentication
       # Return the successfully-authed used from the transaction.
       authed_user
     rescue StandardError => e
-      # Notify DataDog if something goes wrong in the transaction.
+      # Notify DataDog if something goes wrong in the transaction,
+      # and then ensure that we re-raise and bubble up the error.
       DatadogStatsClient.increment("identity.errors", tags: ["error:#{e.class}"], message: e.message)
+      raise e
     end
 
     private

--- a/app/services/authentication/authenticator.rb
+++ b/app/services/authentication/authenticator.rb
@@ -66,7 +66,7 @@ module Authentication
     rescue StandardError => e
       # Notify DataDog if something goes wrong in the transaction,
       # and then ensure that we re-raise and bubble up the error.
-      DatadogStatsClient.increment("identity.errors", tags: ["error:#{e.class}"], message: e.message)
+      DatadogStatsClient.increment("identity.errors", tags: ["error:#{e.class}", "message:#{e.message}"])
       raise e
     end
 

--- a/app/services/authentication/authenticator.rb
+++ b/app/services/authentication/authenticator.rb
@@ -48,8 +48,6 @@ module Authentication
         user.save!
         user
       end
-    rescue StandardError => e
-      Rails.logger.error(e)
     end
 
     private

--- a/spec/services/authentication/authenticator_spec.rb
+++ b/spec/services/authentication/authenticator_spec.rb
@@ -87,6 +87,18 @@ RSpec.describe Authentication::Authenticator, type: :service do
           "identity.created", tags: [provider: "github"]
         )
       end
+
+      it "increments identity.errors if any errors occur in the transaction" do
+        # rubocop:disable RSpec/AnyInstance
+        allow_any_instance_of(Identity).to receive(:save!).and_raise(StandardError)
+        # rubocop:enable RSpec/AnyInstance
+        allow(DatadogStatsClient).to receive(:increment)
+
+        described_class.call(auth_payload)
+
+        tags = hash_including(tags: array_including("error:StandardError"))
+        expect(DatadogStatsClient).to have_received(:increment).with("identity.errors", tags)
+      end
     end
 
     describe "existing user" do
@@ -172,6 +184,18 @@ RSpec.describe Authentication::Authenticator, type: :service do
         expect(
           user.profile_updated_at.to_i > original_profile_updated_at.to_i,
         ).to be(true)
+      end
+
+      it "increments identity.errors if any errors occur in the transaction" do
+        # rubocop:disable RSpec/AnyInstance
+        allow_any_instance_of(Identity).to receive(:save!).and_raise(StandardError)
+        # rubocop:enable RSpec/AnyInstance
+        allow(DatadogStatsClient).to receive(:increment)
+
+        described_class.call(auth_payload)
+
+        tags = hash_including(tags: array_including("error:StandardError"))
+        expect(DatadogStatsClient).to have_received(:increment).with("identity.errors", tags)
       end
     end
 

--- a/spec/services/authentication/authenticator_spec.rb
+++ b/spec/services/authentication/authenticator_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Authentication::Authenticator, type: :service do
         # rubocop:enable RSpec/AnyInstance
         allow(DatadogStatsClient).to receive(:increment)
 
-        described_class.call(auth_payload)
+        expect { described_class.call(auth_payload) }.to raise_error(StandardError)
 
         tags = hash_including(tags: array_including("error:StandardError"))
         expect(DatadogStatsClient).to have_received(:increment).with("identity.errors", tags)
@@ -192,7 +192,7 @@ RSpec.describe Authentication::Authenticator, type: :service do
         # rubocop:enable RSpec/AnyInstance
         allow(DatadogStatsClient).to receive(:increment)
 
-        described_class.call(auth_payload)
+        expect { described_class.call(auth_payload) }.to raise_error(StandardError)
 
         tags = hash_including(tags: array_including("error:StandardError"))
         expect(DatadogStatsClient).to have_received(:increment).with("identity.errors", tags)


### PR DESCRIPTION
What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Creating a `user` and then setting an `identity` should occur as an all-or-nothing step.
Wrapping this in an `ActiveRecord::Transaction` ensures that we don't update an identity
unless we successfully `create`/`update` the `user` first in the same database transaction.

## Related Tickets & Documents
Lol, #emergency.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
N/A

## Added tests?

- [ ] yes
- [ ] no, because they aren't needed
- [x] no, because ~I need help~ how do you...test this?

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed