### PR TITLE
Remove SlackBotPingWorker

### DIFF
--- a/app/workers/slack/messengers/worker.rb
+++ b/app/workers/slack/messengers/worker.rb
@@ -25,6 +25,3 @@ module Slack
     end
   end
 end
-
-# TODO: [@thepracticaldev/oss] remove this when Sidekiq has exhausted Slack::Messengers::Worker workers
-SlackBotPingWorker = Slack::Messengers::Worker


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. This is not always possible, but in general it is.
     - ✅ Provided tests for your changes
     - 📝 Use descriptive commit messages
     - 📗 Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

In #7484 we removed the last vestiges of the old Slack code, we only left in `SlackBotPingWorker` to transition to the new name so that existing jobs could process without failing.

Now 5 days have passed and the Sidekiq queue definitely doesn't have jobs with the old name anymore, we can remove this.

## Related Tickets & Documents

#7484 

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
