### PR TITLE
Flaky Spec Fix: Clear Elasticsearch data for user viewing timeline specs

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -69,7 +69,7 @@ RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
   config.include OmniauthMacros
   config.include SidekiqTestHelpers
-  config.include ElasticsearchHelpers, elasticsearch: true
+  config.include ElasticsearchHelpers
 
   config.before(:suite) do
     Search::Cluster.recreate_indexes

--- a/spec/support/elasticsearch_helpers.rb
+++ b/spec/support/elasticsearch_helpers.rb
@@ -4,4 +4,11 @@ module ElasticsearchHelpers
     Array.wrap(resources).each(&:index_to_elasticsearch_inline)
     described_class.refresh_index
   end
+
+  def clear_elasticsearch_data(search_class)
+    Search::Client.delete_by_query(
+      index: search_class::INDEX_ALIAS, body: { query: { match_all: {} } },
+    )
+    search_class.refresh_index
+  end
 end

--- a/spec/system/articles/user_visits_articles_by_timeframe_spec.rb
+++ b/spec/system/articles/user_visits_articles_by_timeframe_spec.rb
@@ -120,6 +120,7 @@ RSpec.describe "User visits articles by timeframe", type: :system do
     let(:user) { create(:user) }
 
     before do
+      clear_elasticsearch_data(Search::FeedContent)
       sign_in user
       visit "/top/week"
     end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
These tests are some of our more flaky tests and it seems to be because they are showing leftover Elasticsearch data from other specs. I "proved" this by [creating a branch that also checked the Postgres db counts](https://github.com/thepracticaldev/dev.to/compare/mstruve/flaky-test-info) before checking the page. If the db counts were as expected then that means what we are loading on the page is not in Postgres but likely in Elasticsearch. [Here is a green spec run](https://travis-ci.com/github/thepracticaldev/dev.to/builds/161705100) that contains a single failure(retried successfully)
```
expected to find visible css ".single-article-small-pic" 4 times, found 10 matches:
```

In an attempt to prevent this from happening I added a statement to clear the feed content data before each spec. I did not want to completely reset Elasticsearch bc that adds a lot of overhead to tests while this simply adds a single command. If this works well we could attempt to use the helper for other specs as well instead of completely resetting Elasticsearch. 

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/issues/4884

## Added tests?
- [x] updated

![alt_text](https://media1.giphy.com/media/xT5LMDdalzqtMzTqso/source.gif)
