### PR TITLE
Change CarrierWave::ProcessingError error code

### DIFF
--- a/app/controllers/image_uploads_controller.rb
+++ b/app/controllers/image_uploads_controller.rb
@@ -38,7 +38,7 @@ class ImageUploadsController < ApplicationController
     rescue CarrierWave::ProcessingError # server error
       respond_to do |format|
         format.json do
-          render json: { error: "A server error has occurred!" }, status: :server_error
+          render json: { error: "A server error has occurred!" }, status: :unprocessable_entity
         end
       end
       return


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
https://app.honeybadger.io/projects/66984/faults/63232440

We were trying to return a status code of `:server_error` (invalid) when rescuing `CarrierWave::ProcessingError`. This PR returns `:unprocessable_entity` instead.

## Related Tickets & Documents
https://app.honeybadger.io/projects/66984/faults/63232440

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

![mickey_whistling_gif](https://media.giphy.com/media/9E5wP1RiPvnos/giphy.gif)
