### PR TITLE
Replace Cover Image <div> Tags With <img> Tags

### DIFF
--- a/app/assets/stylesheets/article-show.scss
+++ b/app/assets/stylesheets/article-show.scss
@@ -59,16 +59,17 @@ article {
     margin: auto;
     max-width: 1024px;
     z-index: 2;
-    padding-top: 0;
+    background: transparent no-repeat center center; /* TODO[team-delightful]: Remove background styling a few days after merge to avoid conflicts */
+    background-size: cover;
     height: 42vh;
+
+    @media screen and (min-width: 880px) {
+      height: 370px;
+    }
 
     @media screen and (min-width: 950px) {
       border-top-left-radius: 2px;
       border-top-right-radius: 2px;
-    }
-
-    @media screen and (min-width: 880px) {
-      height: 370px;
     }
   }
 

--- a/app/assets/stylesheets/article-show.scss
+++ b/app/assets/stylesheets/article-show.scss
@@ -58,10 +58,8 @@ article {
     width: 100%;
     margin: auto;
     max-width: 1024px;
-    background: transparent no-repeat center center;
-    background-size: cover;
     z-index: 2;
-    padding-top: 42%;
+    padding-top: 14%;
 
     @media screen and (min-width: 950px) {
       border-top-left-radius: 2px;

--- a/app/assets/stylesheets/article-show.scss
+++ b/app/assets/stylesheets/article-show.scss
@@ -62,7 +62,7 @@ article {
     z-index: 2;
     background: transparent no-repeat center center;
     background-size: cover;
-    height: 42vh;
+    height: 42vw;
 
     @media screen and (min-width: 880px) {
       height: 370px;

--- a/app/assets/stylesheets/article-show.scss
+++ b/app/assets/stylesheets/article-show.scss
@@ -59,11 +59,16 @@ article {
     margin: auto;
     max-width: 1024px;
     z-index: 2;
-    padding-top: 14%;
+    padding-top: 0;
+    height: 42vh;
 
     @media screen and (min-width: 950px) {
       border-top-left-radius: 2px;
       border-top-right-radius: 2px;
+    }
+
+    @media screen and (min-width: 880px) {
+      height: 370px;
     }
   }
 

--- a/app/assets/stylesheets/article-show.scss
+++ b/app/assets/stylesheets/article-show.scss
@@ -53,13 +53,14 @@ article {
   padding: 0 0;
   position: relative;
 
+  /* TODO[team-delightful]: Remove background and background-size a few days post merge to avoid caching conflicts */
   .image {
     position: relative;
     width: 100%;
     margin: auto;
     max-width: 1024px;
     z-index: 2;
-    background: transparent no-repeat center center; /* TODO[team-delightful]: Remove background styling a few days after merge to avoid conflicts */
+    background: transparent no-repeat center center;
     background-size: cover;
     height: 42vh;
 

--- a/app/assets/stylesheets/articles.scss
+++ b/app/assets/stylesheets/articles.scss
@@ -680,10 +680,9 @@
     &.big-article {
       padding: 0px;
       .picture {
-        padding-top: 42%;
+        padding-top: 14%;
         border-radius: 3px 3px 0 0;
-        background: no-repeat center center;
-        background-size: cover;
+        width: 100%;
       }
       .content-wrapper {
         padding-bottom: 115px;

--- a/app/assets/stylesheets/articles.scss
+++ b/app/assets/stylesheets/articles.scss
@@ -680,9 +680,10 @@
     &.big-article {
       padding: 0px;
       .picture {
-        padding-top: 14%;
+        padding-top: 42%;
         border-radius: 3px 3px 0 0;
-        width: 100%;
+        background: no-repeat center center;
+        background-size: cover;
       }
       .content-wrapper {
         padding-bottom: 115px;

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -131,7 +131,7 @@
         <% if @article.video.present? %>
           <%= render "articles/video_player", meta_tags: true, article: @article %>
         <% elsif @article.main_image.present? %>
-          <div class="image image-final" style="background-color:<%= @article.main_image_background_hex_color %>;background-image:url(<%= cloud_cover_url(@article.main_image) %>)">
+          <img src="<%= cloud_cover_url(@article.main_image) %>" alt="cover image" style="background-color:<%= @article.main_image_background_hex_color %>">
           </div>
         <% else %>
           <div class="blank-space"></div>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -131,8 +131,7 @@
         <% if @article.video.present? %>
           <%= render "articles/video_player", meta_tags: true, article: @article %>
         <% elsif @article.main_image.present? %>
-          <img src="<%= cloud_cover_url(@article.main_image) %>" alt="cover image" style="background-color:<%= @article.main_image_background_hex_color %>">
-          </div>
+          <img src="<%= cloud_cover_url(@article.main_image) %>" class="image image-final" style="background-color:<%= @article.main_image_background_hex_color %>;" />
         <% else %>
           <div class="blank-space"></div>
         <% end %>

--- a/app/views/stories/_main_stories_feed.html.erb
+++ b/app/views/stories/_main_stories_feed.html.erb
@@ -3,7 +3,7 @@
   <img src="<%= cloud_cover_url(@featured_story.main_image) %>" style="display:none" alt="<%= @featured_story.title %>" />
   <a href="<%= @featured_story.path %>" id="article-link-<%= @featured_story.id %>" class="index-article-link" aria-label="Main Story" data-featured-article="articles-<%= @featured_story.id %>">
     <div class="single-article big-article" data-content-user-id="<%= @featured_story.user_id %>">
-      <img class="picture image-final" src="<%= cloud_cover_url(@featured_story.main_image) %>" style="background-color:<%= @featured_story.main_image_background_hex_color %>;" alt="<% @featured_story.title %>%" />
+      <div class="picture image-final" style="background-color:<%= @featured_story.main_image_background_hex_color %>;background-image:url(<%= cloud_cover_url(@featured_story.main_image) %>)"></div>
       <div class="content-wrapper">
         <h3>
           <%= @featured_story.title %>

--- a/app/views/stories/_main_stories_feed.html.erb
+++ b/app/views/stories/_main_stories_feed.html.erb
@@ -3,7 +3,7 @@
   <img src="<%= cloud_cover_url(@featured_story.main_image) %>" style="display:none" alt="<%= @featured_story.title %>" />
   <a href="<%= @featured_story.path %>" id="article-link-<%= @featured_story.id %>" class="index-article-link" aria-label="Main Story" data-featured-article="articles-<%= @featured_story.id %>">
     <div class="single-article big-article" data-content-user-id="<%= @featured_story.user_id %>">
-      <div class="picture image-final" style="background-color:<%= @featured_story.main_image_background_hex_color %>;background-image:url(<%= cloud_cover_url(@featured_story.main_image) %>)"></div>
+      <img class="picture image-final" src="<%= cloud_cover_url(@featured_story.main_image) %>" style="background-color:<%= @featured_story.main_image_background_hex_color %>;" alt="<% @featured_story.title %>%" />
       <div class="content-wrapper">
         <h3>
           <%= @featured_story.title %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
We currently use `<div>`s with an image class and a `background-image:url` for cover images in place of `<img>` tags, which is not very semantic. This PR not only replaces the `<div>`s with `<img>`s, but also adjusts the styling of cover images for a particular article's show page accordingly.

**A few days post-merge, the background styling (`background` and `background-size`) will need to be removed from `article-show.scss` since it is now dead code. There is both a comment in the stylesheet, as well as an issue (seen below under "Related Tickets & Documents") for this code removal.**

## Related Tickets & Documents
Closes #7289 
Related To #7401 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
**Article Show Page Before:**

<img width="1502" alt="Screen Shot 2020-04-17 at 3 39 18 PM" src="https://user-images.githubusercontent.com/32834804/79617231-363af400-80c4-11ea-9174-ca255844c105.png">
<img width="1105" alt="Screen Shot 2020-04-17 at 3 39 35 PM" src="https://user-images.githubusercontent.com/32834804/79617235-376c2100-80c4-11ea-8982-82ae416dce3a.png">

**Article Show Page After:**

![Screen Shot 2020-04-20 at 11 40 39 AM](https://user-images.githubusercontent.com/32834804/79782199-ef374380-82fb-11ea-97bc-f6ea13a9442c.png)
![Screen Shot 2020-04-20 at 11 39 47 AM](https://user-images.githubusercontent.com/32834804/79782213-f52d2480-82fb-11ea-8fd1-d8d9bb798215.png)


## Added tests?
- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?
- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?
![CSS Family Guy](https://media.giphy.com/media/yYSSBtDgbbRzq/giphy.gif)