### PR TITLE
Fixed "Join the Welcome thread" spelling err

### DIFF
--- a/app/views/onboardings/_task_card.html.erb
+++ b/app/views/onboardings/_task_card.html.erb
@@ -31,7 +31,7 @@
   <p class="task-card-subtitle">SUGGESTED THINGS YOU CAN DO</p>
   <div class="task-card-action">
     <a class="task-card-link" href="/welcome">
-      <p><span class="emoji">😊</span>Join the Welcome thead</p>
+      <p><span class="emoji">😊</span>Join the Welcome thread</p>
       <svg width="8" height="14" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M5.172 7L.222 2.05 1.636.636 8 7l-6.364 6.364L.222 11.95 5.172 7z" fill="#fff" /></svg>
     </a>
   </div>


### PR DESCRIPTION
Was "welcome thead" now is "welcome thread".  I noticed the spelling error show up as I recently just joined dev.to

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Upon joining, user is presented with a welcome screen to recommend their next activities.  Noticed "thread" was spelled as "thread"

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [ ] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
