### PR TITLE
Flaky Spec Fix: Load article page AFTER updating the article

### DIFF
--- a/spec/requests/articles/articles_show_spec.rb
+++ b/spec/requests/articles/articles_show_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe "ArticlesShow", type: :request do
 
     it "renders the proper modified at date" do
       article.update(edited_at: Time.zone.now)
+      get article.path
       expect(response.body).to include CGI.escapeHTML(article.edited_at.strftime("%b %d, %Y"))
     end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Fixes: https://travis-ci.com/github/thepracticaldev/dev.to/builds/162996347
We are loading the page, then updating the article, then checking the response. Since the date parsing is not super granular usually we get the same on the page anyways despite updating after. To prevent this from failing though we need to update the article THEN load the page. 

![alt_text](https://media1.tenor.com/images/c60b0c9f441f523e67e64afc52bec690/tenor.gif?itemid=8665326)
