### PR TITLE
Clear Elasticsearch Data Instead of Resetting Entire Index for Specs

### DIFF
--- a/spec/lib/data_update_scripts/index_chat_channel_memberships_to_elasticsearch_spec.rb
+++ b/spec/lib/data_update_scripts/index_chat_channel_memberships_to_elasticsearch_spec.rb
@@ -1,8 +1,9 @@
 require "rails_helper"
 require Rails.root.join("lib/data_update_scripts/20200218195023_index_chat_channel_memberships_to_elasticsearch.rb")
 
-describe DataUpdateScripts::IndexChatChannelMembershipsToElasticsearch, elasticsearch: true do
+describe DataUpdateScripts::IndexChatChannelMembershipsToElasticsearch do
   it "indexes chat channel memberships to Elasticsearch" do
+    clear_elasticsearch_data(Search::ChatChannelMembership)
     chat_channel_membership = FactoryBot.create(:chat_channel_membership)
     expect { chat_channel_membership.elasticsearch_doc }.to raise_error(Search::Errors::Transport::NotFound)
     described_class.new.run

--- a/spec/lib/data_update_scripts/index_chat_channel_memberships_to_elasticsearch_spec.rb
+++ b/spec/lib/data_update_scripts/index_chat_channel_memberships_to_elasticsearch_spec.rb
@@ -1,9 +1,8 @@
 require "rails_helper"
 require Rails.root.join("lib/data_update_scripts/20200218195023_index_chat_channel_memberships_to_elasticsearch.rb")
 
-describe DataUpdateScripts::IndexChatChannelMembershipsToElasticsearch do
+describe DataUpdateScripts::IndexChatChannelMembershipsToElasticsearch, elasticsearch: "ChatChannelMembership" do
   it "indexes chat channel memberships to Elasticsearch" do
-    clear_elasticsearch_data(Search::ChatChannelMembership)
     chat_channel_membership = FactoryBot.create(:chat_channel_membership)
     expect { chat_channel_membership.elasticsearch_doc }.to raise_error(Search::Errors::Transport::NotFound)
     described_class.new.run

--- a/spec/lib/data_update_scripts/index_classified_listings_to_elasticsearch_spec.rb
+++ b/spec/lib/data_update_scripts/index_classified_listings_to_elasticsearch_spec.rb
@@ -1,9 +1,8 @@
 require "rails_helper"
 require Rails.root.join("lib/data_update_scripts/20200217215802_index_classified_listings_to_elasticsearch.rb")
 
-describe DataUpdateScripts::IndexClassifiedListingsToElasticsearch do
+describe DataUpdateScripts::IndexClassifiedListingsToElasticsearch, elasticsearch: "ClassifiedListing" do
   it "indexes classified_listings to Elasticsearch" do
-    clear_elasticsearch_data(Search::ClassifiedListing)
     classified_listing = create(:classified_listing)
     expect { classified_listing.elasticsearch_doc }.to raise_error(Search::Errors::Transport::NotFound)
     described_class.new.run

--- a/spec/lib/data_update_scripts/index_classified_listings_to_elasticsearch_spec.rb
+++ b/spec/lib/data_update_scripts/index_classified_listings_to_elasticsearch_spec.rb
@@ -1,8 +1,9 @@
 require "rails_helper"
 require Rails.root.join("lib/data_update_scripts/20200217215802_index_classified_listings_to_elasticsearch.rb")
 
-describe DataUpdateScripts::IndexClassifiedListingsToElasticsearch, elasticsearch: true do
+describe DataUpdateScripts::IndexClassifiedListingsToElasticsearch do
   it "indexes classified_listings to Elasticsearch" do
+    clear_elasticsearch_data(Search::ClassifiedListing)
     classified_listing = create(:classified_listing)
     expect { classified_listing.elasticsearch_doc }.to raise_error(Search::Errors::Transport::NotFound)
     described_class.new.run

