### PR TITLE
De-duplicate Cache Busting and Reactable Updates when Destroying Reactions

### DIFF
--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -32,11 +32,13 @@ class Reaction < ApplicationRecord
   after_create :notify_slack_channel_about_vomit_reaction, if: -> { category == "vomit" }
   before_save :assign_points
   after_create_commit :record_field_test_event
-  after_commit :async_bust, :bust_reactable_cache, :update_reactable
+  after_commit :async_bust
+  after_commit :bust_reactable_cache, :update_reactable, on: %i[create update]
   after_commit :index_to_elasticsearch, if: :indexable?, on: %i[create update]
   after_commit :remove_from_elasticsearch, if: :indexable?, on: [:destroy]
   after_save :index_to_algolia
   after_save :touch_user
+
   before_destroy :update_reactable_without_delay, unless: :destroyed_by_association
   before_destroy :bust_reactable_cache_without_delay
   before_destroy :remove_algolia

--- a/spec/models/reaction_spec.rb
+++ b/spec/models/reaction_spec.rb
@@ -248,11 +248,24 @@ RSpec.describe Reaction, type: :model do
   end
 
   context "when callbacks are called before destroy" do
+    let(:reaction) { create(:reaction, reactable: article, user: user) }
+
     it "enqueues a ScoreCalcWorker on article reaction destroy" do
-      reaction = create(:reaction, reactable: article, user: user)
       sidekiq_assert_enqueued_with(job: Articles::ScoreCalcWorker, args: [article.id]) do
         reaction.destroy
       end
+    end
+
+    it "updates reactable without delay" do
+      allow(reaction).to receive(:update_reactable_without_delay)
+      reaction.destroy
+      expect(reaction).to have_received(:update_reactable_without_delay)
+    end
+
+    it "busts reactable cache without delay" do
+      allow(reaction).to receive(:bust_reactable_cache_without_delay)
+      reaction.destroy
+      expect(reaction).to have_received(:bust_reactable_cache_without_delay)
     end
   end
 end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
When we destroy a reaction we will trigger `after_commit` callbacks. This means we were doubling up on busting the reachable cache and updating the reachable. 
```ruby
after_commit :bust_reactable_cache, :update_reactable

before_destroy :update_reactable_without_delay, unless: :destroyed_by_association
before_destroy :bust_reactable_cache_without_delay
```
To fix this I added the condition of `on: %i[create update]` to our after_commit callback so it is not triggered during a destroy

## Added tests?
- [x] yes

![alt_text](https://thumbs.gfycat.com/ClassicPleasantIbisbill-max-1mb.gif)
