### PR TITLE
Search Generalization: Remove Elasticsearch from Index Worker Names

### DIFF
--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -4,7 +4,7 @@ module Searchable
   end
 
   def index_to_elasticsearch
-    Search::IndexToElasticsearchWorker.perform_async(self.class.name, id)
+    Search::IndexWorker.perform_async(self.class.name, id)
   end
 
   def index_to_elasticsearch_inline
@@ -12,7 +12,7 @@ module Searchable
   end
 
   def remove_from_elasticsearch
-    Search::RemoveFromElasticsearchIndexWorker.perform_async(self.class::SEARCH_CLASS.to_s, search_id)
+    Search::RemoveFromIndexWorker.perform_async(self.class::SEARCH_CLASS.to_s, search_id)
   end
 
   def serialized_search_hash

--- a/app/services/users/delete_activity.rb
+++ b/app/services/users/delete_activity.rb
@@ -59,7 +59,7 @@ module Users
       readinglist_ids = user.reactions.readinglist.pluck(:id)
       user.reactions.delete_all
       readinglist_ids.each do |id|
-        Search::RemoveFromElasticsearchIndexWorker.perform_async("Search::Reaction", id)
+        Search::RemoveFromIndexWorker.perform_async("Search::Reaction", id)
       end
     end
   end

--- a/app/services/users/delete_articles.rb
+++ b/app/services/users/delete_articles.rb
@@ -29,7 +29,7 @@ module Users
       readinglist_ids = article.reactions.readinglist.pluck(:id)
       article.reactions.delete_all
       readinglist_ids.each do |id|
-        Search::RemoveFromElasticsearchIndexWorker.perform_async("Search::Reaction", id)
+        Search::RemoveFromIndexWorker.perform_async("Search::Reaction", id)
       end
     end
   end

--- a/app/workers/search/bulk_index_worker.rb
+++ b/app/workers/search/bulk_index_worker.rb
@@ -1,5 +1,5 @@
 module Search
-  class BulkIndexToElasticsearchWorker
+  class BulkIndexWorker
     include Sidekiq::Worker
 
     sidekiq_options queue: :high_priority, lock: :until_executing

--- a/app/workers/search/index_worker.rb
+++ b/app/workers/search/index_worker.rb
@@ -1,5 +1,5 @@
 module Search
-  class IndexToElasticsearchWorker
+  class IndexWorker
     include Sidekiq::Worker
 
     sidekiq_options queue: :high_priority, lock: :until_executing

--- a/app/workers/search/remove_from_index_worker.rb
+++ b/app/workers/search/remove_from_index_worker.rb
@@ -1,5 +1,5 @@
 module Search
-  class RemoveFromElasticsearchIndexWorker
+  class RemoveFromIndexWorker
     include Sidekiq::Worker
 
     sidekiq_options queue: :medium_priority, lock: :until_executing

--- a/lib/data_update_scripts/20200305201627_index_users_to_elasticsearch.rb
+++ b/lib/data_update_scripts/20200305201627_index_users_to_elasticsearch.rb
@@ -2,7 +2,7 @@ module DataUpdateScripts
   class IndexUsersToElasticsearch
     def run
       # User.select(:id).find_each do |user|
-      #   Search::IndexToElasticsearchWorker.set(queue: :low_priority).perform_async(
+      #   Search::IndexWorker.set(queue: :low_priority).perform_async(
       #     "User", user.id
       #   )
       # end

--- a/lib/data_update_scripts/20200305201642_index_feed_content_to_elasticsearch.rb
+++ b/lib/data_update_scripts/20200305201642_index_feed_content_to_elasticsearch.rb
@@ -2,13 +2,13 @@ module DataUpdateScripts
   class IndexFeedContentToElasticsearch
     def run
       # Article.select(:id).find_each do |article|
-      #   Search::IndexToElasticsearchWorker.set(queue: :low_priority).perform_async(
+      #   Search::IndexWorker.set(queue: :low_priority).perform_async(
       #     "Article", article.id
       #   )
       # end
 
       # PodcastEpisode.select(:id).find_each do |pde|
-      #   Search::IndexToElasticsearchWorker.set(queue: :low_priority).perform_async(
+      #   Search::IndexWorker.set(queue: :low_priority).perform_async(
       #     "PodcastEpisode", pde.id
       #   )
       # end

