### PR TITLE
Configurable meta keywords

### DIFF
--- a/app/controllers/internal/configs_controller.rb
+++ b/app/controllers/internal/configs_controller.rb
@@ -60,7 +60,10 @@ class Internal::ConfigsController < Internal::ApplicationController
       sidebar_tags
       suggested_tags
     ]
-    params.require(:site_config).permit(allowed_params, social_media_handles: SiteConfig.social_media_handles.keys, email_addresses: SiteConfig.email_addresses.keys)
+    params.require(:site_config).permit(allowed_params,
+                                        social_media_handles: SiteConfig.social_media_handles.keys,
+                                        email_addresses: SiteConfig.email_addresses.keys,
+                                        meta_keywords: SiteConfig.meta_keywords.keys)
   end
 
   def extra_authorization_and_confirmation

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -36,6 +36,13 @@ class SiteConfig < RailsSettings::Base
     members: "members@dev.to"
   }
 
+  # Meta keywords
+  field :meta_keywords, type: :hash, default: {
+    default: nil,
+    article: nil,
+    tag: nil
+  }
+
   # Authentication
   field :authentication_providers, type: :array, default: %w[twitter github]
 

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -7,7 +7,7 @@
 
   <link rel="canonical" href="<%= app_url(request.path) %>" />
   <meta name="description" content="<%= SiteConfig.community_description %>">
-  <meta name="keywords" content="software development,engineering,rails,javascript,ruby">
+  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
 
   <meta property="og:type" content="website" />
   <meta property="og:url" content="<%= app_url(request.path) %>" />

--- a/app/views/articles/search/_meta.html.erb
+++ b/app/views/articles/search/_meta.html.erb
@@ -1,7 +1,7 @@
 <% title "Search Results" %>
 <link rel="canonical" href="https://<%= ApplicationConfig["APP_DOMAIN"] %>/search" />
 <meta name="description" content="<%= SiteConfig.community_description %>">
-<meta name="keywords" content="software development,engineering,rails,javascript,ruby">
+<meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
 
 <meta property="og:type" content="website" />
 <meta property="og:url" content="<%= community_name %> => Search Results" />

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -42,14 +42,14 @@
 <% end %>
 
 <% if internal_navigation? %>
-    <link rel="canonical" href="<%= @article.canonical_url.presence || "https://#{ApplicationConfig['APP_DOMAIN']}#{@article.path}" %>" />
-    <meta name="description" content="<%= @article.description_and_tags %>">
-    <meta name="keywords" content="<%= @article.cached_tag_list %>, software, coding, development, engineering, inclusive, community">
+  <link rel="canonical" href="<%= @article.canonical_url.presence || "https://#{ApplicationConfig['APP_DOMAIN']}#{@article.path}" %>" />
+  <meta name="description" content="<%= @article.description_and_tags %>">
+  <meta name="keywords" content="<%= @article.cached_tag_list %>, <%= SiteConfig.meta_keywords[:article] %>">
 <% else %>
   <%= content_for :page_meta do %>
     <link rel="canonical" href="<%= @article.canonical_url.presence || "https://#{ApplicationConfig['APP_DOMAIN']}#{@article.path}" %>" />
     <meta name="description" content="<%= @article.description_and_tags %>">
-    <meta name="keywords" content="<%= @article.cached_tag_list %>, software, coding, development, engineering, inclusive, community">
+    <meta name="keywords" content="<%= @article.cached_tag_list %>, <%= SiteConfig.meta_keywords[:article] %>">
 
     <meta property="og:type" content="article" />
     <meta property="og:url" content="<%= article_url(@article) %>" />

--- a/app/views/articles/tags/_meta.html.erb
+++ b/app/views/articles/tags/_meta.html.erb
@@ -6,7 +6,7 @@
 
 <link rel="canonical" href="<%= tag_url(@tag_model, @page) %>" />
 <meta name="description" content="<%= @tag %> content on <%= community_name %>">
-<meta name="keywords" content="software development,engineering,<%= @tag %>">
+<meta name="keywords" content="<%= SiteConfig.meta_keywords[:tag] %>, <%= @tag %>">
 
 <meta property="og:type" content="website" />
 <meta property="og:url" content="<%= tag_url(@tag_model, @page) %>" />

--- a/app/views/classified_listings/index.html.erb
+++ b/app/views/classified_listings/index.html.erb
@@ -3,7 +3,7 @@
 
   <link rel="canonical" href="<%= app_url(request.path) %>" />
   <meta name="description" content="<%= SiteConfig.community_description %>">
