### PR TITLE
Remove Cover Image Background Styling From article-show.css

### DIFF
--- a/app/assets/stylesheets/article-show.scss
+++ b/app/assets/stylesheets/article-show.scss
@@ -53,15 +53,12 @@ article {
   padding: 0 0;
   position: relative;
 
-  /* TODO[team-delightful]: Remove background and background-size a few days post merge to avoid caching conflicts */
   .image {
     position: relative;
     width: 100%;
     margin: auto;
     max-width: 1024px;
     z-index: 2;
-    background: transparent no-repeat center center;
-    background-size: cover;
     height: 42vw;
 
     @media screen and (min-width: 880px) {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
When replacing the article show page `<div>` with an `<img>` tag in `articles/show.html.erb`, styling changes had to be made in `article-show.scss` to accommodate the changes in the template. In order to avoid caching conflicts due to the changes, the background and background-size styling for an article in `article-show.scss` had to remain in the stylesheet. This PR removes what is now dead code from `article-show.scss`.

## Related Tickets & Documents
Closes #7401 

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![The Office](https://media.giphy.com/media/OTszKBXzfG5e8/giphy.gif)
