### PR TITLE
Reorder onboarding slides

### DIFF
--- a/app/javascript/onboarding/Onboarding.jsx
+++ b/app/javascript/onboarding/Onboarding.jsx
@@ -20,8 +20,8 @@ export default class Onboarding extends Component {
 
     const slides = [
       IntroSlide,
-      ProfileForm,
       FollowTags,
+      ProfileForm,
       FollowUsers,
       EmailPreferencesForm,
       ClosingSlide,

--- a/app/javascript/onboarding/__tests__/Onboarding.test.jsx
+++ b/app/javascript/onboarding/__tests__/Onboarding.test.jsx
@@ -80,6 +80,7 @@ describe('<Onboarding />', () => {
     });
 
   describe('IntroSlide', () => {
+    const introSlideIndex = 0;
     let onboardingSlides;
     const codeOfConductCheckEvent = {
       target: {
@@ -106,7 +107,7 @@ describe('<Onboarding />', () => {
     };
 
     beforeEach(() => {
-      onboardingSlides = initializeSlides(0, getUserData());
+      onboardingSlides = initializeSlides(introSlideIndex, getUserData());
     });
 
     test('renders properly', () => {
@@ -115,14 +116,14 @@ describe('<Onboarding />', () => {
 
     test('should advance if required boxes are checked', async () => {
       fetch.once({});
-      expect(onboardingSlides.state().currentSlide).toBe(0);
+      expect(onboardingSlides.state().currentSlide).toBe(introSlideIndex);
 
       updateCodeOfConduct();
       updateTermsAndConditions();
 
       onboardingSlides.find('.next-button').simulate('click');
       await flushPromises();
-      expect(onboardingSlides.state().currentSlide).toBe(1);
+      expect(onboardingSlides.state().currentSlide).toBe(introSlideIndex + 1);
     });
 
     test('should not have basic a11y violations', async () => {
@@ -134,13 +135,14 @@ describe('<Onboarding />', () => {
 
   describe('ProfileForm', () => {
     let onboardingSlides;
+    const profileFormIndex = 1;
     const meta = document.createElement('meta');
 
     meta.setAttribute('name', 'csrf-token');
     document.body.appendChild(meta);
 
     beforeEach(() => {
-      onboardingSlides = initializeSlides(1, getUserData());
+      onboardingSlides = initializeSlides(profileFormIndex, getUserData());
     });
 
     test('renders properly', () => {
@@ -178,20 +180,25 @@ describe('<Onboarding />', () => {
       profileForm.find('.next-button').simulate('click');
       fetch.once(fakeTagsResponse);
       await flushPromises();
-      expect(onboardingSlides.state().currentSlide).toBe(2);
+      expect(onboardingSlides.state().currentSlide).toBe(profileFormIndex + 1);
     });
 
     it('should step backward', () => {
       onboardingSlides.find('.back-button').simulate('click');
-      expect(onboardingSlides.state().currentSlide).toBe(0);
+      expect(onboardingSlides.state().currentSlide).toBe(profileFormIndex - 1);
     });
   });
 
   describe('FollowTags', () => {
     let onboardingSlides;
+    const followTagsIndex = 2;
 
     beforeEach(async () => {
-      onboardingSlides = initializeSlides(2, getUserData(), fakeTagsResponse);
+      onboardingSlides = initializeSlides(
+        followTagsIndex,
+        getUserData(),
+        fakeTagsResponse,
+      );
       await flushPromises();
     });
 
@@ -216,20 +223,25 @@ describe('<Onboarding />', () => {
       onboardingSlides.find('.next-button').simulate('click');
       fetch.once(fakeUsersResponse);
       await flushPromises();
-      expect(onboardingSlides.state().currentSlide).toBe(3);
+      expect(onboardingSlides.state().currentSlide).toBe(followTagsIndex + 1);
     });
 
     it('should step backward', () => {
       onboardingSlides.find('.back-button').simulate('click');
-      expect(onboardingSlides.state().currentSlide).toBe(1);
+      expect(onboardingSlides.state().currentSlide).toBe(followTagsIndex - 1);
     });
   });
 
   describe('FollowUsers', () => {
     let onboardingSlides;
+    const followUsersIndex = 3;
 
     beforeEach(async () => {
-      onboardingSlides = initializeSlides(3, getUserData(), fakeUsersResponse);
+      onboardingSlides = initializeSlides(
+        followUsersIndex,
+        getUserData(),
+        fakeUsersResponse,
+      );
       await flushPromises();
     });
 
@@ -256,7 +268,7 @@ describe('<Onboarding />', () => {
       expect(followUsers.state('selectedUsers').length).toBe(2);
       onboardingSlides.find('.next-button').simulate('click');
       await flushPromises();
-      expect(onboardingSlides.state().currentSlide).toBe(4);
+      expect(onboardingSlides.state().currentSlide).toBe(followUsersIndex + 1);
     });
 
     test('should have a functioning select-all toggle', async () => {
@@ -277,15 +289,19 @@ describe('<Onboarding />', () => {
       fetch.once(fakeTagsResponse);
       onboardingSlides.find('.back-button').simulate('click');
       await flushPromises();
-      expect(onboardingSlides.state().currentSlide).toBe(2);
+      expect(onboardingSlides.state().currentSlide).toBe(followUsersIndex - 1);
     });
   });
 
   describe('EmailPreferencesForm', () => {
     let onboardingSlides;
+    const emailPreferencesFormIndex = 4;
 
     beforeEach(() => {
-      onboardingSlides = initializeSlides(4, getUserData());
+      onboardingSlides = initializeSlides(
+        emailPreferencesFormIndex,
+        getUserData(),
+      );
     });
 
     test('renders properly', () => {
@@ -297,20 +313,25 @@ describe('<Onboarding />', () => {
 
       onboardingSlides.find('.next-button').simulate('click');
       await flushPromises();
-      expect(onboardingSlides.state().currentSlide).toBe(5);
+      expect(onboardingSlides.state().currentSlide).toBe(
+        emailPreferencesFormIndex + 1,
+      );
     });
 
     it('should step backward', () => {
       onboardingSlides.find('.back-button').simulate('click');
-      expect(onboardingSlides.state().currentSlide).toBe(3);
+      expect(onboardingSlides.state().currentSlide).toBe(
+        emailPreferencesFormIndex - 1,
+      );
     });
   });
 
   describe('ClosingSlide', () => {
     let onboardingSlides;
+    const closingSlideIndex = 5;
 
     beforeEach(() => {
-      onboardingSlides = initializeSlides(5, getUserData());
+      onboardingSlides = initializeSlides(closingSlideIndex, getUserData());
     });
 
     test('renders properly', () => {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Reorders the onboarding slides according to the new designs:
![Screenshot 2020-04-16 11 04 57](https://user-images.githubusercontent.com/6921610/79508482-8051a600-7fee-11ea-90ca-5a41455992a0.png)

Also refactors the Onboarding tests, adding some helpful documentation! 😺 

## Related Tickets & Documents
Closes #7344. 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
The "follow tags" slide (below):
<img width="831" alt="Screen Shot 2020-04-21 at 4 54 36 PM" src="https://user-images.githubusercontent.com/6921610/79926092-dfe5f200-83f0-11ea-9df2-ecb65202c9ae.png">

now comes before the "profile form" slide (below):
<img width="830" alt="Screen Shot 2020-04-21 at 4 54 44 PM" src="https://user-images.githubusercontent.com/6921610/79926099-e3797900-83f0-11ea-95df-c938d1741383.png">

## Added tests?
- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [ ] no documentation needed
- [x] inline documentation!