### PR TITLE
Only Calculate Comment Score on Update and Create

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -31,7 +31,7 @@ class Comment < ApplicationRecord
   after_create :notify_slack_channel_about_warned_users
   after_create :after_create_checks
   after_create_commit :record_field_test_event
-  after_commit :calculate_score
+  after_commit :calculate_score, on: %i[create update]
   after_update_commit :update_notifications, if: proc { |comment| comment.saved_changes.include? "body_markdown" }
   after_save     :bust_cache
   after_save     :synchronous_bust


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
No need to waste resources enqueueing a job to rescore a comment after it has been destroyed.

## Added tests?
- [x] no, because they aren't needed

![alt_text](https://media1.tenor.com/images/4f35a38c0b8c7c8fd3bb2fdc45f75b78/tenor.gif?itemid=14429148)