--- a/spec/lib/data_update_scripts/index_reading_list_reactions_spec.rb
+++ b/spec/lib/data_update_scripts/index_reading_list_reactions_spec.rb
@@ -1,8 +1,9 @@
 require "rails_helper"
 require Rails.root.join("lib/data_update_scripts/20200415200651_index_reading_list_reactions.rb")
 
-describe DataUpdateScripts::IndexReadingListReactions, elasticsearch: true do
+describe DataUpdateScripts::IndexReadingListReactions do
   it "indexes feed content(articles, comments, podcast episodes) to Elasticsearch" do
+    clear_elasticsearch_data(Search::Reaction)
     reactions = create_list(:reaction, 3, category: "readinglist")
     Sidekiq::Worker.clear_all
 

--- a/spec/lib/data_update_scripts/index_reading_list_reactions_spec.rb
+++ b/spec/lib/data_update_scripts/index_reading_list_reactions_spec.rb
@@ -1,9 +1,8 @@
 require "rails_helper"
 require Rails.root.join("lib/data_update_scripts/20200415200651_index_reading_list_reactions.rb")
 
-describe DataUpdateScripts::IndexReadingListReactions do
+describe DataUpdateScripts::IndexReadingListReactions, elasticsearch: "Reaction" do
   it "indexes feed content(articles, comments, podcast episodes) to Elasticsearch" do
-    clear_elasticsearch_data(Search::Reaction)
     reactions = create_list(:reaction, 3, category: "readinglist")
     Sidekiq::Worker.clear_all
 

--- a/spec/lib/data_update_scripts/re_index_feed_content_to_elasticsearch_spec.rb
+++ b/spec/lib/data_update_scripts/re_index_feed_content_to_elasticsearch_spec.rb
@@ -1,9 +1,7 @@
 require "rails_helper"
 require Rails.root.join("lib/data_update_scripts/20200326145114_re_index_feed_content_to_elasticsearch.rb")
 
-describe DataUpdateScripts::ReIndexFeedContentToElasticsearch do
-  before { clear_elasticsearch_data(Search::FeedContent) }
-
+describe DataUpdateScripts::ReIndexFeedContentToElasticsearch, elasticsearch: "FeedContent" do
   after { Search::FeedContent.refresh_index }
 
   it "indexes feed content(articles, comments, podcast episodes) to Elasticsearch" do

--- a/spec/lib/data_update_scripts/re_index_feed_content_to_elasticsearch_spec.rb
+++ b/spec/lib/data_update_scripts/re_index_feed_content_to_elasticsearch_spec.rb
@@ -1,7 +1,11 @@
 require "rails_helper"
 require Rails.root.join("lib/data_update_scripts/20200326145114_re_index_feed_content_to_elasticsearch.rb")
 
-describe DataUpdateScripts::ReIndexFeedContentToElasticsearch, elasticsearch: true do
+describe DataUpdateScripts::ReIndexFeedContentToElasticsearch do
+  before { clear_elasticsearch_data(Search::FeedContent) }
+
+  after { Search::FeedContent.refresh_index }
+
   it "indexes feed content(articles, comments, podcast episodes) to Elasticsearch" do
     article = create(:article)
     podcast_episode = create(:podcast_episode)

--- a/spec/lib/data_update_scripts/re_index_users_to_elasticsearch_spec.rb
+++ b/spec/lib/data_update_scripts/re_index_users_to_elasticsearch_spec.rb
@@ -1,8 +1,9 @@
 require "rails_helper"
 require Rails.root.join("lib/data_update_scripts/20200406213152_re_index_users_to_elasticsearch.rb")
 
-describe DataUpdateScripts::ReIndexUsersToElasticsearch, elasticsearch: true do
+describe DataUpdateScripts::ReIndexUsersToElasticsearch do
   it "indexes users to Elasticsearch" do
+    clear_elasticsearch_data(Search::User)
     user = create(:user)
     expect { user.elasticsearch_doc }.to raise_error(Search::Errors::Transport::NotFound)
     sidekiq_perform_enqueued_jobs { described_class.new.run }

