### PR TITLE
Parse comment html as fragments instead of docs

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -164,7 +164,7 @@ class Comment < ApplicationRecord
   end
 
   def shorten_urls!
-    doc = Nokogiri::HTML.parse(processed_html)
+    doc = Nokogiri::HTML.fragment(processed_html)
     doc.css("a").each do |anchor|
       unless anchor.to_s.include?("<img") || anchor.attr("class")&.include?("ltag")
         anchor.content = strip_url(anchor.content) unless anchor.to_s.include?("<img")

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -153,6 +153,13 @@ RSpec.describe Comment, type: :model do
         comment.validate!
         expect(comment.processed_html.include?(">1:52:30</a>")).to eq(false)
       end
+
+      it "does not add DOCTYPE and html body to processed html" do
+        comment.body_markdown = "Hello https://longurl.com/#{'x' * 100}?#{'y' * 100}"
+        comment.validate!
+        expect(comment.processed_html).not_to include("<!DOCTYPE")
+        expect(comment.processed_html).not_to include("<html><body>")
+      end
     end
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

@aaronpk reported seeing comment texts stored as an entire HTML document in issue https://github.com/thepracticaldev/dev.to/issues/7271, and I've run into the same problem trying to display comments in the home page feed: in the database `comments.processed_html` holds an entire HTML document instead of just an HTML fragment after validation is run on `comment.rb`. This PR changes the `Nokogiri` method we're using from `parse` to `fragment` so that we don't end up with the entire HTML document in the database.

## Related Tickets & Documents
resolves #7271 
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

This PR will only fix the saved HTML content for new comments, existing comments will not have their HTML corrected in the database. I separate issue has been reported for that: (xxx)

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/xT5LMuYmpYIQCrOolG/giphy.gif)
