### PR TITLE
Remove index_chat_channels_on_slug from schema

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -308,7 +308,6 @@ ActiveRecord::Schema.define(version: 2020_04_20_130910) do
     t.string "slug"
     t.string "status", default: "active"
     t.datetime "updated_at", null: false
-    t.index ["slug"], name: "index_chat_channels_on_slug", unique: true
   end
 
   create_table "classified_listing_categories", force: :cascade do |t|


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] clean up

## Description
This has to be okay to remove because it still lingers even after `db:reset`

## Related Tickets & Documents
n/a
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
n/a
## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed
