### PR TITLE
Remove FASTLY_SAFE_PARAMS_SNIPPET_NAME env var

### DIFF
--- a/Envfile
+++ b/Envfile
@@ -107,7 +107,6 @@ variable :HCTI_API_KEY, :String, default: "Optional"
 # (https://docs.fastly.com/api/)
 variable :FASTLY_API_KEY, :String, default: ""
 variable :FASTLY_SERVICE_ID, :String, default: ""
-variable :FASTLY_SAFE_PARAMS_SNIPPET_NAME, :String, default: ""
 
 # Honeycomb for monitoring and observability
 # (https://www.honeycomb.io/)


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
In #7654 I forgot to remove `FASTLY_SAFE_PARAMS_SNIPPET_NAME` from the Envfile.

## Related Tickets & Documents
#7654

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## Are there any post deployment tasks we need to perform?
Remove `FASTLY_SAFE_PARAMS_SNIPPET_NAME` from Heroku cc @mstruve 

![oopsie_gif](https://media.giphy.com/media/67urFpVn7qwcd2gWIl/giphy.gif)
