### PR TITLE
Authentication refactoring: cleanups

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,10 +1,9 @@
 class RegistrationsController < Devise::RegistrationsController
   prepend_before_action :require_no_authentication, only: []
-  # No authorization required for public registration route
 
   def new
     if user_signed_in?
-      redirect_to "/dashboard?signed-in-already&t=#{Time.current.to_i}"
+      redirect_to dashboard_path
     else
       super
     end

--- a/app/helpers/authentication_helper.rb
+++ b/app/helpers/authentication_helper.rb
@@ -8,12 +8,4 @@ module AuthenticationHelper
       Authentication::Providers.get!(provider_name)
     end
   end
-
-  def authentication_path(provider_name, params = {})
-    Authentication::Providers.authentication_path(provider_name, params)
-  end
-
-  def sign_in_path(provider_name, params = {})
-    Authentication::Providers.sign_in_path(provider_name, params)
-  end
 end

--- a/app/helpers/authentication_helper.rb
+++ b/app/helpers/authentication_helper.rb
@@ -1,0 +1,19 @@
+module AuthenticationHelper
+  def authentication_provider(provider_name)
+    Authentication::Providers.get!(provider_name)
+  end
+
+  def authentication_enabled_providers
+    Authentication::Providers.enabled.map do |provider_name|
+      Authentication::Providers.get!(provider_name)
+    end
+  end
+
+  def authentication_path(provider_name, params = {})
+    Authentication::Providers.authentication_path(provider_name, params)
+  end
+
+  def sign_in_path(provider_name, params = {})
+    Authentication::Providers.sign_in_path(provider_name, params)
+  end
+end

--- a/app/services/authentication/paths.rb
+++ b/app/services/authentication/paths.rb
@@ -1,0 +1,23 @@
+module Authentication
+  # These are meant to be called from the specific providers
+  module Paths
+    # Returns the authentication path for the given provider
+    def self.authentication_path(provider_name, params = {})
+      Rails.application.routes.url_helpers.public_send(
+        "user_#{provider_name}_omniauth_authorize_path", params
+      )
+    end
+
+    # Returns the sign in URL for the given provider
+    def self.sign_in_path(provider_name, params = {})
+      url_helpers = Rails.application.routes.url_helpers
+
+      callback_url_helper = "user_#{provider_name}_omniauth_callback_path"
+      mandatory_params = {
+        callback_url: URL.url(url_helpers.public_send(callback_url_helper))
+      }
+
+      authentication_path(provider_name, params.merge(mandatory_params))
+    end
+  end
+end

--- a/app/services/authentication/providers.rb
+++ b/app/services/authentication/providers.rb
@@ -1,10 +1,3 @@
-# We require all authentication modules to make sure providers
-# are correctly preloaded both in development and in production and
-# ready to be used when needed at runtime
-Dir[Rails.root.join("app/services/authentication/**/*.rb")].each do |f|
-  require_dependency(f)
-end
-
 module Authentication
   module Providers
     # Retrieves a provider that is both available and enabled
@@ -30,10 +23,7 @@ module Authentication
 
     # Returns available providers
     def self.available
-      # the magic is done in <config/initializers/authentication_providers.rb>
-      Authentication::Providers::Provider.subclasses.map do |subclass|
-        subclass.name.demodulize.downcase.to_sym
-      end.sort
+      Devise.omniauth_providers.sort
     end
 
     # Returns enabled providers

--- a/app/services/authentication/providers.rb
+++ b/app/services/authentication/providers.rb
@@ -48,24 +48,5 @@ module Authentication
     def self.enabled?(provider_name)
       enabled.include?(provider_name.to_sym)
     end
-
-    # Returns the authentication path for the given provider
-    def self.authentication_path(provider_name, params = {})
-      Rails.application.routes.url_helpers.public_send(
-        "user_#{provider_name}_omniauth_authorize_path", params
-      )
-    end
-
-    # Returns the sign in URL for the given provider
-    def self.sign_in_path(provider_name, params = {})
-      url_helpers = Rails.application.routes.url_helpers
-
-      callback_url_helper = "user_#{provider_name}_omniauth_callback_path"
-      mandatory_params = {
-        callback_url: URL.url(url_helpers.public_send(callback_url_helper))
-      }
-
-      authentication_path(provider_name, params.merge(mandatory_params))
-    end
   end
 end

