### PR TITLE
Improve comment posting error handling

### DIFF
--- a/app/assets/javascripts/initializers/initializeCommentsPage.js.erb
+++ b/app/assets/javascripts/initializers/initializeCommentsPage.js.erb
@@ -198,13 +198,6 @@ function handleCommentSubmit(event) {
       if (response.status === 200) {
         response.json().then(function (newComment) {
           var newNode = document.createElement('div');
-          if (newComment.status == "comment already exists") {
-            return false;
-          }
-          if (newComment.status == "errors") {
-            alert("There was a problem submitting this comment.")
-            return false;
-          }
           newNode.innerHTML = buildCommentHTML(newComment);
           var docBody = document.getElementsByTagName('body')[0]
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -54,7 +54,7 @@ class CommentsController < ApplicationController
   def create
     if RateLimitChecker.new(current_user).limit_by_action("comment_creation")
       skip_authorization
-      render json: {}, status: :too_many_requests
+      render json: { error: "Too many requests" }, status: :too_many_requests
       return
     end
 
@@ -75,9 +75,10 @@ class CommentsController < ApplicationController
 
       if @comment.invalid?
         @comment.destroy
-        render json: { status: "comment already exists" }
+        render json: { error: "comment already exists" }, status: :conflict
         return
       end
+
       render json: {
         status: "created",
         css: @comment.custom_css,
@@ -98,13 +99,17 @@ class CommentsController < ApplicationController
           github_username: current_user.github_username
         }
       }
-    elsif (@comment = Comment.where(body_markdown: @comment.body_markdown,
-                                    commentable_id: @comment.commentable.id,
-                                    ancestry: @comment.ancestry)[1])
-      @comment.destroy
-      render json: { status: "comment already exists" }
+    elsif (comment = Comment.where(
+      body_markdown: @comment.body_markdown,
+      commentable_id: @comment.commentable.id,
+      ancestry: @comment.ancestry,
+    )[1])
+
+      comment.destroy
+      render json: { error: "comment already exists" }, status: :conflict
     else
-      render json: { status: "errors" }
+      message = @comment.errors.full_messages.to_sentence
+      render json: { error: message }, status: :unprocessable_entity
     end
   # See https://github.com/thepracticaldev/dev.to/pull/5485#discussion_r366056925
   # for details as to why this is necessary

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -54,7 +54,7 @@ class CommentsController < ApplicationController
   def create
     if RateLimitChecker.new(current_user).limit_by_action("comment_creation")
       skip_authorization
-      render json: { error: "Too many requests" }, status: :too_many_requests
+      render json: { error: "too many requests" }, status: :too_many_requests
       return
     end
 
@@ -75,7 +75,7 @@ class CommentsController < ApplicationController
 
       if @comment.invalid?
         @comment.destroy
-        render json: { error: "comment already exists" }, status: :conflict
+        render json: { error: "comment already exists" }, status: :unprocessable_entity
         return
       end
 
@@ -106,7 +106,7 @@ class CommentsController < ApplicationController
     )[1])
 
       comment.destroy
-      render json: { error: "comment already exists" }, status: :conflict
+      render json: { error: "comment already exists" }, status: :unprocessable_entity
     else
       message = @comment.errors.full_messages.to_sentence
       render json: { error: message }, status: :unprocessable_entity

--- a/spec/requests/comments_create_spec.rb
+++ b/spec/requests/comments_create_spec.rb
@@ -5,31 +5,41 @@ RSpec.describe "CommentsCreate", type: :request do
   let(:blocker) { create(:user) }
   let(:article) { create(:article, user_id: user.id) }
   let(:new_body) { -> { "NEW BODY #{rand(100)}" } }
+  let(:rate_limit_checker) { instance_double(RateLimitChecker) }
 
   before do
     sign_in user
   end
 
-  it "creates ordinary article with proper params" do
-    post "/comments", params: {
-      comment: { body_markdown: new_body.call, commentable_id: article.id, commentable_type: "Article" }
+  def comment_params(params = {})
+    {
+      comment: {
+        body_markdown: new_body.call,
+        commentable_id: article.id,
+        commentable_type: "Article"
+      }.merge(params)
     }
-    expect(Comment.last.user_id).to eq(user.id)
+  end
+
+  it "creates a comment with proper params" do
+    expect do
+      post "/comments", params: comment_params
+    end.to change(user.comments, :count).by(1)
   end
 
   it "creates NotificationSubscription for comment" do
-    post "/comments", params: {
-      comment: { body_markdown: new_body.call, commentable_id: article.id, commentable_type: "Article" }
-    }
+    post "/comments", params: comment_params
+
     expect(NotificationSubscription.last.notifiable).to eq(Comment.last)
   end
 
-  it "returns 429 Too Many Requests when a user reachers their rate limit" do
-    create_list(:comment, 10, user: user, commentable: article)
+  it "returns 429 Too Many Requests when a user reaches their rate limit" do
+    allow(RateLimitChecker).to receive(:new).and_return(rate_limit_checker)
+    allow(rate_limit_checker).to receive(:limit_by_action).
+      with("comment_creation").
+      and_return(true)
 
-    post "/comments", params: {
-      comment: { body_markdown: new_body.call, commentable_id: article.id, commentable_type: "Article" }
-    }
+    post "/comments", params: comment_params
 
     expect(response).to have_http_status(:too_many_requests)
   end
@@ -38,22 +48,24 @@ RSpec.describe "CommentsCreate", type: :request do
     it "returns unauthorized" do
       create(:user_block, blocker: blocker, blocked: user, config: "default")
       user.update(blocked_by_count: 1)
-      blocker_article = create(:article, user_id: blocker.id)
+      blocker_article = create(:article, user: blocker)
+
       expect do
-        post "/comments", params: {
-          comment: { body_markdown: "something", commentable_id: blocker_article.id, commentable_type: "Article" }
-        }
+        post "/comments", params: comment_params(commentable_id: blocker_article.id)
       end.to raise_error(Pundit::NotAuthorizedError)
     end
   end
 
   context "when user is posting on an author that does not block user, but the user has been blocked elsewhere" do
-    it "returns unauthorized" do
+    it "creates the new comment" do
       user.update(blocked_by_count: 1)
-      blocker_article = create(:article, user_id: blocker.id)
-      post "/comments", params: {
-        comment: { body_markdown: "something allowed", commentable_id: blocker_article.id, commentable_type: "Article" }
-      }
+      blocker_article = create(:article, user: blocker)
+
+      post "/comments", params: comment_params(
+        body_markdown: "something allowed",
+        commentable_id: blocker_article.id,
+      )
+
       new_comment = Comment.last
       expect(new_comment.body_markdown).to eq("something allowed")
       expect(new_comment.id).not_to eq(nil)
@@ -61,19 +73,24 @@ RSpec.describe "CommentsCreate", type: :request do
   end
 
   context "when an error is raised before authorization is performed" do
-    let(:rate_limit_checker) { instance_double(RateLimitChecker) }
-
     before do
       allow(RateLimitChecker).to receive(:new).and_return(rate_limit_checker)
       allow(rate_limit_checker).to receive(:limit_by_action).and_raise(StandardError)
     end
 
     it "returns an unprocessable_entity response code" do
-      post "/comments", params: {
-        comment: { body_markdown: "something not allowed", commentable_id: article.id, commentable_type: "Article" }
-      }
+      post "/comments", params: comment_params
 
       expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+
+  context "when a comment is invalid" do
+    it "returns the proper JSON response" do
+      post "/comments", params: comment_params(body_markdown: "a" * 25_001)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body["error"]).to be_present
     end
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Currently validation errors or other errors are treated as `HTTP 200 OK`, which makes it harder for the client to discern when the posting was successful and when it wasn't.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

**when the comment text is too long**

![comment_body_too_long](https://user-images.githubusercontent.com/146201/80317181-8f143600-8802-11ea-8bb9-fc17efd9b09f.gif)

![comment_body_too_long_2](https://user-images.githubusercontent.com/146201/80317184-91769000-8802-11ea-9125-fd6ce122599a.gif)

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
