### PR TITLE
Allow admins to configure default users to follow during onboarding

### DIFF
--- a/app/controllers/internal/configs_controller.rb
+++ b/app/controllers/internal/configs_controller.rb
@@ -60,6 +60,7 @@ class Internal::ConfigsController < Internal::ApplicationController
       shop_url
       sidebar_tags
       suggested_tags
+      suggested_users
       tagline
     ]
 
@@ -79,11 +80,13 @@ class Internal::ConfigsController < Internal::ApplicationController
 
   def clean_up_params
     config = params[:site_config]
-    config[:suggested_tags] = config[:suggested_tags].downcase.delete(" ") if config[:suggested_tags]
     config[:sidebar_tags] = config[:sidebar_tags].downcase.delete(" ") if config[:sidebar_tags]
+    config[:suggested_tags] = config[:suggested_tags].downcase.delete(" ") if config[:suggested_tags]
+    config[:suggested_users] = config[:suggested_users].downcase.delete(" ") if config[:suggested_users]
   end
 
   def bust_relevant_caches
-    CacheBuster.bust("/tags/onboarding") # Needs to change when suggested_tags is edited
+    # Needs to change when suggested_tags is edited.
+    CacheBuster.bust("/tags/onboarding")
   end
 end

--- a/app/controllers/internal/configs_controller.rb
+++ b/app/controllers/internal/configs_controller.rb
@@ -80,9 +80,9 @@ class Internal::ConfigsController < Internal::ApplicationController
 
   def clean_up_params
     config = params[:site_config]
-    config[:sidebar_tags] = config[:sidebar_tags].downcase.delete(" ") if config[:sidebar_tags]
-    config[:suggested_tags] = config[:suggested_tags].downcase.delete(" ") if config[:suggested_tags]
-    config[:suggested_users] = config[:suggested_users].downcase.delete(" ") if config[:suggested_users]
+    %i[sidebar_tags suggested_tags suggested_users].each do |param|
+      config[param] = config[param].downcase.delete(" ") if config[param]
+    end
   end
 
   def bust_relevant_caches

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -282,7 +282,7 @@ class UsersController < ApplicationController
       attributes_to_select: INDEX_ATTRIBUTES_FOR_SERIALIZATION,
     ).suggest
 
-    recent_suggestions.empty? ? default_suggested_users : recent_suggestions
+    recent_suggestions.presence || default_suggested_users
   end
 
   def render_update_response

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,9 +6,9 @@ class UsersController < ApplicationController
   ]
   after_action :verify_authorized, except: %i[index signout_confirm add_org_admin remove_org_admin remove_from_org]
   before_action :authenticate_user!, only: %i[onboarding_update onboarding_checkbox_update]
+  before_action :set_suggested_users, only: %i[index]
   rescue_from Errno::ENAMETOOLONG, with: :log_image_data_to_datadog
 
-  DEFAULT_FOLLOW_SUGGESTIONS = SiteConfig.suggested_users
   INDEX_ATTRIBUTES_FOR_SERIALIZATION = %i[id name username summary profile_image].freeze
   private_constant :INDEX_ATTRIBUTES_FOR_SERIALIZATION
 
@@ -268,8 +268,12 @@ class UsersController < ApplicationController
     params[:user].delete_if { |_k, v| v.blank? }
   end
 
+  def set_suggested_users
+    @suggested_users = SiteConfig.suggested_users
+  end
+
   def default_suggested_users
-    @default_suggested_users ||= User.where(username: DEFAULT_FOLLOW_SUGGESTIONS)
+    @default_suggested_users ||= User.where(username: @suggested_users)
   end
 
   def determine_follow_suggestions(current_user)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -13,12 +13,6 @@ class UsersController < ApplicationController
   private_constant :INDEX_ATTRIBUTES_FOR_SERIALIZATION
 
   def index
-    if !user_signed_in? || less_than_one_day_old?(current_user)
-      # Theoretically, no user should get to this point since they should
-      # already be signed in, but this is here as a safeguard in case they do.
-      @users = default_suggested_users
-      return
-    end
     @users =
       if params[:state] == "follow_suggestions"
         determine_follow_suggestions(current_user)

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -62,6 +62,7 @@ class SiteConfig < RailsSettings::Base
   # Onboarding
   field :onboarding_taskcard_image, type: :string, default: "https://practicaldev-herokuapp-com.freetls.fastly.net/assets/staggered-dev.svg"
   field :suggested_tags, type: :array, default: %w[beginners career computerscience javascript security ruby rails swift kotlin]
+  field :suggested_users, type: :array, default: %w[ben jess peter maestromac andy liana]
 
   # Images
   field :main_social_image, type: :string, default: "https://thepracticaldev.s3.amazonaws.com/i/6hqmcjaxbgbon8ydw93z.png"

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -298,7 +298,7 @@
               <%= f.text_field :suggested_users,
                                class: "form-control",
                                value: SiteConfig.suggested_users.join(","),
-                               placeholder: "List of valid usernames: comma separated, letters only e.g. beginners,javascript,ruby,swift,kotlin" %>
+                               placeholder: "List of valid usernames: comma separated, letters only e.g. ben,jess,peter,maestromac,andy,liana" %>
               <div class="alert alert-info">Determines which users are suggested to follow to new users during onboarding (comma
                 separated, letters only). Please note that these users will be shown as a fallback if no recently-active commenters or producers can be suggested.</div>
             </div>

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -299,8 +299,8 @@
                                class: "form-control",
                                value: SiteConfig.suggested_users.join(","),
                                placeholder: "List of valid usernames: comma separated, letters only e.g. beginners,javascript,ruby,swift,kotlin" %>
-              <div class="alert alert-info">Determines which tags are suggested to new users during onboarding (comma
-                separated, letters only)</div>
+              <div class="alert alert-info">Determines which users are suggested to follow to new users during onboarding (comma
+                separated, letters only). Please note that these users will be shown as a fallback if no recently-active commenters or producers can be suggested.</div>
             </div>
 
             <div class="form-group">

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -294,6 +294,16 @@
             </div>
 
             <div class="form-group">
+              <%= f.label :suggested_users %>
+              <%= f.text_field :suggested_users,
+                               class: "form-control",
+                               value: SiteConfig.suggested_users.join(","),
+                               placeholder: "List of valid usernames: comma separated, letters only e.g. beginners,javascript,ruby,swift,kotlin" %>
+              <div class="alert alert-info">Determines which tags are suggested to new users during onboarding (comma
+                separated, letters only)</div>
+            </div>
+
+            <div class="form-group">
               <%= f.label :suggested_tags %>
               <%= f.text_field :suggested_tags,
                                class: "form-control",

--- a/spec/requests/internal/configs_spec.rb
+++ b/spec/requests/internal/configs_spec.rb
@@ -145,6 +145,16 @@ RSpec.describe "/internal/config", type: :request do
           post "/internal/config", params: { site_config: { suggested_tags: "hey, haha,hoHo, Bobo Fofo" }, confirmation: confirmation_message }
           expect(SiteConfig.suggested_tags).to eq(%w[hey haha hoho bobofofo])
         end
+
+        it "removes space suggested_users" do
+          post "/internal/config", params: { site_config: { suggested_users: "piglet, tigger,eeyore, Christopher Robin, kanga,roo" }, confirmation: confirmation_message }
+          expect(SiteConfig.suggested_users).to eq(%w[piglet tigger eeyore christopherrobin kanga roo])
+        end
+
+        it "downcases suggested_users" do
+          post "/internal/config", params: { site_config: { suggested_users: "piglet, tigger,EEYORE, Christopher Robin, KANGA,RoO" }, confirmation: confirmation_message }
+          expect(SiteConfig.suggested_users).to eq(%w[piglet tigger eeyore christopherrobin kanga roo])
+        end
       end
 
       describe "images" do

--- a/spec/requests/user/user_suggestions_spec.rb
+++ b/spec/requests/user/user_suggestions_spec.rb
@@ -1,69 +1,100 @@
 require "rails_helper"
 
 RSpec.describe "Users", type: :request do
