### PR TITLE
Remove stats from /mod

### DIFF
--- a/app/assets/stylesheets/moderators.scss
+++ b/app/assets/stylesheets/moderators.scss
@@ -1,9 +1,10 @@
 @import 'variables';
 @import 'mixins';
+@import 'config/import';
 
 .mod-index-hero {
   margin: 0 auto;
-  padding: 90px 5px;
+  padding: $su-7 $su-1;
   text-align: center;
   background: var(--body-bg);
   h1 {

--- a/app/views/moderations/index.html.erb
+++ b/app/views/moderations/index.html.erb
@@ -16,28 +16,6 @@
     <div class="mod-index-hero">
       <h1><%= "#" + @tag.name.titleize if @tag %> Moderators</h1>
       <h2>We build the <%= community_qualified_name %></h2>
-      <div class="mod-index-hero-data-pod">
-        <div class="mod-index-hero-data-pod-number">
-          <%= number_with_delimiter(@tag ? Article.cached_tagged_with(@tag).published.where("published_at > ?", 7.days.ago).size : Article.published.where("published_at > ?", 7.days.ago).size) %>
-        </div>
-        Posts This Week
-      </div>
-      <% plucked_article_ids = Article.cached_tagged_with(@tag).pluck(:id) if @tag %>
-      <div class="mod-index-hero-data-pod">
-        <div class="mod-index-hero-data-pod-number">
-          <%= number_with_delimiter(@tag ? Comment.where(commentable_id: plucked_article_ids).where("created_at > ?", 7.days.ago).size : Comment.where("created_at > ?", 7.days.ago).size) %>
-        </div>
-        Comments This Week
-      </div>
-      <div class="mod-index-hero-data-pod">
-        <div class="mod-index-hero-data-pod-number">
-          <%= number_with_delimiter(@tag ? Reaction.where(reactable_id: plucked_article_ids).where("created_at > ?", 7.days.ago).size : Reaction.where("created_at > ?", 7.days.ago).size) %>
-        </div>
-        Reactions This Week
-      </div>
-      <div class="mod-index-hero-sub">
-        <em>Data as of <%= Time.current %></em>
-      </div>
     </div>
   <% end %>
   <div class="mod-index-header">


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
This removes the stats from `/mod`, based on the moderators' feedback. Simple quick win here 👍 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![Screen Shot 2020-04-28 at 4 58 05 PM](https://user-images.githubusercontent.com/17884966/80537597-5004f280-8972-11ea-9dc2-3ef82131a03d.png)

![Screen Shot 2020-04-28 at 4 57 59 PM](https://user-images.githubusercontent.com/17884966/80537598-5004f280-8972-11ea-92e5-fb7e20177d9d.png)


## Added tests?
- [x] no, because they aren't needed