### PR TITLE
Extract onboarding + mascot configs

### DIFF
--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -16,7 +16,11 @@ class SiteConfig < RailsSettings::Base
   field :community_member_description, type: :string, default: "amazing humans who code."
   field :community_member_label, type: :string, default: "user"
   field :tagline, type: :string, default: "We're a place where coders share, stay up-to-date and grow their careers."
+
+  # Mascot
   field :mascot_user_id, type: :integer, default: 1
+  field :mascot_image_url, type: :string, default: "https://practicaldev-herokuapp-com.freetls.fastly.net/assets/sloan.png"
+  field :mascot_image_description, type: :string, default: "Sloan, the sloth mascot"
 
   # Social Media and Email
   field :staff_user_id, type: :integer, default: 1
@@ -55,15 +59,16 @@ class SiteConfig < RailsSettings::Base
   field :campaign_sidebar_enabled, type: :boolean, default: 0
   field :campaign_sidebar_image, type: :string, default: nil
 
+  # Onboarding
+  field :onboarding_taskcard_image, type: :string, default: "https://practicaldev-herokuapp-com.freetls.fastly.net/assets/staggered-dev.svg"
+  field :suggested_tags, type: :array, default: %w[beginners career computerscience javascript security ruby rails swift kotlin]
+
   # Images
   field :main_social_image, type: :string, default: "https://thepracticaldev.s3.amazonaws.com/i/6hqmcjaxbgbon8ydw93z.png"
   field :favicon_url, type: :string, default: "favicon.ico"
   field :logo_png, type: :string, default: "https://practicaldev-herokuapp-com.freetls.fastly.net/assets/devlogo-pwa-512.png"
   field :logo_svg, type: :string, default: ""
   field :primary_sticker_image_url, type: :string, default: "https://practicaldev-herokuapp-com.freetls.fastly.net/assets/rainbowdev.svg"
-  field :onboarding_taskcard_image, type: :string, default: "https://practicaldev-herokuapp-com.freetls.fastly.net/assets/staggered-dev.svg"
-  field :mascot_image_url, type: :string, default: "https://practicaldev-herokuapp-com.freetls.fastly.net/assets/sloan.png"
-  field :mascot_image_description, type: :string, default: "Sloan, the sloth mascot"
 
   # Rate Limits
   field :rate_limit_follow_count_daily, type: :integer, default: 500
@@ -95,7 +100,6 @@ class SiteConfig < RailsSettings::Base
   field :periodic_email_digest_min, type: :integer, default: 2
 
   # Tags
-  field :suggested_tags, type: :array, default: %w[beginners career computerscience javascript security ruby rails swift kotlin]
   field :sidebar_tags, type: :array, default: %w[help challenge discuss explainlikeimfive meta watercooler]
 
   # Shop

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -237,6 +237,43 @@
         <div class="card mt-3">
           <%= render partial: "card_header",
                      locals: {
+                       header: "Onboarding",
+                       state: "collapse",
+                       target: "onboardingBodyContainer",
+                       expanded: "false"
+                     } %>
+          <div id="onboardingBodyContainer" class="card-body collapse hide" aria-labelledby="onboardingBodyContainer">
+            <div class="form-group">
+              <%= f.label :onboarding_taskcard_image %>
+              <%= f.text_field :onboarding_taskcard_image,
+                               class: "form-control",
+                               value: SiteConfig.onboarding_taskcard_image,
+                               placeholder: "https://image.url" %>
+              <div class="row mt-2">
+                <div class="col-12">
+                  <img alt="main social image" class="img-fluid" src="<%= SiteConfig.onboarding_taskcard_image %>" />
+                </div>
+                <div class="col-12">
+                  <div class="alert alert-info"> Used as the onboarding task-card image </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="form-group">
+              <%= f.label :suggested_tags %>
+              <%= f.text_field :suggested_tags,
+                               class: "form-control",
+                               value: SiteConfig.suggested_tags.join(","),
+                               placeholder: "List of valid tags: comma separated, letters only e.g. beginners,javascript,ruby,swift,kotlin" %>
+              <div class="alert alert-info">Determines which tags are suggested to new users during onboarding (comma
+                separated, letters only)</div>
+            </div>
+          </div>
+        </div>
+
+        <div class="card mt-3">
+          <%= render partial: "card_header",
+                     locals: {
                        header: "Images",
                        state: "collapse",
                        target: "imagesBodyContainer",
@@ -300,20 +337,6 @@
                 </div>
                 <div class="col-12">
                   <div class="alert alert-info"> Used as the primary sticker image </div>
-                </div>
-              </div>
-
-              <%= f.label :onboarding_taskcard_image %>
-              <%= f.text_field :onboarding_taskcard_image,
-                               class: "form-control",
-                               value: SiteConfig.onboarding_taskcard_image,
-                               placeholder: "https://image.url" %>
-              <div class="row mt-2">
-                <div class="col-12">
-                  <img alt="main social image" class="img-fluid" src="<%= SiteConfig.onboarding_taskcard_image %>" />
-                </div>
-                <div class="col-12">
-                  <div class="alert alert-info"> Used as the onboarding task-card image </div>
                 </div>
               </div>
 
@@ -521,15 +544,6 @@
                        expanded: "false"
                      } %>
           <div id="tagsBodyContainer" class="card-body collapse hide" aria-labelledby="tagsBodyContainer">