--- a/spec/lib/data_update_scripts/re_index_users_to_elasticsearch_spec.rb
+++ b/spec/lib/data_update_scripts/re_index_users_to_elasticsearch_spec.rb
@@ -1,9 +1,8 @@
 require "rails_helper"
 require Rails.root.join("lib/data_update_scripts/20200406213152_re_index_users_to_elasticsearch.rb")
 
-describe DataUpdateScripts::ReIndexUsersToElasticsearch do
+describe DataUpdateScripts::ReIndexUsersToElasticsearch, elasticsearch: "User" do
   it "indexes users to Elasticsearch" do
-    clear_elasticsearch_data(Search::User)
     user = create(:user)
     expect { user.elasticsearch_doc }.to raise_error(Search::Errors::Transport::NotFound)
     sidekiq_perform_enqueued_jobs { described_class.new.run }

--- a/spec/lib/data_update_scripts/resync_elasticsearch_documents_spec.rb
+++ b/spec/lib/data_update_scripts/resync_elasticsearch_documents_spec.rb
@@ -1,7 +1,18 @@
 require "rails_helper"
 require Rails.root.join("lib/data_update_scripts/20200410152018_resync_elasticsearch_documents.rb")
 
-describe DataUpdateScripts::ResyncElasticsearchDocuments, elasticsearch: true do
+describe DataUpdateScripts::ResyncElasticsearchDocuments do
+  before do
+    clear_elasticsearch_data(Article::SEARCH_CLASS)
+    clear_elasticsearch_data(User::SEARCH_CLASS)
+    clear_elasticsearch_data(Tag::SEARCH_CLASS)
+  end
+
+  after do
+    Article::SEARCH_CLASS.refresh_index
+    User::SEARCH_CLASS.refresh_index
+  end
+
   it "indexes podcast episodes and tags to Elasticsearch" do
     tag = create(:tag)
     podcast_episode = create(:podcast_episode)

--- a/spec/lib/data_update_scripts/resync_elasticsearch_documents_spec.rb
+++ b/spec/lib/data_update_scripts/resync_elasticsearch_documents_spec.rb
@@ -1,13 +1,7 @@
 require "rails_helper"
 require Rails.root.join("lib/data_update_scripts/20200410152018_resync_elasticsearch_documents.rb")
 
-describe DataUpdateScripts::ResyncElasticsearchDocuments do
-  before do
-    clear_elasticsearch_data(Article::SEARCH_CLASS)
-    clear_elasticsearch_data(User::SEARCH_CLASS)
-    clear_elasticsearch_data(Tag::SEARCH_CLASS)
-  end
-
+describe DataUpdateScripts::ResyncElasticsearchDocuments, elasticsearch: %w[FeedContent User Tag] do
   after do
     Article::SEARCH_CLASS.refresh_index
     User::SEARCH_CLASS.refresh_index

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -78,7 +78,7 @@ RSpec.configure do |config|
     Sidekiq::Worker.clear_all # worker jobs shouldn't linger around between tests
   end
 
-  config.around(:each, elasticsearch: true) do |example|
+  config.around(:each, elasticsearch_reset: true) do |example|
     Search::Cluster.recreate_indexes
     example.run
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -84,14 +84,12 @@ RSpec.configure do |config|
     Search::Cluster.recreate_indexes
   end
 
-  config.around do |ex|
-    if ex.metadata.key?(:elasticsearch)
-      klasses = Array.wrap(ex.metadata[:elasticsearch]).map do |search_class|
-        Search.const_get(search_class)
-      end
-      klasses.each { |klass| clear_elasticsearch_data(klass) }
-      ex.run
+  config.around(:each, :elasticsearch) do |ex|
+    klasses = Array.wrap(ex.metadata[:elasticsearch]).map do |search_class|
+      Search.const_get(search_class)
     end
+    klasses.each { |klass| clear_elasticsearch_data(klass) }
+    ex.run
   end
 
   config.around(:each, throttle: true) do |example|

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -84,6 +84,16 @@ RSpec.configure do |config|
     Search::Cluster.recreate_indexes
   end
 
