### PR TITLE
Improve badge slug generation

### DIFF
--- a/app/models/badge.rb
+++ b/app/models/badge.rb
@@ -5,9 +5,9 @@ class Badge < ApplicationRecord
   has_many :tags
   has_many :users, through: :badge_achievements
 
-  validates :title, presence: true, uniqueness: true
-  validates :description, presence: true
   validates :badge_image, presence: true
+  validates :description, presence: true
+  validates :title, presence: true, uniqueness: true
 
   before_validation :generate_slug
   after_save :bust_path
@@ -19,7 +19,7 @@ class Badge < ApplicationRecord
   private
 
   def generate_slug
-    self.slug = title.to_s.parameterize
+    self.slug = CGI.escape(title.to_s).parameterize
   end
 
   def bust_path

--- a/db/migrate/20200420130910_add_unique_index_to_badges_slug.rb
+++ b/db/migrate/20200420130910_add_unique_index_to_badges_slug.rb
@@ -1,0 +1,7 @@
+class AddUniqueIndexToBadgesSlug < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :badges, :slug, unique: true, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_09_050122) do
+ActiveRecord::Schema.define(version: 2020_04_20_130910) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -172,6 +172,7 @@ ActiveRecord::Schema.define(version: 2020_04_09_050122) do
     t.string "slug", null: false
     t.string "title", null: false
     t.datetime "updated_at", null: false
+    t.index ["slug"], name: "index_badges_on_slug", unique: true
     t.index ["title"], name: "index_badges_on_title", unique: true
   end
 

--- a/spec/models/badge_spec.rb
+++ b/spec/models/badge_spec.rb
@@ -1,14 +1,71 @@
 require "rails_helper"
 
 RSpec.describe Badge, type: :model do
-  let_it_be(:badge) { create(:badge) }
+  let(:badge) { create(:badge) }
 
   describe "validations" do
-    it { is_expected.to have_many(:users).through(:badge_achievements) }
-    it { is_expected.to have_many(:badge_achievements) }
-    it { is_expected.to validate_presence_of(:title) }
-    it { is_expected.to validate_presence_of(:description) }
-    it { is_expected.to validate_presence_of(:badge_image) }
-    it { is_expected.to validate_uniqueness_of(:title) }
+    describe "builtin validations" do
+      subject { badge }
+
+      it { is_expected.to have_many(:badge_achievements) }
+      it { is_expected.to have_many(:tags) }
+      it { is_expected.to have_many(:users).through(:badge_achievements) }
+
+      it { is_expected.to validate_presence_of(:title) }
+      it { is_expected.to validate_presence_of(:description) }
+      it { is_expected.to validate_presence_of(:badge_image) }
+      it { is_expected.to validate_uniqueness_of(:title) }
+    end
+  end
+
+  context "when callbacks are triggered after save" do
+    let_it_be_changeable(:badge) { create(:badge) }
+
+    describe "cache busting" do
+      before do
+        allow(CacheBuster).to receive(:bust)
+      end
+
+      it "calls the cache buster with the path" do
+        badge.save
+
+        expect(CacheBuster).to have_received(:bust).with(badge.path)
+      end
+
+      it "calls the cache buster with the internal path" do
+        badge.save
+
+        expect(CacheBuster).to have_received(:bust).with("#{badge.path}?i=i")
+      end
+    end
+  end
+
+  describe "#path" do
+    it "returns the path of the badge" do
+      expect(badge.path).to eq("/badge/#{badge.slug}")
+    end
+  end
+
+  describe "#slug" do
+    it "generates the correct slug for C" do
+      badge = build(:badge, title: "C")
+      badge.validate!
+
+      expect(badge.slug).to eq("c")
+    end
+
+    it "generates the correct slug for C#" do
+      badge = build(:badge, title: "C#")
+      badge.validate!
+
+      expect(badge.slug).to eq("c-23")
+    end
+
+    it "generates the correct slug for '16 Week Streak'" do
+      badge = build(:badge, title: "16 Week Streak")
+      badge.validate!
+
+      expect(badge.slug).to eq("16-week-streak")
+    end
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Our current slug generation doesn't take into account escapable chars, so `C#` as a title becomes `c` as a slug, which is already present as the slug for the language `C`. We also don't have a unique index on slug, otherwise we would have caught this.

I changed how slugs are generated, it doesn't impact existing ones.

## Related Tickets & Documents

Closes #7248 

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## [optional] Are there any post deployment tasks we need to perform?

Pre-deployment we should fix the C# slug to `c-23` in the DB.
