### PR TITLE
Specify SEO-Optimized Width and Height for Cover Images

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -373,7 +373,7 @@ class StoriesController < ApplicationController
       "image": [
         ApplicationController.helpers.article_social_image_url(@article, width: 1080, height: 1080),
         ApplicationController.helpers.article_social_image_url(@article, width: 1280, height: 720),
-        ApplicationController.helpers.article_social_image_url(@article, width: 1920, height: 1080),
+        ApplicationController.helpers.article_social_image_url(@article, width: 1600, height: 900),
       ],
       "publisher": {
         "@context": "http://schema.org",

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -370,7 +370,11 @@ class StoriesController < ApplicationController
         "@id": URL.article(@article)
       },
       "url": URL.article(@article),
-      "image": ApplicationController.helpers.article_social_image_url(@article),
+      "image": [
+        ApplicationController.helpers.article_social_image_url(@article, width: 1080, height: 1080),
+        ApplicationController.helpers.article_social_image_url(@article, width: 1280, height: 720),
+        ApplicationController.helpers.article_social_image_url(@article, width: 1920, height: 1080),
+      ],
       "publisher": {
         "@context": "http://schema.org",
         "@type": "Organization",

--- a/app/helpers/social_image_helper.rb
+++ b/app/helpers/social_image_helper.rb
@@ -17,8 +17,8 @@ module SocialImageHelper
     listing_social_preview_url(listing, format: :png)
   end
 
-  def article_social_image_url(article)
-    Articles::SocialImage.new(article).url
+  def article_social_image_url(article, **options)
+    Articles::SocialImage.new(article, options).url
   end
 
   def comment_social_image_url(comment)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
This PR represents the final work necessary to optimize cover images for SEO purposes. In order to ensure that cover images adhere to a `1:1`, `4:3`, and `16:9` ratio, I specified the necessary `height`s and `width`s for cover images in the JSON-LD found in `stories_controller.rb`, using the aspect ratio logic I set up in `social_image.rb` in my last PR (https://github.com/thepracticaldev/dev.to/pull/7417).

## Related Tickets & Documents
Closes #7291 
Closes #7228 

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [ ] no documentation needed
- [x] inline documentation will be added in a future PR

## [optional] What gif best describes this PR or how it makes you feel?

![That's All Folks](https://media.giphy.com/media/lD76yTC5zxZPG/giphy.gif)