+  config.around do |ex|
+    if ex.metadata.key?(:elasticsearch)
+      klasses = Array.wrap(ex.metadata[:elasticsearch]).map do |search_class|
+        Search.const_get(search_class)
+      end
+      klasses.each { |klass| clear_elasticsearch_data(klass) }
+      ex.run
+    end
+  end
+
   config.around(:each, throttle: true) do |example|
     Rack::Attack.enabled = true
     example.run

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -81,6 +81,7 @@ RSpec.configure do |config|
   config.around(:each, elasticsearch_reset: true) do |example|
     Search::Cluster.recreate_indexes
     example.run
+    Search::Cluster.recreate_indexes
   end
 
   config.around(:each, throttle: true) do |example|

--- a/spec/serializers/search/article_serializer_spec.rb
+++ b/spec/serializers/search/article_serializer_spec.rb
@@ -15,8 +15,7 @@ RSpec.describe Search::ArticleSerializer do
     expect(data_hash.keys).to include(:id, :body_text, :hotness_score)
   end
 
-  it "creates valid json for Elasticsearch" do
-    clear_elasticsearch_data(Search::FeedContent)
+  it "creates valid json for Elasticsearch", elasticsearch: "FeedContent" do
     data_hash = described_class.new(article).serializable_hash.dig(:data, :attributes)
     result = Article::SEARCH_CLASS.index(article.id, data_hash)
     expect(result["result"]).to eq("created")

--- a/spec/serializers/search/article_serializer_spec.rb
+++ b/spec/serializers/search/article_serializer_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe Search::ArticleSerializer do
     expect(data_hash.keys).to include(:id, :body_text, :hotness_score)
   end
 
-  it "creates valid json for Elasticsearch", elasticsearch: true do
+  it "creates valid json for Elasticsearch" do
+    clear_elasticsearch_data(Search::FeedContent)
     data_hash = described_class.new(article).serializable_hash.dig(:data, :attributes)
     result = Article::SEARCH_CLASS.index(article.id, data_hash)
     expect(result["result"]).to eq("created")

--- a/spec/serializers/search/comment_serializer_spec.rb
+++ b/spec/serializers/search/comment_serializer_spec.rb
@@ -12,8 +12,7 @@ RSpec.describe Search::CommentSerializer do
     expect(data_hash.keys).to include(:id, :body_text, :hotness_score, :title)
   end
 
-  it "creates valid json for Elasticsearch" do
-    clear_elasticsearch_data(Search::FeedContent)
+  it "creates valid json for Elasticsearch", elasticsearch: "FeedContent" do
     data_hash = described_class.new(comment).serializable_hash.dig(:data, :attributes)
     result = Comment::SEARCH_CLASS.index(comment.id, data_hash)
     expect(result["result"]).to eq("created")

--- a/spec/serializers/search/comment_serializer_spec.rb
+++ b/spec/serializers/search/comment_serializer_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe Search::CommentSerializer do
     expect(data_hash.keys).to include(:id, :body_text, :hotness_score, :title)
   end
 
-  it "creates valid json for Elasticsearch", elasticsearch: true do
+  it "creates valid json for Elasticsearch" do
+    clear_elasticsearch_data(Search::FeedContent)
     data_hash = described_class.new(comment).serializable_hash.dig(:data, :attributes)
     result = Comment::SEARCH_CLASS.index(comment.id, data_hash)
     expect(result["result"]).to eq("created")

--- a/spec/serializers/search/user_serializer_spec.rb
+++ b/spec/serializers/search/user_serializer_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe Search::UserSerializer do
     expect(data_hash.keys).to include(:id, :name, :path, :username, :roles)
   end
 
-  it "creates valid json for Elasticsearch", elasticsearch: true do
+  it "creates valid json for Elasticsearch" do
+    clear_elasticsearch_data(Search::User)
     data_hash = described_class.new(user).serializable_hash.dig(:data, :attributes)
     result = User::SEARCH_CLASS.index(user.id, data_hash)
     expect(result["result"]).to eq("created")