-  <meta name="keywords" content="software development,engineering,rails,javascript,ruby">
+  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>y">
   <meta property="og:type" content="website" />
   <meta property="og:url" content="<%= app_url(request.path) %>" />
   <meta property="og:site_name" content="<%= community_qualified_name %>" />

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -6,7 +6,7 @@
 
 <%= content_for :page_meta do %>
   <meta name="description" content="<%= @commentable.description || "An article from the community" %>">
-  <meta name="keywords" content="software development, inclusive, community, engineering">
+  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:article] %>">
 
   <meta property="og:type" content="article" />
   <meta property="og:title" content="Discussion of <%= @commentable.title %>" />

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -2,7 +2,7 @@
   <% title("#{community_name} EVENTS") %>
   <link rel="canonical" href="<%= app_url("/events") %>" />
   <meta name="description" content="<%= community_name %> Events">
-  <meta name="keywords" content="software development,engineering,rails,javascript,ruby">
+  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
   <meta property="og:type" content="article" />
   <meta property="og:url" content="<%= app_url("/events") %>" />
   <meta property="og:title" content="<%= community_name %> Events" />

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -2,7 +2,7 @@
   <% title("#{@event.title} - #{community_name}") %>
   <link rel="canonical" href="<%= app_url("/#{@event.slug}") %>" />
   <meta name="description" content="<%= community_name %> | Events">
