### PR TITLE
Include organization in feed_content results

### DIFF
--- a/app/services/search/query_builders/feed_content.rb
+++ b/app/services/search/query_builders/feed_content.rb
@@ -58,6 +58,7 @@ module Search
         tags
         title
         user
+        organization
       ].freeze
 
       attr_accessor :params, :body


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Feed results are not showing organizations when they should. This simple fix does the trick.