### PR TITLE
Render json+ld as proper json

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -202,6 +202,10 @@ module ApplicationHelper
     URL.user(user)
   end
 
+  def organization_url(organization)
+    URL.organization(organization)
+  end
+
   def sanitized_referer(referer)
     URL.sanitized_referer(referer)
   end

--- a/app/lib/url.rb
+++ b/app/lib/url.rb
@@ -62,6 +62,10 @@ module URL
     url(user.username)
   end
 
+  def self.organization(organization)
+    url(organization.slug)
+  end
+
   # Ensures we don't consider serviceworker.js as referer
   #
   # @param referer [String] the unsanitized referer

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -32,37 +32,7 @@
   <% end %>
   <% unless internal_navigation? || user_signed_in? %>
     <script type="application/ld+json">
-      {
-        "@context": "http://schema.org",
-        "@type": "Article",
-        "mainEntityOfPage": {
-          "@type": "WebPage",
-          "@id": "<%= article_url(@article) %>"
-        },
-        "url": "<%= article_url(@article) %>",
-        "image": "<%= article_social_image_url(@article) %>",
-        "publisher": {
-          "@context": "http://schema.org",
-          "@type": "Organization",
-          "name": "<%= community_qualified_name %>",
-          "logo": {
-            "@context": "http://schema.org",
-            "@type": "ImageObject",
-            "url": "<%= cloudinary(SiteConfig.logo_png, 192, "png") %>",
-            "width": "192",
-            "height": "192"
-          }
-        },
-        "headline": "<%= @article.title %>",
-        "author": {
-          "@context": "http://schema.org",
-          "@type": "Person",
-          "url": "<%= user_url(@user) %>",
-          "name": "<%= @user.name %>"
-        },
-        "datePublished": "<%= @article.published_timestamp %>",
-        "dateModified": "<%= @article.edited_at&.iso8601 || @article.published_timestamp %>"
-      }
+      <%= @article_json_ld.to_json.html_safe %>
     </script>
   <% end %>
 

--- a/app/views/users/_profile_header.html.erb
+++ b/app/views/users/_profile_header.html.erb
@@ -12,18 +12,7 @@
 
 <% unless internal_navigation? || user_signed_in? %>
   <script type="application/ld+json">
-    {
-      "@context": "http://schema.org",
-      "@type": "Organization",
-      "mainEntityOfPage": {
-        "@type": "WebPage",
-        "@id": "<%= user_url(@user) %>"
-      },
-      "url": "<%= user_url(@user) %>",
-      "image": "<%= ProfileImage.new(@user).get(width: 320) %>",
-      "name": "<%= sanitize @user.name %>",
-      "description": "<%= sanitize(@user.summary.presence || "404 bio not found") %>"
-    }
+    <%= @organization_json_ld.to_json.html_safe %>
   </script>
 <% end %>
 

--- a/spec/lib/url_spec.rb
+++ b/spec/lib/url_spec.rb
@@ -75,6 +75,14 @@ RSpec.describe URL, type: :lib do
     end
   end
 
+  describe ".organization" do
+    let(:organization) { build(:organization) }
+
+    it "returns the correct URL for a user" do
+      expect(described_class.user(organization)).to eq("https://dev.to/#{organization.slug}")
+    end
+  end
+
   describe ".tag" do
     let(:tag) { build(:tag) }
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

A handful of users with `\` in their name are causing JSON LD to not be properly rendered due to unescaped escaping character.

They are only causing problems on the article page, and not the user profile page because the profile page had already been rendered as an object and had `.to_json` called on it, cleaning up all the issues.

The ones rendered directly in erb, while generally working fine, did not hold up to this one issue.

Closes #7403 