### PR TITLE
Add proper 301 status to username change redirects

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -81,7 +81,7 @@ class StoriesController < ApplicationController
     user_or_org = User.find_by("old_username = ? OR old_old_username = ?", potential_username, potential_username) ||
       Organization.find_by("old_slug = ? OR old_old_slug = ?", potential_username, potential_username)
     if user_or_org.present? && !user_or_org.decorate.fully_banished?
-      redirect_to user_or_org.path
+      redirect_to user_or_org.path, status: :moved_permanently
     else
       not_found
     end
@@ -91,10 +91,10 @@ class StoriesController < ApplicationController
     potential_username = params[:username].tr("@", "").downcase
     @user = User.find_by("old_username = ? OR old_old_username = ?", potential_username, potential_username)
     if @user&.articles&.find_by(slug: params[:slug])
-      redirect_to URI.parse("/#{@user.username}/#{params[:slug]}").path
+      redirect_to URI.parse("/#{@user.username}/#{params[:slug]}").path, status: :moved_permanently
       return
     elsif (@organization = @article.organization)
-      redirect_to URI.parse("/#{@organization.slug}/#{params[:slug]}").path
+      redirect_to URI.parse("/#{@organization.slug}/#{params[:slug]}").path, status: :moved_permanently
       return
     end
     not_found
@@ -121,7 +121,7 @@ class StoriesController < ApplicationController
     @tag_model = Tag.find_by(name: @tag) || not_found
     @moderators = User.with_role(:tag_moderator, @tag_model).select(:username, :profile_image, :id)
     if @tag_model.alias_for.present?
-      redirect_to "/t/#{@tag_model.alias_for}"
+      redirect_to "/t/#{@tag_model.alias_for}", status: :moved_permanently
       return
     end
 

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -240,6 +240,7 @@ RSpec.describe "StoriesIndex", type: :request do
       tag2 = create(:tag, alias_for: tag.name)
       get "/t/#{tag2.name}"
       expect(response.body).to redirect_to "/t/#{tag.name}"
+      expect(response).to have_http_status(:moved_permanently)
     end
 
     it "does not render sponsor if not live" do

--- a/spec/requests/stories_show_spec.rb
+++ b/spec/requests/stories_show_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "StoriesShow", type: :request do
       article.update(organization: org)
       get old_path
       expect(response.body).to redirect_to article.path
+      expect(response).to have_http_status(:moved_permanently)
     end
 
     it "renders second and third users if present" do
@@ -90,6 +91,7 @@ RSpec.describe "StoriesShow", type: :request do
       user.update(username: "new_hotness_#{rand(10_000)}")
       get "/#{old_username}/#{article.slug}"
       expect(response.body).to redirect_to("/#{user.username}/#{article.slug}")
+      expect(response).to have_http_status(:moved_permanently)
     end
 
     it "redirects to appropriate page if user changes username twice" do
@@ -98,6 +100,7 @@ RSpec.describe "StoriesShow", type: :request do
       user.update(username: "new_new_username_#{rand(10_000)}")
       get "/#{old_username}/#{article.slug}"
       expect(response.body).to redirect_to("/#{user.username}/#{article.slug}")
+      expect(response).to have_http_status(:moved_permanently)
     end
 
     it "redirects to appropriate page if user changes username twice and go to middle username" do
@@ -106,6 +109,7 @@ RSpec.describe "StoriesShow", type: :request do
       user.update(username: "new_new_username_#{rand(10_000)}")
       get "/#{middle_username}/#{article.slug}"
       expect(response.body).to redirect_to("/#{user.username}/#{article.slug}")
+      expect(response).to have_http_status(:moved_permanently)
     end
 
     it "renders canonical url when exists" do
@@ -167,6 +171,7 @@ RSpec.describe "StoriesShow", type: :request do
       org.update(slug: "somethingnew")
       get "/#{original_slug}"
       expect(response.body).to redirect_to org.path
+      expect(response).to have_http_status(:moved_permanently)
     end
 
     it "redirects to the appropriate page if given an organization's old old slug" do
@@ -175,6 +180,7 @@ RSpec.describe "StoriesShow", type: :request do
       org.update(slug: "anothernewslug")
       get "/#{original_slug}"
       expect(response.body).to redirect_to org.path
+      expect(response).to have_http_status(:moved_permanently)
     end
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Current redirects for situations where a user changed their username etc. should be 301: Moved Permanently. This is the proper status for search engines etc. vs the current 302 default which is not meant for this kind of redirect.