### PR TITLE
Sanitizing and rendering html entities in article title

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -222,4 +222,8 @@ module ApplicationHelper
   def sanitized_referer(referer)
     URL.sanitized_referer(referer)
   end
+
+  def sanitize_and_decode(str)
+    HTMLEntities.new.decode(sanitize(str).to_str)
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -224,6 +224,7 @@ module ApplicationHelper
   end
 
   def sanitize_and_decode(str)
+    # using to_str instead of to_s to prevent removal of html entity code
     HTMLEntities.new.decode(sanitize(str).to_str)
   end
 end

--- a/app/javascript/src/components/ItemList/ItemListItem.jsx
+++ b/app/javascript/src/components/ItemList/ItemListItem.jsx
@@ -17,7 +17,10 @@ export const ItemListItem = ({ item, children }) => {
   return (
     <div className="item-wrapper">
       <a className="item" href={adaptedItem.path}>
-        <div className="item-title">{adaptedItem.title}</div>
+        <div
+          className="item-title"
+          dangerouslySetInnerHTML={{ __html: filterXSS(adaptedItem.title) }}
+        />
 
         <div className="item-details">
           <a className="item-user" href={`/${adaptedItem.user.username}`}>

--- a/app/javascript/src/components/ItemList/__tests__/ItemListItem.test.jsx
+++ b/app/javascript/src/components/ItemList/__tests__/ItemListItem.test.jsx
@@ -2,6 +2,7 @@ import { h } from 'preact';
 import render from 'preact-render-to-json';
 import { shallow } from 'preact-render-spy';
 import { ItemListItem } from '../ItemListItem';
+import '../../../../../assets/javascripts/lib/xss';
 
 const item = {
   reactable: {

--- a/app/javascript/src/components/ItemList/__tests__/__snapshots__/ItemListItem.test.jsx.snap
+++ b/app/javascript/src/components/ItemList/__tests__/__snapshots__/ItemListItem.test.jsx.snap
@@ -10,9 +10,12 @@ exports[`<ItemListItem /> renders properly with a readinglist item 1`] = `
   >
     <div
       class="item-title"
-    >
-      Title
-    </div>
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "Title",
+        }
+      }
+    />
     <div
       class="item-details"
     >

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -118,7 +118,7 @@
           <% if @article.search_optimized_title_preamble.present? && !user_signed_in? %>
             <span class="article-title-preamble"><%= @article.search_optimized_title_preamble %></span>
           <% end %>
-          <%= @article.title %>
+          <%= sanitize_and_decode @article.title %>
         </h1>
         <h3>
           <span>

--- a/app/views/dashboards/_dashboard_article.html.erb
+++ b/app/views/dashboards/_dashboard_article.html.erb
@@ -21,7 +21,7 @@
     </ul>
   </div>
 
-  <a href="<%= article.current_state_path %>"><h2><%= "[Archived] " if article.archived %><%= article.title %></h2></a>
+  <a href="<%= article.current_state_path %>"><h2><%= "[Archived] " if article.archived %><%= sanitize_and_decode article.title %></h2></a>
   <div class="dashboard-meta-details">
     <% if article.published %>
       <span>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -157,4 +157,11 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(community_members_label).to eq("hobbyists")
     end
   end
+
+  describe "#sanitize_and_decode" do
+    it "Sanitize and decode string" do
+      expect(helper.sanitize_and_decode("<script>alert('alert')</script>")).to eq("alert('alert')")
+      expect(helper.sanitize_and_decode("&lt; hello")).to eq("< hello")
+    end
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR sanitizes and decodes html entities in article title

## Related Tickets & Documents
Closes https://github.com/thepracticaldev/dev.to/issues/7175

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
HTML entities are now rendered properly in the article title
![dashboard](https://user-images.githubusercontent.com/8092120/80602710-0fc67280-8a4d-11ea-95e5-04ddfe6a3b79.png)

![article_heading](https://user-images.githubusercontent.com/8092120/80602723-13f29000-8a4d-11ea-9f46-7c92050aed8a.png)

![readinglist](https://user-images.githubusercontent.com/8092120/80613243-a3eb0680-8a5a-11ea-8bf8-2d182809d610.png)

## Added tests?

- [X] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed

## What gif best describes this PR or how it makes you feel?

![Smile](https://media.giphy.com/media/B0vFTrb0ZGDf2/giphy.gif)
