### PR TITLE
Only Run scoring, touch_collection, and update background Callbacks on Update and Create

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -80,7 +80,7 @@ class Article < ApplicationRecord
   after_save :notify_slack_channel_about_publication
 
   after_update_commit :update_notifications, if: proc { |article| article.notifications.any? && !article.saved_changes.empty? }
-  after_commit :async_score_calc, :update_main_image_background_hex, :touch_collection
+  after_commit :async_score_calc, :update_main_image_background_hex, :touch_collection, on: %i[create update]
   after_commit :index_to_elasticsearch, on: %i[create update]
   after_commit :sync_related_elasticsearch_docs, on: %i[create update]
   after_commit :remove_from_elasticsearch, on: [:destroy]


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
When we run the`async_score_calc` callback on articles that kicks off a worker to rescore the article. For starters, there is no point in rescoring an article that is being destroyed. Secondly, this job can become slightly delayed so that it enqueues an indexing job AFTER we have enqueued and processed a remove from index job for the article deletion. This leads to orphaned documents in Elasticsearch.  

## Added tests?
- [x] no, because they aren't needed

![alt_text](https://media1.tenor.com/images/a75188f2609e9715891087f2c6bf8ed6/tenor.gif?itemid=12713982)
