### PR TITLE
[deploy] Add a more helpful msg for response templates

### DIFF
--- a/app/assets/javascripts/utilities/buildCommentFormHTML.js.erb
+++ b/app/assets/javascripts/utilities/buildCommentFormHTML.js.erb
@@ -30,6 +30,7 @@ function buildCommentFormHTML(commentableId, commentableType, parentId) {
               <div class="moderator-responses-container hidden">\
               </div>\
               <a target="_blank" rel="noopener nofollow" href="/settings/response-templates">Create new template</a>\
+              <p>Create templates to quickly answer FAQs or store snippets for re-use.</p>\
             </div>\
             <textarea id="textarea-for-' + parentId + '" class="embiggened" name="comment[body_markdown]" id="comment_body_markdown" required onkeydown="handleKeyDown.bind(this)(event)"></textarea>\
             '+previewDiv+'\

--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -1,6 +1,7 @@
 @import 'variables';
 @import 'mixins';
 @import 'functions';
+@import 'config/import';
 
 %kbd {
   display: inline-block;
@@ -397,7 +398,7 @@ a.header-link {
 
       a {
         text-align: left;
-        padding: 12px;
+        padding: $su-3;
         font-weight: bold;
         svg {
           width: 20px;
@@ -407,6 +408,10 @@ a.header-link {
           left: 3px;
           @include themeable(fill, link-branded-color, #3b49df)
         }
+      }
+      p {
+        align-self: flex-start;
+        padding: 0 $su-3;
       }
     }
     .article-comment-form-preamble {

--- a/app/javascript/responseTemplates/responseTemplates.js
+++ b/app/javascript/responseTemplates/responseTemplates.js
@@ -19,7 +19,6 @@ function toggleTemplateTypeButton(form, e) {
 const noResponsesHTML = `
 <div class="mod-response-wrapper mod-response-wrapper-empty">
   <p>🤔... It looks like you don't have any templates yet.</p>
-  <p>Create templates to quickly answer FAQs or store snippets for re-use.</p>
 </div>
 `;
 

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -45,6 +45,7 @@
           Create new template
           <%= inline_svg_tag("external-link-logo.svg", aria: true) %>
         </a>
+        <p>Create templates to quickly answer FAQs or store snippets for re-use.</p>
     </div>
     <%= f.text_area :body_markdown,
                     placeholder: "Add to the discussion",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
This adds a more helpful message when opening response templates, in case folks don't know what it is.

This PR is mostly to get deploys going again. 😅 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![Screen Shot 2020-04-27 at 1 07 01 PM](https://user-images.githubusercontent.com/17884966/80399912-0344ed00-8888-11ea-9c56-6eec177d50a6.png)

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed