### PR TITLE
Rate Limit Organization Creation

### DIFF
--- a/app/controllers/internal/configs_controller.rb
+++ b/app/controllers/internal/configs_controller.rb
@@ -56,6 +56,7 @@ class Internal::ConfigsController < Internal::ApplicationController
       rate_limit_follow_count_daily
       rate_limit_image_upload
       rate_limit_published_article_creation
+      rate_limit_organization_creation
       shop_url
       sidebar_tags
       suggested_tags

--- a/app/labor/rate_limit_checker.rb
+++ b/app/labor/rate_limit_checker.rb
@@ -4,8 +4,17 @@ class RateLimitChecker
   RETRY_AFTER = {
     article_update: 30,
     image_upload: 30,
-    published_article_creation: 30
+    published_article_creation: 30,
+    organization_creation: 300
   }.with_indifferent_access.freeze
+
+  CONFIG_LIMIT_KEYS = %i[
+    rate_limit_follow_count_daily
+    rate_limit_comment_creation
+    rate_limit_published_article_creation
+    rate_limit_image_upload
+    rate_limit_email_recipient
+  ].freeze
 
   def initialize(user = nil)
     @user = user
@@ -53,6 +62,11 @@ class RateLimitChecker
       SiteConfig.rate_limit_email_recipient
   end
 
+  def track_organization_creation
+    expires_in = RETRY_AFTER[:organization_creation].seconds
+    Rails.cache.increment("#{@user.id}_organization_creation", 1, expires_in: expires_in)
+  end
+
   private
 
   def check_comment_creation_limit
@@ -63,6 +77,11 @@ class RateLimitChecker
   def check_published_article_creation_limit
     user.articles.published.where("created_at > ?", 30.seconds.ago).size >
       SiteConfig.rate_limit_published_article_creation
+  end
+
+  def check_organization_creation_limit
+    Rails.cache.read("#{user.id}_organization_creation").to_i >=
+      SiteConfig.rate_limit_organization_creation
   end
 
   def check_image_upload_limit

--- a/app/labor/rate_limit_checker.rb
+++ b/app/labor/rate_limit_checker.rb
@@ -1,6 +1,7 @@
 class RateLimitChecker
   attr_reader :user, :action
 
+  # Values are seconds until a user can retry
   RETRY_AFTER = {
     article_update: 30,
     image_upload: 30,

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -69,6 +69,7 @@ class SiteConfig < RailsSettings::Base
   field :rate_limit_follow_count_daily, type: :integer, default: 500
   field :rate_limit_comment_creation, type: :integer, default: 9
   field :rate_limit_published_article_creation, type: :integer, default: 9
+  field :rate_limit_organization_creation, type: :integer, default: 1
   field :rate_limit_image_upload, type: :integer, default: 9
   field :rate_limit_email_recipient, type: :integer, default: 5
   field :rate_limit_article_update, type: :integer, default: 150

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -375,6 +375,16 @@
             </div>
 
             <div class="form-group">
+              <%= f.label :rate_limit_organization_creation %>
+              <%= f.number_field :rate_limit_organization_creation,
+                                 class: "form-control",
+                                 value: SiteConfig.rate_limit_organization_creation,
+                                 min: 0,
+                                 placeholder: 9 %>
+              <div class="alert alert-info">Number of organizations a user can create within a 5 minute period</div>
+            </div>
+
+            <div class="form-group">
               <%= f.label :rate_limit_image_upload %>
               <%= f.number_field :rate_limit_image_upload,
                                  class: "form-control",

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -379,8 +379,8 @@
               <%= f.number_field :rate_limit_organization_creation,
                                  class: "form-control",
                                  value: SiteConfig.rate_limit_organization_creation,
-                                 min: 0,
-                                 placeholder: 9 %>
+                                 min: 1,
+                                 placeholder: 1 %>
               <div class="alert alert-info">Number of organizations a user can create within a 5 minute period</div>
             </div>
 

--- a/docs/backend/elasticsearch.md
+++ b/docs/backend/elasticsearch.md
@@ -55,10 +55,10 @@ error. Mappings for each index can be found in
 
 In order to index the data from Postgres into Elasticsearch, we rely on
 callbacks in our ActiveRecord models. Whenever a model is created or updated we
-use an `after_commit` callback to enqueue a `Search::IndexToElasticsearchWorker`
-which handles indexing the document into Elasticsearch. In order to translate
-our ActiveRecord data to Elasticsearch we use serializers. Each model has its
-own serializer which can be found in `app/serializers/search`
+use an `after_commit` callback to enqueue a `Search::IndexWorker` which handles
+indexing the document into Elasticsearch. In order to translate our ActiveRecord
+data to Elasticsearch we use serializers. Each model has its own serializer
+which can be found in `app/serializers/search`
 
 ### Searching Elasticsearch
 

--- a/spec/labor/rate_limit_checker_spec.rb
+++ b/spec/labor/rate_limit_checker_spec.rb
@@ -98,6 +98,18 @@ RSpec.describe RateLimitChecker, type: :labor do
 
       expect(rate_limit_checker.limit_by_action("article_update")).to be(false)
     end
+
+    it "returns true if user has created too many organizations" do
+      allow(Rails.cache).
+        to receive(:read).with("#{user.id}_organization_creation").
+        and_return(SiteConfig.rate_limit_organization_creation + 1)
+
+      expect(rate_limit_checker.limit_by_action("organization_creation")).to be(true)
+    end
+
+    it "returns false if organization_creation limit has not been reached" do
+      expect(described_class.new(user).limit_by_action("organization_creation")).to be(false)
+    end
   end
 
   describe ".track_image_uploads" do

--- a/spec/requests/internal/configs_spec.rb
+++ b/spec/requests/internal/configs_spec.rb
@@ -189,6 +189,12 @@ RSpec.describe "/internal/config", type: :request do
           end.to change(SiteConfig, :rate_limit_published_article_creation).from(9).to(3)
         end
 
+        it "updates rate_limit_organization_creation" do
+          expect do
+            post "/internal/config", params: { site_config: { rate_limit_organization_creation: 3 }, confirmation: confirmation_message }
+          end.to change(SiteConfig, :rate_limit_organization_creation).from(1).to(3)
+        end
+
         it "updates rate_limit_image_upload" do
           expect do
             post "/internal/config", params: { site_config: { rate_limit_image_upload: 3 }, confirmation: confirmation_message }

--- a/spec/requests/user/user_organization_spec.rb
+++ b/spec/requests/user/user_organization_spec.rb
@@ -41,7 +41,6 @@ RSpec.describe "UserOrganization", type: :request do
 
     it "creates the correct organization_membership association" do
       create_org
-
       org_membership = OrganizationMembership.first
       expect(org_membership.persisted?).to eq true
       expect(org_membership.user).to eq user

--- a/spec/requests/user/user_organization_spec.rb
+++ b/spec/requests/user/user_organization_spec.rb
@@ -28,14 +28,20 @@ RSpec.describe "UserOrganization", type: :request do
   end
 
   context "when creating a new org" do
+    let(:org_params) { build(:organization).attributes }
+    let(:rate_limiter) { RateLimitChecker.new(user) }
+    let(:create_org) { post "/organizations", params: { organization: org_params } }
+
     before do
       sign_in user
-      org_params = build(:organization).attributes
       org_params["profile_image"] = Rack::Test::UploadedFile.new(Rails.root.join("app/assets/images/android-icon-36x36.png"), "image/jpeg")
-      post "/organizations", params: { organization: org_params }
+      allow(RateLimitChecker).to receive(:new).and_return(rate_limiter)
+      allow(rate_limiter).to receive(:limit_by_action).and_return(false)
     end
 
     it "creates the correct organization_membership association" do
+      create_org
+
       org_membership = OrganizationMembership.first
       expect(org_membership.persisted?).to eq true
       expect(org_membership.user).to eq user
@@ -44,8 +50,15 @@ RSpec.describe "UserOrganization", type: :request do
     end
 
     it "redirects to the proper org settings page" do
+      create_org
       expect(response.status).to eq 302
       expect(response.redirect_url).to include "/settings/organization/#{Organization.last.id}"
+    end
+
+    it "raises a Rate limit error if the rate limit is reached" do
+      allow(rate_limiter).to receive(:limit_by_action).and_return(true)
+
+      expect { create_org }.to raise_error(RateLimitChecker::LimitReached)
     end
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Limit the number of organizations a user can make to 1 per 5 minute period. I went with the same approach as article creation and just raised a rate limit reached error. 

There is A LOT of duplicated code here that could use a good refactor. I plan to tackle that in a separate PR. 

## Added tests?
- [x] yes

![alt_text](https://media.giphy.com/media/mHW9TzNpYFFGo/giphy.gif)
