### PR TITLE
Fix finding existing podcast episode by website url

### DIFF
--- a/app/models/podcast.rb
+++ b/app/models/podcast.rb
@@ -32,7 +32,9 @@ class Podcast < ApplicationRecord
     episode = PodcastEpisode.where(media_url: item.enclosure_url).
       or(PodcastEpisode.where(title: item.title)).
       or(PodcastEpisode.where(guid: item.guid.to_s)).presence
-    episode ||= PodcastEpisode.where(website_url: item.link).presence if unique_website_url?
+    # if unique_website_url? is set to true (the default value), we try to find an episode by website_url as well
+    # if unique_website_url? is set to false it usually means that website_url is the same for different episodes
+    episode ||= PodcastEpisode.where(website_url: item.link).presence if item.link.present? && unique_website_url?
     episode.to_a.first
   end
 

--- a/spec/models/podcast_spec.rb
+++ b/spec/models/podcast_spec.rb
@@ -132,17 +132,20 @@ RSpec.describe Podcast, type: :model do
 
   describe "#existing_episode" do
     let(:guid) { "<guid isPermaLink=\"false\">http://podcast.example/file.mp3</guid>" }
-
+    let(:item_attributes) do
+      {
+        pubDate: "2019-06-19",
+        enclosure_url: "https://audio.simplecast.com/2330f132.mp3",
+        description: "yet another podcast",
+        title: "lightalloy's podcast",
+        guid: guid,
+        itunes_subtitle: "hello",
+        content_encoded: nil,
+        itunes_summary: "world"
+      }
+    end
     let(:item) do
-      build(:podcast_episode_rss_item, pubDate: "2019-06-19",
-                                       enclosure_url: "https://audio.simplecast.com/2330f132.mp3",
-                                       description: "yet another podcast",
-                                       title: "lightalloy's podcast",
-                                       guid: guid,
-                                       itunes_subtitle: "hello",
-                                       content_encoded: nil,
-                                       itunes_summary: "world",
-                                       link: "https://litealloy.ru")
+      build(:podcast_episode_rss_item, item_attributes.merge(link: "https://litealloy.ru"))
     end
 
     it "determines existing episode by media_url" do
@@ -163,6 +166,12 @@ RSpec.describe Podcast, type: :model do
     it "determines existing episode by website_url" do
       episode = create(:podcast_episode, podcast: podcast, website_url: "https://litealloy.ru")
       expect(podcast.existing_episode(item)).to eq(episode)
+    end
+
+    it "doesn't determine existing episode if episode link is empty" do
+      create(:podcast_episode, podcast: podcast, website_url: "")
+      no_link_item = build(:podcast_episode_rss_item, item_attributes.merge(link: ""))
+      expect(podcast.existing_episode(no_link_item)).to eq(nil)
     end
 
     it "doesn't determine existing episode by non-unique website_url" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Stop trying to find an existing podcast episode by website url in case item link is empty in the rss.
I also added a comment for our controversial logic related to `unique_website_url?`.

## Added tests?
- [x] yes