--- a/spec/serializers/search/user_serializer_spec.rb
+++ b/spec/serializers/search/user_serializer_spec.rb
@@ -8,8 +8,7 @@ RSpec.describe Search::UserSerializer do
     expect(data_hash.keys).to include(:id, :name, :path, :username, :roles)
   end
 
-  it "creates valid json for Elasticsearch" do
-    clear_elasticsearch_data(Search::User)
+  it "creates valid json for Elasticsearch", elasticsearch: "User" do
     data_hash = described_class.new(user).serializable_hash.dig(:data, :attributes)
     result = User::SEARCH_CLASS.index(user.id, data_hash)
     expect(result["result"]).to eq("created")

--- a/spec/services/search/base_spec.rb
+++ b/spec/services/search/base_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Search::Base, type: :service, elasticsearch_reset: true do
+RSpec.describe Search::Base, type: :service do
   let(:document_id) { 123 }
 
   before do
@@ -8,6 +8,8 @@ RSpec.describe Search::Base, type: :service, elasticsearch_reset: true do
     stub_const("#{described_class}::INDEX_NAME", "tags_#{Rails.env}")
     stub_const("#{described_class}::INDEX_ALIAS", "tags_#{Rails.env}_alias")
     stub_const("#{described_class}::MAPPINGS", Search::Tag::MAPPINGS)
+    Search::Tag.refresh_index
+    clear_elasticsearch_data(Search::Tag)
     allow(described_class).to receive(:index_settings).and_return({})
   end
 
@@ -67,7 +69,7 @@ RSpec.describe Search::Base, type: :service, elasticsearch_reset: true do
     end
   end
 
-  describe "::create_index" do
+  describe "::create_index", elasticsearch_reset: true do
     it "creates an elasticsearch index with INDEX_NAME" do
       described_class.delete_index
       expect(Search::Client.indices.exists(index: described_class::INDEX_NAME)).to eq(false)
@@ -86,7 +88,7 @@ RSpec.describe Search::Base, type: :service, elasticsearch_reset: true do
     end
   end
 
-  describe "::delete_index" do
+  describe "::delete_index", elasticsearch_reset: true do
     it "deletes an elasticsearch index with INDEX_NAME" do
       expect(Search::Client.indices.exists(index: described_class::INDEX_NAME)).to eq(true)
       described_class.delete_index

--- a/spec/services/search/base_spec.rb
+++ b/spec/services/search/base_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Search::Base, type: :service, elasticsearch: true do
+RSpec.describe Search::Base, type: :service, elasticsearch_reset: true do
   let(:document_id) { 123 }
 
   before do

--- a/spec/services/search/chat_channel_membership_spec.rb
+++ b/spec/services/search/chat_channel_membership_spec.rb
@@ -1,10 +1,12 @@
 require "rails_helper"
 
-RSpec.describe Search::ChatChannelMembership, type: :service, elasticsearch: true do
+RSpec.describe Search::ChatChannelMembership, type: :service do
   describe "::search_documents" do
     let(:user) { create(:user) }
     let(:chat_channel_membership1) { create(:chat_channel_membership, user_id: user.id) }
     let(:chat_channel_membership2) { create(:chat_channel_membership, user_id: user.id) }
+
+    before { clear_elasticsearch_data(described_class) }
 
     it "parses chat_channel_membership document hits from search response" do
       mock_search_response = { "hits" => { "hits" => {} } }

--- a/spec/services/search/chat_channel_membership_spec.rb
+++ b/spec/services/search/chat_channel_membership_spec.rb
@@ -1,12 +1,10 @@
 require "rails_helper"
 
 RSpec.describe Search::ChatChannelMembership, type: :service do