--- a/app/services/authentication/providers/github.rb
+++ b/app/services/authentication/providers/github.rb
@@ -29,6 +29,13 @@ module Authentication
         OFFICIAL_NAME
       end
 
+      def self.sign_in_path(params = {})
+        ::Authentication::Paths.sign_in_path(
+          provider_name,
+          params,
+        )
+      end
+
       protected
 
       def cleanup_payload(auth_payload)

--- a/app/services/authentication/providers/provider.rb
+++ b/app/services/authentication/providers/provider.rb
@@ -50,6 +50,14 @@ module Authentication
         raise SubclassResponsibility
       end
 
+      def self.authentication_path(params = {})
+        ::Authentication::Paths.authentication_path(provider_name, params)
+      end
+
+      def self.sign_in_path(_params = {})
+        raise SubclassResponsibility
+      end
+
       protected
 
       # Remove sensible data from the payload

--- a/app/services/authentication/providers/provider.rb
+++ b/app/services/authentication/providers/provider.rb
@@ -41,6 +41,10 @@ module Authentication
         self.class::USERNAME_FIELD
       end
 
+      def self.provider_name
+        name.demodulize.downcase.to_sym
+      end
+
       # Returns the official name of the authentication provider
       def self.official_name
         raise SubclassResponsibility

--- a/app/services/authentication/providers/twitter.rb
+++ b/app/services/authentication/providers/twitter.rb
@@ -34,6 +34,16 @@ module Authentication
         OFFICIAL_NAME
       end
 
+      def self.sign_in_path(params = {})
+        # see https://github.com/arunagw/omniauth-twitter#authentication-options
+        mandatory_params = { secure_image_url: true }
+
+        ::Authentication::Paths.sign_in_path(
+          provider_name,
+          params.merge(mandatory_params),
+        )
+      end
+
       protected
 
       def cleanup_payload(auth_payload)

--- a/app/views/shared/authentication/_providers_nav_menu.html.erb
+++ b/app/views/shared/authentication/_providers_nav_menu.html.erb
@@ -1,8 +1,6 @@
-<% Authentication::Providers.enabled.each do |provider_name| %>
-  <% provider = Authentication::Providers.get!(provider_name) %>
-
+<% authentication_enabled_providers.each do |provider| %>
   <a
-    href="<%= Authentication::Providers.sign_in_path(provider_name, state: "navbar_basic") %>"
+    href="<%= sign_in_path(provider.provider_name, state: "navbar_basic") %>"
     class="crayons-link crayons-link--block pl-5"
     data-no-instant>
     Via <%= provider.official_name %>

--- a/app/views/shared/authentication/_providers_nav_menu.html.erb
+++ b/app/views/shared/authentication/_providers_nav_menu.html.erb
@@ -1,6 +1,6 @@
 <% authentication_enabled_providers.each do |provider| %>
   <a
-    href="<%= sign_in_path(provider.provider_name, state: "navbar_basic") %>"
+    href="<%= provider.sign_in_path(state: "navbar_basic") %>"
     class="crayons-link crayons-link--block pl-5"
     data-no-instant>
     Via <%= provider.official_name %>

--- a/app/views/shared/authentication/_providers_registration_form.html.erb
+++ b/app/views/shared/authentication/_providers_registration_form.html.erb
@@ -1,10 +1,8 @@
-<% Authentication::Providers.enabled.each do |provider_name| %>
-  <% provider = Authentication::Providers.get!(provider_name) %>
-
+<% authentication_enabled_providers.each do |provider| %>
   <a
-    href="<%= Authentication::Providers.sign_in_path(provider_name, state: "join-club-page_basic") %>"
+    href="<%= sign_in_path(provider.provider_name, state: "join-club-page_basic") %>"
     class="sign-up-link"
     data-no-instant>
-    <%= inline_svg_tag("#{provider_name}-logo.svg", class: "icon-img", aria: true, title: "#{provider_name} logo") %> Sign In with <%= provider.official_name %>
+    <%= inline_svg_tag("#{provider.provider_name}-logo.svg", class: "icon-img", aria: true, title: "#{provider.name} logo") %> Sign In with <%= provider.official_name %>
   </a>
 <% end %>

