### PR TITLE
Dont Try Removing Reactions Not in Elasticsearch

### DIFF
--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -26,4 +26,8 @@ module Searchable
   def sync_related_elasticsearch_docs
     self.class::DATA_SYNC_CLASS.new(self).call
   end
+
+  def elasticsearch_doc_exists?
+    self.class::SEARCH_CLASS.document_exists?(search_id)
+  end
 end

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -34,7 +34,7 @@ class Reaction < ApplicationRecord
   after_create_commit :record_field_test_event
   after_commit :async_bust, :bust_reactable_cache, :update_reactable
   after_commit :index_to_elasticsearch, if: :indexable?, on: %i[create update]
-  after_commit :remove_from_elasticsearch, if: :indexable?, on: [:destroy]
+  after_commit :remove_from_elasticsearch, if: :can_remove_from_index?, on: [:destroy]
   after_save :index_to_algolia
   after_save :touch_user
   before_destroy :update_reactable_without_delay, unless: :destroyed_by_association
@@ -112,6 +112,10 @@ class Reaction < ApplicationRecord
 
   def indexable?
     category == "readinglist" && reactable && reactable.published
+  end
+
+  def can_remove_from_index?
+    elasticsearch_doc_exists? && indexable?
   end
 
   def touch_user

--- a/app/services/search/base.rb
+++ b/app/services/search/base.rb
@@ -29,6 +29,10 @@ module Search
         Search::Client.get(id: doc_id, index: self::INDEX_ALIAS)
       end
 
+      def document_exists?(doc_id)
+        Search::Client.exists?(id: doc_id, index: self::INDEX_ALIAS)
+      end
+
       def delete_document(doc_id)
         Search::Client.delete(id: doc_id, index: self::INDEX_ALIAS)
       end

--- a/spec/models/concerns/searchable_spec.rb
+++ b/spec/models/concerns/searchable_spec.rb
@@ -66,4 +66,12 @@ RSpec.describe Searchable do
       expect(model_class::SEARCH_CLASS).to have_received(:find_document)
     end
   end
+
+  describe "#elasticsearch_doc_exists?" do
+    it "checks elasticsearch for a document" do
+      allow(model_class::SEARCH_CLASS).to receive(:document_exists?)
+      searchable_model.elasticsearch_doc_exists?
+      expect(model_class::SEARCH_CLASS).to have_received(:document_exists?)
+    end
+  end
 end

--- a/spec/services/search/base_spec.rb
+++ b/spec/services/search/base_spec.rb
@@ -58,6 +58,17 @@ RSpec.describe Search::Base, type: :service, elasticsearch: true do
     end
   end
 
+  describe "::document_exists?" do
+    it "returns true if document is in elasticsearch" do
+      described_class.index(document_id, id: document_id)
+      expect(described_class.document_exists?(document_id)).to eq(true)
+    end
+
+    it "returns false if document is NOT in elasticsearch" do
+      expect(described_class.document_exists?("bogus_id")).to eq(false)
+    end
+  end
+
   describe "::delete_document" do
     it "deletes a document for a given ID from elasticsearch" do
       described_class.index(document_id, id: document_id)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Often we will never get a chance to execute an indexing job for a Reaction bc it is destroyed before the job can execute. 
```ruby
def perform(object_class, id)
  object = object_class.constantize.find(id)
  object.index_to_elasticsearch_inline
rescue ActiveRecord::RecordNotFound => e
  return if object_class == "Reaction"

  raise e
end
```
When it is destroyed however we will still attempt to remove it from Elasticsearch. This PR checks for its presence in Elasticsearch before it attempts to destroy it. Another solution would be to ignore `Search::Errors::Transport::NotFound` for reactions when removing them like we do when adding them but that worries me that we might run into missing some bugs so I want to try this more accurate approach first. If others think we should jump straight to the easy solution though let me know, this does add a bit of complexity and an ES call to a callback. 

## Added tests?
- [x] yes

![alt_text](https://media.giphy.com/media/RXlkTRLi1S1aM/giphy.gif)