-  describe "::search_documents" do
+  describe "::search_documents", elasticsearch: "ChatChannelMembership" do
     let(:user) { create(:user) }
     let(:chat_channel_membership1) { create(:chat_channel_membership, user_id: user.id) }
     let(:chat_channel_membership2) { create(:chat_channel_membership, user_id: user.id) }
-
-    before { clear_elasticsearch_data(described_class) }
 
     it "parses chat_channel_membership document hits from search response" do
       mock_search_response = { "hits" => { "hits" => {} } }

--- a/spec/services/search/classified_listing_spec.rb
+++ b/spec/services/search/classified_listing_spec.rb
@@ -1,8 +1,10 @@
 require "rails_helper"
 
-RSpec.describe Search::ClassifiedListing, type: :service, elasticsearch: true do
+RSpec.describe Search::ClassifiedListing, type: :service do
   describe "::search_documents" do
     let(:classified_listing) { create(:classified_listing) }
+
+    before { clear_elasticsearch_data(described_class) }
 
     it "parses classified_listing document hits from search response" do
       mock_search_response = { "hits" => { "hits" => {} } }

--- a/spec/services/search/classified_listing_spec.rb
+++ b/spec/services/search/classified_listing_spec.rb
@@ -1,10 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Search::ClassifiedListing, type: :service do
-  describe "::search_documents" do
+  describe "::search_documents", elasticsearch: "ClassifiedListing" do
     let(:classified_listing) { create(:classified_listing) }
-
-    before { clear_elasticsearch_data(described_class) }
 
     it "parses classified_listing document hits from search response" do
       mock_search_response = { "hits" => { "hits" => {} } }

--- a/spec/services/search/feed_content_spec.rb
+++ b/spec/services/search/feed_content_spec.rb
@@ -7,11 +7,9 @@ RSpec.describe Search::FeedContent, type: :service do
     expect(described_class::MAPPINGS).not_to be_nil
   end
 
-  describe "::search_documents" do
+  describe "::search_documents", elasticsearch: "FeedContent" do
     let(:article1) { create(:article) }
     let(:article2) { create(:article) }
-
-    before { clear_elasticsearch_data(described_class) }
 
     it "parses feed content document hits from search response" do
       mock_search_response = { "hits" => { "hits" => {} } }
@@ -142,9 +140,7 @@ RSpec.describe Search::FeedContent, type: :service do
     end
   end
 
-  describe "document counts" do
-    before { clear_elasticsearch_data(described_class) }
-
+  describe "document counts", elasticsearch: "FeedContent" do
     it "returns counts for each document class" do
       article = create(:article)
       comment = create(:comment)

--- a/spec/services/search/feed_content_spec.rb
+++ b/spec/services/search/feed_content_spec.rb
@@ -7,9 +7,11 @@ RSpec.describe Search::FeedContent, type: :service do
     expect(described_class::MAPPINGS).not_to be_nil
   end
 
-  describe "::search_documents", elasticsearch: true do
+  describe "::search_documents" do
     let(:article1) { create(:article) }
     let(:article2) { create(:article) }
+
+    before { clear_elasticsearch_data(described_class) }
 
     it "parses feed content document hits from search response" do
       mock_search_response = { "hits" => { "hits" => {} } }
@@ -141,7 +143,9 @@ RSpec.describe Search::FeedContent, type: :service do
   end
 
   describe "document counts" do
-    it "returns counts for each document class", elasticsearch: true do
+    before { clear_elasticsearch_data(described_class) }
+
+    it "returns counts for each document class" do
       article = create(:article)
       comment = create(:comment)
       pde = create(:podcast_episode)

--- a/spec/services/search/reaction_spec.rb
+++ b/spec/services/search/reaction_spec.rb
@@ -7,12 +7,14 @@ RSpec.describe Search::Reaction, type: :service do
     expect(described_class::MAPPINGS).not_to be_nil
   end
 
-  describe "::search_documents", elasticsearch: true do
+  describe "::search_documents" do
     let(:article1) { create(:article) }
     let(:article2) { create(:article) }
     let(:reaction1) { create(:reaction, category: "readinglist", reactable: article1) }
     let(:reaction2) { create(:reaction, category: "readinglist", reactable: article2) }
     let(:query_params) { { size: 5 } }
