### PR TITLE
Bug Fix: Use strings with colons for all Datadog tags

### DIFF
--- a/app/labor/mailchimp_bot.rb
+++ b/app/labor/mailchimp_bot.rb
@@ -182,7 +182,7 @@ class MailchimpBot
 
   def report_error(exception)
     Rails.logger.error(exception)
-    DatadogStatsClient.increment("mailchimp.errors", tags: [action: "failed", user_id: user.id, source: "gibbon-gem"])
+    DatadogStatsClient.increment("mailchimp.errors", tags: ["action:failed", "user_id:#{user.id}", "source:gibbon-gem"])
   end
 
   def target_md5_email

--- a/app/services/authentication/authenticator.rb
+++ b/app/services/authentication/authenticator.rb
@@ -58,7 +58,7 @@ module Authentication
 
       if log_to_datadog
         # Notify DataDog if a new identity was successfully created.
-        DatadogStatsClient.increment("identity.created", tags: [provider: id_provider])
+        DatadogStatsClient.increment("identity.created", tags: ["provider:#{id_provider}"])
       end
 
       # Return the successfully-authed used from the transaction.

--- a/app/services/search/client.rb
+++ b/app/services/search/client.rb
@@ -49,7 +49,7 @@ module Search
       def record_error(error_message, class_name)
         Honeycomb.add_field("elasticsearch.result", "error")
         Honeycomb.add_field("elasticsearch.error", class_name)
-        DatadogStatsClient.increment("elasticsearch.errors", tags: ["error:#{class_name}"], message: error_message)
+        DatadogStatsClient.increment("elasticsearch.errors", tags: ["error:#{class_name}", "message:#{error_message}"])
       end
 
       def target

--- a/app/workers/metrics/record_daily_usage_worker.rb
+++ b/app/workers/metrics/record_daily_usage_worker.rb
@@ -6,27 +6,27 @@ module Metrics
     def perform
       # Articles published in the past 24 hours with at least 15 "score" (positive/negative reactions)
       articles_min_15_score_past_24h = Article.published.where("score >= ? AND published_at > ?", 15, 1.day.ago).size
-      DatadogStatsClient.count("articles.min_15_score_past_24h", articles_min_15_score_past_24h, tags: { resource: "articles" })
+      DatadogStatsClient.count("articles.min_15_score_past_24h", articles_min_15_score_past_24h, tags: ["resource:articles"])
 
       # Articles published in the past 24 hours with at least 15 "score" (positive/negative reactions)
       articles_min_15_comment_score_past_24h = Article.published.where("comment_score >= ? AND published_at > ?", 15, 1.day.ago).size
-      DatadogStatsClient.count("articles.min_15_comment_score_past_24h", articles_min_15_comment_score_past_24h, tags: { resource: "articles" })
+      DatadogStatsClient.count("articles.min_15_comment_score_past_24h", articles_min_15_comment_score_past_24h, tags: ["resource:articles"])
 
       # Articles published in the past 24 which were that user's first article
       first_articles_past_24h = Article.where(nth_published_by_author: 1).where("published_at > ?", 1.day.ago).size
-      DatadogStatsClient.count("articles.first_past_24h", first_articles_past_24h, tags: { resource: "articles" })
+      DatadogStatsClient.count("articles.first_past_24h", first_articles_past_24h, tags: ["resource:articles"])
 
       # Users who signed up in the past 24 hours who have made at least 1 comment so far
       new_users_min_1_comment_past_24h = User.where("comments_count >= ? AND created_at > ?", 1, 24.hours.ago).size
-      DatadogStatsClient.count("users.new_min_1_comment_past_24h", new_users_min_1_comment_past_24h, tags: { resource: "users" })
+      DatadogStatsClient.count("users.new_min_1_comment_past_24h", new_users_min_1_comment_past_24h, tags: ["resource:users"])
 
       # Total negative reactions in the past 24 hours
       nagative_reactions_past_24h = Reaction.where("points < 0").where("created_at > ?", 1.day.ago).size
-      DatadogStatsClient.count("reactions.negative_past_24h", nagative_reactions_past_24h, tags: { resource: "reactions" })
+      DatadogStatsClient.count("reactions.negative_past_24h", nagative_reactions_past_24h, tags: ["resource:reactions"])
 
       # Total abuse (etc.) reports in the past 24 hours
       reports_past_24_hours = FeedbackMessage.where(category: ["spam", "other", "rude or vulgar", "harassment"]).where("created_at > ?", 1.day.ago).size
-      DatadogStatsClient.count("feedback_messages.reports_past_24_hours", reports_past_24_hours, tags: { resource: "feedback_messages" })
+      DatadogStatsClient.count("feedback_messages.reports_past_24_hours", reports_past_24_hours, tags: ["resource:feedback_messages"])
 
       # Counts of total days active (1-7) in the past week, e.g. 5000 users visited once this week, 3500 visited twice, etc.
       get_days_active_past_week_counts
@@ -51,7 +51,7 @@ module Metrics
       distinct_user_values = user_ids_by_day.flatten.group_by(&:itself).transform_values(&:count).values
       distinct_counts = distinct_user_values.group_by(&:itself).transform_values(&:count)
       distinct_counts.each_key do |key|
-        DatadogStatsClient.count("users.active_days_past_week", distinct_counts[key], tags: { resource: "users", group: group, day_count: key })
+        DatadogStatsClient.count("users.active_days_past_week", distinct_counts[key], tags: ["resource:users", "group:#{group}", "day_count:#{key}"])
       end
     end
   end

