### PR TITLE
Handle rate limit errors gracefully

### DIFF
--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -21,6 +21,8 @@ class Api::V0::ApiController < ApplicationController
     error_unauthorized
   end
 
+  rescue_from RateLimitChecker::LimitReached, with: :too_many_requests
+
   protected
 
   def error_unprocessable_entity(message)
@@ -33,6 +35,10 @@ class Api::V0::ApiController < ApplicationController
 
   def error_not_found
     render json: { error: "not found", status: 404 }, status: :not_found
+  end
+
+  def too_many_requests
+    render json: { error: "too many requests", status: 429 }, status: :too_many_requests
   end
 
   def authenticate!

--- a/app/labor/rate_limit_checker.rb
+++ b/app/labor/rate_limit_checker.rb
@@ -7,6 +7,7 @@ class RateLimitChecker
 
   class UploadRateLimitReached < StandardError; end
   class DailyFollowAccountLimitReached < StandardError; end
+  class LimitReached < StandardError; end
 
   def limit_by_action(action)
     check_method = "check_#{action}_limit"

--- a/app/services/articles/creator.rb
+++ b/app/services/articles/creator.rb
@@ -11,7 +11,7 @@ module Articles
     end
 
     def call
-      raise if RateLimitChecker.new(user).limit_by_action("published_article_creation")
+      raise RateLimitChecker::LimitReached if RateLimitChecker.new(user).limit_by_action("published_article_creation")
 
       article = save_article
 

--- a/config/initializers/honeybadger.rb
+++ b/config/initializers/honeybadger.rb
@@ -19,6 +19,7 @@ Honeybadger.configure do |config|
     Pundit::NotAuthorizedError,
     ActiveRecord::RecordNotFound,
     ActiveRecord::QueryCanceled,
+    RateLimitChecker::LimitReached,
   ]
   config.request.filter_keys += %w[authorization]
   config.sidekiq.attempt_threshold = 10

--- a/spec/requests/articles/articles_spec.rb
+++ b/spec/requests/articles/articles_spec.rb
@@ -218,4 +218,17 @@ RSpec.describe "Articles", type: :request do
       end
     end
   end
+
+  describe "POST /create" do
+    before { sign_in user }
+
+    context "when creation limit is reached" do
+      it "raises a rate limit reached error" do
+        allow(Articles::Creator).to receive(:call).and_raise(RateLimitChecker::LimitReached)
+        expect do
+          post articles_path, params: { article: { markdown: "123" } }
+        end.to raise_error(RateLimitChecker::LimitReached)
+      end
+    end
+  end
 end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Bug Fix

## Description
Rather than raising a RuntimeError when a user hits a creation limit for articles lets raise a more helpful error like `RateLimitChecker::LimitReached`. We can then *ignore this error in Honeybadger* and rescue it in the API to return a helpful status code and message to the API user. 

## Related Tickets & Documents
Fixes: https://app.honeybadger.io/fault/66984/1558093e60d196166e600f756e4cd9da

## Added tests?
- [x] yes

![alt_text](https://media.giphy.com/media/Xjhp27DxwmUUw/giphy.gif)
