### PR TITLE
Use back button svg icon in onboarding slides

### DIFF
--- a/app/assets/stylesheets/preact/onboarding-modal.scss
+++ b/app/assets/stylesheets/preact/onboarding-modal.scss
@@ -126,6 +126,15 @@
       @extend .crayons-btn;
     }
 
+    .back-button {
+      @extend .crayons-btn;
+      @extend .crayons-btn--ghost;
+      @extend .crayons-btn--icon;
+
+      align-items: center;
+      display: flex;
+    }
+
     .stepper {
       display: flex;
       align-items: center;

--- a/app/javascript/onboarding/__tests__/__snapshots__/Onboarding.test.jsx.snap
+++ b/app/javascript/onboarding/__tests__/__snapshots__/Onboarding.test.jsx.snap
@@ -12,7 +12,15 @@ preact-render-spy (1 nodes)
           class="back-button"
           type="button"
         >
-          Back
+          <svg
+            width="16"
+            height="16"
+            fill="none"
+            class="crayons-icon"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path d="M3.828 7H16v2H3.828l5.364 5.364-1.414 1.414L0 8 7.778.222l1.414 1.414L3.828 7z"></path>
+          </svg>
         </button>
         <div class="stepper">
           <span class="dot active"></span>
@@ -86,7 +94,15 @@ preact-render-spy (1 nodes)
           class="back-button"
           type="button"
         >
-          Back
+          <svg
+            width="16"
+            height="16"
+            fill="none"
+            class="crayons-icon"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path d="M3.828 7H16v2H3.828l5.364 5.364-1.414 1.414L0 8 7.778.222l1.414 1.414L3.828 7z"></path>
+          </svg>
         </button>
         <div class="stepper">
           <span class="dot active"></span>
@@ -184,7 +200,15 @@ preact-render-spy (1 nodes)
           class="back-button"
           type="button"
         >
-          Back
+          <svg
+            width="16"
+            height="16"
+            fill="none"
+            class="crayons-icon"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path d="M3.828 7H16v2H3.828l5.364 5.364-1.414 1.414L0 8 7.778.222l1.414 1.414L3.828 7z"></path>
+          </svg>
         </button>
         <div class="stepper">
           <span class="dot active"></span>
@@ -393,7 +417,15 @@ preact-render-spy (1 nodes)
           class="back-button"
           type="button"
         >
-          Back
+          <svg
+            width="16"
+            height="16"
+            fill="none"
+            class="crayons-icon"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path d="M3.828 7H16v2H3.828l5.364 5.364-1.414 1.414L0 8 7.778.222l1.414 1.414L3.828 7z"></path>
+          </svg>
         </button>
         <div class="stepper">
           <span class="dot active"></span>

--- a/app/javascript/onboarding/components/Navigation.jsx
+++ b/app/javascript/onboarding/components/Navigation.jsx
@@ -42,7 +42,15 @@ class Navigation extends Component {
         >
           {!hidePrev && (
             <button onClick={prev} className="back-button" type="button">
-              Back
+              <svg
+                width="16"
+                height="16"
+                fill="none"
+                className="crayons-icon"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path d="M3.828 7H16v2H3.828l5.364 5.364-1.414 1.414L0 8 7.778.222l1.414 1.414L3.828 7z" />
+              </svg>
             </button>
           )}
 


### PR DESCRIPTION
What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Uses a back button svg icon rather than the text `Back` in the onboarding slides! I have used crayon styles (but not crayon "buttons").

## Related Tickets & Documents
Addresses a design change requested in https://github.com/thepracticaldev/dev.to/issues/6544. (More changes related to this issue to come in a later PR!)

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

To QA this, you'll want to step through the onboarding flow locally. The only difference should be that there is now an icon to step backwards, but everything should function the same:

<img width="835" alt="Screen Shot 2020-04-22 at 2 55 46 PM" src="https://user-images.githubusercontent.com/6921610/80038041-9dccb700-84a9-11ea-94b7-5d0caaf85219.png">


## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