-            <div class="form-group">
-              <%= f.label :suggested_tags %>
-              <%= f.text_field :suggested_tags,
-                               class: "form-control",
-                               value: SiteConfig.suggested_tags.join(","),
-                               placeholder: "List of valid tags: comma separated, letters only e.g. beginners,javascript,ruby,swift,kotlin" %>
-              <div class="alert alert-info">Determines which tags are suggested to new users during onboarding (comma
-                separated, letters only)</div>
-            </div>
             <div class="form-group">
               <%= f.label :sidebar_tags %>
               <%= f.text_field :sidebar_tags,

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -67,7 +67,18 @@
                                placeholder: "We're a place where coders share, stay up-to-date and grow their careers." %>
               <div class="alert alert-info">Used in signup modal.</div>
             </div>
+          </div>
+        </div>
 
+        <div class="card mt-3">
+          <%= render partial: "card_header",
+                     locals: {
+                       header: "Mascot",
+                       state: "collapse",
+                       target: "mascotBodyContainer",
+                       expanded: "false"
+                     } %>
+          <div id="mascotBodyContainer" class="card-body collapse hide" aria-labelledby="mascotBodyContainer">
             <div class="form-group">
               <%= f.label :mascot_user_id, "Mascot user ID" %>
               <%= f.text_field :mascot_user_id,
@@ -76,6 +87,29 @@
                                min: 1,
                                placeholder: "1" %>
               <div class="alert alert-info">User ID of the Mascot account</div>
+            </div>
+
+            <div class="form-group">
+              <%= f.label :mascot_image_url %>
+              <%= f.text_field :mascot_image_url,
+                               class: "form-control",
+                               value: SiteConfig.mascot_image_url,
+                               placeholder: "https://image.url" %>
+
+              <div class="col-12">
+                <img alt="<%= SiteConfig.mascot_image_description %>" class="img-fluid" src="<%= SiteConfig.mascot_image_url %>" />
+              </div>
+
+              <div class="alert alert-info"> Used as the mascot image. </div>
+            </div>
+
+            <div class="form-group">
+              <%= f.label :mascot_image_description %>
+              <%= f.text_field :mascot_image_description,
+                               class: "form-control",
+                               value: SiteConfig.mascot_image_description %>
+
+              <div class="alert alert-info">Used as the alt text for the mascot image </div>
             </div>
           </div>
         </div>
@@ -339,26 +373,6 @@
                   <div class="alert alert-info"> Used as the primary sticker image </div>
                 </div>
               </div>
-
-              <%= f.label :mascot_image_url %>
-              <%= f.text_field :mascot_image_url,
-                               class: "form-control",
-                               value: SiteConfig.mascot_image_url,
-                               placeholder: "https://image.url" %>
-              <div class="row mt-2">
-                <div class="col-12">
-                  <img alt="<%= SiteConfig.mascot_image_description %>" class="img-fluid" src="<%= SiteConfig.mascot_image_url %>" />
-                </div>
-                <div class="col-12">
-                  <div class="alert alert-info"> Used as the mascot image. </div>
-                </div>
-              </div>
-
-              <%= f.label :mascot_image_description %>
-              <%= f.text_field :mascot_image_description,
-                               class: "form-control",
-                               value: SiteConfig.mascot_image_description %>
-              <div class="alert alert-info">Used as the alt text for the mascot image </div>
             </div>
           </div>
         </div>

--- a/spec/requests/internal/configs_spec.rb
+++ b/spec/requests/internal/configs_spec.rb
@@ -63,11 +63,25 @@ RSpec.describe "/internal/config", type: :request do
           post "/internal/config", params: { site_config: { tagline: description }, confirmation: confirmation_message }
           expect(SiteConfig.tagline).to eq(description)
         end
+      end
 
+      describe "mascot" do
         it "updates the mascot_user_id" do
           expected_mascot_user_id = 2
           post "/internal/config", params: { site_config: { mascot_user_id: expected_mascot_user_id }, confirmation: confirmation_message }
           expect(SiteConfig.mascot_user_id).to eq(expected_mascot_user_id)
+        end
+
+        it "updates mascot_image_url" do
+          expected_image_url = "https://dummyimage.com/300x300"
+          post "/internal/config", params: { site_config: { mascot_image_url: expected_image_url }, confirmation: confirmation_message }
+          expect(SiteConfig.mascot_image_url).to eq(expected_image_url)
+        end
+
+        it "updates mascot_image_description" do
+          description = "Hey hey #{rand(100)}"
+          post "/internal/config", params: { site_config: { mascot_image_description: description }, confirmation: confirmation_message }
+          expect(SiteConfig.mascot_image_description).to eq(description)
         end
       end
 
