### PR TITLE
Ignore Search::Errors::Transport::NotFound error when Removing Reactions

### DIFF
--- a/app/workers/search/index_to_elasticsearch_worker.rb
+++ b/app/workers/search/index_to_elasticsearch_worker.rb
@@ -8,6 +8,8 @@ module Search
       object = object_class.constantize.find(id)
       object.index_to_elasticsearch_inline
     rescue ActiveRecord::RecordNotFound => e
+      # Reactions can often be destroyed before this indexing job can execute
+      # so we ignore this error
       return if object_class == "Reaction"
 
       raise e

--- a/app/workers/search/remove_from_elasticsearch_index_worker.rb
+++ b/app/workers/search/remove_from_elasticsearch_index_worker.rb
@@ -7,6 +7,8 @@ module Search
     def perform(search_class, id)
       search_class.safe_constantize.delete_document(id)
     rescue Search::Errors::Transport::NotFound => e
+      # Reactions are often destroyed before the indexing job can execute
+      # so we ignore this error when trying to remove them
       return if search_class == "Search::Reaction"
 
       raise e

--- a/app/workers/search/remove_from_elasticsearch_index_worker.rb
+++ b/app/workers/search/remove_from_elasticsearch_index_worker.rb
@@ -6,6 +6,10 @@ module Search
 
     def perform(search_class, id)
       search_class.safe_constantize.delete_document(id)
+    rescue Search::Errors::Transport::NotFound => e
+      return if search_class == "Search::Reaction"
+
+      raise e
     end
   end
 end

--- a/spec/workers/search/remove_from_elasticsearch_index_worker_spec.rb
+++ b/spec/workers/search/remove_from_elasticsearch_index_worker_spec.rb
@@ -2,13 +2,27 @@ require "rails_helper"
 
 RSpec.describe Search::RemoveFromElasticsearchIndexWorker, type: :worker do
   let(:worker) { subject }
+  let(:search_class) { Search::Tag }
 
   include_examples "#enqueues_on_correct_queue", "medium_priority", ["SearchClass", 1]
 
   it "deletes document for given search class" do
-    search_class = Search::Tag
     allow(search_class).to receive(:delete_document)
     described_class.new.perform(search_class.to_s, 1)
     expect(search_class).to have_received(:delete_document).with(1)
+  end
+
+  context "when document is not found" do
+    it "raises error" do
+      expect { described_class.new.perform(search_class.to_s, 1) }.to raise_error(
+        Search::Errors::Transport::NotFound,
+      )
+    end
+
+    it "does not raise error if removing a Reaction" do
+      expect { described_class.new.perform("Search::Reaction", 1) }.not_to raise_error(
+        Search::Errors::Transport::NotFound,
+      )
+    end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Often we will never get a chance to execute an indexing job for a Reaction bc it is destroyed before the job can execute. When it is destroyed however we will still attempt to remove it from Elasticsearch. This PR will ignore `Search::Errors::Transport::NotFound` errors for reactions when removing them like we do when adding them.

## Added tests?
- [x] yes

![alt_text](https://media.giphy.com/media/RXlkTRLi1S1aM/giphy.gif)
