### PR TITLE
Allow Filtering by Approved Attribute for Articles

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,7 +1,7 @@
 class SearchController < ApplicationController
   before_action :authenticate_user!, only: %i[tags chat_channels reactions]
   before_action :format_integer_params
-  before_action :sanitize_params, only: %i[classified_listings reactions]
+  before_action :sanitize_params, only: %i[classified_listings reactions feed_content]
 
   CLASSIFIED_LISTINGS_PARAMS = [
     :category,
@@ -31,14 +31,15 @@ class SearchController < ApplicationController
   ].freeze
 
   FEED_PARAMS = [
+    :approved,
     :class_name,
+    :organization_id,
     :page,
     :per_page,
     :search_fields,
     :sort_by,
     :sort_direction,
     :user_id,
-    :organization_id,
     {
       tag_names: [],
       published_at: [:gte]

--- a/spec/requests/search_spec.rb
+++ b/spec/requests/search_spec.rb
@@ -112,6 +112,17 @@ RSpec.describe "Search", type: :request, proper_status: true do
       expect(Search::User).not_to have_received(:search_documents)
       expect(Search::FeedContent).to have_received(:search_documents)
     end
+
+    it "queries for approved" do
+      allow(Search::FeedContent).to receive(:search_documents).and_return(
+        mock_documents,
+      )
+
+      get "/search/feed_content?class_name=Article&approved=true"
+      expect(Search::FeedContent).to have_received(:search_documents).with(
+        params: { "approved" => "true", "class_name" => "Article" },
+      )
+    end
   end
 
   describe "GET /search/reactions" do


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Make sure we can filter by the article `approved` attribute

## Added tests?
- [x] yes

![alt_text](https://media.tenor.com/images/cae787e7596b1b4a144bfcb9f90acd0f/tenor.gif)