+
+    before { clear_elasticsearch_data(described_class) }
 
     it "parses reaction document hits from search response" do
       mock_search_response = { "hits" => { "hits" => {} } }

--- a/spec/services/search/reaction_spec.rb
+++ b/spec/services/search/reaction_spec.rb
@@ -7,14 +7,12 @@ RSpec.describe Search::Reaction, type: :service do
     expect(described_class::MAPPINGS).not_to be_nil
   end
 
-  describe "::search_documents" do
+  describe "::search_documents", elasticsearch: "Reaction" do
     let(:article1) { create(:article) }
     let(:article2) { create(:article) }
     let(:reaction1) { create(:reaction, category: "readinglist", reactable: article1) }
     let(:reaction2) { create(:reaction, category: "readinglist", reactable: article2) }
     let(:query_params) { { size: 5 } }
-
-    before { clear_elasticsearch_data(described_class) }
 
     it "parses reaction document hits from search response" do
       mock_search_response = { "hits" => { "hits" => {} } }

--- a/spec/services/search/tag_spec.rb
+++ b/spec/services/search/tag_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Search::Tag, type: :service do
-  describe "::search_documents" do
+  describe "::search_documents", elasticsearch: "Tag" do
     let(:tag_doc_1) { { "name" => "tag1" } }
     let(:tag_doc_2) { { "name" => "tag2" } }
     let(:mock_search_response) do
@@ -14,8 +14,6 @@ RSpec.describe Search::Tag, type: :service do
         }
       }
     end
-
-    before { clear_elasticsearch_data(described_class) }
 
     it "searches with name:tag" do
       tag = create(:tag, :search_indexed, name: "tag1")

--- a/spec/services/search/tag_spec.rb
+++ b/spec/services/search/tag_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Search::Tag, type: :service, elasticsearch: true do
+RSpec.describe Search::Tag, type: :service do
   describe "::search_documents" do
     let(:tag_doc_1) { { "name" => "tag1" } }
     let(:tag_doc_2) { { "name" => "tag2" } }
@@ -14,6 +14,8 @@ RSpec.describe Search::Tag, type: :service, elasticsearch: true do
         }
       }
     end
+
+    before { clear_elasticsearch_data(described_class) }
 
     it "searches with name:tag" do
       tag = create(:tag, :search_indexed, name: "tag1")

--- a/spec/services/search/user_spec.rb
+++ b/spec/services/search/user_spec.rb
@@ -7,11 +7,9 @@ RSpec.describe Search::User, type: :service do
     expect(described_class::MAPPINGS).not_to be_nil
   end
 
-  describe "::search_documents" do
+  describe "::search_documents", elasticsearch: "User" do
     let(:user1) { create(:user) }
     let(:user2) { create(:user) }
-
-    before { clear_elasticsearch_data(described_class) }
 
     it "parses user document hits from search response" do
       mock_search_response = { "hits" => { "hits" => {} } }

--- a/spec/services/search/user_spec.rb
+++ b/spec/services/search/user_spec.rb
@@ -7,9 +7,11 @@ RSpec.describe Search::User, type: :service do
     expect(described_class::MAPPINGS).not_to be_nil
   end
 
-  describe "::search_documents", elasticsearch: true do
+  describe "::search_documents" do
     let(:user1) { create(:user) }
     let(:user2) { create(:user) }
+
+    before { clear_elasticsearch_data(described_class) }
 
     it "parses user document hits from search response" do
       mock_search_response = { "hits" => { "hits" => {} } }

--- a/spec/system/articles/user_visits_articles_by_timeframe_spec.rb
+++ b/spec/system/articles/user_visits_articles_by_timeframe_spec.rb
@@ -116,11 +116,10 @@ RSpec.describe "User visits articles by timeframe", type: :system do
     end
   end
 
