### PR TITLE
Add campaign_stories_start_date to site config

### DIFF
--- a/app/controllers/internal/configs_controller.rb
+++ b/app/controllers/internal/configs_controller.rb
@@ -28,6 +28,7 @@ class Internal::ConfigsController < Internal::ApplicationController
     allowed_params = %i[
       authentication_providers
       campaign_featured_tags
+      campaign_stories_start_date
       campaign_hero_html_variant_name
       campaign_sidebar_enabled
       campaign_sidebar_image
@@ -64,7 +65,7 @@ class Internal::ConfigsController < Internal::ApplicationController
   end
 
   def extra_authorization_and_confirmation
-    not_authorized unless current_user.has_role?(:single_resource_admin, Config) # Special additional permission
+    not_authorized unless current_user.has_role?(:single_resource_admin, Config) && current_user.has_role?(:super_admin) # Special additional permission
     not_authorized if params[:confirmation] != "My username is @#{current_user.username} and this action is 100% safe and appropriate."
   end
 
@@ -73,6 +74,11 @@ class Internal::ConfigsController < Internal::ApplicationController
     config[:suggested_tags] = config[:suggested_tags].downcase.delete(" ") if config[:suggested_tags]
     config[:authentication_providers] = config[:authentication_providers].downcase.delete(" ") if config[:authentication_providers]
     config[:sidebar_tags] = config[:sidebar_tags].downcase.delete(" ") if config[:sidebar_tags]
+    begin
+      Date.parse(config[:campaign_stories_start_date])
+    rescue ArgumentError
+      config[:campaign_stories_start_date] = "12/31/2019" # return valid default date if invalid date passed.
+    end
   end
 
   def bust_relevant_caches

--- a/app/controllers/internal/configs_controller.rb
+++ b/app/controllers/internal/configs_controller.rb
@@ -74,6 +74,13 @@ class Internal::ConfigsController < Internal::ApplicationController
     config[:suggested_tags] = config[:suggested_tags].downcase.delete(" ") if config[:suggested_tags]
     config[:authentication_providers] = config[:authentication_providers].downcase.delete(" ") if config[:authentication_providers]
     config[:sidebar_tags] = config[:sidebar_tags].downcase.delete(" ") if config[:sidebar_tags]
+
+    ensure_proper_date(config)
+  end
+
+  def ensure_proper_date(config)
+    return unless config[:campaign_stories_start_date]
+
     begin
       Date.parse(config[:campaign_stories_start_date])
     rescue ArgumentError

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -68,7 +68,7 @@ class StoriesController < ApplicationController
 
   def get_latest_campaign_articles
     campaign_articles_scope = Article.tagged_with(SiteConfig.campaign_featured_tags, any: true).
-      where("published_at > ?", 2.weeks.ago).where(approved: true).
+      where("published_at > ?", SiteConfig.campaign_stories_start_date).where(approved: true).
       order("hotness_score DESC")
 
     @campaign_articles_count = campaign_articles_scope.count

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -45,6 +45,7 @@ class SiteConfig < RailsSettings::Base
   # Campaign
   field :campaign_hero_html_variant_name, type: :string, default: ""
   field :campaign_featured_tags, type: :array, default: %w[]
+  field :campaign_stories_start_date, type: :string, default: "12/31/2019" # 12/31 makes the default clearly middle-endian
   field :campaign_sidebar_enabled, type: :boolean, default: 0
   field :campaign_sidebar_image, type: :string, default: nil
 

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -200,9 +200,17 @@
                                placeholder: "List of campaign tags: comma separated, letters only e.g. shecoded,theycoded" %>
               <div class="alert alert-info">Posts with which tags will be featured in the campaign sidebar (comma separated, letters only)</div>
             </div>
+
+            <div class="form-group">
+              <%= f.label :campaign_stories_start_date %>
+              <%= f.text_field :campaign_stories_start_date,
+                               class: "form-control",
+                               value: SiteConfig.campaign_stories_start_date,
+                               placeholder: "01/01/2020" %>
+              <div class="alert alert-info">Start date from which to show posts from featured tags</div>
+            </div>
           </div>
         </div>
-
         <div class="card mt-3">
           <%= render partial: "card_header",
                      locals: {

--- a/spec/requests/internal/configs_spec.rb
+++ b/spec/requests/internal/configs_spec.rb
@@ -306,6 +306,18 @@ RSpec.describe "/internal/config", type: :request do
           expect(SiteConfig.authentication_providers).to eq(%w[github twitter])
         end
       end
+
+      describe "Campaign" do
+        it "accepts proper date" do
+          post "/internal/config", params: { site_config: { campaign_stories_start_date: "01/25/20" }, confirmation: confirmation_message }
+          expect(SiteConfig.authentication_providers).to eq("01/25/20")
+        end
+
+        it "takes incorrect date and returns default instead" do
+          post "/internal/config", params: { site_config: { campaign_stories_start_date: "25/01/20" }, confirmation: confirmation_message }
+          expect(SiteConfig.authentication_providers).to eq("12/31/19")
+        end
+      end
     end
   end
   # rubocop:enable RSpec/NestedGroups


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. This is not always possible, but in general it is.
     - ✅ Provided tests for your changes
     - 📝 Use descriptive commit messages
     - 📗 Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This adds a proper start date for the sidebar stories in the campaign. Right now it defaults to 2 weeks ago, which might not be appropriate in a lot of cases.

In the future I could see the client being a date picker, but I don't know if that's fully necessary to get this live.