--- a/app/views/shared/authentication/_providers_registration_form.html.erb
+++ b/app/views/shared/authentication/_providers_registration_form.html.erb
@@ -1,6 +1,6 @@
 <% authentication_enabled_providers.each do |provider| %>
   <a
-    href="<%= sign_in_path(provider.provider_name, state: "join-club-page_basic") %>"
+    href="<%= provider.sign_in_path(state: "join-club-page_basic") %>"
     class="sign-up-link"
     data-no-instant>
     <%= inline_svg_tag("#{provider.provider_name}-logo.svg", class: "icon-img", aria: true, title: "#{provider.name} logo") %> Sign In with <%= provider.official_name %>

--- a/app/views/shared/authentication/_providers_sidebar.html.erb
+++ b/app/views/shared/authentication/_providers_sidebar.html.erb
@@ -1,6 +1,6 @@
 <% authentication_enabled_providers.each do |provider| %>
   <a
-    href="<%= sign_in_path(provider.provider_name, state: "navbar_basic") %>"
+    href="<%= provider.sign_in_path(state: "navbar_basic") %>"
     class="cta cta-button login-cta-button"
     data-no-instant>
     Sign In With <%= provider.official_name %>

--- a/app/views/shared/authentication/_providers_sidebar.html.erb
+++ b/app/views/shared/authentication/_providers_sidebar.html.erb
@@ -1,8 +1,6 @@
-<% Authentication::Providers.enabled.each do |provider_name| %>
-  <% provider = Authentication::Providers.get!(provider_name) %>
-
+<% authentication_enabled_providers.each do |provider| %>
   <a
-    href="<%= Authentication::Providers.sign_in_path(provider_name, state: "navbar_basic") %>"
+    href="<%= sign_in_path(provider.provider_name, state: "navbar_basic") %>"
     class="cta cta-button login-cta-button"
     data-no-instant>
     Sign In With <%= provider.official_name %>

--- a/app/views/shared/authentication/_providers_signup_modal.html.erb
+++ b/app/views/shared/authentication/_providers_signup_modal.html.erb
@@ -1,13 +1,11 @@
-<% Authentication::Providers.enabled.each do |provider_name| %>
-  <% provider = Authentication::Providers.get!(provider_name) %>
-
+<% authentication_enabled_providers.each do |provider| %>
   <a
-    href="<%= Authentication::Providers.sign_in_path(provider_name, state: "signup-modal") %>"
+    href="<%= sign_in_path(provider.provider_name, state: "signup-modal") %>"
     class="sign-up-link cta"
     data-no-instant>
     <img
-      src="<%= asset_path("#{provider_name}-logo.svg") %>"
+      src="<%= asset_path("#{provider.provider_name}-logo.svg") %>"
       class="icon-img"
-      alt="<%= provider.official_name %> logo" /> Auth With <%= provider.official_name %>
+      alt="<%= provider.official_name %> logo" /> Sign In With <%= provider.official_name %>
   </a>
 <% end %>

--- a/app/views/shared/authentication/_providers_signup_modal.html.erb
+++ b/app/views/shared/authentication/_providers_signup_modal.html.erb
@@ -1,6 +1,6 @@
 <% authentication_enabled_providers.each do |provider| %>
   <a
-    href="<%= sign_in_path(provider.provider_name, state: "signup-modal") %>"
+    href="<%= provider.sign_in_path(state: "signup-modal") %>"
     class="sign-up-link cta"
     data-no-instant>
     <img

--- a/app/views/users/_additional_authentication.html.erb
+++ b/app/views/users/_additional_authentication.html.erb
@@ -1,7 +1,7 @@
 <% authentication_enabled_providers.each do |provider| %>
   <% unless @user.identities.exists?(provider: provider.provider_name) %>
     <a
