### PR TITLE
Ensure Readinglist Reactions are Removed from Elasticsearch when Deleted

### DIFF
--- a/app/services/users/delete_articles.rb
+++ b/app/services/users/delete_articles.rb
@@ -7,7 +7,7 @@ module Users
 
       virtual_articles = user.articles.map { |article| Article.new(article.attributes) }
       user.articles.find_each do |article|
-        article.reactions.delete_all
+        remove_reactions(article)
         article.buffer_updates.delete_all
         article.comments.includes(:user).find_each do |comment|
           comment.reactions.delete_all
@@ -23,6 +23,14 @@ module Users
       end
       virtual_articles.each do |article|
         cache_buster.bust_article(article)
+      end
+    end
+
+    def remove_reactions(article)
+      readinglist_ids = article.reactions.readinglist.pluck(:id)
+      article.reactions.delete_all
+      readinglist_ids.each do |id|
+        Search::RemoveFromElasticsearchIndexWorker.perform_async("Search::Reaction", id)
       end
     end
   end

--- a/spec/services/users/delete_spec.rb
+++ b/spec/services/users/delete_spec.rb
@@ -56,6 +56,27 @@ RSpec.describe Users::Delete, type: :service do
     expect { user.elasticsearch_doc }.to raise_error(Search::Errors::Transport::NotFound)
   end
 
+  it "removes articles from Elasticsearch" do
+    article = create(:article, user: user)
+    sidekiq_perform_enqueued_jobs
+    expect(article.elasticsearch_doc).not_to be_nil
+    sidekiq_perform_enqueued_jobs do
+      described_class.call(user)
+    end
+    expect { article.elasticsearch_doc }.to raise_error(Search::Errors::Transport::NotFound)
+  end
+
+  it "removes reactions from Elasticsearch" do
+    article = create(:article, user: user)
+    reaction = create(:reaction, category: "readinglist", reactable: article)
+    sidekiq_perform_enqueued_jobs
+    expect(reaction.elasticsearch_doc).not_to be_nil
+    sidekiq_perform_enqueued_jobs do
+      described_class.call(user)
+    end
+    expect { reaction.elasticsearch_doc }.to raise_error(Search::Errors::Transport::NotFound)
+  end
+
   # check that all the associated records are being destroyed, except for those that are kept explicitly (kept_associations)
   describe "deleting associations" do
     let(:kept_association_names) do

--- a/spec/services/users/delete_spec.rb
+++ b/spec/services/users/delete_spec.rb
@@ -69,12 +69,15 @@ RSpec.describe Users::Delete, type: :service do
   it "removes reactions from Elasticsearch" do
     article = create(:article, user: user)
     reaction = create(:reaction, category: "readinglist", reactable: article)
+    user_reaction = create(:reaction, user_id: user.id, category: "readinglist")
     sidekiq_perform_enqueued_jobs
     expect(reaction.elasticsearch_doc).not_to be_nil
+    expect(user_reaction.elasticsearch_doc).not_to be_nil
     sidekiq_perform_enqueued_jobs do
       described_class.call(user)
     end
     expect { reaction.elasticsearch_doc }.to raise_error(Search::Errors::Transport::NotFound)
+    expect { user_reaction.elasticsearch_doc }.to raise_error(Search::Errors::Transport::NotFound)
   end
 
   # check that all the associated records are being destroyed, except for those that are kept explicitly (kept_associations)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
When clearing out user data we use `.delete_all` on reactions which does not trigger any callbacks. This means any reading list reactions will be left in Elasticsearch. This PR updates the that delete class to remove the reactions from Elasticsearch after we have removed them from Postgres.

I also made sure to reindex reactions that were updated during a user merge since `update_all` also does not trigger any callbacks. 

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-36679085

## Added tests?
- [x] yes

![alt_text](https://media1.giphy.com/media/pHWPC1N5IZGVTfRgsN/giphy.gif?cid=ecf05e4716996bb365b25f173e53c0169e80c2cdd6f62b6d&rid=giphy.gif)
