### PR TITLE
Refactor to create a helper for the mailer links 

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -304,15 +304,12 @@ class UsersController < ApplicationController
     community_name = ApplicationConfig["COMMUNITY_NAME"]
     @email_body = <<~HEREDOC
       Hello #{community_name} Team,
-      %0A
-      %0A
+      \n
       I would like to delete my account.
-      %0A%0A
+      \n
       You can keep any comments and discussion posts under the Ghost account.
-      %0A
-      %0A
+      \n
       Regards,
-      %0A
       YOUR-#{community_name}-USERNAME-HERE
     HEREDOC
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -303,12 +303,9 @@ class UsersController < ApplicationController
   def handle_account_tab
     community_name = ApplicationConfig["COMMUNITY_NAME"]
     @email_body = <<~HEREDOC
-      Hello #{community_name} Team,
-      \n
-      I would like to delete my account.
-      \n
-      You can keep any comments and discussion posts under the Ghost account.
-      \n
+      Hello #{community_name} Team,\n
+      I would like to delete my account.\n
+      You can keep any comments and discussion posts under the Ghost account.\n
       Regards,
       YOUR-#{community_name}-USERNAME-HERE
     HEREDOC

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -172,20 +172,9 @@ module ApplicationHelper
 
   def email_link(type = :default, text: nil, additional_info: nil)
     # The allowed types for type is :default, :business, :privacy, and members.
-    # The options can be found in field :email_addresses of models/site_config.rb
+    # These options can be found in field :email_addresses of models/site_config.rb
     email = SiteConfig.email_addresses[type] || SiteConfig.email_addresses[:default]
-    additional_info = (additional_info || {}).stringify_keys
-
-    sanitized_add_info = %w[cc bcc body subject reply_to].map! do |item|
-      option = additional_info.delete(item).presence || next
-      "#{item.dasherize}=#{ERB::Util.url_encode(option)}"
-    end.compact
-    sanitized_add_info = sanitized_add_info.empty? ? "".freeze : "?" + sanitized_add_info.join("&")
-
-    encoded_email_address = ERB::Util.url_encode(email).gsub("%40", "@")
-    additional_info["href"] = "mailto:#{encoded_email_address}#{sanitized_add_info}"
-
-    content_tag("a".freeze, text || email, additional_info)
+    mail_to email, text || email, additional_info
   end
 
   # Creates an app internal URL

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -170,7 +170,9 @@ module ApplicationHelper
     "#{start_year} - #{current_year}"
   end
 
-  def mail_link(type = :default, text: nil, additional_info: nil)
+  def email_link(type = :default, text: nil, additional_info: nil)
+    # The allowed types for type is :default, :business, :privacy, and members.
+    # The options can be found in field :email_addresses of models/site_config.rb
     email = SiteConfig.email_addresses[type] || SiteConfig.email_addresses[:default]
     href = "mailto:#{email}#{"?#{additional_info}" if additional_info}"
     options = { href: href }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -170,12 +170,11 @@ module ApplicationHelper
     "#{start_year} - #{current_year}"
   end
 
-  def mail_link(type = :default, text: nil, rel: false, additional_info: nil)
+  def mail_link(type = :default, text: nil, additional_info: nil)
     email = SiteConfig.email_addresses[type] || SiteConfig.email_addresses[:default]
 
     href = "mailto:#{email}#{"?#{additional_info}" if additional_info}"
     options = { href: href }
-    options[:rel] = "noopener noreferrer" if rel
 
     content_tag("a", text || email, options)
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -170,9 +170,11 @@ module ApplicationHelper
     "#{start_year} - #{current_year}"
   end
 
-  def mail_link(type = :default, text: nil, rel: false)
+  def mail_link(type = :default, text: nil, rel: false, additional_info: nil)
     email = SiteConfig.email_addresses[type] || SiteConfig.email_addresses[:default]
-    options = { href: "mailto:#{email}" }
+
+    href = "mailto:#{email}#{"?#{additional_info}" if additional_info}"
+    options = { href: href }
     options[:rel] = "noopener noreferrer" if rel
 
     content_tag("a", text || email, options)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -172,7 +172,6 @@ module ApplicationHelper
 
   def mail_link(type = :default, text: nil, additional_info: nil)
     email = SiteConfig.email_addresses[type] || SiteConfig.email_addresses[:default]
-
     href = "mailto:#{email}#{"?#{additional_info}" if additional_info}"
     options = { href: href }
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -171,7 +171,7 @@ module ApplicationHelper
   end
 
   def mail_link(type = :default, text: nil, rel: false)
-    email = SiteConfig.email_addresses[type]
+    email = SiteConfig.email_addresses[type] || SiteConfig.email_addresses[:default]
     options = { href: "mailto:#{email}" }
     options[:rel] = "noopener noreferrer" if rel
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -170,6 +170,14 @@ module ApplicationHelper
     "#{start_year} - #{current_year}"
   end
 
+  def mail_link(type = :default, text: nil, rel: false)
+    email = SiteConfig.email_addresses[type]
+    options = { href: "mailto:#{email}" }
+    options[:rel] = "noopener noreferrer" if rel
+
+    content_tag("a", text || email, options)
+  end
+
   # Creates an app internal URL
   #
   # @note Uses protocol and domain specified in the environment, ensure they are set.

--- a/app/javascript/packs/articleForm.jsx
+++ b/app/javascript/packs/articleForm.jsx
@@ -2,7 +2,7 @@ import { h, render } from 'preact';
 import { getUserDataAndCsrfToken } from '../chat/util';
 import ArticleForm from '../article-form/articleForm';
 