-      href="<%= authentication_path(provider.provider_name) %>"
+      href="<%= provider.authentication_path %>"
       class="crayons-btn crayons-btn--outlined mr-2"
       data-no-instant>
       <%= inline_svg_tag(

--- a/app/views/users/_additional_authentication.html.erb
+++ b/app/views/users/_additional_authentication.html.erb
@@ -1,15 +1,14 @@
-<% Authentication::Providers.enabled.each do |provider_name| %>
-  <% unless @user.identities.exists?(provider: provider_name) %>
-    <% provider = Authentication::Providers.get!(provider_name) %>
+<% authentication_enabled_providers.each do |provider| %>
+  <% unless @user.identities.exists?(provider: provider.provider_name) %>
     <a
-      href="<%= Authentication::Providers.authentication_path(provider_name) %>"
+      href="<%= authentication_path(provider.provider_name) %>"
       class="crayons-btn crayons-btn--outlined mr-2"
       data-no-instant>
       <%= inline_svg_tag(
-            "#{provider_name}.svg",
+            "#{provider.provider_name}.svg",
             aria: true,
             class: "crayons-icon",
-            title: provider_name.to_s.titleize.to_s,
+            title: provider.official_name,
           ) %>
       Connect <%= provider.official_name %> Account
     </a>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -235,6 +235,8 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
+  config.omniauth :github, ApplicationConfig["GITHUB_KEY"], ApplicationConfig["GITHUB_SECRET"], scope: "user:email"
+  config.omniauth :twitter, ApplicationConfig["TWITTER_KEY"], ApplicationConfig["TWITTER_SECRET"]
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or
@@ -258,8 +260,4 @@ Devise.setup do |config|
   # When using OmniAuth, Devise cannot automatically set OmniAuth path,
   # so you need to do it manually. For the users scope, it would be:
   # config.omniauth_path_prefix = '/my_engine/users/auth'
-
-  config.omniauth :github,
-                  ApplicationConfig["GITHUB_KEY"], ApplicationConfig["GITHUB_SECRET"], scope: "user:email"
-  config.omniauth :twitter, ApplicationConfig["TWITTER_KEY"], ApplicationConfig["TWITTER_SECRET"]
 end

--- a/config/initializers/persistent_csrf_token_cookie.rb
+++ b/config/initializers/persistent_csrf_token_cookie.rb
@@ -1,5 +1,3 @@
-# config/initializers/monkey_patches/persistent_csrf_token_cookie.rb
-#
 # Workaround for CSRF protection bug.
 #
 # https://github.com/rails/rails/issues/21948

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,11 @@ Rails.application.routes.draw do
     registrations: "registrations"
   }
 
+  devise_scope :user do
+    get "/enter", to: "registrations#new", as: :sign_up
+    delete "/sign_out", to: "devise/sessions#destroy"
+  end
+
   require "sidekiq/web"
   require "sidekiq_unique_jobs/web"
 
@@ -21,11 +26,6 @@ Rails.application.routes.draw do
     end
     mount Sidekiq::Web => "/sidekiq"
     mount FieldTest::Engine, at: "abtests"
-  end
-
-  devise_scope :user do
-    delete "/sign_out" => "devise/sessions#destroy"
-    get "/enter" => "registrations#new", :as => :sign_up
   end
 
   namespace :admin do

--- a/spec/labor/badge_rewarder_spec.rb
+++ b/spec/labor/badge_rewarder_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe BadgeRewarder, type: :labor do
     end
 
     before do
-      mock_github
+      omniauth_mock_github_payload
       allow(Octokit::Client).to receive(:new).and_return(my_ocktokit_client)
       allow(my_ocktokit_client).to receive(:commits).and_return(stubbed_github_commit)
       create(:badge, title: "DEV Contributor")

--- a/spec/models/github_repo_spec.rb
+++ b/spec/models/github_repo_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe GithubRepo, type: :model do
   let(:user) { create(:user, :with_identity, identities: ["github"]) }
   let(:repo) { build(:github_repo, user_id: user.id) }
 
-  before { mock_github }
+  before { omniauth_mock_github_payload }
 
   it { is_expected.to validate_presence_of(:name) }
   it { is_expected.to validate_presence_of(:url) }

--- a/spec/models/identity_spec.rb
+++ b/spec/models/identity_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Identity, type: :model do
     let(:user) { create(:user) }
 
     before do
-      mock_auth_hash
+      omniauth_mock_providers_payload
     end
 
     context "with Github payload" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe User, type: :model do
   let(:other_user) { create(:user) }
   let(:org) { create(:organization) }
 
