### PR TITLE
Upgrade field_test to 0.3.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,7 +138,7 @@ GEM
     bootsnap (1.4.6)
       msgpack (~> 1.0)
     brakeman (4.8.1)
-    browser (2.7.1)
+    browser (4.0.0)
     buffer (0.1.3)
       addressable
       environs
@@ -318,9 +318,9 @@ GEM
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
-    field_test (0.3.1)
+    field_test (0.3.2)
       activerecord (>= 5)
-      browser (~> 2.0)
+      browser (>= 2.0)
       distribution
       railties (>= 5)
     figaro (1.1.1)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -66,6 +66,7 @@ class User < ApplicationRecord
   has_many :display_ad_events, dependent: :destroy
   has_many :email_authorizations, dependent: :delete_all
   has_many :email_messages, class_name: "Ahoy::Message", dependent: :destroy
+  has_many :field_test_memberships, class_name: "FieldTest::Membership", as: :participant, dependent: :destroy
   has_many :github_repos, dependent: :destroy
   has_many :html_variants, dependent: :destroy
   has_many :identities, dependent: :destroy

--- a/config/field_test.yml
+++ b/config/field_test.yml
@@ -35,6 +35,6 @@ exclude:
 # Dashboard performance
 cache: true
 
-# For logged-in users we'll explicitely pass participant. 
+# For logged-in users we'll explicitely pass participant.
 # If we experiment on non-logged in, we don't want to collect cookies anyway.
 cookies: false

--- a/spec/factories/field_test_memberships.rb
+++ b/spec/factories/field_test_memberships.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :field_test_memberships, class: "FieldTest::Membership" do
+  factory :field_test_membership, class: "FieldTest::Membership" do
     converted         { false }
     experiment        { :user_home_feed }
     participant_type  { "User" }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe User, type: :model do
       it { is_expected.to have_many(:display_ad_events).dependent(:destroy) }
       it { is_expected.to have_many(:email_authorizations).dependent(:delete_all) }
       it { is_expected.to have_many(:email_messages).class_name("Ahoy::Message").dependent(:destroy) }
+      it { is_expected.to have_many(:field_test_memberships).class_name("FieldTest::Membership").dependent(:destroy) }
       it { is_expected.to have_many(:github_repos).dependent(:destroy) }
       it { is_expected.to have_many(:html_variants).dependent(:destroy) }
       it { is_expected.to have_many(:identities).dependent(:destroy) }
@@ -139,10 +140,8 @@ RSpec.describe User, type: :model do
         expect(fourth_field).not_to be_valid
       end
 
-      it { is_expected.to have_many(:organization_memberships).dependent(:destroy) }
       it { is_expected.to have_one(:counters).class_name("UserCounter").dependent(:destroy) }
       it { is_expected.to have_one(:pro_membership).dependent(:destroy) }
-      it { is_expected.to validate_uniqueness_of(:username).case_insensitive }
       it { is_expected.not_to allow_value("#xyz").for(:bg_color_hex) }
       it { is_expected.not_to allow_value("#xyz").for(:text_color_hex) }
       it { is_expected.not_to allow_value("AcMe_1%").for(:username) }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -57,7 +57,7 @@ RSpec::Matchers.define_negated_matcher :not_change, :change
 Rack::Attack.enabled = false
 
 # `browser`, a dependency of `field_test`, starting from version 3.0
-# considers the empty user agent a bot, with will fail tests as we
+# considers the empty user agent a bot, which will fail tests as we
 # explicitly configure field tests to exclude bots
 # see https://github.com/fnando/browser/blob/master/CHANGELOG.md#300
 Browser::Bot.matchers.delete(Browser::Bot::EmptyUserAgentMatcher)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -56,6 +56,12 @@ RSpec::Matchers.define_negated_matcher :not_change, :change
 
 Rack::Attack.enabled = false
 
+# `browser`, a dependency of `field_test`, starting from version 3.0
+# considers the empty user agent a bot, with will fail tests as we
+# explicitly configure field tests to exclude bots
+# see https://github.com/fnando/browser/blob/master/CHANGELOG.md#300
+Browser::Bot.matchers.delete(Browser::Bot::EmptyUserAgentMatcher)
+
 RSpec.configure do |config|
   config.use_transactional_fixtures = true
   config.fixture_path = "#{::Rails.root}/spec/fixtures"

--- a/spec/requests/stories/feeds_spec.rb
+++ b/spec/requests/stories/feeds_spec.rb
@@ -100,17 +100,20 @@ RSpec.describe "Stories::Feeds", type: :request do
       end
 
       it "sets a field test" do
