### PR TITLE
Remove Algolia from Podcast Episodes w/ Specs 😉

### DIFF
--- a/app/decorators/podcast_episode_decorator.rb
+++ b/app/decorators/podcast_episode_decorator.rb
@@ -34,4 +34,8 @@ class PodcastEpisodeDecorator < ApplicationDecorator
       podcastImageUrl: image_url
     }
   end
+
+  def published_at_int
+    published_at.to_i
+  end
 end

--- a/app/models/podcast_episode.rb
+++ b/app/models/podcast_episode.rb
@@ -3,9 +3,7 @@ class PodcastEpisode < ApplicationRecord
     duration_in_seconds
   ]
 
-  include AlgoliaSearch
   include Searchable
-
   SEARCH_SERIALIZER = Search::PodcastEpisodeSerializer
   SEARCH_CLASS = Search::FeedContent
 
@@ -14,6 +12,7 @@ class PodcastEpisode < ApplicationRecord
   delegate :slug, to: :podcast, prefix: true
   delegate :image_url, to: :podcast, prefix: true
   delegate :title, to: :podcast, prefix: true
+  delegate :published, to: :podcast
 
   belongs_to :podcast
   has_many :comments, as: :commentable, inverse_of: :commentable
@@ -44,43 +43,8 @@ class PodcastEpisode < ApplicationRecord
     joins(:podcast).where(podcasts: { creator_id: user.id })
   }
 
-  algoliasearch per_environment: true do
-    attribute :id
-    add_index "searchables",
-              id: :index_id,
-              per_environment: true do
-      attribute :title, :body, :quote, :summary, :subtitle, :website_url,
-                :published_at, :comments_count, :path, :class_name,
-                :user_name, :user_username, :published, :comments_blob,
-                :body_text, :tag_list, :tag_keywords_for_search,
-                :positive_reactions_count, :search_score
-      attribute :user do
-        { name: podcast.name,
-          username: user_username,
-          profile_image_90: ProfileImage.new(user).get(width: 90) }
-      end
-      searchableAttributes ["unordered(title)",
-                            "body_text",
-                            "tag_list",
-                            "tag_keywords_for_search",
-                            "user_name",
-                            "user_username",
-                            "comments_blob"]
-      attributesForFaceting [:class_name]
-      customRanking ["desc(search_score)", "desc(hotness_score)"]
-    end
-  end
-
   def search_id
     "podcast_episode_#{id}"
-  end
-
-  def user_username
-    podcast_slug
-  end
-
-  def user_name
-    podcast_title
   end
 
   def comments_blob
@@ -93,20 +57,8 @@ class PodcastEpisode < ApplicationRecord
     "/#{podcast.slug}/#{slug}"
   end
 
-  def published_at_int
-    published_at.to_i
-  end
-
-  def published
-    true
-  end
-
   def description
     ActionView::Base.full_sanitizer.sanitize(body)
-  end
-
-  def main_image
-    nil
   end
 
   def profile_image_url
@@ -115,10 +67,6 @@ class PodcastEpisode < ApplicationRecord
 
   def body_text
     ActionView::Base.full_sanitizer.sanitize(processed_html)
-  end
-
-  def user
-    podcast
   end
 
   def zero_method
@@ -144,15 +92,7 @@ class PodcastEpisode < ApplicationRecord
   alias second_user_id nil_method
   alias third_user_id nil_method
 
-  def liquid_tags_used
-    []
-  end
-
   private
-
-  def index_id
-    "podcast_episodes-#{id}"
-  end
 
   def bust_cache
     PodcastEpisodes::BustCacheWorker.perform_async(id, path, podcast_slug)

--- a/app/serializers/search/podcast_episode_serializer.rb
+++ b/app/serializers/search/podcast_episode_serializer.rb
@@ -5,15 +5,12 @@ module Search
     attribute :id, &:search_id
 
     attributes :body_text, :class_name, :comments_count, :hotness_score, :path,
-               :positive_reactions_count, :published_at, :quote,
+               :positive_reactions_count, :published, :published_at, :quote,
                :reactions_count, :search_score, :subtitle, :summary, :title,
                :website_url
 
     attribute :main_image do |pde|
       ProfileImage.new(pde.podcast).get(width: 90)
-    end
-    attribute :published do |pde|
-      pde.podcast.published
     end
     attribute :slug, &:podcast_slug
 

--- a/spec/models/podcast_episode_spec.rb
+++ b/spec/models/podcast_episode_spec.rb
@@ -60,13 +60,6 @@ RSpec.describe PodcastEpisode, type: :model do
     end
   end
 
-  describe "#index_id" do
-    it "is equal to articles-ID" do
-      # NOTE: we shouldn't test private things but cheating a bit for Algolia here
-      expect(podcast_episode.send(:index_id)).to eq("podcast_episodes-#{podcast_episode.id}")
-    end
-  end
-
   describe ".available" do
     let_it_be(:podcast) { create(:podcast) }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor 🔪 

## Description
Specs passing for reallz this time!!!

I decided to remove Algolia from all the FeedContent models in separate PRs to make them a little more digestible and so if any bugs pop up they are easier to track down and fix. 

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-32955089

## Added tests?
- [x] no, because they aren't needed

![alt_text](https://media2.giphy.com/media/3oriO5t2QB4IPKgxHi/giphy.gif)