### PR TITLE
Setup Elasticsearch before Postgres for New Dev Envs

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -37,6 +37,10 @@ FileUtils.chdir APP_ROOT do
     FileUtils.cp "config/database.yml.sample", "config/database.yml"
   end
 
+  puts "\n== Preparing Elasticsearch =="
+  system! "bin/rails search:setup"
+  system! 'RAILS_ENV="test" bin/rails search:setup'
+
   puts "\n== Preparing database =="
   command = "psql -o /dev/null -q -n -c 'select 1' #{DB}"
   db_exists = system(command)
@@ -45,10 +49,6 @@ FileUtils.chdir APP_ROOT do
   else
     system! "bin/rails db:setup"
   end
-
-  puts "\n== Preparing Elasticsearch =="
-  system! "bin/rails search:setup"
-  system! 'RAILS_ENV="test" bin/rails search:setup'
 
   puts "\n== Updating Data =="
   system! "bin/rails data_updates:run"


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
When we setup Postgres, if it is a new dev environment we will seed the database. Seeding the database involves indexing records to Elasticsearch so we need to make sure Elasticsearch is setup BEFORE we setup the database. 

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-37100951

## Added tests?
- [x] no, because they aren't needed

I could see in the future having a little quick test suite for new env spin up. 


![alt_text](https://media1.tenor.com/images/86ca4f091d18bb82bb51880f41985c9a/tenor.gif?itemid=13829866)
