### PR TITLE
Authentication refactoring: generalize account settings

### DIFF
--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -109,7 +109,7 @@ class UserPolicy < ApplicationPolicy
     OrganizationMembership.exists?(user_id: user.id, organization_id: record.id)
   end
 
-  def remove_association?
+  def remove_identity?
     current_user?
   end
 

--- a/app/services/authentication/authenticator.rb
+++ b/app/services/authentication/authenticator.rb
@@ -96,7 +96,7 @@ module Authentication
 
     def find_or_create_user!
       existing_user = User.where(
-        provider.class.user_username_field => provider.user_nickname,
+        provider.user_username_field => provider.user_nickname,
       ).take
       return existing_user if existing_user
 
@@ -132,12 +132,12 @@ module Authentication
     end
 
     def update_profile_updated_at(user)
-      field_name = "#{provider.class.user_username_field}_changed?"
+      field_name = "#{provider.user_username_field}_changed?"
       user.profile_updated_at = Time.current if user.public_send(field_name)
     end
 
     def account_less_than_a_week_old?(user, logged_in_identity)
-      provider_created_at = user.public_send(provider.class.user_created_at_field)
+      provider_created_at = user.public_send(provider.user_created_at_field)
       user_identity_age = provider_created_at ||
         Time.zone.parse(logged_in_identity.auth_data_dump.extra.raw_info.created_at)
 

--- a/app/services/authentication/authenticator.rb
+++ b/app/services/authentication/authenticator.rb
@@ -96,7 +96,7 @@ module Authentication
 
     def find_or_create_user!
       existing_user = User.where(
-        provider.user_username_field => provider.user_nickname,
+        provider.class.user_username_field => provider.user_nickname,
       ).take
       return existing_user if existing_user
 
@@ -132,12 +132,12 @@ module Authentication
     end
 
     def update_profile_updated_at(user)
-      field_name = "#{provider.user_username_field}_changed?"
+      field_name = "#{provider.class.user_username_field}_changed?"
       user.profile_updated_at = Time.current if user.public_send(field_name)
     end
 
     def account_less_than_a_week_old?(user, logged_in_identity)
-      provider_created_at = user.public_send(provider.user_created_at_field)
+      provider_created_at = user.public_send(provider.class.user_created_at_field)
       user_identity_age = provider_created_at ||
         Time.zone.parse(logged_in_identity.auth_data_dump.extra.raw_info.created_at)
 

--- a/app/services/authentication/providers/github.rb
+++ b/app/services/authentication/providers/github.rb
@@ -5,6 +5,7 @@ module Authentication
       OFFICIAL_NAME = "GitHub".freeze
       CREATED_AT_FIELD = "github_created_at".freeze
       USERNAME_FIELD = "github_username".freeze
+      SETTINGS_URL = "https://github.com/settings/applications".freeze
 
       def new_user_data
         name = raw_info.name.presence || info.name
@@ -35,6 +36,10 @@ module Authentication
 
       def self.official_name
         OFFICIAL_NAME
+      end
+
+      def self.settings_url
+        SETTINGS_URL
       end
 
       def self.sign_in_path(params = {})

--- a/app/services/authentication/providers/github.rb
+++ b/app/services/authentication/providers/github.rb
@@ -25,6 +25,14 @@ module Authentication
         }
       end
 
+      def self.user_created_at_field
+        CREATED_AT_FIELD
+      end
+
+      def self.user_username_field
+        USERNAME_FIELD
+      end
+
       def self.official_name
         OFFICIAL_NAME
       end

--- a/app/services/authentication/providers/provider.rb
+++ b/app/services/authentication/providers/provider.rb
@@ -3,6 +3,7 @@ module Authentication
     # Authentication provider
     class Provider
       delegate :email, :nickname, to: :info, prefix: :user
+      delegate :user_created_at_field, :user_username_field, to: :class
 
       def initialize(auth_payload)
         @auth_payload = cleanup_payload(auth_payload.dup)

--- a/app/services/authentication/providers/provider.rb
+++ b/app/services/authentication/providers/provider.rb
@@ -44,6 +44,10 @@ module Authentication
         raise SubclassResponsibility
       end
 
+      def self.settings_url
+        raise SubclassResponsibility
+      end
+
       def self.authentication_path(params = {})
         ::Authentication::Paths.authentication_path(provider_name, params)
       end

--- a/app/services/authentication/providers/provider.rb
+++ b/app/services/authentication/providers/provider.rb
@@ -2,11 +2,6 @@ module Authentication
   module Providers
     # Authentication provider
     class Provider
-      # name of the field to store the upstream identity's creation date in
-      CREATED_AT_FIELD = "".freeze
-      # name of the field to store the upstream identity's username in
-      USERNAME_FIELD = "".freeze
-
       delegate :email, :nickname, to: :info, prefix: :user
 
       def initialize(auth_payload)
@@ -33,19 +28,18 @@ module Authentication
         auth_payload
       end
 
