### PR TITLE
Make database url for test env different from the dev env one

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -64,7 +64,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  url: <%= ENV.fetch('DATABASE_URL', '') %>
+  url: <%= ENV.fetch('DATABASE_URL_TEST', '') %>
   database: PracticalDeveloper_test<%= ENV['TEST_ENV_NUMBER'] %>
 
 # As with config/secrets.yml, you never want to store sensitive information,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
We have the same database url in `config/database.yml` for dev and test environments, so this can cause problems in case a developer uses custom urls.
In this pr I changed the test db url to use another env variable.
