### PR TITLE
Update bin/setup's db setup logic

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -4,16 +4,6 @@ require "fileutils"
 # path to your application root.
 APP_ROOT = File.expand_path("..", __dir__)
 
-db_url = ENV["DATABASE_URL"].to_s
-
-# We explicitly unset DATABASE_URL for Gitpod so bin/setup can do its job.
-# See: https://github.com/thepracticaldev/dev.to/issues/7040
-DB = if db_url.to_s.empty? || db_url == "postgresql://gitpod@localhost"
-       "PracticalDeveloper_development"
-     else
-       db_url
-     end
-
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")
 end
@@ -42,11 +32,7 @@ FileUtils.chdir APP_ROOT do
   system! 'RAILS_ENV="test" bin/rails search:setup'
 
   puts "\n== Preparing database =="
-  command = "psql -o /dev/null -q -n -c 'select 1' #{DB}"
-  db_exists = system(command)
-  if db_exists
-    system! "bin/rails db:migrate"
-  else
+  unless system("bin/rails db:migrate")
     system! "bin/rails db:setup"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -372,49 +372,6 @@ end
 ##############################################################################
 
 counter += 1
-Rails.logger.info "#{counter}. Creating Classified Listings"
-
-users_in_random_order.each { |user| Credit.add_to(user, rand(100)) }
-users = users_in_random_order.to_a
-
-listings_categories = ClassifiedListingCategory.pluck(:id)
-listings_categories.each.with_index(1) do |category_id, index|
-  # rotate users if they are less than the categories
-  user = users.at(index % users.length)
-  2.times do
-    ClassifiedListing.create!(
-      user: user,
-      title: Faker::Lorem.sentence,
-      body_markdown: Faker::Markdown.random,
-      location: Faker::Address.city,
-      organization_id: user.organizations.first&.id,
-      classified_listing_category_id: category_id,
-      contact_via_connect: true,
-      published: true,
-      bumped_at: Time.current,
-      tag_list: Tag.order(Arel.sql("RANDOM()")).first(2).pluck(:name),
-    )
-  end
-end
-
-##############################################################################
-
-counter += 1
-Rails.logger.info "#{counter}. Creating Pages"
-
-5.times do
-  Page.create!(
-    title: Faker::Hacker.say_something_smart,
-    body_markdown: Faker::Markdown.random,
-    slug: Faker::Internet.slug,
-    description: Faker::Books::Dune.quote,
-    template: %w[contained full_within_layout].sample,
-  )
-end
-
-##############################################################################
-
-counter += 1
 Rails.logger.info "#{counter}. Creating Classified Listing Categories"
 
 CATEGORIES = [


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix/DX

## Description
Instead of trying to check if a database exists, this change will run db:migrate and it will run db:setup as a backup. This is more inline with how [Rails 6 will handle this](https://github.com/rails/rails/blob/98754de1412870d7dae9eba1c7bac944b9b90093/activerecord/lib/active_record/railties/databases.rake#L311). The downside is new contributor will see an error briefly. 😬 

I made this change because I rely on `DATABASE_URL` to access postgresql in Docker; Checking if database exist with `psql -o /dev/null...` does not work for me and I can't think of a way for `bin/setup` to access env var in `application.yml`.

Also, I removed dome dupe seeds.
## Related Tickets & Documents
n/a
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
n/a
## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a