-      def user_created_at_field
-        self.class::CREATED_AT_FIELD
-      end
-
-      def user_username_field
-        self.class::USERNAME_FIELD
-      end
-
       def self.provider_name
         name.demodulize.downcase.to_sym
       end
 
-      # Returns the official name of the authentication provider
+      def self.user_created_at_field
+        raise SubclassResponsibility
+      end
+
+      def self.user_username_field
+        raise SubclassResponsibility
+      end
+
       def self.official_name
         raise SubclassResponsibility
       end

--- a/app/services/authentication/providers/twitter.rb
+++ b/app/services/authentication/providers/twitter.rb
@@ -30,6 +30,14 @@ module Authentication
         }
       end
 
+      def self.user_created_at_field
+        CREATED_AT_FIELD
+      end
+
+      def self.user_username_field
+        USERNAME_FIELD
+      end
+
       def self.official_name
         OFFICIAL_NAME
       end

--- a/app/services/authentication/providers/twitter.rb
+++ b/app/services/authentication/providers/twitter.rb
@@ -5,6 +5,7 @@ module Authentication
       OFFICIAL_NAME = "Twitter".freeze
       CREATED_AT_FIELD = "twitter_created_at".freeze
       USERNAME_FIELD = "twitter_username".freeze
+      SETTINGS_URL = "https://twitter.com/settings/applications".freeze
 
       def new_user_data
         name = raw_info.name.presence || info.name
@@ -40,6 +41,10 @@ module Authentication
 
       def self.official_name
         OFFICIAL_NAME
+      end
+
+      def self.settings_url
+        SETTINGS_URL
       end
 
       def self.sign_in_path(params = {})

--- a/app/views/users/_account.html.erb
+++ b/app/views/users/_account.html.erb
@@ -45,7 +45,7 @@
 <div class="crayons-box crayons-box--danger p-6 grid gap-6">
   <h2 class="color-accent-danger">Danger Zone</h2>
 
-  <% if @user.identities.size == 2 %>
+  <% if @user.identities.size > 1 %>
     <div class="grid gap-2">
       <h3>Remove OAuth Associations</h3>
       <p>You can remove one of your authentication methods. We'll still need one to authenticate you.</p>
@@ -55,40 +55,40 @@
         <li>remove the associated URL from your profile</li>
       </ul>
       <p>
-        Note that this does not revoke our OAuth app access; you will have to do so in your
-        <a href="https://twitter.com/settings/applications">Twitter profile settings</a> or your
-        <a href="https://github.com/settings/applications">GitHub profile settings</a>.
+        Note that this does not revoke our OAuth app access;
+        you will have to do so in your settings for the specific provider:
+
+        <%= render partial: "users/account_providers_settings" %>
       </p>
     </div>
 
-    <%= form_tag "/users/remove_identity", method: :delete, onsubmit: "return confirm('Are you absolutely sure you want to remove your Twitter account?');" do %>
-      <%= hidden_field_tag :provider, "twitter" %>
-      <button class="crayons-btn crayons-btn--danger crayons-btn--icon-left" type="submit">
-        <%= inline_svg_tag("twitter.svg", aria: true, class: "crayons-icon", title: "Twitter") %>
-        Remove Twitter
-      </button>
-    <% end %>
+    <% authentication_enabled_providers.each do |provider| %>
+      <% onsubmit = "return confirm('Are you absolutely sure you want to remove your #{provider.official_name} account?');" %>
+      <%= form_tag users_remove_identity_path, method: :delete, onsubmit: onsubmit do %>
+        <%= hidden_field_tag :provider, provider.provider_name %>
 
-    <%= form_tag "/users/remove_identity", method: :delete, onsubmit: "return confirm('Are you absolutely sure you want to remove your GitHub account?');" do %>
-      <%= hidden_field_tag :provider, "github" %>
-      <button class="crayons-btn crayons-btn--danger crayons-btn--icon-left" type="submit">
-        <%= inline_svg_tag("github.svg", aria: true, class: "crayons-icon", title: "Twitter") %>
-        Remove GitHub
-      </button>
+        <button class="crayons-btn crayons-btn--danger crayons-btn--icon-left" type="submit">
+          <%= inline_svg_tag("#{provider.provider_name}.svg", aria: true, class: "crayons-icon", title: provider.official_name) %>
+          Remove <%= provider.official_name %>
+        </button>
+      <% end %>
     <% end %>
   <% end %>
 
   <div class="grid gap-2">
     <h3>Delete Account</h3>
+
     <% if current_user.email? %>
       <%= form_tag user_request_destroy_path, method: :post, autocomplete: "off", id: "delete__account", class: "grid gap-2" do %>
         <p>Deleting your account will:</p>
         <ul class="list-disc pl-6">
