### PR TITLE
Fix showing "Remove OAuth" in settings with disabled identities

### DIFF
--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -1,6 +1,8 @@
 class Identity < ApplicationRecord
   belongs_to :user
-  has_many  :backup_data, as: :instance, class_name: "BackupData", dependent: :destroy
+  has_many :backup_data, as: :instance, class_name: "BackupData", dependent: :destroy
+
+  scope :enabled, -> { where(provider: Authentication::Providers.enabled) }
 
   validates :uid, :provider, presence: true
   validates :uid, uniqueness: { scope: :provider }, if: proc { |identity| identity.uid_changed? || identity.provider_changed? }

--- a/app/views/users/_account.html.erb
+++ b/app/views/users/_account.html.erb
@@ -45,7 +45,7 @@
 <div class="crayons-box crayons-box--danger p-6 grid gap-6">
   <h2 class="color-accent-danger">Danger Zone</h2>
 
-  <% if @user.identities.size > 1 %>
+  <% if @user.identities.enabled.size > 1 %>
     <div class="grid gap-2">
       <h3>Remove OAuth Associations</h3>
       <p>You can remove one of your authentication methods. We'll still need one to authenticate you.</p>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

There's a scenario in which the "remove oauth accounts" section in `Settings -> Account` should not appear:

1. a user has multiple identities
1. one of the related providers is disabled by an admin
1. the user can now disconnect their only visible identity/provider

This last step shouldn't be allowed

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

**user has 2 identities, but there's only 1 provider enabled**

![Screenshot_2020-05-04 DEV(local) Community](https://user-images.githubusercontent.com/146201/80964796-c772d000-8e11-11ea-8e47-34bf24ee20d1.png)

**before**

![Screenshot_2020-05-04 Settings - DEV(local) Community 👩‍💻👨‍💻](https://user-images.githubusercontent.com/146201/80964816-ce014780-8e11-11ea-8bc3-460fa7d32e04.png)

**after**

![Screenshot_2020-05-04 Settings - DEV(local) Community 👩‍💻👨‍💻(1)](https://user-images.githubusercontent.com/146201/80964833-d2c5fb80-8e11-11ea-9edd-1d405b89550b.png)

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
