### PR TITLE
Adds an extra check for Android Native app for playing podcasts

### DIFF
--- a/app/assets/javascripts/initializers/initializePodcastPlayback.js
+++ b/app/assets/javascripts/initializers/initializePodcastPlayback.js
@@ -114,7 +114,8 @@ function initializePodcastPlayback() {
     return (
       navigator.userAgent === 'DEV-Native-android' &&
       typeof AndroidBridge !== 'undefined' &&
-      AndroidBridge !== null
+      AndroidBridge !== null &&
+      AndroidBridge.metadataPodcast !== undefined
     );
   }
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Since we merged #7554 I ran a quick test and found out we do have older native app versions that won't be able to play podcasts because **they do have** `DEV-Native-android` as user agent but the native bridge side is still not implemented. 

This simple check fixes this issue by falling back to the full on web player until the users have a a version installed that does include the necessary native functions.

## Related Tickets & Documents

#7554 

When the native side is in production (https://github.com/thepracticaldev/DEV-Android/pull/72) we can have this check removed although it wouldn't hurt to keep it for a while since not everyone updates immediately

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![double check](https://media.giphy.com/media/3o6nV2K1jBuanc9ffa/giphy.gif)
