### PR TITLE
Bug Fix: Remove article clear_index! from seeds file

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -117,8 +117,6 @@ num_articles = 25 * SEEDS_MULTIPLIER
 counter += 1
 Rails.logger.info "#{counter}. Creating #{num_articles} Articles"
 
-Article.clear_index!
-
 num_articles.times do |i|
   tags = []
   tags << "discuss" if (i % 3).zero?


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Algolia is no longer used by Articles so we can remove this. 

![alt_text](https://media1.tenor.com/images/552386738cae69335e2c75891974cf11/tenor.gif?itemid=6140783)
