### PR TITLE
Fix task card unstyled issue for rollout

### DIFF
--- a/app/views/onboardings/_task_card.html.erb
+++ b/app/views/onboardings/_task_card.html.erb
@@ -10,6 +10,11 @@
     localStorage.setItem('task-card-closed', 'yes');
   }
 </script>
+<style>
+.onboarding-task-card {
+  display: none;
+}
+</style>
 
 <div class="onboarding-task-card">
   <button class="close" onclick="closeTaskCard()">


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Because we store styles in the app shell with service workers, certain features can roll out where the body is not lined up with the assets from the shell. This is kind of rare, but a problem we have not yet fully tackled.

This adds some in-html styling to ensure the `display:none` attribute is paid attention to here.

Currently some scenarios result in this...

<img width="761" alt="Screen Shot 2020-04-22 at 2 03 24 PM" src="https://user-images.githubusercontent.com/3102842/80017137-1a5b9780-84a2-11ea-9b0d-5a257c6b02d5.png">
