### PR TITLE
Throttle General Site Requests

### DIFF
--- a/config/initializers/rack/attack.rb
+++ b/config/initializers/rack/attack.rb
@@ -17,7 +17,7 @@ class Rack::Attack
     end
   end
 
-  throttle("site_hits", limit: 20, period: 1) do |request|
+  throttle("site_hits", limit: 100, period: 2) do |request|
     if request.env["HTTP_FASTLY_CLIENT_IP"].present?
       request.env["HTTP_FASTLY_CLIENT_IP"].to_s
     end

--- a/config/initializers/rack/attack.rb
+++ b/config/initializers/rack/attack.rb
@@ -16,4 +16,10 @@ class Rack::Attack
       request.env["HTTP_API_KEY"]
     end
   end
+
+  throttle("site_hits", limit: 10, period: 1) do |request|
+    if request.env["HTTP_FASTLY_CLIENT_IP"].present?
+      request.env["HTTP_FASTLY_CLIENT_IP"].to_s
+    end
+  end
 end

--- a/config/initializers/rack/attack.rb
+++ b/config/initializers/rack/attack.rb
@@ -17,7 +17,7 @@ class Rack::Attack
     end
   end
 
-  throttle("site_hits", limit: 10, period: 1) do |request|
+  throttle("site_hits", limit: 20, period: 1) do |request|
     if request.env["HTTP_FASTLY_CLIENT_IP"].present?
       request.env["HTTP_FASTLY_CLIENT_IP"].to_s
     end

--- a/spec/initializers/rack/attack_spec.rb
+++ b/spec/initializers/rack/attack_spec.rb
@@ -5,6 +5,7 @@ describe Rack::Attack, type: :request, throttle: true do
     redis_url = "redis://localhost:6379"
     cache_db = ActiveSupport::Cache::RedisStore.new(redis_url)
     allow(Rails).to receive(:cache) { cache_db }
+    cache_db.data.flushdb
   end
 
   describe "search_throttle" do


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Bug Fix
- [x] Optimization

## Description
Don't allow more than 10 requests per second from a single IP address. I am open to suggestions on the limit number. 10 felt like it was super lenient and safe but I could see us ratcheting it down to 5 or less. I just didn't want to bork any background requests Fastly might be making during a page load or things like that. 

## Added tests?
- [x] no, because the time frame on this is so low and the limit so high we can't fire off 10 requests in sequence before the key expires. Even though we use Timecop, there is an expiration set on the keys in Redis and that does not adhere to any freezing from the Timecop helper. 

![alt_text](https://media1.tenor.com/images/b78094896c109b9d93a811d1af265d79/tenor.gif?itemid=9844100)