-  describe "GET /users" do
-    it "returns no users if state is not present" do
-      get users_path
+  RSpec.shared_examples "a default suggested_users request" do |path|
+    let(:suggested_users_list) { %w[eeyore] }
+    let!(:suggested_user) { create(:user, name: "Eeyore", username: "eeyore", summary: "I am always sad :(") }
 
-      expect(response).to have_http_status(:ok)
-
-      expect(response.parsed_body).to be_empty
+    before do
+      allow(SiteConfig).to receive(:suggested_users).and_return(suggested_users_list)
     end
 
-    it "returns users from the original core team if they are present" do
-      user = create(:user, username: "ben", summary: "Something something")
-
-      get users_path
+    it "returns the default suggested_users from SiteConfig if they are present" do
+      get path
 
       expect(response).to have_http_status(:ok)
 
       response_user = response.parsed_body.first
-      expect(response_user["id"]).to eq(user.id)
-      expect(response_user["name"]).to eq(user.name)
-      expect(response_user["username"]).to eq(user.username)
-      expect(response_user["summary"]).to eq(user.summary)
-      expect(response_user["profile_image_url"]).to eq(ProfileImage.new(user).get(width: 90))
+      expect(response_user["id"]).to eq(suggested_user.id)
+      expect(response_user["name"]).to eq(suggested_user.name)
+      expect(response_user["username"]).to eq(suggested_user.username)
+      expect(response_user["summary"]).to eq(suggested_user.summary)
+      expect(response_user["profile_image_url"]).to eq(ProfileImage.new(suggested_user).get(width: 90))
       expect(response_user["following"]).to be(false)
     end
+  end
 
-    it "returns follow suggestions for an authenticated user" do
-      user = create(:user)
-      tag = create(:tag)
-      user.follow(tag)
+  describe "GET /users" do
+    let(:user) { create(:user) }
 
-      other_user = create(:user)
-      create(:article, user: other_user, tags: [tag.name])
-
-      sign_in user
-
-      get users_path(state: "follow_suggestions")
-
-      response_user = response.parsed_body.first
-      expect(response_user["id"]).to eq(other_user.id)
+    context "when the user is not signed in" do
+      it_behaves_like "a default suggested_users request", "/users"
     end
 
-    it "returns follow suggestions that have profile images" do
-      user = create(:user)
-      tag = create(:tag)
-      user.follow(tag)
+    context "when no state params are present" do
+      before { sign_in user }
 
-      other_user = create(:user)
-      create(:article, user: other_user, tags: [tag.name])
+      it "returns default suggested_users from SiteConfig if they are present" do
+        get users_path
 
-      sign_in user
-
-      get users_path(state: "follow_suggestions")
-
-      response_user = response.parsed_body.first
-      expect(response_user["profile_image_url"]).to eq(other_user.profile_image_url)
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to be_empty
+      end
     end
 
-    it "returns no sidebar suggestions for an authenticated user" do
-      sign_in create(:user)
+    context "when follow_suggestions params are present and no suggestions are found" do
+      let(:my_instance) { instance_double(Suggester::Users::Recent) }
 
-      get users_path(state: "sidebar_suggestions")
+      before do
+        allow(Suggester::Users::Recent).to receive(:new).and_return(my_instance)
+        allow(my_instance).to receive(:suggest).and_return([])
+      end
 
-      expect(response.parsed_body).to be_empty
+      it_behaves_like "a default suggested_users request", "/users"
+    end
+
+    context "when follow_suggestions params are present" do
+      it "returns follow suggestions for an authenticated user" do
+        user = create(:user)
+        tag = create(:tag)
+        user.follow(tag)
+
+        other_user = create(:user)
+        create(:article, user: other_user, tags: [tag.name])
+
+        sign_in user
+
+        get users_path(state: "follow_suggestions")
+
+        response_user = response.parsed_body.first
+        expect(response_user["id"]).to eq(other_user.id)
+      end
+
+      it "returns follow suggestions that have profile images" do
+        user = create(:user)
+        tag = create(:tag)
+        user.follow(tag)
+
+        other_user = create(:user)
+        create(:article, user: other_user, tags: [tag.name])
+
+        sign_in user
+
+        get users_path(state: "follow_suggestions")
+
+        response_user = response.parsed_body.first
+        expect(response_user["profile_image_url"]).to eq(other_user.profile_image_url)
+      end
+    end
+
+    context "when sidebar_suggestions params are present" do
+      it "returns no sidebar suggestions for an authenticated user" do
+        sign_in create(:user)
+
+        get users_path(state: "sidebar_suggestions")
+
+        expect(response.parsed_body).to be_empty
+      end
     end
   end
 end

