### PR TITLE
Add /play codenames proof-of-concept to /connect

### DIFF
--- a/app/javascript/chat/chat.jsx
+++ b/app/javascript/chat/chat.jsx
@@ -617,6 +617,13 @@ export default class Chat extends Component {
       };
       this.setState({ videoPath: `/video_chats/${activeChannelId}` });
       sendMessage(messageObject, this.handleSuccess, this.handleFailure);
+    } else if (message.startsWith('/play ')) {
+      const messageObject = {
+        activeChannelId,
+        message: message,
+        mentionedUsersId: this.getMentionedUsers(message),
+      };
+      sendMessage(messageObject, this.handleSuccess, this.handleFailure);
     } else if (message.startsWith('/new')) {
       this.setActiveContentState(activeChannelId, {
         type_of: 'loading-post',
@@ -815,6 +822,15 @@ export default class Chat extends Component {
           path: `/chat_channel_memberships/${activeChannel.id}/edit`,
           type_of: 'article',
         });
+      } else if (content.startsWith('sidecar-content-plus-video')) {
+        this.setActiveContentState(activeChannelId, {
+          type_of: 'loading-post',
+        });
+        this.setActiveContent({
+          path: target.href || target.parentElement.href,
+          type_of: 'article',
+        });
+        this.setState({ videoPath: `/video_chats/${activeChannelId}` });
       } else if (content.startsWith('sidecar-video')) {
         this.setState({ videoPath: target.href || target.parentElement.href });
       } else if (

--- a/app/javascript/packs/videoChat.jsx
+++ b/app/javascript/packs/videoChat.jsx
@@ -1,5 +1,6 @@
 const { createLocalVideoTrack, connect } = require('twilio-video');
 const root = document.getElementById('videochat');
+const remoteMedia = document.getElementById('remote-media');
 const muteButton = document.getElementById('mute-toggle');
 const videoToggleButton = document.getElementById('videohide-toggle');
 const localMediaContainer = document.getElementById('local-media');
@@ -56,9 +57,10 @@ createLocalVideoTrack().then(track => {
 
 
 function participantConnected(participant) {
+  const numExistingDivs = document.getElementsByClassName('individual-video').length;
   const div = document.createElement('div');
   div.id = participant.sid;
-  div.className = "individual-video"
+  div.className = "individual-video" + (numExistingDivs > 3 ? " one-of-many-videos" : "")
   div.innerHTML = '<div class="participant-info">\
       <div class="participant-name">'+ participant.identity + '</div>\
       <div class="disabled-audio-indicator">audio off</div>\
@@ -76,7 +78,7 @@ function participantConnected(participant) {
       trackSubscribed(div, publication.track);
     }
   });
-  root.appendChild(div);
+  remoteMedia.appendChild(div);
 }
 
 function participantDisconnected(participant) {

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -43,7 +43,7 @@ class Message < ApplicationRecord
     html = target_blank_links(html)
     html = append_rich_links(html)
     html = wrap_mentions_with_links(html)
-    html = handle_call(html)
+    html = handle_slash_command(html)
     self.message_html = html
   end
 
@@ -144,16 +144,26 @@ class Message < ApplicationRecord
     html
   end
 
-  def handle_call(html)
-    return html if html.to_s.exclude?("<p>/call</p>")
-
-    "<a href='/video_chats/#{chat_channel_id}'
-        class='chatchannels__richlink chatchannels__richlink--base'
-        target='_blank' rel='noopener' data-content='sidecar-video'>
-        <h1 data-content='sidecar-video'>
-          Let's video chat 😄
-        </h1>
-        </a>".html_safe
+  def handle_slash_command(html)
+    response = if html.to_s.strip == "<p>/call</p>"
+                 "<a href='/video_chats/#{chat_channel_id}'
+                    class='chatchannels__richlink chatchannels__richlink--base'
+                    target='_blank' rel='noopener' data-content='sidecar-video'>
+                    <h1 data-content='sidecar-video'>
+                      Let's video chat 😄
+                    </h1>
+                    </a>".html_safe
+               elsif html.to_s.strip == "<p>/play codenames</p>" #proof of concept
+                 "<a href='https://www.horsepaste.com/connect-channel-#{rand(1_000_000_000)}'
+                    class='chatchannels__richlink chatchannels__richlink--base'
+                    target='_blank' rel='noopener' data-content='sidecar-content-plus-video'>
+                    <h1 data-content='sidecar-content-plus-video'>
+                      Let's play codenames 🤐
+                    </h1>
+                    </a>".html_safe
+                end
+    html = response if response
+    html
   end
 
   def cl_path(img_src)

--- a/app/views/video_chats/show.html.erb
+++ b/app/views/video_chats/show.html.erb
@@ -9,20 +9,33 @@
     overflow: scroll;
   }
   .individual-video video {
-    max-width: 600px;
+    max-height: 100vh;
     background: #232324;
     width: 100%;
   }
 
+  #remote-media {
+    display:flex;
+    flex-wrap: wrap;
+    /* flex-direction:row; */
+  }
+
+
   .individual-video {
     overflow: hidden;
     position: relative;
-    display: inline-block;
-    line-height: 0;
+    margin-bottom: -6px;
+    flex: 1 0 21%;
+    text-align: center;
+    min-width:20%;
+    background: #232324;
   }
-  .individual-video:last-child {
+  .one-of-many-videos {
+    min-width:33%;
+  }
+  /* .individual-video:last-child {
     margin-bottom: 100px;
-  }
+  } */
 
   #local-media video {
     width: 150px;
@@ -30,16 +43,14 @@
     bottom: 10px;
     right: 10px;
     z-index: 5;
+    border-radius:3px;
+    border: 1px solid #232324;
   }
 
   #local-media.video-hidden {
     opacity: 0.1;
   }
 
-  .individual-video {
-    position: relative;
-    margin-bottom: -6px;
-  }
   .participant-info {
     padding: 3px 8px;
     border-radius: 3px;
@@ -107,6 +118,12 @@
     margin-top: 30px;
   }
 
+  @media screen and (max-width: 400px) {
+    .individual-video {
+      flex: 1 0 100%;
+      width: 100%;
+    }
+  }
   @media screen and (max-width: 280px) {
     .video-controls {
       width: 92%;


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This is the last silly proof of concept before refactoring and extending these concepts. Enjoy 🙂.

This adds the `/play x` namespace which can open minigames in connect.

<img width="941" alt="Screen Shot 2020-04-27 at 6 16 38 PM" src="https://user-images.githubusercontent.com/3102842/80426235-4bc5d000-88b3-11ea-944d-66d3f984469e.png">