@@ -115,6 +129,24 @@ RSpec.describe "/internal/config", type: :request do
         end
       end
 
+      describe "onboarding" do
+        it "updates onboarding_taskcard_image" do
+          expected_image_url = "https://dummyimage.com/300x300"
+          post "/internal/config", params: { site_config: { onboarding_taskcard_image: expected_image_url }, confirmation: confirmation_message }
+          expect(SiteConfig.onboarding_taskcard_image).to eq(expected_image_url)
+        end
+
+        it "removes space suggested_tags" do
+          post "/internal/config", params: { site_config: { suggested_tags: "hey, haha,hoho, bobo fofo" }, confirmation: confirmation_message }
+          expect(SiteConfig.suggested_tags).to eq(%w[hey haha hoho bobofofo])
+        end
+
+        it "downcases suggested_tags" do
+          post "/internal/config", params: { site_config: { suggested_tags: "hey, haha,hoHo, Bobo Fofo" }, confirmation: confirmation_message }
+          expect(SiteConfig.suggested_tags).to eq(%w[hey haha hoho bobofofo])
+        end
+      end
+
       describe "images" do
         it "updates main_social_image" do
           expected_image_url = "https://dummyimage.com/300x300"
@@ -144,24 +176,6 @@ RSpec.describe "/internal/config", type: :request do
           expected_image_url = "https://dummyimage.com/300x300"
           post "/internal/config", params: { site_config: { primary_sticker_image_url: expected_image_url }, confirmation: confirmation_message }
           expect(SiteConfig.primary_sticker_image_url).to eq(expected_image_url)
-        end
-
-        it "updates onboarding_taskcard_image" do
-          expected_image_url = "https://dummyimage.com/300x300"
-          post "/internal/config", params: { site_config: { onboarding_taskcard_image: expected_image_url }, confirmation: confirmation_message }
-          expect(SiteConfig.onboarding_taskcard_image).to eq(expected_image_url)
-        end
-
-        it "updates mascot_image_url" do
-          expected_image_url = "https://dummyimage.com/300x300"
-          post "/internal/config", params: { site_config: { mascot_image_url: expected_image_url }, confirmation: confirmation_message }
-          expect(SiteConfig.mascot_image_url).to eq(expected_image_url)
-        end
-
-        it "updates mascot_image_description" do
-          description = "Hey hey #{rand(100)}"
-          post "/internal/config", params: { site_config: { mascot_image_description: description }, confirmation: confirmation_message }
-          expect(SiteConfig.mascot_image_description).to eq(description)
         end
 
         it "rejects update without proper confirmation" do
@@ -260,16 +274,6 @@ RSpec.describe "/internal/config", type: :request do
       end
 
       describe "Tags" do
-        it "removes space suggested_tags" do
-          post "/internal/config", params: { site_config: { suggested_tags: "hey, haha,hoho, bobo fofo" }, confirmation: confirmation_message }
-          expect(SiteConfig.suggested_tags).to eq(%w[hey haha hoho bobofofo])
-        end
-
-        it "downcases suggested_tags" do
-          post "/internal/config", params: { site_config: { suggested_tags: "hey, haha,hoHo, Bobo Fofo" }, confirmation: confirmation_message }
-          expect(SiteConfig.suggested_tags).to eq(%w[hey haha hoho bobofofo])
-        end
-
         it "removes space sidebar_tags" do
           post "/internal/config", params: { site_config: { sidebar_tags: "hey, haha,hoho, bobo fofo" }, confirmation: confirmation_message }
           expect(SiteConfig.sidebar_tags).to eq(%w[hey haha hoho bobofofo])


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
I am going to be adding some more configs for onboarding, and it is currently hard to find all the onboarding-related configs. I have pulled them all into their own little "Onboarding" section within the `/internal/config` page.

While I was at it, I also pulled all the mascot-related configs into a "Mascot" section when I noticed that the mascot-related configs are scattered across different sections as well.

## Related Tickets & Documents
All of this is the initial work before I tackle https://github.com/thepracticaldev/dev.to/issues/7106.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
This PR makes the below visual changes to the `/internal/config` page:
<img width="931" alt="Screen_Shot_2020-04-30_at_10_10_59_AM" src="https://user-images.githubusercontent.com/6921610/80739552-82763300-8acb-11ea-8b1d-1d33bfb5cda6.png">

Here's what the mascot section looks like:
<img width="902" alt="Screen Shot 2020-04-30 at 10 11 15 AM" src="https://user-images.githubusercontent.com/6921610/80739561-886c1400-8acb-11ea-8490-e7d1a10c49dd.png">

And here's what the onboarding section looks like:
<img width="896" alt="Screen Shot 2020-04-30 at 10 11 23 AM" src="https://user-images.githubusercontent.com/6921610/80739558-85712380-8acb-11ea-9e91-9b4d19914305.png">

## Added tests?

- [ ] yes
- [x] no, because they aren't needed **Please QA this locally!**
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed