### PR TITLE
Removed yarn integrity check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_install:
   - sudo systemctl start elasticsearch
 install:
   - bundle install --path vendor/bundle
-  - yarn install
+  - yarn install --frozen-lockfile
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64
     > ./cc-test-reporter
   - chmod +x ./cc-test-reporter

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ COPY ./.yarn ./.yarn
 # Install packages
 #
 #------------------------------------------------------------------------------
-RUN yarn install && yarn check --integrity
+RUN yarn install
 
 # timeout extension required to ensure
 # system work properly on first time load

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -3,12 +3,6 @@
 $VERBOSE = nil
 
 Rails.application.configure do
-  # Verifies that versions and hashed value of the package contents in the project's package.json
-  # As the integrity check is currently broken under Docker with webpacker,
-  # we can't enable this flag by default
-  # see <https://github.com/thepracticaldev/dev.to/pull/296#discussion_r210635685>
-  config.webpacker.check_yarn_integrity = ENV.fetch("YARN_INTEGRITY_ENABLED", "true") == "true"
-
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded on

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,6 @@ services:
     environment:
       RAILS_ENV: development
       DATABASE_URL: postgresql://devto:devto@db:5432/PracticalDeveloper_development
-      YARN_INTEGRITY_ENABLED: "false"
       ELASTICSEARCH_URL: http://elasticsearch:9200
       REDIS_URL: redis://redis:6379
       REDIS_SESSIONS_URL: redis://redis:6379

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,7 +5,7 @@
 # @TODO - add as scripts instead within /bin? - this will help auto fill?
 #
 echo "" > ~/.bashrc
-echo "alias devto-setup='cd /usr/src/app/ && gem install bundler && bundle install --jobs 20 --retry 5 && yarn install && yarn check --integrity && bin/setup'" >> ~/.bashrc
+echo "alias devto-setup='cd /usr/src/app/ && gem install bundler && bundle install --jobs 20 --retry 5 && yarn install && bin/setup'" >> ~/.bashrc
 echo "alias devto-migrate='cd /usr/src/app/ && bin/rails db:migrate'" >> ~/.bashrc
 echo "alias devto-start='cd /usr/src/app/ && bundle exec rails server -b 0.0.0.0 -p 3000'" >> ~/.bashrc
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

With https://github.com/thepracticaldev/dev.to/pull/7469 and https://github.com/thepracticaldev/dev.to/pull/7466 the whole concept of "yarn integrity checked" was removed from Webpacker.

Also changed `yarn install` to `yarn install --frozen-lockfile` per [new README](https://github.com/rails/webpacker#deployment):

> When compiling assets for production on a remote server, such as a continuous integration environment, it's recommended to use yarn install --frozen-lockfile to install NPM packages on the remote host to ensure that the installed packages match the yarn.lock file.