-  before { mock_auth_hash }
+  before { omniauth_mock_providers_payload }
 
   describe "validations" do
     describe "builtin validations" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -67,7 +67,7 @@ RSpec.configure do |config|
   config.include Devise::Test::IntegrationHelpers, type: :system
   config.include Devise::Test::IntegrationHelpers, type: :request
   config.include FactoryBot::Syntax::Methods
-  config.include OmniauthMacros
+  config.include OmniauthHelpers
   config.include SidekiqTestHelpers
   config.include ElasticsearchHelpers
 

--- a/spec/requests/github_repos_spec.rb
+++ b/spec/requests/github_repos_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "GithubRepos", type: :request do
   end
 
   before do
-    mock_github
+    omniauth_mock_github_payload
     allow(Octokit::Client).to receive(:new).and_return(my_octokit_client)
     allow(my_octokit_client).to receive(:repositories) { stubbed_github_repos }
   end

--- a/spec/requests/internal/users_spec.rb
+++ b/spec/requests/internal/users_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "internal/users", type: :request do
   let!(:user) do
-    mock_github
+    omniauth_mock_github_payload
     create(:user, :with_identity, identities: ["github"])
   end
   let(:admin) { create(:user, :super_admin) }

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -15,10 +15,8 @@ RSpec.describe "Registrations", type: :request do
       it "redirects to /dashboard" do
         sign_in user
 
-        Timecop.freeze(Time.current) do
-          get "/enter"
-          expect(response).to redirect_to("/dashboard?signed-in-already&t=#{Time.current.to_i}")
-        end
+        get "/enter"
+        expect(response).to redirect_to("/dashboard")
       end
     end
   end

--- a/spec/requests/user/user_settings_spec.rb
+++ b/spec/requests/user/user_settings_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "UserSettings", type: :request do
 
     describe "connect providers accounts" do
       before do
-        mock_auth_hash
+        omniauth_mock_providers_payload
       end
 
       it "does not render the text for the enabled provider the user has an identity for" do
@@ -296,7 +296,7 @@ RSpec.describe "UserSettings", type: :request do
       let(:user) { create(:user, :with_identity, identities: %w[github twitter]) }
 
       before do
-        mock_auth_hash
+        omniauth_mock_providers_payload
         sign_in user
       end
 

--- a/spec/services/authentication/authenticator_spec.rb
+++ b/spec/services/authentication/authenticator_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Authentication::Authenticator, type: :service do
-  before { mock_auth_hash }
+  before { omniauth_mock_providers_payload }
 
   context "when authenticating through an unknown provider" do
     it "raises ProviderNotFound" do

--- a/spec/services/authentication/providers/github_spec.rb
+++ b/spec/services/authentication/providers/github_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe Authentication::Providers::Github, type: :service do
+  describe ".authentication_path" do
+    it "returns the correct authentication path" do
+      expected_path = Rails.application.routes.url_helpers.user_github_omniauth_authorize_path
+      expect(described_class.authentication_path).to eq(expected_path)
+    end
+
+    it "supports additional parameters" do
+      path = described_class.authentication_path(state: "state")
+      expect(path).to include("state=state")
+    end
+  end
+
+  describe ".sign_in_path" do
+    let(:expected_path) do
+      "/users/auth/github?callback_url=http%3A%2F%2Flocalhost%3A3000%2Fusers%2Fauth%2Fgithub%2Fcallback"
+    end
+
+    it "returns the correct sign in path" do
+      expect(described_class.sign_in_path).to eq(expected_path)
+    end
+
+    it "supports additional parameters" do
+      path = described_class.sign_in_path(state: "state")
+      expect(path).to include("state=state")
+    end
+
+    it "does not override the callback_url parameter" do
+      path = described_class.sign_in_path(callback_url: "https://example.com/callback")
+      expect(path).to eq(expected_path)
+    end
+  end
+end

