### PR TITLE
Chat search icon color fix

### DIFF
--- a/app/assets/stylesheets/chat.scss
+++ b/app/assets/stylesheets/chat.scss
@@ -83,6 +83,7 @@
     margin-left: 2px;
     svg {
       vertical-align: -5px;
+      fill: var(--indicator-default-color);
     }
   }
   input {


### PR DESCRIPTION
Added svg color fill property for search icon

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
When the website theme changes, the chat search icon was not visible due to the absence of color property. I fixed by adding a default color property to the search icon. 

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/issues/7398

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![Screenshot 2020-04-22 at 9 09 22 AM](https://user-images.githubusercontent.com/6629348/79938131-5a5a5480-8479-11ea-8817-e2971fc09b99.png)

![Screenshot 2020-04-22 at 9 12 38 AM](https://user-images.githubusercontent.com/6629348/79938170-72ca6f00-8479-11ea-8022-47aeee097043.png)


## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
