### PR TITLE
Remove ClassifiedListing.categories_available.keys in seed

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -423,10 +423,10 @@ Rails.logger.info "#{counter}. Creating Classified Listings"
 users_in_random_order.each { |user| Credit.add_to(user, rand(100)) }
 users = users_in_random_order.to_a
 
-listings_categories = ClassifiedListing.categories_available.keys
-listings_categories.each_with_index do |category, index|
+listings_categories = ClassifiedListingCategory.pluck(:id)
+listings_categories.each.with_index(1) do |category_id, index|
   # rotate users if they are less than the categories
-  user = users.at((index + 1) % users.length)
+  user = users.at(index % users.length)
   2.times do
     ClassifiedListing.create!(
       user: user,
@@ -434,7 +434,7 @@ listings_categories.each_with_index do |category, index|
       body_markdown: Faker::Markdown.random,
       location: Faker::Address.city,
       organization_id: user.organizations.first&.id,
-      category: category,
+      classified_listing_category_id: category_id,
       contact_via_connect: true,
       published: true,
       bumped_at: Time.current,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
The combination of changes in https://github.com/thepracticaldev/dev.to/pull/7498 and https://github.com/thepracticaldev/dev.to/pull/7512 and how rails helper is loaded messed me up. Anyway I get this error randomly when I try to set up my db.

```
NoMethodError: undefined method `categories_available' for #<Class:0x000000000e2c75f0>
/home/mac/dev.to/db/seeds.rb:426:in `<main>'
bin/rails:4:in `<main>'
Tasks: TOP => db:reset => db:setup => db:seed
(See full trace by running task with --trace)
```
This fixes it by not using `ClassifiedListing.categories_available.keys`

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a