### PR TITLE
Make DATABASE_URL_TEST optional

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -64,7 +64,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  url: <%= ENV.fetch('DATABASE_URL_TEST', '') %>
+  url: <%= ENV['DATABASE_URL_TEST'] || ENV['DATABASE_URL'] || ''%>
   database: PracticalDeveloper_test<%= ENV['TEST_ENV_NUMBER'] %>
 
 # As with config/secrets.yml, you never want to store sensitive information,

--- a/docs/installation/postgresql.md
+++ b/docs/installation/postgresql.md
@@ -40,6 +40,9 @@ connection string.
 
 ```yml
 DATABASE_URL: postgresql://USERNAME:PASSWORD@localhost
+
+# Incase you use a separate database for test. This is optional.
+DATABASE_URL_TEST: postgresql://USERNAME:PASSWORD@localhost
 ```
 
 1. Replace `USERNAME` with your database username, `PASSWORD` with your database

--- a/docs/installation/postgresql.md
+++ b/docs/installation/postgresql.md
@@ -41,7 +41,7 @@ connection string.
 ```yml
 DATABASE_URL: postgresql://USERNAME:PASSWORD@localhost
 
-# Incase you use a separate database for test. This is optional.
+# Optional: If your test database is in a different url, be sure to set this.
 DATABASE_URL_TEST: postgresql://USERNAME:PASSWORD@localhost
 ```
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix/DX

## Description
When relying on `DATABASE_URL` and forgetting to set `DATABASE_URL_TEST`, users would be hit with error similar to the following when setting up database.
```
Couldn't create 'PracticalDeveloper_test' database. Please check your configuration.
```

The need for `DATABASE_URL_TEST` could be pretty niche and I think this a good middle ground for  things to work as expected while providing the option for a separate database URL for those who look within `database.yml`

## Related Tickets & Documents
Resolve https://github.com/thepracticaldev/dev.to/issues/7557

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a