-        get "/stories/feed"
-        expect(FieldTest::Membership.all.size).to be(1)
-        expect(FieldTest::Membership.last.participant_id).to eq(user.id.to_s)
-        expect(FieldTest::Membership.last.experiment).to eq("user_home_feed")
+        expect do
+          get "/stories/feed"
+        end.to change(user.field_test_memberships, :count).by(1)
+
+        ftm = user.field_test_memberships.last
+        expect(ftm.experiment).to eq("user_home_feed")
       end
     end
 
-    context "when there are no params passed (base feed) and user is signed not in" do
+    context "when there are no params passed (base feed) and user is not signed in" do
       it "sets a field test" do
-        get "/stories/feed"
-        expect(FieldTest::Membership.all.size).to be(0)
+        expect do
+          get "/stories/feed"
+        end.not_to change(FieldTest::Membership, :count)
       end
     end
 
@@ -133,8 +136,10 @@ RSpec.describe "Stories::Feeds", type: :request do
 
       it "does not sets a field test" do
         allow_any_instance_of(Stories::FeedsController).to receive(:field_test) # rubocop:disable RSpec/AnyInstance
-        get "/stories/feed"
-        expect(FieldTest::Membership.all.count).to be(0)
+
+        expect do
+          get "/stories/feed"
+        end.not_to change(user.field_test_memberships, :count)
       end
     end
   end

--- a/spec/services/users/delete_spec.rb
+++ b/spec/services/users/delete_spec.rb
@@ -80,6 +80,14 @@ RSpec.describe Users::Delete, type: :service do
     expect { user_reaction.elasticsearch_doc }.to raise_error(Search::Errors::Transport::NotFound)
   end
 
+  it "deletes field tests memberships" do
+    create(:field_test_membership, participant_id: user.id)
+
+    expect do
+      described_class.call(user)
+    end.to change(FieldTest::Membership, :count).by(-1)
+  end
+
   # check that all the associated records are being destroyed, except for those that are kept explicitly (kept_associations)
   describe "deleting associations" do
     let(:kept_association_names) do

--- a/spec/workers/field_tests/prune_old_experiments_worker_spec.rb
+++ b/spec/workers/field_tests/prune_old_experiments_worker_spec.rb
@@ -8,14 +8,17 @@ RSpec.describe FieldTests::PruneOldExperimentsWorker, type: :worker do
     let(:worker) { subject }
 
     it "prunes first 5% of memberships and events" do
-      create_list(:user, 40)
-      User.all.each do |user|
-        create(:field_test_memberships, participant_id: user.id.to_s)
+      users = create_list(:user, 40)
+
+      users.each do |user|
+        create(:field_test_membership, participant_id: user.id.to_s)
         field_test_converted(:user_home_feed, participant: user, goal: "user_creates_comment")
       end
+
       worker.perform
-      expect(FieldTest::Membership.count).to be(38)
-      expect(FieldTest::Event.count).to be(38)
+
+      expect(FieldTest::Membership.count).to eq(38)
+      expect(FieldTest::Event.count).to eq(38)
       expect(FieldTest::Event.pluck(:field_test_membership_id).sort).to eq(FieldTest::Membership.pluck(:id).sort)
     end
   end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. This is not always possible, but in general it is.
     - ✅ Provided tests for your changes
     - 📝 Use descriptive commit messages
     - 📗 Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Upgrading `field_test` to the latest 0.3.2 version. [dependabot tried](https://github.com/thepracticaldev/dev.to/pull/7475) but fortunately one of the tests broke as there's breaking change in one of the transitive dependencies 👀 , the gem `browser`.

Basically the empty user agent, sent by request specs, is considererd a bot now, thus failing to create the new experiment.

For more details, see [browser: Bots](https://github.com/fnando/browser#bots).

**note:**, this will change the behavior in production as well:

- requests with a missing user agent will be considered a bot
- requests with these keywords - `/crawl|fetch|search|monitoring|spider|bot/` - will be considered a bot.

If we want to keep the existing behavior, we need to undo this change like suggested:

> To restore v2's bot detection, remove the following matchers:
> Browser::Bot.matchers.delete(Browser::Bot::KeywordMatcher)
> Browser::Bot.matchers.delete(Browser::Bot::EmptyUserAgentMatcher)

I also linked user to memberships as suggested in [field_test: Associations](https://github.com/ankane/field_test#associations), so that we can have `user.field_test_memberships`

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
