### PR TITLE
Fix sort_by expectations with pagination

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -36,6 +36,7 @@ class SearchController < ApplicationController
     :per_page,
     :search_fields,
     :sort_by,
+    :sort_direction,
     :user_id,
     {
       tag_names: [],

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -27,7 +27,7 @@
 
 <% cache(cache_key_heroku_slug("main-stories-index-#{params}-#{user_signed_in?}"), expires_in: 90.seconds) do %>
   <div class="home" id="index-container"
-      data-params="<%= params.merge(sort_by: "hotness_score").to_json(only: %i[tag username q sort_by]) %>" data-which="<%= @list_of %>"
+      data-params="<%= params.merge(sort_by: "hotness_score", sort_direction: "desc").to_json(only: %i[tag username q sort_by sort_direction]) %>" data-which="<%= @list_of %>"
       data-tag=""
       data-feed="<%= params[:timeframe] || "base-feed" %>"
       data-articles-since="<%= Timeframer.new(params[:timeframe]).datetime&.iso8601 %>">

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -27,7 +27,7 @@
 
 <% cache(cache_key_heroku_slug("main-stories-index-#{params}-#{user_signed_in?}"), expires_in: 90.seconds) do %>
   <div class="home" id="index-container"
-      data-params="<%= params.to_json(only: %i[tag username q]) %>" data-which="<%= @list_of %>"
+      data-params="<%= params.merge(sort_by: "hotness_score").to_json(only: %i[tag username q sort_by]) %>" data-which="<%= @list_of %>"
       data-tag=""
       data-feed="<%= params[:timeframe] || "base-feed" %>"
       data-articles-since="<%= Timeframer.new(params[:timeframe]).datetime&.iso8601 %>">

--- a/app/views/articles/tag_index.html.erb
+++ b/app/views/articles/tag_index.html.erb
@@ -30,7 +30,7 @@
     </div>
   </div>
   <div class="home sub-home" id="index-container"
-      data-params="<%= params.to_json(only: %i[tag username q]) %>" data-which=""
+      data-params="<%= params.merge(sort_by: "hotness_score").to_json(only: %i[tag username q sort_by]) %>" data-which=""
       data-tag="<%= @tag %>"
       data-feed="<%= params[:timeframe] || "base-feed" %>"
       data-requires-approval="<%= @tag_model.requires_approval %>"

--- a/app/views/articles/tag_index.html.erb
+++ b/app/views/articles/tag_index.html.erb
@@ -30,7 +30,7 @@
     </div>
   </div>
   <div class="home sub-home" id="index-container"
-      data-params="<%= params.merge(sort_by: "hotness_score", sort_direction: "desc").to_json(only: %i[tag username  sort_direction]) %>" data-which=""
+      data-params="<%= params.merge(sort_by: "hotness_score", sort_direction: "desc").to_json(only: %i[tag username sort_by sort_direction]) %>" data-which=""
       data-tag="<%= @tag %>"
       data-feed="<%= params[:timeframe] || "base-feed" %>"
       data-requires-approval="<%= @tag_model.requires_approval %>"

--- a/app/views/articles/tag_index.html.erb
+++ b/app/views/articles/tag_index.html.erb
@@ -30,7 +30,7 @@
     </div>
   </div>
   <div class="home sub-home" id="index-container"
-      data-params="<%= params.merge(sort_by: "hotness_score").to_json(only: %i[tag username q sort_by]) %>" data-which=""
+      data-params="<%= params.merge(sort_by: "hotness_score", sort_direction: "desc").to_json(only: %i[tag username  sort_direction]) %>" data-which=""
       data-tag="<%= @tag %>"
       data-feed="<%= params[:timeframe] || "base-feed" %>"
       data-requires-approval="<%= @tag_model.requires_approval %>"

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -5,7 +5,7 @@
 <% end %>
 <%= render "users/profile_header" %>
 <div class="home sub-home" id="index-container"
-     data-params="<%= params.merge(sort_by: "published_at").to_json(only: %i[tag username q sort_by]) %>" data-which="<%= @list_of %>"
+     data-params="<%= params.merge(sort_by: "published_at", sort_direction: "desc").to_json(only: %i[tag username q sort_by sort_direction]) %>" data-which="<%= @list_of %>"
      data-tag="<%= "organization_#{@organization.id}" %>"
      data-feed="<%= params[:timeframe] || "base-feed" %>"
      data-articles-since="<%= Timeframer.new(params[:timeframe]).datetime&.iso8601 %>">

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -5,7 +5,7 @@
 <% end %>
 <%= render "users/profile_header" %>
 <div class="home sub-home" id="index-container"
-     data-params="<%= params.to_json(only: %i[tag username q]) %>" data-which="<%= @list_of %>"
+     data-params="<%= params.merge(sort_by: "published_at").to_json(only: %i[tag username q sort_by]) %>" data-which="<%= @list_of %>"
      data-tag="<%= "organization_#{@organization.id}" %>"
      data-feed="<%= params[:timeframe] || "base-feed" %>"
      data-articles-since="<%= Timeframer.new(params[:timeframe]).datetime&.iso8601 %>">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -176,7 +176,7 @@
 <% end %>
 
 <div class="home sub-home" id="index-container"
-     data-params="<%= params.merge(user_id: @user.id, class_name: "Article").to_json(only: %i[tag user_id q class_name]) %>" data-which="<%= @list_of %>"
+     data-params="<%= params.merge(user_id: @user.id, class_name: "Article", sort_by: "published_at").to_json(only: %i[tag user_id q class_name sort_by]) %>" data-which="<%= @list_of %>"
      data-tag=""
      data-feed="<%= params[:timeframe] || "base-feed" %>"
      data-articles-since="0">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -176,7 +176,7 @@
 <% end %>
 
 <div class="home sub-home" id="index-container"
-     data-params="<%= params.merge(user_id: @user.id, class_name: "Article", sort_by: "published_at").to_json(only: %i[tag user_id q class_name sort_by]) %>" data-which="<%= @list_of %>"
+     data-params="<%= params.merge(user_id: @user.id, class_name: "Article", sort_by: "published_at", sort_direction: "desc").to_json(only: %i[tag user_id q class_name sort_by sort_direction]) %>" data-which="<%= @list_of %>"
      data-tag=""
      data-feed="<%= params[:timeframe] || "base-feed" %>"
      data-articles-since="0">


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We are currently sorting by "the default" on views such as the main feed and user feeds etc. for pagination.

If you scroll down on my profile you'll see that it begins to sort by essentially top all time after the initial articles loaded, when it should sort by `published_at`. This PR modifies the inputs to search by proper value for different scenarios.

`sort_params_present?` also expects `sort_direction` to be available so I made it available via the view. Not 100% sure this is the right way to go about it but it seems to do the trick and seems like an okay approach.