### PR TITLE
Add a progress stepper to onboarding flow

### DIFF
--- a/app/assets/stylesheets/preact/onboarding-modal.scss
+++ b/app/assets/stylesheets/preact/onboarding-modal.scss
@@ -125,6 +125,25 @@
     button {
       @extend .crayons-btn;
     }
+
+    .stepper {
+      display: flex;
+      align-items: center;
+    }
+
+    .dot {
+      $dot-size: 10px;
+
+      background-color: var(--base-30);
+      border-radius: 50%;
+      width: $dot-size;
+      height: $dot-size;
+      margin: $su-1;
+    }
+
+    .active {
+      background-color: var(--base-90);
+    }
   }
 }
 

--- a/app/javascript/onboarding/Onboarding.jsx
+++ b/app/javascript/onboarding/Onboarding.jsx
@@ -14,9 +14,6 @@ export default class Onboarding extends Component {
     const url = new URL(window.location);
     const previousLocation = url.searchParams.get('referrer');
 
-    this.nextSlide = this.nextSlide.bind(this);
-    this.prevSlide = this.prevSlide.bind(this);
-
     const slides = [
       IntroSlide,
       FollowTags,
@@ -25,17 +22,23 @@ export default class Onboarding extends Component {
       EmailPreferencesForm,
     ];
 
-    this.slides = slides.map((SlideComponent) => (
-      <SlideComponent
-        next={this.nextSlide}
-        prev={this.prevSlide}
-        previousLocation={previousLocation}
-      />
-    ));
+    this.nextSlide = this.nextSlide.bind(this);
+    this.prevSlide = this.prevSlide.bind(this);
+    this.slidesCount = slides.length;
 
     this.state = {
       currentSlide: 0,
     };
+
+    this.slides = slides.map((SlideComponent, index) => (
+      <SlideComponent
+        next={this.nextSlide}
+        prev={this.prevSlide}
+        slidesCount={this.slidesCount}
+        currentSlideIndex={index}
+        previousLocation={previousLocation}
+      />
+    ));
   }
 
   nextSlide() {
@@ -46,6 +49,7 @@ export default class Onboarding extends Component {
         currentSlide: nextSlide,
       });
     } else {
+      // Redirect to the main feed at the end of onboarding.
       window.location.href = '/';
     }
   }

--- a/app/javascript/onboarding/__tests__/Onboarding.test.jsx
+++ b/app/javascript/onboarding/__tests__/Onboarding.test.jsx
@@ -9,6 +9,16 @@ import FollowTags from '../components/FollowTags';
 import FollowUsers from '../components/FollowUsers';
 
 global.fetch = fetch;
+
+// Corresponds to the order of slides declared in the Onboarding component.
+const slides = [
+  'IntroSlide',
+  'FollowTags',
+  'ProfileForm',
+  'FollowUsers',
+  'EmailPreferencesForm',
+];
+
 function flushPromises() {
   return new Promise((resolve) => setImmediate(resolve));
 }
