### PR TITLE
Add multiple select to authentication providers configuration

### DIFF
--- a/app/helpers/authentication_helper.rb
+++ b/app/helpers/authentication_helper.rb
@@ -3,6 +3,12 @@ module AuthenticationHelper
     Authentication::Providers.get!(provider_name)
   end
 
+  def authentication_available_providers
+    Authentication::Providers.available.map do |provider_name|
+      Authentication::Providers.const_get(provider_name.to_s.titleize)
+    end
+  end
+
   def authentication_enabled_providers
     Authentication::Providers.enabled.map do |provider_name|
       Authentication::Providers.get!(provider_name)

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -44,7 +44,7 @@ class SiteConfig < RailsSettings::Base
   }
 
   # Authentication
-  field :authentication_providers, type: :array, default: %w[twitter github]
+  field :authentication_providers, type: :array, default: Authentication::Providers.available
 
   # Broadcast
   field :welcome_notifications_live_at, type: :date

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -169,11 +169,16 @@
           <div id="authenticationBodyContainer" class="card-body collapse hide" aria-labelledby="authenticationBodyContainer">
             <div class="form-group">
               <%= f.label :authentication_providers, "Authentication providers" %>
-              <%= f.text_field :authentication_providers,
-                               class: "form-control",
-                               value: SiteConfig.authentication_providers.join(","),
-                               placeholder: "List of valid providers: comma separated, letters only e.g. twitter,github" %>
-              <div class="alert alert-info">How can users sign in? (More options coming)</div>
+              <%= select_tag "site_config[authentication_providers]",
+                             options_from_collection_for_select(
+                               authentication_available_providers,
+                               :provider_name,
+                               :official_name,
+                               authentication_enabled_providers.map(&:provider_name),
+                             ),
+                             multiple: true,
+                             class: "form-control selectpicker" %>
+              <div class="alert alert-info">How can users sign in?</div>
             </div>
           </div>
         </div>

--- a/app/views/layouts/internal.html.erb
+++ b/app/views/layouts/internal.html.erb
@@ -19,6 +19,7 @@
   <!-- Bootstrap and FontAwesome -->
   <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.13.16/css/bootstrap-select.min.css" integrity="sha256-g19F2KOr/H58l6XdI/rhCdEK3NmB8OILHwP/QYBQ8M4=" crossorigin="anonymous" />
 
   <%= stylesheet_link_tag "internal/layout" %>
 
@@ -49,6 +50,7 @@
   <!-- Bootstrap Dependencies -->
   <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.13.16/js/bootstrap-select.min.js" integrity="sha256-COIM4OdXvo3jkE0/jD/QIEDe3x0jRuqHhOdGTkno3uM=" crossorigin="anonymous"></script>
 
   <%= javascript_include_tag "internal" %>
 

--- a/spec/requests/internal/configs_spec.rb
+++ b/spec/requests/internal/configs_spec.rb
@@ -307,14 +307,17 @@ RSpec.describe "/internal/config", type: :request do
       end
 
       describe "Authentication" do
-        it "removes space authentication_providers" do
-          post "/internal/config", params: { site_config: { authentication_providers: "github, twitter" }, confirmation: confirmation_message }
-          expect(SiteConfig.authentication_providers).to eq(%w[github twitter])
+        it "updates enabled authentication providers" do
+          enabled = Array.wrap(Authentication::Providers.available.first.to_s)
+          post "/internal/config", params: { site_config: { authentication_providers: enabled }, confirmation: confirmation_message }
+          expect(SiteConfig.authentication_providers).to eq(enabled)
         end
 
-        it "downcases authentication_providers" do
-          post "/internal/config", params: { site_config: { authentication_providers: "GitHub, Twitter" }, confirmation: confirmation_message }
-          expect(SiteConfig.authentication_providers).to eq(%w[github twitter])
+        it "strips empty elements" do
+          provider = Authentication::Providers.available.first.to_s
+          enabled = [provider, "", nil]
+          post "/internal/config", params: { site_config: { authentication_providers: enabled }, confirmation: confirmation_message }
+          expect(SiteConfig.authentication_providers).to eq([provider])
         end
       end
     end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Right now the authentication providers selection in the configuration is a bit cumbersome.

This PR switches to a select (I had to use [bootstrap-select](https://developer.snapappointments.com/bootstrap-select/) as the regular select had issues with multiple selection and default values, too much went into trying to get that right :D).

With this new select, see the `selectpicker` class in the select, it also opens the possibility of it being used in other configuration options. Out of the scope for this PR

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![auth_providers](https://user-images.githubusercontent.com/146201/80710164-b3b42a80-8aee-11ea-96c8-c9c53e0577ba.gif)


## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