-          <li>delete your profile, along with your Twitter and/or GitHub associations.
-            This does not include app permissions. You will have to remove them yourself on
-            <a href="https://twitter.com/settings/applications">Twitter profile settings</a> and
-            <a href="https://github.com/settings/applications">GitHub profile settings</a>.
+          <li>delete your profile, along with your authentication associations.
+
+            This does not include applications permissions. You will have to remove them yourself:
+
+            <%= render partial: "users/account_providers_settings" %>
           </li>
+
           <%# TODO: expand the delete messaging later %>
           <li>delete any and all content you have, such as articles, comments, your reading list or chat messages.</li>
           <li>allow your username to become available to anyone.</li>

--- a/app/views/users/_account.html.erb
+++ b/app/views/users/_account.html.erb
@@ -61,7 +61,7 @@
       </p>
     </div>
 
-    <%= form_tag "/users/remove_association", method: :delete, onsubmit: "return confirm('Are you absolutely sure you want to remove your Twitter account?');" do %>
+    <%= form_tag "/users/remove_identity", method: :delete, onsubmit: "return confirm('Are you absolutely sure you want to remove your Twitter account?');" do %>
       <%= hidden_field_tag :provider, "twitter" %>
       <button class="crayons-btn crayons-btn--danger crayons-btn--icon-left" type="submit">
         <%= inline_svg_tag("twitter.svg", aria: true, class: "crayons-icon", title: "Twitter") %>
@@ -69,7 +69,7 @@
       </button>
     <% end %>
 
-    <%= form_tag "/users/remove_association", method: :delete, onsubmit: "return confirm('Are you absolutely sure you want to remove your GitHub account?');" do %>
+    <%= form_tag "/users/remove_identity", method: :delete, onsubmit: "return confirm('Are you absolutely sure you want to remove your GitHub account?');" do %>
       <%= hidden_field_tag :provider, "github" %>
       <button class="crayons-btn crayons-btn--danger crayons-btn--icon-left" type="submit">
         <%= inline_svg_tag("github.svg", aria: true, class: "crayons-icon", title: "Twitter") %>
@@ -77,6 +77,7 @@
       </button>
     <% end %>
   <% end %>
+
   <div class="grid gap-2">
     <h3>Delete Account</h3>
     <% if current_user.email? %>

--- a/app/views/users/_account_providers_settings.html.erb
+++ b/app/views/users/_account_providers_settings.html.erb
@@ -1,0 +1,5 @@
+<ul>
+  <% authentication_enabled_providers.each do |provider| %>
+    <li><a href="<%= provider.settings_url %>"><%= provider.official_name %> profile settings</a></li>
+  <% end %>
+</ul>

--- a/app/views/users/_additional_authentication.html.erb
+++ b/app/views/users/_additional_authentication.html.erb
@@ -1,7 +1,7 @@
 <% authentication_enabled_providers.each do |provider| %>
   <% unless @user.identities.exists?(provider: provider.provider_name) %>
     <a
-      href="<%= provider.authentication_path %>"
+      href="<%= provider.sign_in_path(state: "profile") %>"
       class="crayons-btn crayons-btn--outlined mr-2"
       data-no-instant>
       <%= inline_svg_tag(

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -285,7 +285,7 @@ Rails.application.routes.draw do
   post "users/add_org_admin" => "users#add_org_admin"
   post "users/remove_org_admin" => "users#remove_org_admin"
   post "users/remove_from_org" => "users#remove_from_org"
-  delete "users/remove_association", to: "users#remove_association"
+  delete "users/remove_identity", to: "users#remove_identity"
   post "users/request_destroy", to: "users#request_destroy", as: :user_request_destroy
   get "users/confirm_destroy/:token", to: "users#confirm_destroy", as: :user_confirm_destroy
   delete "users/full_delete", to: "users#full_delete", as: :user_full_delete

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe UserPolicy, type: :policy do
     let(:user) { other_user }
 
     permitted_actions = %i[
-      edit update onboarding_update join_org dashboard_show remove_association destroy
+      edit update onboarding_update join_org dashboard_show remove_identity destroy
     ]
 
     it { is_expected.to permit_actions(permitted_actions) }

--- a/spec/support/omniauth_helpers.rb
+++ b/spec/support/omniauth_helpers.rb
@@ -33,7 +33,7 @@ module OmniauthHelpers
   )
 
   OMNIAUTH_BASIC_INFO = {
-    uid: "1234567",
+    uid: SecureRandom.hex(3),
     info: OMNIAUTH_INFO,
     extra: OMNIAUTH_EXTRA_INFO,
     credentials: {


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

In this PR we generalize the last (hopefully) remaining part of the user facing code, the settings/account panel.

- renamed `remove_association` to `remove_identity`
- made sure one can only remove enabled providers (we don't show disabled providers anyway, but it's good to check server side as well)
- added `settings_url` which points to the URL where the user can land to remove the oauth association
- future proof some code and tests which checked if the total number of identities was 2 (we'll soon have more)
- use `sign_in_path` everywhere

## Related Tickets & Documents

Closes https://github.com/thepracticaldev/dev.to/issues/7585

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
