### PR TITLE
Fix response template non-logged-in navigation issue

### DIFF
--- a/app/javascript/responseTemplates/responseTemplates.js
+++ b/app/javascript/responseTemplates/responseTemplates.js
@@ -290,10 +290,10 @@ export function loadResponseTemplates() {
   const { userStatus } = document.body.dataset;
   const form = document.getElementById('new_comment');
 
-  if (userStatus === 'logged-out') {
-    handleLoggedOut();
-  }
   if (document.getElementById('response-templates-data')) {
+    if (userStatus === 'logged-out') {
+      handleLoggedOut();
+    }
     if (
       form &&
       form.querySelector('.response-templates-button').dataset.hasListener === 'false'


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Navigating to pages that don't have the proper response template elements causes a non-intrusive runtime error for non-logged in cases. This moves the `if` statement a few lines to account for that.