-HTMLDocument.prototype.ready = new Promise(resolve => {
+HTMLDocument.prototype.ready = new Promise((resolve) => {
   if (document.readyState !== 'loading') {
     return resolve();
   }
@@ -38,5 +38,3 @@ document.ready.then(() => {
     }
   });
 });
-
-

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -7,9 +7,13 @@ class ApplicationMailer < ActionMailer::Base
   helper ApplicationHelper
 
   default(
-    from: -> { "#{ApplicationConfig['COMMUNITY_NAME']} Community <#{SiteConfig.email_addresses[:default]}>" },
+    from: -> { email_from("Community") },
     template_path: ->(mailer) { "mailers/#{mailer.class.name.underscore}" },
   )
+
+  def email_from(topic)
+    "#{ApplicationConfig['COMMUNITY_NAME']} #{topic} <#{SiteConfig.email_addresses[:default]}>"
+  end
 
   def generate_unsubscribe_token(id, email_type)
     Rails.application.message_verifier(:unsubscribe).generate(

--- a/app/mailers/digest_mailer.rb
+++ b/app/mailers/digest_mailer.rb
@@ -1,5 +1,5 @@
 class DigestMailer < ApplicationMailer
-  default from: -> { "#{ApplicationConfig['COMMUNITY_NAME']} Digest <#{SiteConfig.email_addresses[:default]}>" }
+  default from: -> { email_from("Digest") }
 
   def digest_email(user, articles)
     @user = user

--- a/app/mailers/pro_membership_mailer.rb
+++ b/app/mailers/pro_membership_mailer.rb
@@ -1,5 +1,5 @@
 class ProMembershipMailer < ApplicationMailer
-  default from: -> { "#{ApplicationConfig['COMMUNITY_NAME']} Pro Memberships <#{SiteConfig.email_addresses[:default]}>" }
+  default from: -> { email_from("Pro Memberships") }
 
   def expiring_membership(pro_membership, expiration_date)
     @pro_membership = pro_membership

--- a/app/views/chat_channel_memberships/edit.html.erb
+++ b/app/views/chat_channel_memberships/edit.html.erb
@@ -98,7 +98,7 @@
 
   <div class="crayons-card grid gap-2 p-4">
     <% if @membership.role == "mod" %>
-      <p>Questions about Connect Channel moderation? Contact <%= mail_link %></p>
+      <p>Questions about Connect Channel moderation? Contact <%= email_link %></p>
     <% else %>
       <h3>Danger Zone</h3>
       <%= form_for(@membership, html: { method: :delete, onsubmit: "return confirm('Are you absolutely sure you want to leave this channel? This action is permanent.');" }) do |f| %>

--- a/app/views/chat_channel_memberships/edit.html.erb
+++ b/app/views/chat_channel_memberships/edit.html.erb
@@ -98,7 +98,7 @@
 
   <div class="crayons-card grid gap-2 p-4">
     <% if @membership.role == "mod" %>
-      <p>Questions about Connect Channel moderation? Contact <a href="mailto:<%= SiteConfig.email_addresses[:default] %>"><%= SiteConfig.email_addresses[:default] %></a></p>
+      <p>Questions about Connect Channel moderation? Contact <%= mail_link %></p>
     <% else %>
       <h3>Danger Zone</h3>
       <%= form_for(@membership, html: { method: :delete, onsubmit: "return confirm('Are you absolutely sure you want to leave this channel? This action is permanent.');" }) do |f| %>

--- a/app/views/credits/new.html.erb
+++ b/app/views/credits/new.html.erb
@@ -37,7 +37,7 @@
     </div>
       <br />
     </div>
-    <p class="bulk-description"><em>Contact <a href="mailto:<%= SiteConfig.email_addresses[:business] %>?subject=Custom Bulk Pricing/Partnerships"><%= SiteConfig.email_addresses[:business] %></a> for custom bulk pricing and partnerships.</em></p>
+    <p class="bulk-description"><em>Contact <%= mail_link(:business, additional_info: "subject=Custom Bulk Pricing/Partnerships") %> for custom bulk pricing and partnerships.</em></p>
     <details>
       <summary>
         How many credits does one listing cost?

--- a/app/views/credits/new.html.erb
+++ b/app/views/credits/new.html.erb
@@ -37,7 +37,7 @@
     </div>
       <br />
     </div>
-    <p class="bulk-description"><em>Contact <%= email_link(:business, additional_info: "subject=Custom Bulk Pricing/Partnerships") %> for custom bulk pricing and partnerships.</em></p>
+    <p class="bulk-description"><em>Contact <%= email_link(:business, additional_info: { subject: "Custom Bulk Pricing/Partnerships" }) %> for custom bulk pricing and partnerships.</em></p>
     <details>
       <summary>
         How many credits does one listing cost?

--- a/app/views/credits/new.html.erb
+++ b/app/views/credits/new.html.erb
@@ -37,7 +37,7 @@
     </div>
       <br />
     </div>
-    <p class="bulk-description"><em>Contact <%= mail_link(:business, additional_info: "subject=Custom Bulk Pricing/Partnerships") %> for custom bulk pricing and partnerships.</em></p>
+    <p class="bulk-description"><em>Contact <%= email_link(:business, additional_info: "subject=Custom Bulk Pricing/Partnerships") %> for custom bulk pricing and partnerships.</em></p>
     <details>
       <summary>
         How many credits does one listing cost?

--- a/app/views/devise/shared/_authorization_error.html.erb
+++ b/app/views/devise/shared/_authorization_error.html.erb
@@ -25,6 +25,6 @@
       <%= flash[:alert] %>
       <br>
     <% end %>
-    Please try again below, or contact <%= mail_link %> if this persists.
+    Please try again below, or contact <%= email_link %> if this persists.
   </div>
 <% end %>

--- a/app/views/devise/shared/_authorization_error.html.erb
+++ b/app/views/devise/shared/_authorization_error.html.erb
@@ -25,6 +25,6 @@
       <%= flash[:alert] %>
       <br>
     <% end %>
-    Please try again below, or contact <a href="mailto:<%= SiteConfig.email_addresses[:default] %>"><%= SiteConfig.email_addresses[:default] %></a> if this persists.
+    Please try again below, or contact <%= mail_link %> if this persists.
   </div>
 <% end %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -30,7 +30,7 @@
     <p><%= community_name %> Events is a series of ongoing talks and workshops designed to cover important topics to help community members level up. Because we have a global community we will be hosting events at varying times so nobody is restricted by time zone. Additionally,
       <strong>some workshops are repeated multiple times</strong> to further account for this.</p>
     <p>We have many more planned if you do not see a topic that interests you. Email
-      <%= mail_link(:members) %> to request a topic. And if you're interested in speaking, please
+      <%= email_link(:members) %> to request a topic. And if you're interested in speaking, please
       <a href="https://dev.to/jess/would-you-like-to-give-a-dev-talkworkshop--31c6">apply to our CFP</a>.</p>
 
     <% @events.each do |event| %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -30,7 +30,7 @@
     <p><%= community_name %> Events is a series of ongoing talks and workshops designed to cover important topics to help community members level up. Because we have a global community we will be hosting events at varying times so nobody is restricted by time zone. Additionally,
       <strong>some workshops are repeated multiple times</strong> to further account for this.</p>
     <p>We have many more planned if you do not see a topic that interests you. Email
-      <a href="mailto:<%= SiteConfig.email_addresses[:members] %>"><%= SiteConfig.email_addresses[:members] %></a> to request a topic. And if you're interested in speaking, please
+      <%= mail_link(:members) %> to request a topic. And if you're interested in speaking, please
       <a href="https://dev.to/jess/would-you-like-to-give-a-dev-talkworkshop--31c6">apply to our CFP</a>.</p>
 
     <% @events.each do |event| %>

--- a/app/views/feedback_messages/index.html.erb
+++ b/app/views/feedback_messages/index.html.erb
@@ -9,7 +9,7 @@
     <h2>Thank you for your report.</h2>
     <h3><a href="/">Return to home page</a></h3>
     <p>
-      Questions? Send an email to <a href="mailto:<%= SiteConfig.email_addresses[:default] %>"><%= SiteConfig.email_addresses[:default] %></a>
+      Questions? Send an email to <%= mail_link %>
     </p>
   </div>
 </div>

--- a/app/views/feedback_messages/index.html.erb
+++ b/app/views/feedback_messages/index.html.erb
@@ -9,7 +9,7 @@
     <h2>Thank you for your report.</h2>
     <h3><a href="/">Return to home page</a></h3>
     <p>
-      Questions? Send an email to <%= mail_link %>
+      Questions? Send an email to <%= email_link %>
     </p>
   </div>
 </div>

--- a/app/views/mailers/notify_mailer/account_deleted_email.html.erb
+++ b/app/views/mailers/notify_mailer/account_deleted_email.html.erb
@@ -7,7 +7,7 @@
 </p>
 
 <p>
-  Contact us at <a href="mailto:<%= SiteConfig.email_addresses[:default] %>"><%= SiteConfig.email_addresses[:default] %></a> if there is anything more we can help with. 😊
+  Contact us at <%= mail_link %> if there is anything more we can help with. 😊
 </p>
 
 <p>

--- a/app/views/mailers/notify_mailer/account_deleted_email.html.erb
+++ b/app/views/mailers/notify_mailer/account_deleted_email.html.erb
@@ -7,7 +7,7 @@
 </p>
 
 <p>
-  Contact us at <%= mail_link %> if there is anything more we can help with. 😊
+  Contact us at <%= email_link %> if there is anything more we can help with. 😊
 </p>
 
 <p>

--- a/app/views/mailers/notify_mailer/account_deletion_requested_email.html.erb
+++ b/app/views/mailers/notify_mailer/account_deletion_requested_email.html.erb
@@ -8,7 +8,7 @@
 </p>
 
 <p>
-  Contact us at <a href="mailto:<%= SiteConfig.email_addresses[:default] %>"><%= SiteConfig.email_addresses[:default] %></a> if there is anything more we can help with. 😊
+  Contact us at <%= mail_link %> if there is anything more we can help with. 😊
 </p>
 
 <p>

--- a/app/views/mailers/notify_mailer/account_deletion_requested_email.html.erb
+++ b/app/views/mailers/notify_mailer/account_deletion_requested_email.html.erb
@@ -8,7 +8,7 @@
 </p>
 
 <p>
-  Contact us at <%= mail_link %> if there is anything more we can help with. 😊
+  Contact us at <%= email_link %> if there is anything more we can help with. 😊
 </p>
 
 <p>

--- a/app/views/moderations/index.html.erb
+++ b/app/views/moderations/index.html.erb
@@ -85,7 +85,7 @@
     <h1 style="text-align: center"><%= community_name %> Mods</h1>
     <div class="body">
       <p>We periodically award some <%= community_name %> members with heightened privileges to help moderate the community.</p>
-      <p>Email <a href="mailto:<%= SiteConfig.email_addresses[:default] %>"><%= SiteConfig.email_addresses[:default] %></a> if you'd like to be considered right away.</p>
+      <p>Email <%= mail_link %> if you'd like to be considered right away.</p>
       <% unless user_signed_in? %>
         <p><em>P.S. You are not currently signed in.</em></p>
       <% end %>

--- a/app/views/moderations/index.html.erb
+++ b/app/views/moderations/index.html.erb
@@ -85,7 +85,7 @@
     <h1 style="text-align: center"><%= community_name %> Mods</h1>
     <div class="body">
       <p>We periodically award some <%= community_name %> members with heightened privileges to help moderate the community.</p>
-      <p>Email <%= mail_link %> if you'd like to be considered right away.</p>
+      <p>Email <%= email_link %> if you'd like to be considered right away.</p>
       <% unless user_signed_in? %>
         <p><em>P.S. You are not currently signed in.</em></p>
       <% end %>

--- a/app/views/notifications/_notifications_list.html.erb
+++ b/app/views/notifications/_notifications_list.html.erb
@@ -14,7 +14,7 @@
   <div class="content notification-content comment-content">
     An error occurred! This has been logged and we're tracking it.
     <br>
-    If you see too many of these, please report it to <a href="mailto:<%= SiteConfig.email_addresses[:default] %>"><%= SiteConfig.email_addresses[:default] %></a>!
+    If you see too many of these, please report it to <%= mail_link %>!
   </div>
 <% end %>
 

--- a/app/views/notifications/_notifications_list.html.erb
+++ b/app/views/notifications/_notifications_list.html.erb
@@ -14,7 +14,7 @@
   <div class="content notification-content comment-content">
     An error occurred! This has been logged and we're tracking it.
     <br>
-    If you see too many of these, please report it to <%= mail_link %>!
+    If you see too many of these, please report it to <%= email_link %>!
   </div>
 <% end %>
 

--- a/app/views/notifications/_tagadjustment.html.erb
+++ b/app/views/notifications/_tagadjustment.html.erb
@@ -23,6 +23,6 @@
   <% end %>
   <br><br />
   Thanks for being part of <%= community_name %>! If you feel like this mod action was a mistake, feel free to contact
-  <%= mail_link %>. 🤗
+  <%= email_link %>. 🤗
   <br /><br />
 </div>

--- a/app/views/notifications/_tagadjustment.html.erb
+++ b/app/views/notifications/_tagadjustment.html.erb
@@ -23,6 +23,6 @@
   <% end %>
   <br><br />
   Thanks for being part of <%= community_name %>! If you feel like this mod action was a mistake, feel free to contact
-  <a href="mailto:<%= SiteConfig.email_addresses[:default] %>"><%= SiteConfig.email_addresses[:default] %></a>. 🤗
+  <%= mail_link %>. 🤗
   <br /><br />
 </div>

--- a/app/views/pages/_coc_text.html.erb
+++ b/app/views/pages/_coc_text.html.erb
@@ -31,7 +31,7 @@
 </ul>
 <h2>Enforcement</h2>
 <p>Violations of the Code of Conduct may be reported by contacting the team via the
-  <a href="<%= app_url("/report-abuse") %>">abuse report form</a> or by sending an email to <%= mail_link %>. All reports will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. Further details of specific enforcement policies may be posted separately.
+  <a href="<%= app_url("/report-abuse") %>">abuse report form</a> or by sending an email to <%= email_link %>. All reports will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. Further details of specific enforcement policies may be posted separately.
 </p>
 <p>Moderators have the right and responsibility to remove comments or other contributions that are not aligned to this Code of Conduct, or to suspend temporarily or permanently any members for other behaviors that they deem inappropriate, threatening, offensive, or harmful.</p>
 <h2>Attribution</h2>

--- a/app/views/pages/_coc_text.html.erb
+++ b/app/views/pages/_coc_text.html.erb
@@ -31,7 +31,7 @@
 </ul>
 <h2>Enforcement</h2>
 <p>Violations of the Code of Conduct may be reported by contacting the team via the
-  <a href="<%= app_url("/report-abuse") %>">abuse report form</a> or by sending an email to <a href="mailto:<%= SiteConfig.email_addresses[:default] %>" rel="noopener noreferrer"><%= SiteConfig.email_addresses[:default] %></a>. All reports will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. Further details of specific enforcement policies may be posted separately.
+  <a href="<%= app_url("/report-abuse") %>">abuse report form</a> or by sending an email to <%= mail_link %>. All reports will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. Further details of specific enforcement policies may be posted separately.
 </p>
 <p>Moderators have the right and responsibility to remove comments or other contributions that are not aligned to this Code of Conduct, or to suspend temporarily or permanently any members for other behaviors that they deem inappropriate, threatening, offensive, or harmful.</p>
 <h2>Attribution</h2>

--- a/app/views/pages/_terms_text.html.erb
+++ b/app/views/pages/_terms_text.html.erb
@@ -76,7 +76,7 @@
 
     <p>
       Users agree and certify that they have rights to share all content that they post on dev.to — including, but not limited to, information posted in articles, discussions, and comments. This rule applies to prose, code snippets, collections of links, etc. Regardless of citation, users may not post copy and pasted content that does not belong to them. Users assume all risk for the content they post, including someone else's reliance on its accuracy, claims relating to intellectual property, or other legal rights. If you believe that a user has plagiarized content, misrepresented their identity, misappropriated work, or otherwise run afoul of DMCA regulations, please email
-      <a href="mailto:<%= SiteConfig.email_addresses[:default] %>"><%= SiteConfig.email_addresses[:default] %></a>. <%= community_name %> may remove any content users post for any reason.
+      <%= mail_link %>. <%= community_name %> may remove any content users post for any reason.
     </p>
 
     <h3 id="site-terms-of-use-modifications">
@@ -92,7 +92,7 @@
     </h3>
 
     <p>
-      All uses of the <%= community_name %> logo, <%= community_name %> badges, brand slogans, iconography, and the like, may only be used with express permission from <%= community_name %>. <%= community_name %> reserves all rights, even if certain assets are included in <%= community_name %> open source projects. Please contact <a href="mailto:<%= SiteConfig.email_addresses[:default] %>"><%= SiteConfig.email_addresses[:default] %></a> with any questions or to request permission.
+      All uses of the <%= community_name %> logo, <%= community_name %> badges, brand slogans, iconography, and the like, may only be used with express permission from <%= community_name %>. <%= community_name %> reserves all rights, even if certain assets are included in <%= community_name %> open source projects. Please contact <%= mail_link %> with any questions or to request permission.
     </p>
 
     <h3 id="reserved-names">

--- a/app/views/pages/_terms_text.html.erb
+++ b/app/views/pages/_terms_text.html.erb
@@ -76,7 +76,7 @@
 
     <p>
       Users agree and certify that they have rights to share all content that they post on dev.to — including, but not limited to, information posted in articles, discussions, and comments. This rule applies to prose, code snippets, collections of links, etc. Regardless of citation, users may not post copy and pasted content that does not belong to them. Users assume all risk for the content they post, including someone else's reliance on its accuracy, claims relating to intellectual property, or other legal rights. If you believe that a user has plagiarized content, misrepresented their identity, misappropriated work, or otherwise run afoul of DMCA regulations, please email
-      <%= mail_link %>. <%= community_name %> may remove any content users post for any reason.
+      <%= email_link %>. <%= community_name %> may remove any content users post for any reason.
     </p>
 
     <h3 id="site-terms-of-use-modifications">
@@ -92,7 +92,7 @@
     </h3>
 
     <p>
-      All uses of the <%= community_name %> logo, <%= community_name %> badges, brand slogans, iconography, and the like, may only be used with express permission from <%= community_name %>. <%= community_name %> reserves all rights, even if certain assets are included in <%= community_name %> open source projects. Please contact <%= mail_link %> with any questions or to request permission.
+      All uses of the <%= community_name %> logo, <%= community_name %> badges, brand slogans, iconography, and the like, may only be used with express permission from <%= community_name %>. <%= community_name %> reserves all rights, even if certain assets are included in <%= community_name %> open source projects. Please contact <%= email_link %> with any questions or to request permission.
     </p>
 
     <h3 id="reserved-names">

--- a/app/views/pages/contact.html.erb
+++ b/app/views/pages/contact.html.erb
@@ -30,7 +30,7 @@
       The Practical Dev would love to hear from you!
     </p>
     <p>
-      Email: <%= mail_link %> 😁
+      Email: <%= email_link %> 😁
     </p>
     <p>
       Twitter: <a href="http://twitter.com/<%= SiteConfig.social_media_handles["twitter"] %>">@<%= SiteConfig.social_media_handles["twitter"] %></a> 👻

--- a/app/views/pages/contact.html.erb
+++ b/app/views/pages/contact.html.erb
@@ -30,7 +30,7 @@
       The Practical Dev would love to hear from you!
     </p>
     <p>
-      Email: <a href="mailto:<%= SiteConfig.email_addresses[:default] %>"><%= SiteConfig.email_addresses[:default] %></a> 😁
+      Email: <%= mail_link %> 😁
     </p>
     <p>
       Twitter: <a href="http://twitter.com/<%= SiteConfig.social_media_handles["twitter"] %>">@<%= SiteConfig.social_media_handles["twitter"] %></a> 👻

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -164,14 +164,14 @@
     </p>
     <p><strong>Deleting Your Personal Information</strong>
       <br>
-      You may request deletion of your personal information and account by emailing <%= mail_link(:privacy) %>.
+      You may request deletion of your personal information and account by emailing <%= email_link(:privacy) %>.
       <br>
       <br>
       To protect information from accidental or malicious destruction, we may maintain residual copies for a brief time period. But, if you delete your account, your information and content will be unrecoverable after that time.
     </p>
     <p><strong>Data Portability</strong>
       <br>
-      If you would like to request a copy of your user data, please email <%= mail_link(:privacy) %>.</p>
+      If you would like to request a copy of your user data, please email <%= email_link(:privacy) %>.</p>
     <p><strong>Business Transfers</strong>
       <br>
       If we are involved in a merger, acquisition, bankruptcy, reorganization or sale of assets such that your information would be transferred or become subject to a different privacy policy, we’ll notify you in advance of any such change.
@@ -182,6 +182,6 @@
     </p>
     <p><strong>Questions</strong>
       <br>
-      We welcome feedback about this policy at <%= mail_link(:privacy) %>.</p>
+      We welcome feedback about this policy at <%= email_link(:privacy) %>.</p>
   </div>
 </div>

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -164,14 +164,14 @@
     </p>
     <p><strong>Deleting Your Personal Information</strong>
       <br>
-      You may request deletion of your personal information and account by emailing <a href="mailto:<%= SiteConfig.email_addresses[:privacy] %>"><%= SiteConfig.email_addresses[:privacy] %></a>.
+      You may request deletion of your personal information and account by emailing <%= mail_link(:privacy) %>.
       <br>
       <br>
       To protect information from accidental or malicious destruction, we may maintain residual copies for a brief time period. But, if you delete your account, your information and content will be unrecoverable after that time.
     </p>
     <p><strong>Data Portability</strong>
       <br>
-      If you would like to request a copy of your user data, please email <a href="mailto:<%= SiteConfig.email_addresses[:privacy] %>"><%= SiteConfig.email_addresses[:privacy] %></a>.</p>
+      If you would like to request a copy of your user data, please email <%= mail_link(:privacy) %>.</p>
     <p><strong>Business Transfers</strong>
       <br>
       If we are involved in a merger, acquisition, bankruptcy, reorganization or sale of assets such that your information would be transferred or become subject to a different privacy policy, we’ll notify you in advance of any such change.
@@ -182,6 +182,6 @@
     </p>
     <p><strong>Questions</strong>
       <br>
-      We welcome feedback about this policy at <a href="mailto:<%= SiteConfig.email_addresses[:privacy] %>"><%= SiteConfig.email_addresses[:privacy] %></a>.</p>
+      We welcome feedback about this policy at <%= mail_link(:privacy) %>.</p>
   </div>
 </div>

--- a/app/views/partnerships/_devrel_consult_copy.html.erb
+++ b/app/views/partnerships/_devrel_consult_copy.html.erb
@@ -11,5 +11,5 @@ The <%= community_name %> team sees over 1000 new posts published every week to 
 You will be invited to a shared Slack channel to aid communication and provide a line of communication for deep collaboration.  It is an open line to our devrel experts available during extended US East business hours.
 </p>
 <% unless user_signed_in? %>
-  <h2>Email <%= mail_link(:business) %>  for pricing information</h2>
+  <h2>Email <%= mail_link(:business) %> for pricing information</h2>
 <% end %>

--- a/app/views/partnerships/_devrel_consult_copy.html.erb
+++ b/app/views/partnerships/_devrel_consult_copy.html.erb
@@ -11,5 +11,5 @@ The <%= community_name %> team sees over 1000 new posts published every week to 
 You will be invited to a shared Slack channel to aid communication and provide a line of communication for deep collaboration.  It is an open line to our devrel experts available during extended US East business hours.
 </p>
 <% unless user_signed_in? %>
-  <h2>Email <%= mail_link(:business) %> for pricing information</h2>
+  <h2>Email <%= email_link(:business) %> for pricing information</h2>
 <% end %>

--- a/app/views/partnerships/_devrel_consult_copy.html.erb
+++ b/app/views/partnerships/_devrel_consult_copy.html.erb
@@ -11,5 +11,5 @@ The <%= community_name %> team sees over 1000 new posts published every week to 
 You will be invited to a shared Slack channel to aid communication and provide a line of communication for deep collaboration.  It is an open line to our devrel experts available during extended US East business hours.
 </p>
 <% unless user_signed_in? %>
-  <h2>Email <a href="mailto:<%= SiteConfig.email_addresses[:business] %>"><%= SiteConfig.email_addresses[:business] %></a> for pricing information</h2>
+  <h2>Email <%= mail_link(:business) %>  for pricing information</h2>
 <% end %>

--- a/app/views/partnerships/_form.html.erb
+++ b/app/views/partnerships/_form.html.erb
@@ -120,5 +120,5 @@
     <% end %>
   <% end %>
 <% else %>
-<h2>Contact <a href="mailto:<%= SiteConfig.email_addresses[:business] %>"><%= SiteConfig.email_addresses[:business] %></a> to sign up</h1>
+<h2>Contact <%= mail_link(:business) %>  to sign up</h1>
 <% end %>

--- a/app/views/partnerships/_form.html.erb
+++ b/app/views/partnerships/_form.html.erb
@@ -50,7 +50,7 @@
             <div class="partner-explainer-notice">
               <%# this should never happen but better safe than sorry %>
               <% sponsorships.each do |sponsorship| %>
-              🛑 You are already subscribed as a <%= sponsorship.level %> sponsor. Contact <%= mail_link(:business) %>to change plans.
+              🛑 You are already subscribed as a <%= sponsorship.level %> sponsor. Contact <%= email_link(:business) %>to change plans.
               <% end %>
             </div>
           <% else %>
@@ -120,5 +120,5 @@
     <% end %>
   <% end %>
 <% else %>
-<h2>Contact <%= mail_link(:business) %> to sign up</h1>
+<h2>Contact <%= email_link(:business) %> to sign up</h1>
 <% end %>

--- a/app/views/partnerships/_form.html.erb
+++ b/app/views/partnerships/_form.html.erb
@@ -50,7 +50,7 @@
             <div class="partner-explainer-notice">
               <%# this should never happen but better safe than sorry %>
               <% sponsorships.each do |sponsorship| %>
-              🛑 You are already subscribed as a <%= sponsorship.level %> sponsor. Contact <%= mail_link(:business) %> to change plans.
+              🛑 You are already subscribed as a <%= sponsorship.level %> sponsor. Contact <%= mail_link(:business) %>to change plans.
               <% end %>
             </div>
           <% else %>
@@ -120,5 +120,5 @@
     <% end %>
   <% end %>
 <% else %>
-<h2>Contact <%= mail_link(:business) %>  to sign up</h1>
+<h2>Contact <%= mail_link(:business) %> to sign up</h1>
 <% end %>

--- a/app/views/partnerships/_form.html.erb
+++ b/app/views/partnerships/_form.html.erb
@@ -50,7 +50,7 @@
             <div class="partner-explainer-notice">
               <%# this should never happen but better safe than sorry %>
               <% sponsorships.each do |sponsorship| %>
-              🛑 You are already subscribed as a <%= sponsorship.level %> sponsor. Contact <%= SiteConfig.email_addresses[:business] %> to change plans.
+              🛑 You are already subscribed as a <%= sponsorship.level %> sponsor. Contact <%= mail_link(:business) %> to change plans.
               <% end %>
             </div>
           <% else %>

--- a/app/views/partnerships/_gold_sponsor_copy.html.erb
+++ b/app/views/partnerships/_gold_sponsor_copy.html.erb
@@ -40,5 +40,5 @@ It will also include a call-to-action to follow your organization directly in th
 As a Gold sponsor, you will receive special flair that lives on your organization page.  This visual cue will show the <%= community_name %> Community and broader ecosystem that you are an important community supporter, providing a natural draw for increased engagement on the platform.  And, of course, you’ll have bragging rights and company pride knowing that you’re supporting a wonderful community.
 </p>
 <% unless user_signed_in? %>
-    <h2>Email <%= mail_link(:business) %>  for pricing information</h2>
+    <h2>Email <%= mail_link(:business) %> for pricing information</h2>
 <% end %>

--- a/app/views/partnerships/_gold_sponsor_copy.html.erb
+++ b/app/views/partnerships/_gold_sponsor_copy.html.erb
@@ -40,5 +40,5 @@ It will also include a call-to-action to follow your organization directly in th
 As a Gold sponsor, you will receive special flair that lives on your organization page.  This visual cue will show the <%= community_name %> Community and broader ecosystem that you are an important community supporter, providing a natural draw for increased engagement on the platform.  And, of course, you’ll have bragging rights and company pride knowing that you’re supporting a wonderful community.
 </p>
 <% unless user_signed_in? %>
-    <h2>Email <a href="mailto:<%= SiteConfig.email_addresses[:business] %>"><%= SiteConfig.email_addresses[:business] %></a> for pricing information</h2>
+    <h2>Email <%= mail_link(:business) %>  for pricing information</h2>
 <% end %>

--- a/app/views/partnerships/_gold_sponsor_copy.html.erb
+++ b/app/views/partnerships/_gold_sponsor_copy.html.erb
@@ -40,5 +40,5 @@ It will also include a call-to-action to follow your organization directly in th
 As a Gold sponsor, you will receive special flair that lives on your organization page.  This visual cue will show the <%= community_name %> Community and broader ecosystem that you are an important community supporter, providing a natural draw for increased engagement on the platform.  And, of course, you’ll have bragging rights and company pride knowing that you’re supporting a wonderful community.
 </p>
 <% unless user_signed_in? %>
-    <h2>Email <%= mail_link(:business) %> for pricing information</h2>
+    <h2>Email <%= email_link(:business) %> for pricing information</h2>
 <% end %>

--- a/app/views/partnerships/_media_sponsor_copy.html.erb
+++ b/app/views/partnerships/_media_sponsor_copy.html.erb
@@ -22,5 +22,5 @@ Sponsorship video insertion
 As a media sponsor, your company will be included in all relevant sections around the content.  For instance, in the <%= community_name %> post, in social media postings, email announcements, etc.
 </p>
 <% unless user_signed_in? %>
-  <h2>Email <%= mail_link(:business) %> for pricing information</h2>
+  <h2>Email <%= email_link(:business) %> for pricing information</h2>
 <% end %>

--- a/app/views/partnerships/_media_sponsor_copy.html.erb
+++ b/app/views/partnerships/_media_sponsor_copy.html.erb
@@ -22,5 +22,5 @@ Sponsorship video insertion
 As a media sponsor, your company will be included in all relevant sections around the content.  For instance, in the <%= community_name %> post, in social media postings, email announcements, etc.
 </p>
 <% unless user_signed_in? %>
-  <h2>Email <a href="mailto:<%= SiteConfig.email_addresses[:business] %>"><%= SiteConfig.email_addresses[:business] %></a> for pricing information</h2>
+  <h2>Email <%= mail_link(:business) %>  for pricing information</h2>
 <% end %>

--- a/app/views/partnerships/_media_sponsor_copy.html.erb
+++ b/app/views/partnerships/_media_sponsor_copy.html.erb
@@ -22,5 +22,5 @@ Sponsorship video insertion
 As a media sponsor, your company will be included in all relevant sections around the content.  For instance, in the <%= community_name %> post, in social media postings, email announcements, etc.
 </p>
 <% unless user_signed_in? %>
-  <h2>Email <%= mail_link(:business) %>  for pricing information</h2>
+  <h2>Email <%= mail_link(:business) %> for pricing information</h2>
 <% end %>

--- a/app/views/partnerships/index.html.erb
+++ b/app/views/partnerships/index.html.erb
@@ -111,6 +111,6 @@
     </div>
   </div>
   <div style="text-align: center;">
-    <h2>Questions about anything?<br /><br />Email <a href="mailto:<%= SiteConfig.email_addresses[:business] %>"><%= SiteConfig.email_addresses[:business] %></a></h2>
+    <h2>Questions about anything?<br /><br />Email <%= mail_link(:business) %> </h2>
   </div>
 </div>

--- a/app/views/partnerships/index.html.erb
+++ b/app/views/partnerships/index.html.erb
@@ -111,6 +111,6 @@
     </div>
   </div>
   <div style="text-align: center;">
-    <h2>Questions about anything?<br /><br />Email <%= mail_link(:business) %> </h2>
+    <h2>Questions about anything?<br /><br />Email <%= mail_link(:business) %></h2>
   </div>
 </div>

--- a/app/views/partnerships/index.html.erb
+++ b/app/views/partnerships/index.html.erb
@@ -111,6 +111,6 @@
     </div>
   </div>
   <div style="text-align: center;">
-    <h2>Questions about anything?<br /><br />Email <%= mail_link(:business) %></h2>
+    <h2>Questions about anything?<br /><br />Email <%= email_link(:business) %></h2>
   </div>
 </div>

--- a/app/views/users/_account.html.erb
+++ b/app/views/users/_account.html.erb
@@ -103,10 +103,10 @@
     <% if current_user.articles_count.positive? || current_user.comments_count.positive? %>
       <p>
         If you would like to keep your content under the <%= link_to "@ghost", "/ghost" %> account,
-        please <%= mail_link(text: "click here", additional_info: "subject=Request Account Deletion&body=#{@email_body}") %>.
+        please <%= email_link(text: "click here", additional_info: "subject=Request Account Deletion&body=#{@email_body}") %>.
       </p>
     <% end %>
 
-    <p>Feel free to contact <%= mail_link %> with any questions.</p>
+    <p>Feel free to contact <%= email_link %> with any questions.</p>
   </div>
 </div>

--- a/app/views/users/_account.html.erb
+++ b/app/views/users/_account.html.erb
@@ -103,7 +103,7 @@
     <% if current_user.articles_count.positive? || current_user.comments_count.positive? %>
       <p>
         If you would like to keep your content under the <%= link_to "@ghost", "/ghost" %> account,
-        please <a href="mailto:<%= SiteConfig.email_addresses[:default] %>?subject=Request Account Deletion&body=<%= @email_body %>">click here.</a>
+        please <%= mail_link(text: "click here", additional_info: "subject=Request Account Deletion&body=#{@email_body}") %>.
       </p>
     <% end %>
 

--- a/app/views/users/_account.html.erb
+++ b/app/views/users/_account.html.erb
@@ -103,7 +103,7 @@
     <% if current_user.articles_count.positive? || current_user.comments_count.positive? %>
       <p>
         If you would like to keep your content under the <%= link_to "@ghost", "/ghost" %> account,
-        please <%= email_link(text: "click here", additional_info: "subject=Request Account Deletion&body=#{@email_body}") %>.
+        please <%= email_link(text: "click here", additional_info: { subject: "Request Account Deletion", body: @email_body }) %>.
       </p>
     <% end %>
 

--- a/app/views/users/_account.html.erb
+++ b/app/views/users/_account.html.erb
@@ -107,6 +107,6 @@
       </p>
     <% end %>
 
-    <p>Feel free to contact <a href="mailto:<%= SiteConfig.email_addresses[:default] %>"><%= SiteConfig.email_addresses[:default] %></a> with any questions.</p>
+    <p>Feel free to contact <%= mail_link %> with any questions.</p>
   </div>
 </div>

--- a/app/views/users/_publishing_from_rss.html.erb
+++ b/app/views/users/_publishing_from_rss.html.erb
@@ -22,7 +22,7 @@
     </p>
     <p>
       Your feed will be fetched every time you submit this form and updates will be automatically fetched periodically thereafter. Contact
-      <%= mail_link %> if you encounter issues.
+      <%= email_link %> if you encounter issues.
     </p>
     <p>FYI: Medium RSS feed URLs are <em>https://medium.com/feed/@your_username</em></p>
     <p><em>By submitting your RSS Feed URL, you agree that you own and/or have permission to syndicate the associated content.</em></p>

--- a/app/views/users/_publishing_from_rss.html.erb
+++ b/app/views/users/_publishing_from_rss.html.erb
@@ -22,7 +22,7 @@
     </p>
     <p>
       Your feed will be fetched every time you submit this form and updates will be automatically fetched periodically thereafter. Contact
-      <a href="mailto:<%= SiteConfig.email_addresses[:default] %>"><%= SiteConfig.email_addresses[:default] %></a> if you encounter issues.
+      <%= mail_link %> if you encounter issues.
     </p>
     <p>FYI: Medium RSS feed URLs are <em>https://medium.com/feed/@your_username</em></p>
     <p><em>By submitting your RSS Feed URL, you agree that you own and/or have permission to syndicate the associated content.</em></p>

--- a/app/views/users/confirm_destroy.html.erb
+++ b/app/views/users/confirm_destroy.html.erb
@@ -45,11 +45,11 @@
     </script>
     <p>
       If you would like to keep your content under the <%= link_to "@ghost", "/ghost" %> account,
-      please <%= mail_link(text: "click here", additional_info: "subject=Request Account Deletion&body=#{@email_body}") %>
+      please <%= email_link(text: "click here", additional_info: "subject=Request Account Deletion&body=#{@email_body}") %>
     </p>
 
     <p>
-      Feel free to contact <%= mail_link %> with any questions.
+      Feel free to contact <%= email_link %> with any questions.
     </p>
   </div>
 </div>

--- a/app/views/users/confirm_destroy.html.erb
+++ b/app/views/users/confirm_destroy.html.erb
@@ -49,7 +49,7 @@
     </p>
 
     <p>
-      Feel free to contact <a href="mailto:<%= SiteConfig.email_addresses[:default] %>"><%= SiteConfig.email_addresses[:default] %></a> with any questions.
+      Feel free to contact <%= mail_link %> with any questions.
     </p>
   </div>
 </div>

--- a/app/views/users/confirm_destroy.html.erb
+++ b/app/views/users/confirm_destroy.html.erb
@@ -45,7 +45,7 @@
     </script>
     <p>
       If you would like to keep your content under the <%= link_to "@ghost", "/ghost" %> account,
-      please <%= email_link(text: "click here", additional_info: "subject=Request Account Deletion&body=#{@email_body}") %>
+      please <%= email_link(text: "click here", additional_info: { subject: "Request Account Deletion", body: @email_body }) %>
     </p>
 
     <p>

--- a/app/views/users/confirm_destroy.html.erb
+++ b/app/views/users/confirm_destroy.html.erb
@@ -45,7 +45,7 @@
     </script>
     <p>
       If you would like to keep your content under the <%= link_to "@ghost", "/ghost" %> account,
-      please <a href="mailto:<%= SiteConfig.email_addresses[:default] %>?subject=Request Account Deletion&body=<%= @email_body %>">click here.</a>
+      please <%= mail_link(text: "click here", additional_info: "subject=Request Account Deletion&body=#{@email_body}") %>
     </p>
 
     <p>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -15,7 +15,7 @@
 <% if params[:state] == "previous-registration" %>
   <div class="crayons-banner crayons-banner--error">
     There is an existing account authorized with that social account. Contact
-    <%= mail_link %> if this is a mistake.
+    <%= email_link %> if this is a mistake.
   </div>
 <% end %>
 

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -15,7 +15,7 @@
 <% if params[:state] == "previous-registration" %>
   <div class="crayons-banner crayons-banner--error">
     There is an existing account authorized with that social account. Contact
-    <a href="mailto:<%= SiteConfig.email_addresses[:default] %>"><%= SiteConfig.email_addresses[:default] %></a> if this is a mistake.
+    <%= mail_link %> if this is a mistake.
   </div>
 <% end %>
 

--- a/app/views/videos/new.html.erb
+++ b/app/views/videos/new.html.erb
@@ -33,7 +33,7 @@
   <% end %>
   <div style="margin:50px auto;max-width:80%;font-size:0.86em;">
     <p>
-      <strong>Video is beta:</strong> Email <a href="mailto:<%= SiteConfig.email_addresses[:default] %>"><%= SiteConfig.email_addresses[:default] %></a> if you have any problems.
+      <strong>Video is beta:</strong> Email <%= mail_link %> if you have any problems.
     </p>
   </div>
 </center>

--- a/app/views/videos/new.html.erb
+++ b/app/views/videos/new.html.erb
@@ -33,7 +33,7 @@
   <% end %>
   <div style="margin:50px auto;max-width:80%;font-size:0.86em;">
     <p>
-      <strong>Video is beta:</strong> Email <%= mail_link %> if you have any problems.
+      <strong>Video is beta:</strong> Email <%= email_link %> if you have any problems.
     </p>
   </div>
 </center>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -138,13 +138,13 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(helper.email_link(:nonsense)).to have_link(href: "mailto:hi@dev.to")
     end
 
-    it "appends additional_info parameters in a url encoded format to the href" do
+    it "returns an href with additional_info parameters" do
       additional_info = {
         subject: "This is a long subject",
         body: "This is a longer body with a question mark ? \n and a newline"
       }
 
-      expect(email_link(text: "text", additional_info: additional_info)).to eq("<a href=\"mailto:yodsahdgafdghsj@dev.to?body=This%20is%20a%20longer%20body%20with%20a%20question%20mark%20%3F%20%0A%20and%20a%20newline&amp;subject=This%20is%20a%20long%20subject\">text</a>")
+      expect(email_link(text: "text", additional_info: additional_info)).to eq("<a href=\"mailto:hi@dev.to?body=This%20is%20a%20longer%20body%20with%20a%20question%20mark%20%3F%20%0A%20and%20a%20newline&amp;subject=This%20is%20a%20long%20subject\">text</a>")
     end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -131,5 +131,9 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(helper.mail_link(text: "Link Name")).to have_text("Link Name")
       expect(helper.mail_link).to have_text("hi@dev.to")
     end
+
+    it "returns the default if it doesn't understand the type parameter" do
+      expect(helper.mail_link(:nonsense)).to have_link(href: "mailto:hi@dev.to")
+    end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -110,12 +110,14 @@ RSpec.describe ApplicationHelper, type: :helper do
 
   describe "#mail_link" do
     before do
-      allow(SiteConfig).to receive(:email_addresses).and_return({
-                                                                  default: "hi@dev.to",
-                                                                  business: "business@dev.to",
-                                                                  privacy: "privacy@dev.to",
-                                                                  members: "members@dev.to"
-                                                                })
+      allow(SiteConfig).to receive(:email_addresses).and_return(
+        {
+          default: "hi@dev.to",
+          business: "business@dev.to",
+          privacy: "privacy@dev.to",
+          members: "members@dev.to"
+        },
+      )
     end
 
     it "returns an 'a' tag" do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe ApplicationHelper, type: :helper do
                                                                 })
     end
 
