### PR TITLE
Add skip/continue functionality to onboarding navigation

### DIFF
--- a/app/assets/stylesheets/preact/onboarding-modal.scss
+++ b/app/assets/stylesheets/preact/onboarding-modal.scss
@@ -141,7 +141,7 @@
       $button-size: 40px; // Explicitly set size for accessibility.
 
       border-radius: 100%;
-      width: $button-size;
+      min-width: $button-size;
       height: $button-size;
       align-items: center;
       display: flex;

--- a/app/assets/stylesheets/preact/onboarding-modal.scss
+++ b/app/assets/stylesheets/preact/onboarding-modal.scss
@@ -124,6 +124,7 @@
 
     button {
       @extend .crayons-btn;
+      width: $su-10; // Explicitly set width to avoid buttons re-sizing with text.
     }
 
     .back-button {
@@ -135,9 +136,15 @@
       display: flex;
     }
 
+    .skip-for-now {
+      @extend .crayons-btn;
+      @extend .crayons-btn--secondary;
+    }
+
     .stepper {
       display: flex;
       align-items: center;
+      justify-content: center;
     }
 
     .dot {

--- a/app/assets/stylesheets/preact/onboarding-modal.scss
+++ b/app/assets/stylesheets/preact/onboarding-modal.scss
@@ -124,7 +124,13 @@
 
     button {
       @extend .crayons-btn;
-      width: $su-10; // Explicitly set width to avoid buttons re-sizing with text.
+    }
+
+    .back-button-container,
+    .next-button {
+      // Explicitly set width to avoid next-button re-sizing with text,
+      // and to ensure that back-button-container takes up the same amount of space.
+      width: $su-10;
     }
 
     .back-button {
@@ -132,8 +138,18 @@
       @extend .crayons-btn--ghost;
       @extend .crayons-btn--icon;
 
+      $button-size: 40px; // Explicitly set size for accessibility.
+
+      border-radius: 100%;
+      width: $button-size;
+      height: $button-size;
       align-items: center;
       display: flex;
+
+      &:hover,
+      &:active {
+        background: var(--base-10);
+      }
     }
 
     .skip-for-now {

--- a/app/javascript/onboarding/__tests__/Onboarding.test.jsx
+++ b/app/javascript/onboarding/__tests__/Onboarding.test.jsx
@@ -194,8 +194,16 @@ describe('<Onboarding />', () => {
         .find('.onboarding-tags__button')
         .first();
 
+      expect(onboardingSlides.find('.next-button').text()).toContain(
+        'Skip for now',
+      );
+
       firstButton.simulate('click');
       expect(followTags.state('selectedTags').length).toBe(1);
+
+      expect(onboardingSlides.find('.next-button').text()).toContain(
+        'Continue',
+      );
 
       onboardingSlides.find('.next-button').simulate('click');
       fetch.once(fakeUsersResponse);
@@ -243,18 +251,29 @@ describe('<Onboarding />', () => {
         target: { value: 'my employer name', name: 'employer_name' },
       };
 
+      expect(onboardingSlides.find('.next-button').text()).toContain(
+        'Skip for now',
+      );
+
       onboardingSlides.find('textarea').simulate('change', summaryEvent);
       onboardingSlides.find('#location').simulate('change', locationEvent);
       onboardingSlides.find('#employment_title').simulate('change', titleEvent);
       onboardingSlides.find('#employer_name').simulate('change', employerEvent);
-
-      expect(profileForm.state('summary')).toBe(summaryEvent.target.value);
-      expect(profileForm.state('location')).toBe(locationEvent.target.value);
-      expect(profileForm.state('employment_title')).toBe(
+      expect(profileForm.state().formValues.summary).toBe(
+        summaryEvent.target.value,
+      );
+      expect(profileForm.state().formValues.location).toBe(
+        locationEvent.target.value,
+      );
+      expect(profileForm.state().formValues.employment_title).toBe(
         titleEvent.target.value,
       );
-      expect(profileForm.state('employer_name')).toBe(
+      expect(profileForm.state().formValues.employer_name).toBe(
         employerEvent.target.value,
+      );
+
+      expect(onboardingSlides.find('.next-button').text()).toContain(
+        'Continue',
       );
 
       profileForm.find('.next-button').simulate('click');
@@ -300,6 +319,10 @@ describe('<Onboarding />', () => {
       fetch.once({});
       const followUsers = onboardingSlides.find(<FollowUsers />);
 
+      expect(onboardingSlides.find('.next-button').text()).toContain(
+        'Skip for now',
+      );
+
       onboardingSlides.find('.user').first().simulate('click');
       expect(onboardingSlides.find('p').last().text()).toBe(
         "You're following 1 person",
@@ -308,6 +331,11 @@ describe('<Onboarding />', () => {
       expect(onboardingSlides.find('p').last().text()).toBe(
         "You're following 2 people",
       );
+
+      expect(onboardingSlides.find('.next-button').text()).toContain(
+        'Continue',
+      );
+
       expect(followUsers.state('selectedUsers').length).toBe(2);
       onboardingSlides.find('.next-button').simulate('click');
       await flushPromises();

--- a/app/javascript/onboarding/__tests__/__snapshots__/Onboarding.test.jsx.snap
+++ b/app/javascript/onboarding/__tests__/__snapshots__/Onboarding.test.jsx.snap
@@ -7,21 +7,23 @@ preact-render-spy (1 nodes)
   <div class="onboarding-main">
     <nav class="onboarding-navigation">
       <div class="navigation-content">
-        <button
-          onClick={[Function bound prevSlide]}
-          class="back-button"
-          type="button"
-        >
-          <svg
-            width="16"
-            height="16"
-            fill="none"
-            class="crayons-icon"
-            xmlns="http://www.w3.org/2000/svg"
+        <div class="back-button-container">
+          <button
+            onClick={[Function bound prevSlide]}
+            class="back-button"
+            type="button"
           >
-            <path d="M3.828 7H16v2H3.828l5.364 5.364-1.414 1.414L0 8 7.778.222l1.414 1.414L3.828 7z"></path>
-          </svg>
-        </button>
+            <svg
+              width="24"
+              height="24"
+              fill="none"
+              class="crayons-icon"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path d="M7.828 11H20v2H7.828l5.364 5.364-1.414 1.414L4 12l7.778-7.778 1.414 1.414L7.828 11z"></path>
+            </svg>
+          </button>
+        </div>
         <div class="stepper">
           <span class="dot active"></span>
           <span class="dot active"></span>
@@ -89,21 +91,23 @@ preact-render-spy (1 nodes)
   <div class="onboarding-main">
     <nav class="onboarding-navigation">
       <div class="navigation-content">
-        <button
-          onClick={[Function bound prevSlide]}
-          class="back-button"
-          type="button"
-        >
-          <svg
-            width="16"
-            height="16"
-            fill="none"
-            class="crayons-icon"
-            xmlns="http://www.w3.org/2000/svg"
+        <div class="back-button-container">
+          <button
+            onClick={[Function bound prevSlide]}
+            class="back-button"
+            type="button"
           >
-            <path d="M3.828 7H16v2H3.828l5.364 5.364-1.414 1.414L0 8 7.778.222l1.414 1.414L3.828 7z"></path>
-          </svg>
-        </button>
+            <svg
+              width="24"
+              height="24"
+              fill="none"
+              class="crayons-icon"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path d="M7.828 11H20v2H7.828l5.364 5.364-1.414 1.414L4 12l7.778-7.778 1.414 1.414L7.828 11z"></path>
+            </svg>
+          </button>
+        </div>
         <div class="stepper">
           <span class="dot active"></span>
           <span class="dot "></span>
@@ -195,21 +199,23 @@ preact-render-spy (1 nodes)
   <div class="onboarding-main">
     <nav class="onboarding-navigation">
       <div class="navigation-content">
-        <button
-          onClick={[Function bound prevSlide]}
-          class="back-button"
-          type="button"
-        >
-          <svg
-            width="16"
-            height="16"
-            fill="none"
-            class="crayons-icon"
-            xmlns="http://www.w3.org/2000/svg"
+        <div class="back-button-container">
+          <button
+            onClick={[Function bound prevSlide]}
+            class="back-button"
+            type="button"
           >
-            <path d="M3.828 7H16v2H3.828l5.364 5.364-1.414 1.414L0 8 7.778.222l1.414 1.414L3.828 7z"></path>
-          </svg>
-        </button>
+            <svg
+              width="24"
+              height="24"
+              fill="none"
+              class="crayons-icon"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path d="M7.828 11H20v2H7.828l5.364 5.364-1.414 1.414L4 12l7.778-7.778 1.414 1.414L7.828 11z"></path>
+            </svg>
+          </button>
+        </div>
         <div class="stepper">
           <span class="dot active"></span>
           <span class="dot active"></span>
@@ -412,21 +418,23 @@ preact-render-spy (1 nodes)
   <div class="onboarding-main">
     <nav class="onboarding-navigation">
       <div class="navigation-content">
-        <button
-          onClick={[Function bound prevSlide]}
-          class="back-button"
-          type="button"
-        >
-          <svg
-            width="16"
-            height="16"
-            fill="none"
-            class="crayons-icon"
-            xmlns="http://www.w3.org/2000/svg"
+        <div class="back-button-container">
+          <button
+            onClick={[Function bound prevSlide]}
+            class="back-button"
+            type="button"
           >
-            <path d="M3.828 7H16v2H3.828l5.364 5.364-1.414 1.414L0 8 7.778.222l1.414 1.414L3.828 7z"></path>
-          </svg>
-        </button>
+            <svg
+              width="24"
+              height="24"
+              fill="none"
+              class="crayons-icon"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path d="M7.828 11H20v2H7.828l5.364 5.364-1.414 1.414L4 12l7.778-7.778 1.414 1.414L7.828 11z"></path>
+            </svg>
+          </button>
+        </div>
         <div class="stepper">
           <span class="dot active"></span>
           <span class="dot active"></span>

--- a/app/javascript/onboarding/__tests__/__snapshots__/Onboarding.test.jsx.snap
+++ b/app/javascript/onboarding/__tests__/__snapshots__/Onboarding.test.jsx.snap
@@ -34,7 +34,7 @@ preact-render-spy (1 nodes)
           class="next-button"
           type="button"
         >
-          Continue
+          Finish
         </button>
       </div>
     </nav>

--- a/app/javascript/onboarding/__tests__/__snapshots__/Onboarding.test.jsx.snap
+++ b/app/javascript/onboarding/__tests__/__snapshots__/Onboarding.test.jsx.snap
@@ -113,10 +113,10 @@ preact-render-spy (1 nodes)
         <button
           disabled={false}
           onClick={[Function bound handleComplete]}
-          class="next-button"
+          class="next-button skip-for-now"
           type="button"
         >
-          Continue
+          Skip for now
         </button>
       </div>
     </nav>
@@ -219,10 +219,10 @@ preact-render-spy (1 nodes)
         <button
           disabled={false}
           onClick={[Function bound handleComplete]}
-          class="next-button"
+          class="next-button skip-for-now"
           type="button"
         >
-          Continue
+          Skip for now
         </button>
       </div>
     </nav>
@@ -436,10 +436,10 @@ preact-render-spy (1 nodes)
         <button
           disabled={false}
           onClick={[Function bound onSubmit]}
-          class="next-button"
+          class="next-button skip-for-now"
           type="button"
         >
-          Continue
+          Skip for now
         </button>
       </div>
     </nav>

--- a/app/javascript/onboarding/components/FollowTags.jsx
+++ b/app/javascript/onboarding/components/FollowTags.jsx
@@ -97,11 +97,14 @@ class FollowTags extends Component {
   render() {
     const { prev, currentSlideIndex, slidesCount } = this.props;
     const { selectedTags, allTags } = this.state;
+    const canSkip = selectedTags.length === 0;
+
     return (
       <div className="onboarding-main">
         <Navigation
           prev={prev}
           next={this.handleComplete}
+          canSkip={canSkip}
           slidesCount={slidesCount}
           currentSlideIndex={currentSlideIndex}
         />

--- a/app/javascript/onboarding/components/FollowUsers.jsx
+++ b/app/javascript/onboarding/components/FollowUsers.jsx
@@ -130,12 +130,14 @@ class FollowUsers extends Component {
   render() {
     const { users, selectedUsers } = this.state;
     const { prev, slidesCount, currentSlideIndex } = this.props;
+    const canSkip = selectedUsers.length === 0;
 
     return (
       <div className="onboarding-main">
         <Navigation
           prev={prev}
           next={this.handleComplete}
+          canSkip={canSkip}
           slidesCount={slidesCount}
           currentSlideIndex={currentSlideIndex}
         />

--- a/app/javascript/onboarding/components/Navigation.jsx
+++ b/app/javascript/onboarding/components/Navigation.jsx
@@ -69,17 +69,19 @@ class Navigation extends Component {
           }`}
         >
           {!hidePrev && (
-            <button onClick={prev} className="back-button" type="button">
-              <svg
-                width="16"
-                height="16"
-                fill="none"
-                className="crayons-icon"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path d="M3.828 7H16v2H3.828l5.364 5.364-1.414 1.414L0 8 7.778.222l1.414 1.414L3.828 7z" />
-              </svg>
-            </button>
+            <div className="back-button-container">
+              <button onClick={prev} className="back-button" type="button">
+                <svg
+                  width="24"
+                  height="24"
+                  fill="none"
+                  className="crayons-icon"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path d="M7.828 11H20v2H7.828l5.364 5.364-1.414 1.414L4 12l7.778-7.778 1.414 1.414L7.828 11z" />
+                </svg>
+              </button>
+            </div>
           )}
 
           {this.createStepper()}

--- a/app/javascript/onboarding/components/Navigation.jsx
+++ b/app/javascript/onboarding/components/Navigation.jsx
@@ -27,6 +27,26 @@ class Navigation extends Component {
     return <div className="stepper">{stepsList}</div>;
   }
 
+  /**
+   * A function to render the text for the "next-button" within the `Navigation` component.
+   * By default, it renders "Continue" for every slide.
+   * If the slide can be skipped, it renders "Skip for now".
+   * On the final slide, it renders "Finish".
+   *
+   * @returns {String} The HTML markup for the stepper.
+   */
+  buttonText() {
+    const { canSkip, currentSlideIndex, slidesCount } = this.props;
+    if (slidesCount - 1 === currentSlideIndex) {
+      return 'Finish';
+    }
+    if (canSkip) {
+      return 'Skip for now';
+    }
+
+    return 'Continue';
+  }
+
   render() {
     const {
       next,
@@ -71,7 +91,7 @@ class Navigation extends Component {
               className={`next-button${canSkip ? ' skip-for-now' : ''}`}
               type="button"
             >
-              {canSkip ? 'Skip for now' : 'Continue'}
+              {this.buttonText()}
             </button>
           )}
         </div>

--- a/app/javascript/onboarding/components/Navigation.jsx
+++ b/app/javascript/onboarding/components/Navigation.jsx
@@ -28,7 +28,15 @@ class Navigation extends Component {
   }
 
   render() {
-    const { next, prev, hideNext, hidePrev, disabled, className } = this.props;
+    const {
+      next,
+      prev,
+      hideNext,
+      hidePrev,
+      disabled,
+      canSkip,
+      className,
+    } = this.props;
     return (
       <nav
         className={`onboarding-navigation${
@@ -60,10 +68,10 @@ class Navigation extends Component {
             <button
               disabled={disabled}
               onClick={next}
-              className="next-button"
+              className={`next-button${canSkip ? ' skip-for-now' : ''}`}
               type="button"
             >
-              Continue
+              {canSkip ? 'Skip for now' : 'Continue'}
             </button>
           )}
         </div>
@@ -74,6 +82,7 @@ class Navigation extends Component {
 
 Navigation.propTypes = {
   disabled: PropTypes.bool,
+  canSkip: PropTypes.bool,
   className: PropTypes.string,
   prev: PropTypes.func.isRequired,
   next: PropTypes.string.isRequired,
@@ -85,6 +94,7 @@ Navigation.propTypes = {
 
 Navigation.defaultProps = {
   disabled: false,
+  canSkip: false,
   hideNext: false,
   hidePrev: false,
   className: '',


### PR DESCRIPTION
What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Updates the "next" button in the onboarding slides in the three "interactive" components: `FollowTags`, `ProfileForm`, `FollowUsers`. 

For these three slides, the text reads "Skip for now" unless the user has taken an action on the page. If they have (for example, selected a tag, or filled out a field on the form), the button text will update to read "Continue". The button state should return back to "Skip for now" if the user reverts their action (for example, hasn't selected a tag or removes all the text from the form inputs).

Also refactors the `ProfileForm` component to nest values on the `state` within a `formValues` object in order to make it easier to determine whether any of the form inputs have a value or not.

## Related Tickets & Documents
Closes https://github.com/thepracticaldev/dev.to/issues/6544.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
To QA this feature, you'll want to pull down this branch and check the `FollowTags` and `FollowUsers` components, and make sure that the button text updates correctly:
<img width="823" alt="Screen_Shot_2020-04-23_at_11_28_07_AM" src="https://user-images.githubusercontent.com/6921610/80136320-6536e700-8556-11ea-916b-74a017476380.png">
<img width="826" alt="Screen_Shot_2020-04-23_at_11_28_19_AM" src="https://user-images.githubusercontent.com/6921610/80136365-708a1280-8556-11ea-8e6f-4ceafdd5f088.png">

For the `ProfileForm` component, you'll want to check that the button text updates whenever _any_ input in the form is filled out. **Keep in mind that you need to click off the input, since we're not updating the text on each keystroke, just when the input's value changes.**
<img width="826" alt="Screen Shot 2020-04-23 at 11 28 51 AM" src="https://user-images.githubusercontent.com/6921610/80136379-75e75d00-8556-11ea-88ae-c2bca12493a1.png">
<img width="835" alt="Screen Shot 2020-04-23 at 11 28 42 AM" src="https://user-images.githubusercontent.com/6921610/80136387-7849b700-8556-11ea-9a70-0e60c9ee84fa.png">

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed **(but I added inline docs!)**