-  <meta name="keywords" content="software development,engineering,rails,javascript,ruby">
+  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
 
   <meta property="og:type" content="article" />
   <meta property="og:url" content="<%= app_url("/#{@event.slug}") %>" />

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -109,6 +109,32 @@
         <div class="card mt-3">
           <%= render partial: "card_header",
                      locals: {
+                       header: "Meta Keywords",
+                       state: "collapse",
+                       target: "metaKeywordsBodyContainer",
+                       expanded: "false"
+                     } %>
+          <div id="metaKeywordsBodyContainer" class="card-body collapse hide" aria-labelledby="metaKeywordsBodyContainer">
+            <div class="form-group">
+              <%= f.fields_for :meta_keywords do |meta_keywords_field| %>
+                <% SiteConfig.meta_keywords.each do |area, keywords| %>
+                  <div>
+                    <%= meta_keywords_field.label area %>
+                    <%= meta_keywords_field.text_field area,
+                                                       class: "form-control",
+                                                       value: SiteConfig.meta_keywords[area],
+                                                       placeholder: "" %>
+                    <div class="alert alert-info"><%= area.capitalize %> keywords</div>
+                  </div>
+                <% end %>
+              <% end %>
+            </div>
+          </div>
+        </div>
+
+        <div class="card mt-3">
+          <%= render partial: "card_header",
+                     locals: {
                        header: "Emails",
                        state: "collapse",
                        target: "emailBodyContainer",

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -124,7 +124,7 @@
                                                        class: "form-control",
                                                        value: SiteConfig.meta_keywords[area],
                                                        placeholder: "" %>
-                    <div class="alert alert-info"><%= area.capitalize %> keywords</div>
+                    <div class="alert alert-info"><%= area.capitalize %><%= " page" unless area == "default" %> keywords</div>
                   </div>
                 <% end %>
               <% end %>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -3,7 +3,7 @@
 <%= content_for :page_meta do %>
   <link rel="canonical" href="<%= app_url("/notifications") %>" />
   <meta name="description" content="Notifications inbox for <%= community_name %>">
-  <meta name="keywords" content="software development,engineering,rails,javascript,ruby">
+  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
 
   <meta property="og:type" content="article" />
   <meta property="og:url" content="<%= app_url("/notifications") %>" />

--- a/app/views/pages/badges.html.erb
+++ b/app/views/pages/badges.html.erb
@@ -3,7 +3,7 @@
 <%= content_for :page_meta do %>
   <link rel="canonical" href="<%= app_url("/p/badges") %>" />
   <meta name="description" content="Add the <%= community_name %> Badge to your personal site">
-  <meta name="keywords" content="software development,engineering,rails,javascript,ruby">
+  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
 
   <meta property="og:type" content="article" />
   <meta property="og:url" content="<%= app_url("/p/badges") %>" />

--- a/app/views/pages/code_of_conduct.html.erb
+++ b/app/views/pages/code_of_conduct.html.erb
@@ -3,7 +3,7 @@
 <%= content_for :page_meta do %>
   <link rel="canonical" href="<%= app_url(code_of_conduct_path) %>" />
   <meta name="description" content="<%= community_qualified_name %> Code of Conduct">
-  <meta name="keywords" content="software development,engineering,rails,javascript,ruby">
+  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
   <meta property="og:type" content="article" />
   <meta property="og:url" content="<%= app_url(code_of_conduct_path) %>" />
   <meta property="og:title" content="<%= community_qualified_name %> Code of Conduct" />

--- a/app/views/pages/contact.html.erb
+++ b/app/views/pages/contact.html.erb
@@ -3,7 +3,7 @@
 <%= content_for :page_meta do %>
   <link rel="canonical" href="<%= app_url("/contact") %>" />
   <meta name="description" content="Contact #{community_qualified_name}">
-  <meta name="keywords" content="software development,engineering,rails,javascript,ruby">
+  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
 
   <meta property="og:type" content="article" />
   <meta property="og:url" content="<%= app_url("/contact") %>" />

--- a/app/views/pages/editor_guide.html.erb
+++ b/app/views/pages/editor_guide.html.erb
@@ -3,8 +3,7 @@
 <%= content_for :page_meta do %>
   <link rel="canonical" href="<%= app_url("/p/editor_guide") %>" />
   <meta name="description" content="<%= community_name %> | editor guideline">
-  <meta name="keywords" content="software development,engineering,rails,javascript,ruby">
-
+  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
 <% end %>
 
 <div class="blank-space"></div>

--- a/app/views/pages/generator.html.erb
+++ b/app/views/pages/generator.html.erb
@@ -6,7 +6,7 @@
 <%= content_for :page_meta do %>
   <link rel="canonical" href="<%= app_url("/rlyslack") %>" />
   <meta name="description" content="Insult your co-workers with snarky O RLY parody book covers. All without leaving Slack!">
-  <meta name="keywords" content="software development,engineering,rails,javascript,ruby">
+  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
 
   <meta property="og:type" content="website" />
   <meta property="og:url" content="<%= app_url("/rlyslack") %>" />

--- a/app/views/pages/information.html.erb
+++ b/app/views/pages/information.html.erb
@@ -3,7 +3,7 @@
 <%= content_for :page_meta do %>
   <link rel="canonical" href="<%= app_url("/p/information") %>" />
   <meta name="description" content="All information about <%= community_qualified_name %>">
-  <meta name="keywords" content="software development,engineering,rails,javascript,ruby">
+  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
 
   <meta property="og:type" content="article" />
   <meta property="og:url" content="<%= app_url("/p/information") %>" />

--- a/app/views/pages/markdown_basics.html.erb
+++ b/app/views/pages/markdown_basics.html.erb
@@ -3,8 +3,7 @@
 <%= content_for :page_meta do %>
   <link rel="canonical" href="<%= app_url("/p/markdown_basics") %>" />
   <meta name="description" content="dev.to | markdown basics">
-  <meta name="keywords" content="software development,engineering,rails,javascript,ruby">
-
+  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
 <% end %>
 
 <div class="blank-space"></div>

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -3,7 +3,7 @@
 <%= content_for :page_meta do %>
   <link rel="canonical" href="<%= app_url("/privacy") %>" />
   <meta name="description" content="Privacy Policy for <%= community_name %>">
-  <meta name="keywords" content="software development,engineering,rails,javascript,ruby">
+  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
 
   <meta property="og:type" content="article" />
   <meta property="og:url" content="<%= app_url("/privacy") %>" />

--- a/app/views/pages/publishing_from_rss_guide.html.erb
+++ b/app/views/pages/publishing_from_rss_guide.html.erb
@@ -3,7 +3,7 @@
 <%= content_for :page_meta do %>
   <link rel="canonical" href="<%= app_url("/p/publishing_from_rss_guide") %>" />
   <meta name="description" content="dev.to | publishing from rss guideline">
-  <meta name="keywords" content="software development,engineering,rails,javascript,ruby">
+  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
 
 <% end %>
 

--- a/app/views/pages/report-abuse.html.erb
+++ b/app/views/pages/report-abuse.html.erb
@@ -2,7 +2,7 @@
 <%= content_for :page_meta do %>
   <link rel="canonical" href="<%= app_url("/report-abuse") %>" />
   <meta name="description" content="Report Abuse">
-  <meta name="keywords" content="software development,engineering,rails,javascript,ruby">
+  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
   <meta property="og:type" content="article" />
   <meta property="og:url" content="<%= app_url("/report-abuse") %>" />
   <meta property="og:title" content="Report Abuse" />

--- a/app/views/pages/rlyweb.html.erb
+++ b/app/views/pages/rlyweb.html.erb
@@ -6,7 +6,7 @@
 <%= content_for :page_meta do %>
   <link rel="canonical" href="<%= app_url("/rly") %>" />
   <meta name="description" content="Insult your co-workers with snarky O RLY parody book covers!">
-  <meta name="keywords" content="software development,engineering,rails,javascript,ruby">
+  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
 
   <meta property="og:type" content="website" />
   <meta property="og:url" content="<%= app_url("/rly") %>" />

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -2,7 +2,7 @@
 <%= content_for :page_meta do %>
   <link rel="canonical" href="<%= app_url(@page.path) %>" />
   <meta name="description" content="<%= @page.title %> — <%= community_qualified_name %>">
-  <meta name="keywords" content="software development,engineering,rails,javascript,ruby">
+  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
 
   <meta property="og:type" content="article" />
   <meta property="og:url" content="<%= app_url(@page.path) %>" />

--- a/app/views/pages/sponsors.html.erb
+++ b/app/views/pages/sponsors.html.erb
@@ -3,7 +3,7 @@
 <%= content_for :page_meta do %>
   <link rel="canonical" href="<%= app_url("/sponsors") %>" />
   <meta name="description" content="<%= community_name %> | Sponsors">
-  <meta name="keywords" content="software development,engineering,rails,javascript,ruby">
+  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
 <% end %>
 
 <div class="blank-space"></div>

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -3,7 +3,7 @@
 <%= content_for :page_meta do %>
   <link rel="canonical" href="<%= app_url("/terms") %>" />
   <meta name="description" content="Terms of Use for the <%= community_qualified_name %>">
-  <meta name="keywords" content="software development,engineering,rails,javascript,ruby">
+  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
 
   <meta property="og:type" content="article" />
   <meta property="og:url" content="<%= app_url("/terms") %>" />

--- a/app/views/podcast_episodes/_meta.html.erb
+++ b/app/views/podcast_episodes/_meta.html.erb
@@ -4,7 +4,7 @@
   <%= content_for :page_meta do %>
     <link rel="canonical" href="<%= app_url(@podcast.slug) %>" />
     <meta name="description" content="<%= @podcast.description %>">
-    <meta name="keywords" content="software development,engineering,rails,javascript,ruby">
+    <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
 
     <meta property="og:type" content="article" />
     <meta property="og:url" content="<%= app_url(@podcast.slug) %>" />
@@ -26,7 +26,7 @@
   <%= content_for :page_meta do %>
     <link rel="canonical" href="<%= app_url(pod_path) %>" />
     <meta name="description" content="Discover technical podcasts for <%= community_members_label %>">
-    <meta name="keywords" content="software development,engineering,rails,javascript,ruby">
+    <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
 
     <meta property="og:type" content="article" />
     <meta property="og:url" content="<%= app_url(pod_path) %>" />

--- a/app/views/podcast_episodes/show.html.erb
+++ b/app/views/podcast_episodes/show.html.erb
@@ -3,7 +3,7 @@
 <%= content_for :page_meta do %>
   <link rel="canonical" href="<%= app_url("/#{@podcast.slug}/#{@episode.slug}") %>" />
   <meta name="description" content="<%= truncate(strip_tags(@episode.body), length: 140) %>">
-  <meta name="keywords" content="software development,engineering,rails,javascript,ruby">
+  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
 
   <meta property="og:type" content="article" />
   <meta property="og:url" content="<%= app_url("/#{@podcast.slug}/#{@episode.slug}") %>" />

--- a/app/views/reading_list_items/index.html.erb
+++ b/app/views/reading_list_items/index.html.erb
@@ -3,7 +3,7 @@
 <%= content_for :page_meta do %>
   <link rel="canonical" href="<%= app_url("/readinglist") %>" />
   <meta name="description" content="Notifications inbox for dev.to">
-  <meta name="keywords" content="software development,engineering,rails,javascript,ruby">
+  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
 
   <meta property="og:type" content="article" />
   <meta property="og:url" content="<%= app_url("/readinglist") %>" />

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -3,7 +3,7 @@
 <%= content_for :page_meta do %>
   <link rel="canonical" href="<%= app_url("/about") %>" />
   <meta name="description" content="Tags to follow on <%= community_name %>">
-  <meta name="keywords" content="software development,engineering,rails,javascript,ruby">
+  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
 
   <meta property="og:type" content="article" />
   <meta property="og:url" content="<%= app_url("/about") %>" />

--- a/app/views/users/_meta.html.erb
+++ b/app/views/users/_meta.html.erb
@@ -1,6 +1,6 @@
 <link rel="canonical" href="<%= user_url(@user) %>" />
 <meta name="description" content="<%= @user.summary %>">
-<meta name="keywords" content="software development,engineering,rails,javascript,ruby">
+<meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
 
 <meta property="og:type" content="website" />
 <meta property="og:url" content="<%= user_url(@user) %>" />

--- a/app/views/videos/index.html.erb
+++ b/app/views/videos/index.html.erb
@@ -3,7 +3,7 @@
 
   <link rel="canonical" href="<%= app_url(request.path) %>" />
   <meta name="description" content="<%= SiteConfig.community_description %>">
-  <meta name="keywords" content="software development,engineering,rails,javascript,ruby">
+  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
 
   <meta property="og:type" content="website" />
   <meta property="og:url" content="<%= app_url(request.path) %>" />

--- a/spec/requests/articles/articles_show_spec.rb
+++ b/spec/requests/articles/articles_show_spec.rb
@@ -38,6 +38,15 @@ RSpec.describe "ArticlesShow", type: :request do
     end
   end
 
+  context "when keywords are set up" do
+    it "shows keywords" do
+      SiteConfig.meta_keywords = { article: "hello, world" }
+      article.update_column(:cached_tag_list, "super sheep")
+      get article.path
+      expect(response.body).to include('<meta name="keywords" content="super sheep, hello, world">')
+    end
+  end
+
   context "when user signed in" do
     before do
       sign_in user

--- a/spec/requests/internal/configs_spec.rb
+++ b/spec/requests/internal/configs_spec.rb
@@ -87,6 +87,17 @@ RSpec.describe "/internal/config", type: :request do
         end
       end
 
+      describe "meta keywords" do
+        it "updates meta keywords" do
+          expected_keywords = { "default" => "software, people", "article" => "user, experience", "tag" => "bye" }
+          post "/internal/config", params: { site_config: { meta_keywords: expected_keywords },
+                                             confirmation: confirmation_message }
+          expect(SiteConfig.meta_keywords[:default]).to eq("software, people")
+          expect(SiteConfig.meta_keywords[:article]).to eq("user, experience")
+          expect(SiteConfig.meta_keywords[:tag]).to eq("bye")
+        end
+      end
+
       describe "emails" do
         it "updates email_addresses" do
           expected_email_addresses = {

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -92,6 +92,12 @@ RSpec.describe "StoriesIndex", type: :request do
       expect(response.headers["Surrogate-Key"].split(", ")).to match_array(expected_surrogate_key_headers)
     end
 
+    it "shows default meta keywords" do
+      SiteConfig.meta_keywords = { default: "cool developers, civil engineers" }
+      get "/"
+      expect(response.body).to include("<meta name=\"keywords\" content=\"cool developers, civil engineers\">")
+    end
+
     context "with campaign hero" do
       let_it_be_readonly(:hero_html) do
         create(
@@ -251,6 +257,12 @@ RSpec.describe "StoriesIndex", type: :request do
       get "/t/#{tag.name}"
       expect(response.body).to include("is sponsored by")
       expect(response.body).to include(sponsorship.blurb_html)
+    end
+
+    it "shows meta keywords" do
+      SiteConfig.meta_keywords = { tag: "software engineering, ruby" }
+      get "/t/#{tag.name}"
+      expect(response.body).to include("<meta name=\"keywords\" content=\"software engineering, ruby, #{tag.name}\">")
     end
 
     context "with user signed in" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
Replaced hardcoded meta keywords with the configurable ones.

## Related Tickets & Documents
#7523

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![изображение](https://user-images.githubusercontent.com/30115/80591370-44730380-8a26-11ea-9cfb-d0eb7c4090d3.png)

## Added tests?

- [x] yes


## [optional] Are there any post-deployment tasks we need to perform?
 - need to set in the console:
```ruby
SiteConfig.meta_keywords = {
  default: "software development, engineering, rails, javascript, ruby",
  article: "software, coding, development, engineering, inclusive, community",
  tag: "software development, engineering"
}
```
 - alert new-communities