-    it "returns an a tag" do
+    it "returns an 'a' tag" do
       expect(helper.mail_link).to have_selector("a")
     end
 
@@ -127,16 +127,16 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(helper.mail_link(:business)).to have_link(href: "mailto:business@dev.to")
     end
 
-    it "has the correct text" do
+    it "has the correct text in the a tag" do
       expect(helper.mail_link(text: "Link Name")).to have_text("Link Name")
       expect(helper.mail_link).to have_text("hi@dev.to")
     end
 
-    it "returns the default if it doesn't understand the type parameter" do
+    it "returns the default email if it doesn't understand the type parameter" do
       expect(helper.mail_link(:nonsense)).to have_link(href: "mailto:hi@dev.to")
     end
 
-    it "displays the any extra parameters we pass through" do
+    it "appends any additional_info parameters to the href" do
       additional_info = "subject=This is a subject test"
       more_additional_info = "#{additional_info}&body=This is a body"
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -107,4 +107,29 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(sanitized_referer("")).to be nil
     end
   end
+
+  describe "#mail_link" do
+    before do
+      allow(SiteConfig).to receive(:email_addresses).and_return({
+                                                                  default: "hi@dev.to",
+                                                                  business: "business@dev.to",
+                                                                  privacy: "privacy@dev.to",
+                                                                  members: "members@dev.to"
+                                                                })
+    end
+
+    it "returns an a tag" do
+      expect(helper.mail_link).to have_selector("a")
+    end
+
+    it "sets the correct href" do
+      expect(helper.mail_link).to have_link(href: "mailto:hi@dev.to")
+      expect(helper.mail_link(:business)).to have_link(href: "mailto:business@dev.to")
+    end
+
+    it "has the correct text" do
+      expect(helper.mail_link(text: "Link Name")).to have_text("Link Name")
+      expect(helper.mail_link).to have_text("hi@dev.to")
+    end
+  end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -138,12 +138,13 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(helper.email_link(:nonsense)).to have_link(href: "mailto:hi@dev.to")
     end
 