--- a/lib/data_update_scripts/20200313123108_index_users_to_elasticsearch.rb
+++ b/lib/data_update_scripts/20200313123108_index_users_to_elasticsearch.rb
@@ -2,7 +2,7 @@ module DataUpdateScripts
   class IndexUsersToElasticsearch
     def run
       # User.select(:id).find_each do |user|
-      #   Search::IndexToElasticsearchWorker.set(queue: :low_priority).perform_async(
+      #   Search::IndexWorker.set(queue: :low_priority).perform_async(
       #     "User", user.id
       #   )
       # end

--- a/lib/data_update_scripts/20200326145114_re_index_feed_content_to_elasticsearch.rb
+++ b/lib/data_update_scripts/20200326145114_re_index_feed_content_to_elasticsearch.rb
@@ -19,7 +19,7 @@ module DataUpdateScripts
 
     def index_docs(ids, doc_type)
       ids.each do |id|
-        Search::IndexToElasticsearchWorker.set(queue: :low_priority).perform_async(
+        Search::IndexWorker.set(queue: :low_priority).perform_async(
           doc_type, id
         )
       end

--- a/lib/data_update_scripts/20200406213152_re_index_users_to_elasticsearch.rb
+++ b/lib/data_update_scripts/20200406213152_re_index_users_to_elasticsearch.rb
@@ -2,7 +2,7 @@ module DataUpdateScripts
   class ReIndexUsersToElasticsearch
     def run
       User.select(:id).find_each do |user|
-        Search::IndexToElasticsearchWorker.set(queue: :low_priority).perform_async(
+        Search::IndexWorker.set(queue: :low_priority).perform_async(
           "User", user.id
         )
       end

--- a/lib/data_update_scripts/20200410152018_resync_elasticsearch_documents.rb
+++ b/lib/data_update_scripts/20200410152018_resync_elasticsearch_documents.rb
@@ -15,7 +15,7 @@ module DataUpdateScripts
 
     def index_docs(ids, doc_type)
       ids.each do |id|
-        Search::IndexToElasticsearchWorker.set(queue: :low_priority).perform_async(
+        Search::IndexWorker.set(queue: :low_priority).perform_async(
           doc_type, id
         )
       end

--- a/lib/data_update_scripts/20200415200651_index_reading_list_reactions.rb
+++ b/lib/data_update_scripts/20200415200651_index_reading_list_reactions.rb
@@ -2,7 +2,7 @@ module DataUpdateScripts
   class IndexReadingListReactions
     def run
       Reaction.readinglist.select(:id).in_batches do |batch|
-        Search::BulkIndexToElasticsearchWorker.set(queue: :default).perform_async(
+        Search::BulkIndexWorker.set(queue: :default).perform_async(
           "Reaction", batch.pluck(:id)
         )
       end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Article, type: :model do
     describe "#after_commit" do
       it "on update enqueues job to index article to elasticsearch" do
         article.save
-        sidekiq_assert_enqueued_with(job: Search::IndexToElasticsearchWorker, args: [described_class.to_s, article.id]) do
+        sidekiq_assert_enqueued_with(job: Search::IndexWorker, args: [described_class.to_s, article.id]) do
           article.save
         end
       end
@@ -40,7 +40,7 @@ RSpec.describe Article, type: :model do
       it "on destroy enqueues job to delete article from elasticsearch" do
         article = create(:article)
 
-        sidekiq_assert_enqueued_with(job: Search::RemoveFromElasticsearchIndexWorker, args: [described_class::SEARCH_CLASS.to_s, article.search_id]) do
+        sidekiq_assert_enqueued_with(job: Search::RemoveFromIndexWorker, args: [described_class::SEARCH_CLASS.to_s, article.search_id]) do
           article.destroy
         end
       end
@@ -83,7 +83,7 @@ RSpec.describe Article, type: :model do
         allow(article).to receive(:index_to_elasticsearch)
         allow(article.user).to receive(:index_to_elasticsearch)
 
-        sidekiq_assert_enqueued_with(job: Search::IndexToElasticsearchWorker, args: ["Reaction", reaction.id]) do
+        sidekiq_assert_enqueued_with(job: Search::IndexWorker, args: ["Reaction", reaction.id]) do
           article.update(body_markdown: "---\ntitle: NEW TITLE#{rand(1000)}\n")
         end
       end
@@ -826,7 +826,7 @@ RSpec.describe Article, type: :model do
 
   describe "#touch_by_reaction" do
     it "reindexes elasticsearch doc" do
-      sidekiq_assert_enqueued_with(job: Search::IndexToElasticsearchWorker, args: [described_class.to_s, article.id]) do
+      sidekiq_assert_enqueued_with(job: Search::IndexWorker, args: [described_class.to_s, article.id]) do
         article.touch_by_reaction
       end
     end

--- a/spec/models/chat_channel_membership_spec.rb
+++ b/spec/models/chat_channel_membership_spec.rb
@@ -15,14 +15,14 @@ RSpec.describe ChatChannelMembership, type: :model do
   describe "#after_commit" do
     it "on update enqueues job to index chat_channel_membership to elasticsearch" do
       chat_channel_membership.save
-      sidekiq_assert_enqueued_with(job: Search::IndexToElasticsearchWorker, args: [described_class.to_s, chat_channel_membership.id]) do
+      sidekiq_assert_enqueued_with(job: Search::IndexWorker, args: [described_class.to_s, chat_channel_membership.id]) do
         chat_channel_membership.save
       end
     end
 
     it "on destroy enqueues job to delete chat_channel_membership from elasticsearch" do
       chat_channel_membership.save
-      sidekiq_assert_enqueued_with(job: Search::RemoveFromElasticsearchIndexWorker, args: [described_class::SEARCH_CLASS.to_s, chat_channel_membership.id]) do
+      sidekiq_assert_enqueued_with(job: Search::RemoveFromIndexWorker, args: [described_class::SEARCH_CLASS.to_s, chat_channel_membership.id]) do
         chat_channel_membership.destroy
       end
     end

--- a/spec/models/classified_listing_spec.rb
+++ b/spec/models/classified_listing_spec.rb
@@ -76,17 +76,16 @@ RSpec.describe ClassifiedListing, type: :model do
     it "on update enqueues worker to index tag to elasticsearch" do
       classified_listing.save
 
-      sidekiq_assert_enqueued_with(job: Search::IndexToElasticsearchWorker, args: [described_class.to_s, classified_listing.id]) do
+      sidekiq_assert_enqueued_with(job: Search::IndexWorker, args: [described_class.to_s, classified_listing.id]) do
         classified_listing.save
       end
     end
 
     it "on destroy enqueues job to delete classified_listing from elasticsearch" do
       classified_listing.save
-      sidekiq_assert_enqueued_with(job: Search::RemoveFromElasticsearchIndexWorker, args: [described_class::SEARCH_CLASS.to_s, classified_listing.id]) do
+      sidekiq_assert_enqueued_with(job: Search::RemoveFromIndexWorker, args: [described_class::SEARCH_CLASS.to_s, classified_listing.id]) do
         classified_listing.destroy
       end
     end
   end
 end
-

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Comment, type: :model do
 
     describe "#after_commit" do
       it "on update enqueues job to index comment to elasticsearch" do
-        sidekiq_assert_enqueued_with(job: Search::IndexToElasticsearchWorker, args: [described_class.to_s, comment.id]) do
+        sidekiq_assert_enqueued_with(job: Search::IndexWorker, args: [described_class.to_s, comment.id]) do
           comment.save
         end
       end
@@ -47,7 +47,7 @@ RSpec.describe Comment, type: :model do
       it "on destroy enqueues job to delete comment from elasticsearch" do
         comment = create(:comment)
 
-        sidekiq_assert_enqueued_with(job: Search::RemoveFromElasticsearchIndexWorker, args: [described_class::SEARCH_CLASS.to_s, comment.search_id]) do
+        sidekiq_assert_enqueued_with(job: Search::RemoveFromIndexWorker, args: [described_class::SEARCH_CLASS.to_s, comment.search_id]) do
           comment.destroy
         end
       end

--- a/spec/models/concerns/searchable_spec.rb
+++ b/spec/models/concerns/searchable_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Searchable do
 
   describe "#remove_from_elasticsearch" do
     it "enqueues job to delete model document from elasticsearch" do
-      sidekiq_assert_enqueued_with(job: Search::RemoveFromElasticsearchIndexWorker, args: [SearchableModel::SEARCH_CLASS.to_s, searchable_model.search_id]) do
+      sidekiq_assert_enqueued_with(job: Search::RemoveFromIndexWorker, args: [SearchableModel::SEARCH_CLASS.to_s, searchable_model.search_id]) do
         searchable_model.remove_from_elasticsearch
       end
     end
@@ -39,7 +39,7 @@ RSpec.describe Searchable do
 
   describe "#index_to_elasticsearch" do
     it "enqueues job to index document to elasticsearch" do
-      sidekiq_assert_enqueued_with(job: Search::IndexToElasticsearchWorker, args: ["SearchableModel", searchable_model.id]) do
+      sidekiq_assert_enqueued_with(job: Search::IndexWorker, args: ["SearchableModel", searchable_model.id]) do
         searchable_model.index_to_elasticsearch
       end
     end

--- a/spec/models/podcast_episode_spec.rb
+++ b/spec/models/podcast_episode_spec.rb
@@ -32,14 +32,14 @@ RSpec.describe PodcastEpisode, type: :model do
   describe "#after_commit" do
     it "on update enqueues job to index podcast_episode to elasticsearch" do
       podcast_episode.save
-      sidekiq_assert_enqueued_with(job: Search::IndexToElasticsearchWorker, args: [described_class.to_s, podcast_episode.id]) do
+      sidekiq_assert_enqueued_with(job: Search::IndexWorker, args: [described_class.to_s, podcast_episode.id]) do
         podcast_episode.save
       end
     end
 
     it "on destroy enqueues job to delete podcast_episode from elasticsearch" do
       podcast_episode.save
-      sidekiq_assert_enqueued_with(job: Search::RemoveFromElasticsearchIndexWorker, args: [described_class::SEARCH_CLASS.to_s, podcast_episode.search_id]) do
+      sidekiq_assert_enqueued_with(job: Search::RemoveFromIndexWorker, args: [described_class::SEARCH_CLASS.to_s, podcast_episode.search_id]) do
         podcast_episode.destroy
       end
     end

--- a/spec/models/reaction_spec.rb
+++ b/spec/models/reaction_spec.rb
@@ -72,14 +72,14 @@ RSpec.describe Reaction, type: :model do
     context "when category is readingList and reactable is published" do
       it "on update enqueues job to index reaction to elasticsearch" do
         reaction.save
-        sidekiq_assert_enqueued_with(job: Search::IndexToElasticsearchWorker, args: [described_class.to_s, reaction.id]) do
+        sidekiq_assert_enqueued_with(job: Search::IndexWorker, args: [described_class.to_s, reaction.id]) do
           reaction.update(category: "readinglist")
         end
       end
 
       it "on create enqueues job to index reaction to elasticsearch" do
         reaction.category = "readinglist"
-        sidekiq_assert_enqueued_with(job: Search::IndexToElasticsearchWorker) do
+        sidekiq_assert_enqueued_with(job: Search::IndexWorker) do
           reaction.save
         end
       end
@@ -87,7 +87,7 @@ RSpec.describe Reaction, type: :model do
       it "on destroy enqueues job to delete reaction from elasticsearch" do
         reaction.category = "readinglist"
         reaction.save
-        sidekiq_assert_enqueued_with(job: Search::RemoveFromElasticsearchIndexWorker, args: [described_class::SEARCH_CLASS.to_s, reaction.id]) do
+        sidekiq_assert_enqueued_with(job: Search::RemoveFromIndexWorker, args: [described_class::SEARCH_CLASS.to_s, reaction.id]) do
           reaction.destroy
         end
       end
@@ -103,20 +103,20 @@ RSpec.describe Reaction, type: :model do
 
       it "on update does not enqueue job to index reaction to elasticsearch" do
         reaction.save
-        sidekiq_assert_no_enqueued_jobs(only: Search::IndexToElasticsearchWorker) do
+        sidekiq_assert_no_enqueued_jobs(only: Search::IndexWorker) do
           reaction.update(category: "unicorn")
         end
       end
 
       it "on create does not enqueue job to index reaction to elasticsearch" do
-        sidekiq_assert_no_enqueued_jobs(only: Search::IndexToElasticsearchWorker) do
+        sidekiq_assert_no_enqueued_jobs(only: Search::IndexWorker) do
           reaction.save
         end
       end
 
       it "on destroy does not enqueue job to delete reaction from elasticsearch" do
         reaction.save
-        sidekiq_assert_no_enqueued_jobs(only: Search::RemoveFromElasticsearchIndexWorker) do
+        sidekiq_assert_no_enqueued_jobs(only: Search::RemoveFromIndexWorker) do
           reaction.destroy
         end
       end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -92,14 +92,14 @@ RSpec.describe Tag, type: :model do
   describe "#after_commit" do
     it "on update enqueues job to index tag to elasticsearch" do
       tag.save
-      sidekiq_assert_enqueued_with(job: Search::IndexToElasticsearchWorker, args: [described_class.to_s, tag.id]) do
+      sidekiq_assert_enqueued_with(job: Search::IndexWorker, args: [described_class.to_s, tag.id]) do
         tag.save
       end
     end
 
     it "on destroy enqueues job to delete tag from elasticsearch" do
       tag.save
-      sidekiq_assert_enqueued_with(job: Search::RemoveFromElasticsearchIndexWorker, args: [described_class::SEARCH_CLASS.to_s, tag.id]) do
+      sidekiq_assert_enqueued_with(job: Search::RemoveFromIndexWorker, args: [described_class::SEARCH_CLASS.to_s, tag.id]) do
         tag.destroy
       end
     end

--- a/spec/services/moderator/banish_user_spec.rb
+++ b/spec/services/moderator/banish_user_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Moderator::BanishUser, type: :service do
     create(:comment, user: user, commentable: article)
     sidekiq_perform_enqueued_jobs
 
-    sidekiq_perform_enqueued_jobs(except: Search::IndexToElasticsearchWorker) do
+    sidekiq_perform_enqueued_jobs(except: Search::IndexWorker) do
       described_class.call(user: user, admin: admin)
     end
     expect(user.comments.count).to eq 0

--- a/spec/services/users/delete_articles_spec.rb
+++ b/spec/services/users/delete_articles_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Users::DeleteArticles, type: :service do
       sidekiq_perform_enqueued_jobs
       comments = article.comments
       comments.each { |comment| expect(comment.elasticsearch_doc).not_to be_nil }
-      sidekiq_perform_enqueued_jobs(only: Search::RemoveFromElasticsearchIndexWorker) do
+      sidekiq_perform_enqueued_jobs(only: Search::RemoveFromIndexWorker) do
         described_class.call(user)
       end
 

--- a/spec/workers/search/bulk_index_worker_spec.rb
+++ b/spec/workers/search/bulk_index_worker_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Search::BulkIndexToElasticsearchWorker, type: :worker, elasticsearch: true do
+RSpec.describe Search::BulkIndexWorker, type: :worker, elasticsearch: true do
   let(:worker) { subject }
   let(:article) { create(:article) }
 

--- a/spec/workers/search/index_worker_spec.rb
+++ b/spec/workers/search/index_worker_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Search::IndexToElasticsearchWorker, type: :worker, elasticsearch: true do
+RSpec.describe Search::IndexWorker, type: :worker, elasticsearch: true do
   let(:worker) { subject }
 
   include_examples "#enqueues_on_correct_queue", "high_priority", ["Tag", 1]

--- a/spec/workers/search/remove_from_index_worker_spec.rb
+++ b/spec/workers/search/remove_from_index_worker_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Search::RemoveFromElasticsearchIndexWorker, type: :worker do
+RSpec.describe Search::RemoveFromIndexWorker, type: :worker do
   let(:worker) { subject }
   let(:search_class) { Search::Tag }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor

## Description
Sorry for the large dif! Now that we have removed the Algolia Index Workers we can steal their names for our Elasticsearch workers. 

YES, I choose to do it inline, I will deal with any fallout or failed jobs that occur from this switch. I don't expect there to be a ton, we don't have a super high indexing volume yet. 

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-32887789

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?
- [x] updated

![alt_text](https://i.gifer.com/origin/71/71475c2df385ed6c40575f1d5c66f7da_w200.gif)
