### PR TITLE
Honeybadger Fix: Return Usable Error Message when chat creation fails

### DIFF
--- a/app/controllers/chat_channels_controller.rb
+++ b/app/controllers/chat_channels_controller.rb
@@ -80,6 +80,7 @@ class ChatChannelsController < ApplicationController
     chat_recipient = User.find(params[:user_id])
     valid_listing = ClassifiedListing.where(user_id: params[:user_id], contact_via_connect: true).limit(1)
     authorize ChatChannel
+
     if chat_recipient.inbox_type == "open" || valid_listing.length == 1
       chat = ChatChannel.create_with_users(users: [current_user, chat_recipient], channel_type: "direct")
       message_markdown = params[:message]
@@ -93,6 +94,8 @@ class ChatChannelsController < ApplicationController
     else
       render json: { status: "error", message: "not allowed!" }, status: :bad_request
     end
+  rescue StandardError => e
+    render json: { status: "error", message: e.message }, status: :bad_request
   end
 
   def block_chat

--- a/spec/requests/chat_channels_spec.rb
+++ b/spec/requests/chat_channels_spec.rb
@@ -237,6 +237,13 @@ RSpec.describe "ChatChannels", type: :request do
            params: { user_id: user_open_inbox.id }
       expect(user_open_inbox.chat_channel_memberships.size).to eq(1)
     end
+
+    it "returns error message if create_with_users fails" do
+      allow(ChatChannel).to receive(:create_with_users).and_raise(StandardError.new("Blocked"))
+      post "/chat_channels/create_chat",
+           params: { user_id: user_open_inbox.id }
+      expect(response.parsed_body["message"]).to eq("Blocked")
+    end
   end
 
   describe "POST /chat_channels/block_chat" do


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Rather than raising an error and alerting us of an invalid or blocked chat channel that attempted to be created, lets return the error message to the user. These error messages are raised [from the model](https://github.com/thepracticaldev/dev.to/blob/master/app/models/chat_channel.rb#L61) method `create_with_users`.
Fixes: https://app.honeybadger.io/fault/66984/68c73cbac26355e307a9d755712bd8e9

## Added tests?
- [x] yes

![alt_text](https://media1.tenor.com/images/46d638d2a0a560748ab66ef0375bc1f4/tenor.gif?itemid=3723064)