@@ -24,6 +34,15 @@ function initializeSlides(currentSlide, userData = null, mockData = null) {
   onboardingSlides.setState({ currentSlide });
 
   return onboardingSlides;
+}
+
+function expectStepperToRender(onboardingSlides, activeDotCount) {
+  // We do not show the stepper on the IntroSlide.
+  const stepperDotCount = slides.length - 1;
+
+  expect(onboardingSlides.find('.stepper').exists()).toEqual(true);
+  expect(onboardingSlides.find('.dot').length).toBe(stepperDotCount);
+  expect(onboardingSlides.find('.active').length).toBe(activeDotCount);
 }
 
 describe('<Onboarding />', () => {
@@ -83,7 +102,7 @@ describe('<Onboarding />', () => {
     });
 
   describe('IntroSlide', () => {
-    const introSlideIndex = 0;
+    const slideIndex = slides.indexOf('IntroSlide');
     let onboardingSlides;
     const codeOfConductCheckEvent = {
       target: {
@@ -110,16 +129,20 @@ describe('<Onboarding />', () => {
     };
 
     beforeEach(() => {
-      onboardingSlides = initializeSlides(introSlideIndex, getUserData());
+      onboardingSlides = initializeSlides(slideIndex, getUserData());
     });
 
     test('renders properly', () => {
       expect(onboardingSlides).toMatchSnapshot();
     });
 
+    test('it does not render a stepper', () => {
+      expect(onboardingSlides.find('.stepper').length).toBe(0);
+    });
+
     test('should advance if required boxes are checked', async () => {
       fetch.once({});
-      expect(onboardingSlides.state().currentSlide).toBe(introSlideIndex);
+      expect(onboardingSlides.state().currentSlide).toBe(slideIndex);
 
       updateCodeOfConduct();
       updateTermsAndConditions();
@@ -129,7 +152,7 @@ describe('<Onboarding />', () => {
       // Fetch the fakeTagsResponse before trying to render the next slide (followTags).
       fetch.once(fakeTagsResponse);
       await flushPromises();
-      expect(onboardingSlides.state().currentSlide).toBe(introSlideIndex + 1);
+      expect(onboardingSlides.state().currentSlide).toBe(slideIndex + 1);
     });
 
     test('should not have basic a11y violations', async () => {
@@ -141,11 +164,11 @@ describe('<Onboarding />', () => {
 
   describe('FollowTags', () => {
     let onboardingSlides;
-    const followTagsIndex = 1;
+    const slideIndex = slides.indexOf('FollowTags');
 
     beforeEach(async () => {
       onboardingSlides = initializeSlides(
-        followTagsIndex,
+        slideIndex,
         getUserData(),
         fakeTagsResponse,
       );
@@ -154,6 +177,10 @@ describe('<Onboarding />', () => {
 
     test('renders properly', () => {
       expect(onboardingSlides).toMatchSnapshot();
+    });
+
+    test('renders a stepper', () => {
+      expectStepperToRender(onboardingSlides, slideIndex);
     });
 
     test('should render three tags', async () => {
@@ -173,29 +200,33 @@ describe('<Onboarding />', () => {
       onboardingSlides.find('.next-button').simulate('click');
       fetch.once(fakeUsersResponse);
       await flushPromises();
-      expect(onboardingSlides.state().currentSlide).toBe(followTagsIndex + 1);
+      expect(onboardingSlides.state().currentSlide).toBe(slideIndex + 1);
     });
 
     it('should step backward', () => {
       onboardingSlides.find('.back-button').simulate('click');
-      expect(onboardingSlides.state().currentSlide).toBe(followTagsIndex - 1);
+      expect(onboardingSlides.state().currentSlide).toBe(slideIndex - 1);
     });
   });
 
   describe('ProfileForm', () => {
     let onboardingSlides;
-    const profileFormIndex = 2;
+    const slideIndex = slides.indexOf('ProfileForm');
     const meta = document.createElement('meta');
 
     meta.setAttribute('name', 'csrf-token');
     document.body.appendChild(meta);
 
     beforeEach(() => {
-      onboardingSlides = initializeSlides(profileFormIndex, getUserData());
+      onboardingSlides = initializeSlides(slideIndex, getUserData());
     });
 
     test('renders properly', () => {
       expect(onboardingSlides).toMatchSnapshot();
+    });
+
+    test('renders a stepper', () => {
+      expectStepperToRender(onboardingSlides, slideIndex);
     });
 
     test('should allow user to fill forms and advance', async () => {
@@ -229,24 +260,24 @@ describe('<Onboarding />', () => {
       profileForm.find('.next-button').simulate('click');
       fetch.once(fakeTagsResponse);
       await flushPromises();
-      expect(onboardingSlides.state().currentSlide).toBe(profileFormIndex + 1);
+      expect(onboardingSlides.state().currentSlide).toBe(slideIndex + 1);
     });
 
     it('should step backward', () => {
       // Fetch the fakeTagsResponse before trying to render the previous slide (followTags).
       fetch.once(fakeTagsResponse);
       onboardingSlides.find('.back-button').simulate('click');
-      expect(onboardingSlides.state().currentSlide).toBe(profileFormIndex - 1);
+      expect(onboardingSlides.state().currentSlide).toBe(slideIndex - 1);
     });
   });
 
   describe('FollowUsers', () => {
     let onboardingSlides;
-    const followUsersIndex = 3;
+    const slideIndex = slides.indexOf('FollowUsers');
 
     beforeEach(async () => {
       onboardingSlides = initializeSlides(
-        followUsersIndex,
+        slideIndex,
         getUserData(),
         fakeUsersResponse,
       );
@@ -255,6 +286,10 @@ describe('<Onboarding />', () => {
 
     test('renders properly', () => {
       expect(onboardingSlides).toMatchSnapshot();
+    });
+
+    test('renders a stepper', () => {
+      expectStepperToRender(onboardingSlides, slideIndex);
     });
 
     test('should render three users', async () => {
@@ -276,7 +311,7 @@ describe('<Onboarding />', () => {
       expect(followUsers.state('selectedUsers').length).toBe(2);
       onboardingSlides.find('.next-button').simulate('click');
       await flushPromises();
-      expect(onboardingSlides.state().currentSlide).toBe(followUsersIndex + 1);
+      expect(onboardingSlides.state().currentSlide).toBe(slideIndex + 1);
     });
 
     test('should have a functioning select-all toggle', async () => {
@@ -296,20 +331,17 @@ describe('<Onboarding />', () => {
     it('should step backward', async () => {
       onboardingSlides.find('.back-button').simulate('click');
       await flushPromises();
-      expect(onboardingSlides.state().currentSlide).toBe(followUsersIndex - 1);
+      expect(onboardingSlides.state().currentSlide).toBe(slideIndex - 1);
     });
   });
 
   describe('EmailPreferencesForm', () => {
     let onboardingSlides;
     const { location } = window;
-    const emailPreferencesFormIndex = 4;
+    const slideIndex = slides.indexOf('EmailPreferencesForm');
 
     beforeEach(() => {
-      onboardingSlides = initializeSlides(
-        emailPreferencesFormIndex,
-        getUserData(),
-      );
+      onboardingSlides = initializeSlides(slideIndex, getUserData());
     });
 
     afterEach(() => {
@@ -318,6 +350,10 @@ describe('<Onboarding />', () => {
 
     test('renders properly', () => {
       expect(onboardingSlides).toMatchSnapshot();
+    });
+
+    test('renders a stepper', () => {
+      expectStepperToRender(onboardingSlides, slideIndex);
     });
 
     test('should redirect user when finished', async () => {
@@ -334,17 +370,13 @@ describe('<Onboarding />', () => {
       onboardingSlides.find('.next-button').simulate('click');
       await flushPromises();
       // No longer advance slide.
-      expect(onboardingSlides.state().currentSlide).toBe(
-        emailPreferencesFormIndex,
-      );
+      expect(onboardingSlides.state().currentSlide).toBe(slideIndex);
       expect(window.location.href).toBe('/');
     });
 
     it('should step backward', () => {
       onboardingSlides.find('.back-button').simulate('click');
-      expect(onboardingSlides.state().currentSlide).toBe(
-        emailPreferencesFormIndex - 1,
-      );
+      expect(onboardingSlides.state().currentSlide).toBe(slideIndex - 1);
     });
   });
 });

--- a/app/javascript/onboarding/__tests__/__snapshots__/Onboarding.test.jsx.snap
+++ b/app/javascript/onboarding/__tests__/__snapshots__/Onboarding.test.jsx.snap
@@ -14,7 +14,14 @@ preact-render-spy (1 nodes)
         >
           Back
         </button>
+        <div class="stepper">
+          <span class="dot active"></span>
+          <span class="dot active"></span>
+          <span class="dot active"></span>
+          <span class="dot active"></span>
+        </div>
         <button
+          disabled={false}
           onClick={[Function bound onSubmit]}
           class="next-button"
           type="button"
@@ -81,7 +88,14 @@ preact-render-spy (1 nodes)
         >
           Back
         </button>
+        <div class="stepper">
+          <span class="dot active"></span>
+          <span class="dot "></span>
+          <span class="dot "></span>
+          <span class="dot "></span>
+        </div>
         <button
+          disabled={false}
           onClick={[Function bound handleComplete]}
           class="next-button"
           type="button"
@@ -172,7 +186,14 @@ preact-render-spy (1 nodes)
         >
           Back
         </button>
+        <div class="stepper">
+          <span class="dot active"></span>
+          <span class="dot active"></span>
+          <span class="dot active"></span>
+          <span class="dot "></span>
+        </div>
         <button
+          disabled={false}
           onClick={[Function bound handleComplete]}
           class="next-button"
           type="button"
@@ -374,7 +395,14 @@ preact-render-spy (1 nodes)
         >
           Back
         </button>
+        <div class="stepper">
+          <span class="dot active"></span>
+          <span class="dot active"></span>
+          <span class="dot "></span>
+          <span class="dot "></span>
+        </div>
         <button
+          disabled={false}
           onClick={[Function bound onSubmit]}
           class="next-button"
           type="button"

--- a/app/javascript/onboarding/components/EmailPreferencesForm.jsx
+++ b/app/javascript/onboarding/components/EmailPreferencesForm.jsx
@@ -51,10 +51,15 @@ class EmailPreferencesForm extends Component {
 
   render() {
     const { email_newsletter, email_digest_periodic } = this.state;
-    const { prev } = this.props;
+    const { prev, slidesCount, currentSlideIndex } = this.props;
     return (
       <div className="onboarding-main">
-        <Navigation prev={prev} next={this.onSubmit} />
+        <Navigation
+          prev={prev}
+          next={this.onSubmit}
+          slidesCount={slidesCount}
+          currentSlideIndex={currentSlideIndex}
+        />
         <div className="onboarding-content terms-and-conditions-wrapper">
           <header className="onboarding-content-header">
             <h1 className="title">Almost there!</h1>
@@ -104,6 +109,8 @@ class EmailPreferencesForm extends Component {
 EmailPreferencesForm.propTypes = {
   prev: PropTypes.func.isRequired,
   next: PropTypes.string.isRequired,
+  slidesCount: PropTypes.number.isRequired,
+  currentSlideIndex: PropTypes.func.isRequired,
 };
 
 export default EmailPreferencesForm;

--- a/app/javascript/onboarding/components/FollowTags.jsx
+++ b/app/javascript/onboarding/components/FollowTags.jsx
@@ -95,11 +95,16 @@ class FollowTags extends Component {
   }
 
   render() {
-    const { prev } = this.props;
+    const { prev, currentSlideIndex, slidesCount } = this.props;
     const { selectedTags, allTags } = this.state;
     return (
       <div className="onboarding-main">
-        <Navigation prev={prev} next={this.handleComplete} />
+        <Navigation
+          prev={prev}
+          next={this.handleComplete}
+          slidesCount={slidesCount}
+          currentSlideIndex={currentSlideIndex}
+        />
         <div className="onboarding-content toggle-bottom">
           <header className="onboarding-content-header">
             <h1 className="title">What are you interested in?</h1>
@@ -171,6 +176,8 @@ class FollowTags extends Component {
 FollowTags.propTypes = {
   prev: PropTypes.func.isRequired,
   next: PropTypes.string.isRequired,
+  slidesCount: PropTypes.number.isRequired,
+  currentSlideIndex: PropTypes.func.isRequired,
 };
 
 export default FollowTags;

--- a/app/javascript/onboarding/components/FollowUsers.jsx
+++ b/app/javascript/onboarding/components/FollowUsers.jsx
@@ -129,11 +129,16 @@ class FollowUsers extends Component {
 
   render() {
     const { users, selectedUsers } = this.state;
-    const { prev } = this.props;
+    const { prev, slidesCount, currentSlideIndex } = this.props;
 
     return (
       <div className="onboarding-main">
-        <Navigation prev={prev} next={this.handleComplete} />
+        <Navigation
+          prev={prev}
+          next={this.handleComplete}
+          slidesCount={slidesCount}
+          currentSlideIndex={currentSlideIndex}
+        />
         <div className="onboarding-content toggle-bottom">
           <header className="onboarding-content-header">
             <h1 className="title">Suggested people to follow</h1>
@@ -184,6 +189,8 @@ class FollowUsers extends Component {
 FollowUsers.propTypes = {
   prev: PropTypes.func.isRequired,
   next: PropTypes.string.isRequired,
+  slidesCount: PropTypes.number.isRequired,
+  currentSlideIndex: PropTypes.func.isRequired,
 };
 
 export default FollowUsers;

--- a/app/javascript/onboarding/components/IntroSlide.jsx
+++ b/app/javascript/onboarding/components/IntroSlide.jsx
@@ -66,7 +66,7 @@ class IntroSlide extends Component {
   }
 
   render() {
-    const { prev } = this.props;
+    const { slidesCount, currentSlideIndex, prev } = this.props;
     const {
       checked_code_of_conduct,
       checked_terms_and_conditions,
@@ -165,6 +165,8 @@ class IntroSlide extends Component {
             disabled={this.isButtonDisabled()}
             className="intro-slide"
             prev={prev}
+            slidesCount={slidesCount}
+            currentSlideIndex={currentSlideIndex}
             next={this.onSubmit}
             hidePrev
           />
@@ -176,7 +178,9 @@ class IntroSlide extends Component {
 
 IntroSlide.propTypes = {
   prev: PropTypes.func.isRequired,
-  next: PropTypes.string.isRequired,
+  next: PropTypes.func.isRequired,
+  slidesCount: PropTypes.number.isRequired,
+  currentSlideIndex: PropTypes.func.isRequired,
 };
 
 export default IntroSlide;

--- a/app/javascript/onboarding/components/Navigation.jsx
+++ b/app/javascript/onboarding/components/Navigation.jsx
@@ -1,42 +1,68 @@
-import { h } from 'preact';
+import { h, Component } from 'preact';
 import PropTypes from 'prop-types';
 
-const Navigation = ({
-  next,
-  prev,
-  hideNext,
-  hidePrev,
-  disabled,
-  className,
-}) => (
-  <nav
-    className={`onboarding-navigation${
-      className && className.length > 0 ? ` ${className}` : ''
-    }`}
-  >
-    <div
-      className={`navigation-content${
-        className && className.length > 0 ? ` ${className}` : ''
-      }`}
-    >
-      {!hidePrev && (
-        <button onClick={prev} className="back-button" type="button">
-          Back
-        </button>
-      )}
-      {!hideNext && (
-        <button
-          disabled={disabled}
-          onClick={next}
-          className="next-button"
-          type="button"
+class Navigation extends Component {
+  /**
+   * A function to render the progress stepper within the `Navigation` component.
+   * By default, it does not show the stepper for the first slide (the `IntroSlide` component).
+   * It builds a list of `<span>` elements correseponding to the slides, and adds an "active"
+   * class to any slide that has already been seen or is currently being seen.
+   *
+   * @returns {String} The HTML markup for the stepper.
+   */
+  createStepper() {
+    const { currentSlideIndex, slidesCount } = this.props;
+    if (currentSlideIndex === 0) {
+      return '';
+    }
+
+    const stepsList = [];
+
+    // We do not show the stepper on the IntroSlide so we start with `i = 1`.
+    for (let i = 1; i < slidesCount; i += 1) {
+      const active = i <= currentSlideIndex;
+
+      stepsList.push(<span className={`dot ${active ? 'active' : ''}`} />);
+    }
+    return <div className="stepper">{stepsList}</div>;
+  }
+
+  render() {
+    const { next, prev, hideNext, hidePrev, disabled, className } = this.props;
+    return (
+      <nav
+        className={`onboarding-navigation${
+          className && className.length > 0 ? ` ${className}` : ''
+        }`}
+      >
+        <div
+          className={`navigation-content${
+            className && className.length > 0 ? ` ${className}` : ''
+          }`}
         >
-          Continue
-        </button>
-      )}
-    </div>
-  </nav>
-);
+          {!hidePrev && (
+            <button onClick={prev} className="back-button" type="button">
+              Back
+            </button>
+          )}
+
+          {this.createStepper()}
+
+          {!hideNext && (
+            <button
+              disabled={disabled}
+              onClick={next}
+              className="next-button"
+              type="button"
+            >
+              Continue
+            </button>
+          )}
+        </div>
+      </nav>
+    );
+  }
+}
 
 Navigation.propTypes = {
   disabled: PropTypes.bool,
@@ -45,6 +71,8 @@ Navigation.propTypes = {
   next: PropTypes.string.isRequired,
   hideNext: PropTypes.bool,
   hidePrev: PropTypes.bool,
+  slidesCount: PropTypes.number.isRequired,
+  currentSlideIndex: PropTypes.number.isRequired,
 };
 
 Navigation.defaultProps = {

--- a/app/javascript/onboarding/components/ProfileForm.jsx
+++ b/app/javascript/onboarding/components/ProfileForm.jsx
@@ -53,11 +53,16 @@ class ProfileForm extends Component {
   }
 
   render() {
-    const { prev } = this.props;
+    const { prev, slidesCount, currentSlideIndex } = this.props;
     const { profile_image_90, username, name } = this.user;
     return (
       <div className="onboarding-main">
-        <Navigation prev={prev} next={this.onSubmit} />
+        <Navigation
+          prev={prev}
+          next={this.onSubmit}
+          slidesCount={slidesCount}
+          currentSlideIndex={currentSlideIndex}
+        />
         <div className="onboarding-content about">
           <header className="onboarding-content-header">
             <h1 className="title">Build your profile</h1>
@@ -132,7 +137,9 @@ class ProfileForm extends Component {
 
 ProfileForm.propTypes = {
   prev: PropTypes.func.isRequired,
-  next: PropTypes.string.isRequired,
+  next: PropTypes.func.isRequired,
+  slidesCount: PropTypes.number.isRequired,
+  currentSlideIndex: PropTypes.func.isRequired,
 };
 
 export default ProfileForm;


### PR DESCRIPTION
What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
✨ Adds the world's _cutest-ever_ progress stepper to the onboarding slides! ✨

The four main "interactive" steps of the onboarding flow now are represented by a little progress stepper that shows up in the navigation of the onboarding slides.

As a part of this PR, I have also cleaned up the onboarding JS tests as well. 💪 

## Related Tickets & Documents
Addresses the first half of https://github.com/thepracticaldev/dev.to/issues/6544. (I will address the skip/continue feature in a later PR! 😄)

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

To QA this, you'll want to step through the onboarding flow locally.

You'll want to check that the stepper does _not_ render for the intro slide:
<img width="608" alt="Screen Shot 2020-04-22 at 12 11 16 PM" src="https://user-images.githubusercontent.com/6921610/80023621-ab2a7700-8492-11ea-8218-f466b7eecd7c.png">

You'll also want to make sure that the stepper changes based on which slide you're looking at!

For example, the first slide looks like this:
<img width="829" alt="Screen Shot 2020-04-22 at 12 11 26 PM" src="https://user-images.githubusercontent.com/6921610/80023586-9a7a0100-8492-11ea-890f-dc147ef60267.png">

And the last slide looks like this:
<img width="827" alt="Screen Shot 2020-04-22 at 12 11 38 PM" src="https://user-images.githubusercontent.com/6921610/80023594-9e0d8800-8492-11ea-9902-f5b02d4e3630.png">

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [ ] ~no documentation needed~ **I added inline docs!**

## What gif best describes this PR or how it makes you feel?

![glittery computer face](https://media1.giphy.com/media/5yLgoctdubLO8XGodOM/giphy.webp?cid=5a38a5a22cdef9b01fcef5332f2a73ad4759c16d15624bab&rid=giphy.webp)
