### PR TITLE
Don't reindex Elasticsearch before suite

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -71,6 +71,10 @@ RSpec.configure do |config|
   config.include SidekiqTestHelpers
   config.include ElasticsearchHelpers
 
+  config.before(:suite) do
+    Search::Cluster.delete_indexes
+  end
+
   config.before do
     Sidekiq::Worker.clear_all # worker jobs shouldn't linger around between tests
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -71,10 +71,6 @@ RSpec.configure do |config|
   config.include SidekiqTestHelpers
   config.include ElasticsearchHelpers
 
-  config.before(:suite) do
-    Search::Cluster.recreate_indexes
-  end
-
   config.before do
     Sidekiq::Worker.clear_all # worker jobs shouldn't linger around between tests
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor
- [X] Optimization

## Description

I looked into our Elasticsearch spec setup during an effort to make our specs run faster. 
As @ledestin mentioned that Elasticsearch I/O slows down the spec for him, I got curious, since he shouldn't need ES for that specific spec.

Looking `spec/rails_helper.rb` I noticed that we perform this operation twice, once before the whole test suite, once before specs tagged with `elasticsearch`:

```ruby
  config.before(:suite) do
    Search::Cluster.recreate_indexes
  end

  config.around(:each, elasticsearch: true) do |example|
    Search::Cluster.recreate_indexes
    example.run
  end
```

Looking at the implementation of  `Search::Cluster.delete_indexes` it seems to be able to handle non-existant indexes:

```ruby
next unless Search::Client.indices.exists(index: search_class::INDEX_NAME)
```

This makes me wonder if we need the `berfore_suite` block at all since any index we create there would be removed and recreated as soon as we hit the first spec tagged with `:elasticsearch`.

I experimented with removing `before(:suite)` locally, which shaved off a few more seconds so the particular spec we investigated now finished in ~16 seconds for me. 

I created this draft PR to see how the whole suite deals with the `before(:suit)` index creation removed.

## Related Tickets & Documents

#7383

## Added tests?

- [X] no, because they aren't needed

## Added to documentation?

- [X] no documentation needed

