### PR TITLE
Allow Reaction Search to Use AND Operator for Tag Searching

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -18,6 +18,7 @@ class SearchController < ApplicationController
     :per_page,
     :category,
     :search_fields,
+    :tag_boolean_mode,
     {
       tag_names: [],
       status: []

--- a/app/services/search/query_builders/reaction.rb
+++ b/app/services/search/query_builders/reaction.rb
@@ -64,7 +64,13 @@ module Search
         TERM_KEYS.map do |term_key, search_key|
           next unless @params.key? term_key
 
-          { terms: { search_key => Array.wrap(@params[term_key]) } }
+          values = Array.wrap(@params[term_key])
+
+          if params[:tag_boolean_mode] == "all"
+            values.map { |val| { term: { search_key => val } } }
+          else
+            { terms: { search_key => values } }
+          end
         end.compact
       end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature
- [x] Bug Fix

## Description
Last piece of the puzzle before I PR the frontend Readinglist code! When a user filters by tags on their Reading List we want to use the AND operator between those tags. For example a search for #ruby and #rails should only return articles with BOTH tags.

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-36754138

## Added tests?
- [x] yes

![alt_text](https://media.giphy.com/media/4QEPowNLhHdQBdjaYG/giphy.gif)