-  context "when user has logged in", js: true do
+  context "when user has logged in", js: true, elasticsearch: "FeedContent" do
     let(:user) { create(:user) }
 
     before do
-      clear_elasticsearch_data(Search::FeedContent)
       sign_in user
       visit "/top/week"
     end

--- a/spec/workers/search/bulk_index_worker_spec.rb
+++ b/spec/workers/search/bulk_index_worker_spec.rb
@@ -1,12 +1,13 @@
 require "rails_helper"
 
-RSpec.describe Search::BulkIndexWorker, type: :worker, elasticsearch: true do
+RSpec.describe Search::BulkIndexWorker, type: :worker do
   let(:worker) { subject }
   let(:article) { create(:article) }
 
   include_examples "#enqueues_on_correct_queue", "high_priority", ["Reaction", 1]
 
   it "indexes documents for a set of given ids and object class" do
+    clear_elasticsearch_data(Search::Reaction)
     reactions = [create(:reaction, reactable: article), create(:reaction), create(:reaction)]
     Sidekiq::Worker.clear_all
 

--- a/spec/workers/search/bulk_index_worker_spec.rb
+++ b/spec/workers/search/bulk_index_worker_spec.rb
@@ -6,8 +6,7 @@ RSpec.describe Search::BulkIndexWorker, type: :worker do
 
   include_examples "#enqueues_on_correct_queue", "high_priority", ["Reaction", 1]
 
-  it "indexes documents for a set of given ids and object class" do
-    clear_elasticsearch_data(Search::Reaction)
+  it "indexes documents for a set of given ids and object class", elasticsearch: "Reaction" do
     reactions = [create(:reaction, reactable: article), create(:reaction), create(:reaction)]
     Sidekiq::Worker.clear_all
 

--- a/spec/workers/search/index_worker_spec.rb
+++ b/spec/workers/search/index_worker_spec.rb
@@ -1,9 +1,7 @@
 require "rails_helper"
 
-RSpec.describe Search::IndexWorker, type: :worker do
+RSpec.describe Search::IndexWorker, type: :worker, elasticsearch: "Tag" do
   let(:worker) { subject }
-
-  before { clear_elasticsearch_data(Search::Tag) }
 
   include_examples "#enqueues_on_correct_queue", "high_priority", ["Tag", 1]
 

--- a/spec/workers/search/index_worker_spec.rb
+++ b/spec/workers/search/index_worker_spec.rb
@@ -1,7 +1,9 @@
 require "rails_helper"
 
-RSpec.describe Search::IndexWorker, type: :worker, elasticsearch: true do
+RSpec.describe Search::IndexWorker, type: :worker do
   let(:worker) { subject }
+
+  before { clear_elasticsearch_data(Search::Tag) }
 
   include_examples "#enqueues_on_correct_queue", "high_priority", ["Tag", 1]
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
By default if we are using Elasticsearch for a spec we will reset ALL of our indexes with a very brute force approach. This is fine until you have a lot of Elasticsearch dependant tests, then it gets very sloooooow. In all of our search specs I replaced the full elasticsearch reset with a simple clear data method which uses a `delete_by_query` to ensure there is no data in the index.

So how much faster does this make the specs? Here are before and afters of all the `/search/` specs.
```
# BEFORE: Complete Reset
.........................................................................................................................

Finished in 2 minutes 40.4 seconds (files took 7.88 seconds to load)
121 examples, 0 failures

# AFTER: Only Clearing Data
.........................................................................................................................

Finished in 50.01 seconds (files took 7.73 seconds to load)
121 examples, 0 failures

````

I kept the full reset helper and use it in the `base_spec` for search bc in that spec we are deleting and creating indexes all over the place so its easier to just do a full reset for those specs. 

https://github.com/thepracticaldev/dev.to/projects/6#card-37267458

## Added tests?
- [x] yes

![alt_text](https://media1.tenor.com/images/69f6a5033c91d15323812045a40cbd42/tenor.gif?itemid=14781681)
