### PR TITLE
Removes iOS only label from mobile notifications settings

### DIFF
--- a/app/views/users/_notifications.html.erb
+++ b/app/views/users/_notifications.html.erb
@@ -58,7 +58,7 @@
   <div class="crayons-card mb-6 grid gap-6 p-6">
     <header>
       <h3 class="mb-2">Mobile Notification Settings (Beta)</h3>
-      <p>iOS only for now. Additional settings and platforms will be rolled out as new notification features are made available.</p>
+      <p>Additional settings will be rolled out as new notification features are made available.</p>
     </header>
     <div class="crayons-field crayons-field--checkbox">
       <%= f.check_box :mobile_comment_notifications, class: "crayons-checkbox" %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

A fix to the label in the Settings under Mobile Notifications since PN's are now available in Android too. Leaving the label though because there's still a few notifications that could be implemented in the near future.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

<img width="784" alt="Screen Shot 2020-04-28 at 06 04 49" src="https://user-images.githubusercontent.com/6045239/80485200-359d2b80-8916-11ea-8779-74e7ef3c8d72.png">

<img width="796" alt="Screen Shot 2020-04-28 at 06 04 38" src="https://user-images.githubusercontent.com/6045239/80485205-3766ef00-8916-11ea-8a63-4f5cde7c1f26.png">


## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![teeny-tiny one](https://media.giphy.com/media/Z9iAMfODlQG7wLoXKN/giphy.gif)