--- a/spec/requests/user/user_suggestions_spec.rb
+++ b/spec/requests/user/user_suggestions_spec.rb
@@ -1,40 +1,18 @@
 require "rails_helper"
 
 RSpec.describe "Users", type: :request do
-  RSpec.shared_examples "a default suggested_users request" do |path|
-    let(:suggested_users_list) { %w[eeyore] }
+  describe "GET /users" do
+    let(:user) { create(:user) }
+    let!(:suggested_users_list) { %w[eeyore] }
     let!(:suggested_user) { create(:user, name: "Eeyore", username: "eeyore", summary: "I am always sad :(") }
 
     before do
       allow(SiteConfig).to receive(:suggested_users).and_return(suggested_users_list)
     end
 
-    it "returns the default suggested_users from SiteConfig if they are present" do
-      get path
-
-      expect(response).to have_http_status(:ok)
-
-      response_user = response.parsed_body.first
-      expect(response_user["id"]).to eq(suggested_user.id)
-      expect(response_user["name"]).to eq(suggested_user.name)
-      expect(response_user["username"]).to eq(suggested_user.username)
-      expect(response_user["summary"]).to eq(suggested_user.summary)
-      expect(response_user["profile_image_url"]).to eq(ProfileImage.new(suggested_user).get(width: 90))
-      expect(response_user["following"]).to be(false)
-    end
-  end
-
-  describe "GET /users" do
-    let(:user) { create(:user) }
-
-    context "when the user is not signed in" do
-      it_behaves_like "a default suggested_users request", "/users"
-    end
-
     context "when no state params are present" do
-      before { sign_in user }
-
-      it "returns default suggested_users from SiteConfig if they are present" do
+      it "returns no users" do
+        sign_in user
         get users_path
 
         expect(response).to have_http_status(:ok)
@@ -43,14 +21,21 @@ RSpec.describe "Users", type: :request do
     end
 
     context "when follow_suggestions params are present and no suggestions are found" do
-      let(:my_instance) { instance_double(Suggester::Users::Recent) }
+      it "returns the default suggested_users from SiteConfig if they are present" do
+        sign_in user
 
-      before do
-        allow(Suggester::Users::Recent).to receive(:new).and_return(my_instance)
-        allow(my_instance).to receive(:suggest).and_return([])
+        get users_path(state: "follow_suggestions")
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body.first).to include(
+          "id" => suggested_user.id,
+          "name" => suggested_user.name,
+          "username" => suggested_user.username,
+          "summary" => suggested_user.summary,
+          "profile_image_url" => ProfileImage.new(suggested_user).get(width: 90),
+          "following" => false,
+        )
       end
-
-      it_behaves_like "a default suggested_users request", "/users"
     end
 
     context "when follow_suggestions params are present" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
- [x] Allows the onboarding "follow users" slide to be configured by admins.
- [x] Also does some refactoring of the `user_suggestions_spec.rb` spec.

## Related Tickets & Documents
Closes https://github.com/thepracticaldev/dev.to/issues/7106.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
The suggested "users to follow" can now be set by admins via the `SiteConfig`:
<img width="1123" alt="Screen_Shot_2020-04-30_at_2_12_00_PM" src="https://user-images.githubusercontent.com/6921610/80759995-0b519680-8aed-11ea-91a2-2b4e58e16937.png">

Those suggested default users will show up in onboarding as a fallback:
<img width="822" alt="Screen_Shot_2020-04-30_at_11_24_01_AM" src="https://user-images.githubusercontent.com/6921610/80760002-0e4c8700-8aed-11ea-9fc5-2030ed881891.png">


## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed (although I added some comments internally)