### PR TITLE
Fix broken migration after strong_migrations 0.6.4

### DIFF
--- a/db/migrate/20200409050122_add_listing_category_to_classified_listing.rb
+++ b/db/migrate/20200409050122_add_listing_category_to_classified_listing.rb
@@ -2,9 +2,11 @@ class AddListingCategoryToClassifiedListing < ActiveRecord::Migration[5.2]
   disable_ddl_transaction!
 
   def change
-    add_reference :classified_listings,
-                  :classified_listing_category,
-                  foreign_key: true,
-                  index: { algorithm: :concurrently }
+    safety_assured do
+      add_reference :classified_listings,
+                    :classified_listing_category,
+                    foreign_key: true,
+                    index: { algorithm: :concurrently }
+    end
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Running `bin/setup` or `rails db:migrate` from scratch will fail as #7476 through the upgrade to `strong_migrations 0.8.4` introduced a new check:

> Added check for add_reference with foreign_key: true

## Related Tickets & Documents

#7476 