--- a/spec/services/authentication/providers/twitter_spec.rb
+++ b/spec/services/authentication/providers/twitter_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe Authentication::Providers::Twitter, type: :service do
+  describe ".authentication_path" do
+    it "returns the correct authentication path" do
+      expected_path = Rails.application.routes.url_helpers.user_twitter_omniauth_authorize_path
+      expect(described_class.authentication_path).to eq(expected_path)
+    end
+
+    it "supports additional parameters" do
+      path = described_class.authentication_path(state: "state")
+      expect(path).to include("state=state")
+    end
+  end
+
+  describe ".sign_in_path" do
+    let(:expected_path) do
+      "/users/auth/twitter?callback_url=http%3A%2F%2Flocalhost%3A3000%2Fusers%2Fauth%2Ftwitter%2Fcallback&secure_image_url=true"
+    end
+
+    it "returns the correct sign in path" do
+      expect(described_class.sign_in_path).to eq(expected_path)
+    end
+
+    it "supports additional parameters" do
+      path = described_class.sign_in_path(state: "state")
+      expect(path).to include("state=state")
+    end
+
+    it "does not override the callback_url parameter" do
+      path = described_class.sign_in_path(callback_url: "https://example.com/callback")
+      expect(path).to eq(expected_path)
+    end
+
+    it "does not override the secure_image_url parameter" do
+      path = described_class.sign_in_path(secure_image_url: "https://dummyimage.com/300")
+      expect(path).to eq(expected_path)
+    end
+  end
+end

--- a/spec/services/authentication/providers_spec.rb
+++ b/spec/services/authentication/providers_spec.rb
@@ -58,36 +58,4 @@ RSpec.describe Authentication::Providers, type: :service do
       expect(described_class.enabled?(:github)).to be(false)
     end
   end
-
-  describe ".authentication_path" do
-    it "returns the correct authentication path for given provider" do
-      expected_path = Rails.application.routes.url_helpers.user_github_omniauth_authorize_path
-      expect(described_class.authentication_path(:github)).to eq(expected_path)
-    end
-
-    it "supports additional parameters" do
-      path = described_class.authentication_path(:github, state: "state")
-      expect(path).to include("state=state")
-    end
-  end
-
-  describe ".sign_in_path" do
-    let(:expected_path) do
-      "/users/auth/github?callback_url=http%3A%2F%2Flocalhost%3A3000%2Fusers%2Fauth%2Fgithub%2Fcallback"
-    end
-
-    it "returns the correct sign in URL for given provider" do
-      expect(described_class.sign_in_path(:github)).to eq(expected_path)
-    end
-
-    it "supports additional parameters" do
-      path = described_class.sign_in_path(:github, state: "state")
-      expect(path).to include("state=state")
-    end
-
-    it "does not override the callback_url parameter" do
-      path = described_class.sign_in_path(:github, callback_url: "https://example.com/callback")
-      expect(path).to eq(expected_path)
-    end
-  end
 end

--- a/spec/services/broadcasts/welcome_notification/generator_spec.rb
+++ b/spec/services/broadcasts/welcome_notification/generator_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Broadcasts::WelcomeNotification::Generator, type: :service do
   let_it_be_readonly(:customize_ux_broadcast)    { create(:customize_ux_broadcast) }
 
   before do
-    mock_auth_hash
+    omniauth_mock_providers_payload
     allow(Notification).to receive(:send_welcome_notification).and_call_original
     allow(User).to receive(:mascot_account).and_return(mascot_account)
     SiteConfig.staff_user_id = mascot_account.id
@@ -143,7 +143,7 @@ RSpec.describe Broadcasts::WelcomeNotification::Generator, type: :service do
 
   describe "#send_feed_customization_notification" do
     let!(:user) do
-      mock_auth_hash
+      omniauth_mock_providers_payload
       create(:user, :with_identity, identities: %w[twitter github], created_at: 3.days.ago)
     end
 

--- a/spec/services/users/delete_spec.rb
+++ b/spec/services/users/delete_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Users::Delete, type: :service do
-  before { mock_github }
+  before { omniauth_mock_github_payload }
 
   let(:user) { create(:user, :with_identity, identities: ["github"]) }
 

--- a/spec/system/authentication/user_logs_in_with_github_spec.rb
+++ b/spec/system/authentication/user_logs_in_with_github_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "Authenticating with GitHub" do
   let(:sign_in_link) { "Sign In With GitHub" }
 
-  before { mock_github }
+  before { omniauth_mock_github_payload }
 
   context "when a user is new" do
     context "when using valid credentials" do