-    it "appends any additional_info parameters to the href" do
-      additional_info = "subject=This is a subject test"
-      more_additional_info = "#{additional_info}&body=This is a body"
+    it "appends additional_info parameters in a url encoded format to the href" do
+      additional_info = {
+        subject: "This is a long subject",
+        body: "This is a longer body with a question mark ? \n and a newline"
+      }
 
-      expect(helper.email_link(additional_info: additional_info)).to have_link(href: "mailto:hi@dev.to?#{additional_info}")
-      expect(helper.email_link(additional_info: more_additional_info)).to have_link(href: "mailto:hi@dev.to?#{more_additional_info}")
+      expect(email_link(text: "text", additional_info: additional_info)).to eq("<a href=\"mailto:yodsahdgafdghsj@dev.to?body=This%20is%20a%20longer%20body%20with%20a%20question%20mark%20%3F%20%0A%20and%20a%20newline&amp;subject=This%20is%20a%20long%20subject\">text</a>")
     end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -135,5 +135,13 @@ RSpec.describe ApplicationHelper, type: :helper do
     it "returns the default if it doesn't understand the type parameter" do
       expect(helper.mail_link(:nonsense)).to have_link(href: "mailto:hi@dev.to")
     end
+
+    it "displays the any extra parameters we pass through" do
+      additional_info = "subject=This is a subject test"
+      more_additional_info = "#{additional_info}&body=This is a body"
+
+      expect(helper.mail_link(additional_info: additional_info)).to have_link(href: "mailto:hi@dev.to?#{additional_info}")
+      expect(helper.mail_link(additional_info: more_additional_info)).to have_link(href: "mailto:hi@dev.to?#{more_additional_info}")
+    end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
-  describe "#mail_link" do
+  describe "#email_link" do
     before do
       allow(SiteConfig).to receive(:email_addresses).and_return(
         {
@@ -121,29 +121,29 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
 
     it "returns an 'a' tag" do
-      expect(helper.mail_link).to have_selector("a")
+      expect(helper.email_link).to have_selector("a")
     end
 
     it "sets the correct href" do
-      expect(helper.mail_link).to have_link(href: "mailto:hi@dev.to")
-      expect(helper.mail_link(:business)).to have_link(href: "mailto:business@dev.to")
+      expect(helper.email_link).to have_link(href: "mailto:hi@dev.to")
+      expect(helper.email_link(:business)).to have_link(href: "mailto:business@dev.to")
     end
 
     it "has the correct text in the a tag" do
-      expect(helper.mail_link(text: "Link Name")).to have_text("Link Name")
-      expect(helper.mail_link).to have_text("hi@dev.to")
+      expect(helper.email_link(text: "Link Name")).to have_text("Link Name")
+      expect(helper.email_link).to have_text("hi@dev.to")
     end
 
     it "returns the default email if it doesn't understand the type parameter" do
-      expect(helper.mail_link(:nonsense)).to have_link(href: "mailto:hi@dev.to")
+      expect(helper.email_link(:nonsense)).to have_link(href: "mailto:hi@dev.to")
     end
 
     it "appends any additional_info parameters to the href" do
       additional_info = "subject=This is a subject test"
       more_additional_info = "#{additional_info}&body=This is a body"
 
-      expect(helper.mail_link(additional_info: additional_info)).to have_link(href: "mailto:hi@dev.to?#{additional_info}")
-      expect(helper.mail_link(additional_info: more_additional_info)).to have_link(href: "mailto:hi@dev.to?#{more_additional_info}")
+      expect(helper.email_link(additional_info: additional_info)).to have_link(href: "mailto:hi@dev.to?#{additional_info}")
+      expect(helper.email_link(additional_info: more_additional_info)).to have_link(href: "mailto:hi@dev.to?#{more_additional_info}")
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
We use mailer links in multiple place and so it makes sense to pull it out into a helper and just pass through the necessary parameters.

We also add a helper to set the email_from attribute for a mail.

This is based of the PR [#7438](https://github.com/thepracticaldev/dev.to/pull/7438)

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
There are no UI changes but here's an example of a mail test (I set the email address yodsahdgafdghsj@dev.to on site config so please don't be alarmed 😁, and I've concealed the from field):

<img width="839" alt="Screenshot 2020-04-27 at 12 23 27" src="https://user-images.githubusercontent.com/2786819/80362002-2c627f00-8882-11ea-99e3-994dcd0f1b9c.png">

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/GioqgIVEGaHIs/giphy.gif)
