### PR TITLE
Don't Allow Travis to Return False Successes When Specs Fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ script:
   - bundle exec rails webpacker:compile
   - bundle exec rails db:schema:load
   - './cc-test-reporter before-build'
-  - 'bundle exec rspec spec --color --tty --failure-exit-code 42 --fail-fast=1'
+  - 'bundle exec rspec spec --color --tty --failure-exit-code 42'
   - '[ ! -f .approvals ] || bundle exec approvals verify --ask false'
   - './cc-test-reporter format-coverage -t simplecov -o coverage/codeclimate.simplecov.json'
   - 'yarn test --colors'

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ script:
   - bundle exec rails webpacker:compile
   - bundle exec rails db:schema:load
   - './cc-test-reporter before-build'
-  - 'bundle exec rspec spec --color --tty'
+  - 'bundle exec rspec spec --color --tty --failure-exit-code 42 --fail-fast=1'
   - '[ ! -f .approvals ] || bundle exec approvals verify --ask false'
   - './cc-test-reporter format-coverage -t simplecov -o coverage/codeclimate.simplecov.json'
   - 'yarn test --colors'

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -74,4 +74,17 @@ Rails.application.configure do
   end
 end
 
+if defined?(RUBY_ENGINE) && RUBY_ENGINE == "ruby" && RUBY_VERSION >= "1.9"
+  module Kernel
+    alias __at_exit at_exit
+    def at_exit
+      __at_exit do
+        exit_status = $ERROR_INFO.status if $ERROR_INFO.is_a?(SystemExit)
+        yield
+        exit exit_status if exit_status # rubocop:disable Rails/Exit
+      end
+    end
+  end
+end
+
 Rails.application.routes.default_url_options = { host: "test.host" }

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -76,17 +76,17 @@ end
 
 # Prevent false success statuses from Travis when the build fails. Code snippet from:
 # https://docs.travis-ci.com/user/common-build-problems/#ruby-rspec-returns-0-even-though-the-build-failed
-if defined?(RUBY_ENGINE) && RUBY_ENGINE == "ruby" && RUBY_VERSION >= "1.9"
-  module Kernel
-    alias __at_exit at_exit
-    def at_exit
-      __at_exit do
-        exit_status = $ERROR_INFO.status if $ERROR_INFO.is_a?(SystemExit)
-        yield
-        exit exit_status if exit_status # rubocop:disable Rails/Exit
-      end
-    end
-  end
-end
+# if defined?(RUBY_ENGINE) && RUBY_ENGINE == "ruby" && RUBY_VERSION >= "1.9"
+#   module Kernel
+#     alias __at_exit at_exit
+#     def at_exit
+#       __at_exit do
+#         exit_status = $ERROR_INFO.status if $ERROR_INFO.is_a?(SystemExit)
+#         yield
+#         exit exit_status if exit_status # rubocop:disable Rails/Exit
+#       end
+#     end
+#   end
+# end
 
 Rails.application.routes.default_url_options = { host: "test.host" }

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -74,19 +74,4 @@ Rails.application.configure do
   end
 end
 
-# Prevent false success statuses from Travis when the build fails. Code snippet from:
-# https://docs.travis-ci.com/user/common-build-problems/#ruby-rspec-returns-0-even-though-the-build-failed
-# if defined?(RUBY_ENGINE) && RUBY_ENGINE == "ruby" && RUBY_VERSION >= "1.9"
-#   module Kernel
-#     alias __at_exit at_exit
-#     def at_exit
-#       __at_exit do
-#         exit_status = $ERROR_INFO.status if $ERROR_INFO.is_a?(SystemExit)
-#         yield
-#         exit exit_status if exit_status # rubocop:disable Rails/Exit
-#       end
-#     end
-#   end
-# end
-
 Rails.application.routes.default_url_options = { host: "test.host" }

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -74,6 +74,8 @@ Rails.application.configure do
   end
 end
 
+# Prevent false success statuses from Travis when the build fails. Code snippet from:
+# https://docs.travis-ci.com/user/common-build-problems/#ruby-rspec-returns-0-even-though-the-build-failed
 if defined?(RUBY_ENGINE) && RUBY_ENGINE == "ruby" && RUBY_VERSION >= "1.9"
   module Kernel
     alias __at_exit at_exit

--- a/spec/black_box/black_box_spec.rb
+++ b/spec/black_box/black_box_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe BlackBox, type: :black_box do
     let!(:article) { build_stubbed(:article, published_at: Time.current) }
 
     it "calls function caller" do
+      raise "Foobar"
       allow(function_caller).to receive(:call).and_return(5)
       described_class.article_hotness_score(article, function_caller)
       expect(function_caller).to have_received(:call).once


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Code snippet from [travis trouble shooting docs](https://docs.travis-ci.com/user/common-build-problems/#ruby-rspec-returns-0-even-though-the-build-failed) bc ya know its not that big of a deal if your suite tells you all is well when shit is broken 🤦‍♀️ 


![alt_text](https://media.giphy.com/media/Xj8orUvjQ2SLS/giphy.gif)