--- a/app/workers/metrics/record_data_counts_worker.rb
+++ b/app/workers/metrics/record_data_counts_worker.rb
@@ -13,7 +13,7 @@ module Metrics
                    end
 
         Rails.logger.info("db_table_size", table_info: { table_name: model.table_name, table_size: db_count })
-        DatadogStatsClient.gauge("postgres.db_table_size", db_count, tags: { table_name: model.table_name })
+        DatadogStatsClient.gauge("postgres.db_table_size", db_count, tags: ["table_name:#{model.table_name}"])
 
         next unless model.const_defined?(:SEARCH_CLASS)
 
@@ -22,7 +22,7 @@ module Metrics
                          else
                            model::SEARCH_CLASS.document_count
                          end
-        DatadogStatsClient.gauge("elasticsearch.document_count", document_count, tags: { table_name: model.table_name })
+        DatadogStatsClient.gauge("elasticsearch.document_count", document_count, tags: ["table_name:#{model.table_name}"])
       end
     end
   end

--- a/spec/services/authentication/authenticator_spec.rb
+++ b/spec/services/authentication/authenticator_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Authentication::Authenticator, type: :service do
         service.call
 
         expect(DatadogStatsClient).to have_received(:increment).with(
-          "identity.created", tags: [provider: "github"]
+          "identity.created", tags: ["provider:github"]
         )
       end
 
@@ -288,7 +288,7 @@ RSpec.describe Authentication::Authenticator, type: :service do
         service.call
 
         expect(DatadogStatsClient).to have_received(:increment).with(
-          "identity.created", tags: [provider: "twitter"]
+          "identity.created", tags: ["provider:twitter"]
         )
       end
     end

--- a/spec/workers/metrics/record_daily_usage_worker_spec.rb
+++ b/spec/workers/metrics/record_daily_usage_worker_spec.rb
@@ -20,37 +20,37 @@ RSpec.describe Metrics::RecordDailyUsageWorker, type: :worker do
     it "logs articles with at least 15 score" do
       expect(
         DatadogStatsClient,
-      ).to have_received(:count).with("articles.min_15_score_past_24h", 2, Hash).at_least(1)
+      ).to have_received(:count).with("articles.min_15_score_past_24h", 2, tags: Array).at_least(1)
     end
 
     it "logs articles with at least comment 15 score" do
       expect(
         DatadogStatsClient,
-      ).to have_received(:count).with("articles.min_15_comment_score_past_24h", 1, Hash).at_least(1)
+      ).to have_received(:count).with("articles.min_15_comment_score_past_24h", 1, tags: Array).at_least(1)
     end
 
     it "records first articles" do
       expect(
         DatadogStatsClient,
-      ).to have_received(:count).with("articles.first_past_24h", 1, Hash).at_least(1)
+      ).to have_received(:count).with("articles.first_past_24h", 1, tags: Array).at_least(1)
     end
 
     it "records new users with at least one comment" do
       expect(
         DatadogStatsClient,
-      ).to have_received(:count).with("users.new_min_1_comment_past_24h", 2, Hash).at_least(1)
+      ).to have_received(:count).with("users.new_min_1_comment_past_24h", 2, tags: Array).at_least(1)
     end
 
     it "records negative reactions" do
       expect(
         DatadogStatsClient,
-      ).to have_received(:count).with("reactions.negative_past_24h", 1, Hash).at_least(1)
+      ).to have_received(:count).with("reactions.negative_past_24h", 1, tags: Array).at_least(1)
     end
 
     it "records report feedback_messages" do
       expect(
         DatadogStatsClient,
-      ).to have_received(:count).with("feedback_messages.reports_past_24_hours", 1, Hash).at_least(1)
+      ).to have_received(:count).with("feedback_messages.reports_past_24_hours", 1, tags: Array).at_least(1)
     end
   end
 end

--- a/spec/workers/metrics/record_data_counts_worker_spec.rb
+++ b/spec/workers/metrics/record_data_counts_worker_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Metrics::RecordDataCountsWorker, type: :worker do
 
       expect(
         DatadogStatsClient,
-      ).to have_received(:gauge).with("postgres.db_table_size", 0, Hash).at_least(1)
+      ).to have_received(:gauge).with("postgres.db_table_size", 0, tags: Array).at_least(1)
     end
 
     it "logs index counts in Datadog" do
@@ -45,7 +45,7 @@ RSpec.describe Metrics::RecordDataCountsWorker, type: :worker do
 
       expect(
         DatadogStatsClient,
-      ).to have_received(:gauge).with("elasticsearch.document_count", 0, Hash).at_least(1)
+      ).to have_received(:gauge).with("elasticsearch.document_count", 0, tags: Array).at_least(1)
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Using symbols and a hash for tags seems to work OK for `gauge` metrics, however, they do not work for increment and count metrics properly. I am sure the underlying gem code has some differences for each scenario. Rather than worrying about what type of metric we are sending to Datadog we should get in the habit of always using an array with strings.

Since I updated the existing specs so I am inclined to ignore the CodeClimate failure in this case. 

## Added tests?
- [x] updated

![alt_text](https://media1.tenor.com/images/c906b9da69dea6bfa0307ad3802efa8b/tenor.gif?itemid=14008959)