@@ -54,13 +54,13 @@ RSpec.describe "Authenticating with GitHub" do
       end
 
       before do
-        mock_auth_with_invalid_credentials(:github)
+        omniauth_setup_invalid_credentials(:github)
 
         allow(DatadogStatsClient).to receive(:increment)
       end
 
       after do
-        OmniAuth.config.on_failure = OmniauthMacros.const_get("OMNIAUTH_DEFAULT_FAILURE_HANDLER")
+        OmniAuth.config.on_failure = OmniauthHelpers.const_get("OMNIAUTH_DEFAULT_FAILURE_HANDLER")
       end
 
       it "does not create a new user" do
@@ -85,7 +85,7 @@ RSpec.describe "Authenticating with GitHub" do
           "Callback error", "Error reason", "https://example.com/error"
         )
 
-        setup_omniauth_error(error)
+        omniauth_setup_authentication_error(error)
 
         visit root_path
         click_link sign_in_link
@@ -101,7 +101,7 @@ RSpec.describe "Authenticating with GitHub" do
         allow(request).to receive(:code).and_return(401)
         allow(request).to receive(:message).and_return("unauthorized")
         error = OAuth::Unauthorized.new(request)
-        setup_omniauth_error(error)
+        omniauth_setup_authentication_error(error)
 
         visit root_path
         click_link sign_in_link
@@ -114,7 +114,7 @@ RSpec.describe "Authenticating with GitHub" do
 
       it "notifies Datadog even with no OmniAuth error present" do
         error = nil
-        setup_omniauth_error(error)
+        omniauth_setup_authentication_error(error)
 
         visit root_path
         click_link sign_in_link

--- a/spec/system/authentication/user_logs_in_with_twitter_spec.rb
+++ b/spec/system/authentication/user_logs_in_with_twitter_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "Authenticating with Twitter" do
   let(:sign_in_link) { "Sign In With Twitter" }
 
-  before { mock_twitter }
+  before { omniauth_mock_twitter_payload }
 
   context "when a user is new" do
     context "when using valid credentials" do
@@ -50,13 +50,13 @@ RSpec.describe "Authenticating with Twitter" do
 
     context "when using invalid credentials" do
       before do
-        mock_auth_with_invalid_credentials(:twitter)
+        omniauth_setup_invalid_credentials(:twitter)
 
         allow(DatadogStatsClient).to receive(:increment)
       end
 
       after do
-        OmniAuth.config.on_failure = OmniauthMacros.const_get("OMNIAUTH_DEFAULT_FAILURE_HANDLER")
+        OmniAuth.config.on_failure = OmniauthHelpers.const_get("OMNIAUTH_DEFAULT_FAILURE_HANDLER")
       end
 
       it "does not create a new user" do
@@ -81,7 +81,7 @@ RSpec.describe "Authenticating with Twitter" do
           "Callback error", "Error reason", "https://example.com/error"
         )
 
-        setup_omniauth_error(error)
+        omniauth_setup_authentication_error(error)
 
         visit root_path
         click_link sign_in_link
@@ -97,7 +97,7 @@ RSpec.describe "Authenticating with Twitter" do
         allow(request).to receive(:code).and_return(401)
         allow(request).to receive(:message).and_return("unauthorized")
         error = OAuth::Unauthorized.new(request)
-        setup_omniauth_error(error)
+        omniauth_setup_authentication_error(error)
 
         visit root_path
         click_link sign_in_link
@@ -110,7 +110,7 @@ RSpec.describe "Authenticating with Twitter" do
 
       it "notifies Datadog even with no OmniAuth error present" do
         error = nil
-        setup_omniauth_error(error)
+        omniauth_setup_authentication_error(error)
 
         visit root_path
         click_link sign_in_link


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This is mainly an "interim" PR with some cleanups. I read up Devise's and OmniAuth's documentation and added the following:

- restructured `sign_in_path` and `authentication_path` so that a specific provider can add params (some Omniauth strategies support additional params)
- added some comments
- added a parameter for Twitter to send back a secure image URL, see https://github.com/arunagw/omniauth-twitter#authentication-options
- renamed some stuff :D

## Related Tickets & Documents

#7505 

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
