### PR TITLE
Refactor JSON-LD Within user_show_spec to Improve Testing

### DIFF
--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -144,5 +144,26 @@ FactoryBot.define do
         create(:user_optional_field, user: user, label: "another field2", value: "another value2")
       end
     end
+
+    trait :with_all_info do
+      education { "DEV University" }
+      employment_title { "Software Engineer" }
+      employer_name { "DEV" }
+      employer_url { "http://dev.to" }
+      currently_learning { "Preact" }
+      mostly_work_with { "Ruby" }
+      currently_hacking_on { "JSON-LD" }
+      mastodon_url { "https://mastodon.social/@test" }
+      facebook_url { "www.facebook.com/example" }
+      linkedin_url { "www.linkedin.com/company/example/" }
+      youtube_url { "https://youtube.com/example" }
+      behance_url { "www.behance.net/#{username}" }
+      stackoverflow_url { "www.stackoverflow.com/example" }
+      dribbble_url { "www.dribbble.com/example" }
+      medium_url { "www.medium.com/example" }
+      gitlab_url { "www.gitlab.com/example" }
+      instagram_url { "www.instagram.com/example" }
+      twitch_username { "Example007" }
+    end
   end
 end

--- a/spec/requests/user/user_show_spec.rb
+++ b/spec/requests/user/user_show_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "UserShow", type: :request do
-  let_it_be(:user) { create(:user, email_public: true, education: "DEV University") }
+  let_it_be(:user) { create(:user, :with_all_info, email_public: true) }
   let(:doc) { Nokogiri::HTML(response.body) }
   let(:text) { doc.at('script[type="application/ld+json"]').text }
   let(:response_json) { JSON.parse(text) }
@@ -37,26 +37,6 @@ RSpec.describe "UserShow", type: :request do
 
   describe "GET /:slug (user)" do
     before do
-      user.update_columns(
-        employment_title: "SEO",
-        employer_name: "DEV",
-        employer_url: "www.dev.to",
-        currently_learning: "Preact",
-        mostly_work_with: "Ruby",
-        currently_hacking_on: "JSON-LD",
-        mastodon_url: "www.example.com",
-        facebook_url: "www.facebook.com/example",
-        linkedin_url: "www.linkedin.com/company/example/",
-        youtube_url: "www.youtube.com/example",
-        behance_url: "www.behance.com/example",
-        stackoverflow_url: "www.stackoverflow.com/example",
-        dribbble_url: "www.dribbble.com/example",
-        medium_url: "www.medium.com/example",
-        gitlab_url: "www.gitlab.com/example",
-        instagram_url: "www.instagram.com/example",
-        twitch_username: "Example007",
-        website_url: "www.example.com/example",
-      )
       get user.path
     end
 

--- a/spec/requests/user/user_show_spec.rb
+++ b/spec/requests/user/user_show_spec.rb
@@ -5,35 +5,6 @@ RSpec.describe "UserShow", type: :request do
   let(:doc) { Nokogiri::HTML(response.body) }
   let(:text) { doc.at('script[type="application/ld+json"]').text }
   let(:response_json) { JSON.parse(text) }
-  let(:main_entity_of_page) { { "@type" => "WebPage", "@id" => URL.user(user) } }
-  let(:same_as) do
-    [
-      "https://twitter.com/#{user.twitter_username}",
-      "https://github.com/#{user.github_username}",
-      user.mastodon_url,
-      user.facebook_url,
-      user.youtube_url,
-      user.linkedin_url,
-      user.behance_url,
-      user.stackoverflow_url,
-      user.dribbble_url,
-      user.medium_url,
-      user.gitlab_url,
-      user.instagram_url,
-      user.twitch_username,
-      user.website_url,
-    ]
-  end
-
-  let(:disambiguating_description) do
-    [
-      user.mostly_work_with,
-      user.currently_hacking_on,
-      user.currently_learning,
-    ]
-  end
-
-  let(:works_for) { [{ "@type" => "Organization", "name" => user.employer_name, "url" => user.employer_url }] }
 
   describe "GET /:slug (user)" do
     before do
@@ -44,23 +15,53 @@ RSpec.describe "UserShow", type: :request do
       expect(response).to have_http_status(:ok)
     end
 
+    # rubocop:disable Rspec/ExampleLength
     it "renders the proper JSON-LD for a user" do
       expect(response_json).to include(
         "@context" => "http://schema.org",
         "@type" => "Person",
-        "mainEntityOfPage" => main_entity_of_page,
+        "mainEntityOfPage" => {
+          "@type" => "WebPage",
+          "@id" => URL.user(user)
+        },
         "url" => URL.user(user),
-        "sameAs" => same_as,
+        "sameAs" => [
+          "https://twitter.com/#{user.twitter_username}",
+          "https://github.com/#{user.github_username}",
+          user.mastodon_url,
+          user.facebook_url,
+          user.youtube_url,
+          user.linkedin_url,
+          user.behance_url,
+          user.stackoverflow_url,
+          user.dribbble_url,
+          user.medium_url,
+          user.gitlab_url,
+          user.instagram_url,
+          user.twitch_username,
+          user.website_url,
+        ],
         "image" => ProfileImage.new(user).get(width: 320),
         "name" => user.name,
         "email" => user.email,
         "jobTitle" => user.employment_title,
         "description" => user.summary,
-        "disambiguatingDescription" => disambiguating_description,
-        "worksFor" => works_for,
+        "disambiguatingDescription" => [
+          user.mostly_work_with,
+          user.currently_hacking_on,
+          user.currently_learning,
+        ],
+        "worksFor" => [
+          {
+            "@type" => "Organization",
+            "name" => user.employer_name,
+            "url" => user.employer_url
+          },
+        ],
         "alumniOf" => user.education,
       )
     end
+    # rubocop:enable Rspec/ExampleLength
   end
 
   context "when user signed in" do

--- a/spec/requests/user/user_show_spec.rb
+++ b/spec/requests/user/user_show_spec.rb
@@ -37,12 +37,26 @@ RSpec.describe "UserShow", type: :request do
 
   describe "GET /:slug (user)" do
     before do
-      user.update_columns(employment_title: "SEO", employer_name: "DEV", employer_url: "www.dev.to")
-      user.update_columns(currently_learning: "Preact", mostly_work_with: "Ruby", currently_hacking_on: "JSON-LD")
-      user.update_columns(mastodon_url: "www.example.com", facebook_url: "www.facebook.com/example", linkedin_url: "www.linkedin.com/company/example/")
-      user.update_columns(youtube_url: "www.youtube.com/example", behance_url: "www.behance.com/example", stackoverflow_url: "www.stackoverflow.com/example")
-      user.update_columns(dribbble_url: "www.dribbble.com/example", medium_url: "www.medium.com/example", gitlab_url: "www.gitlab.com/example")
-      user.update_columns(instagram_url: "www.instagram.com/example", twitch_username: "Example007", website_url: "www.example.com/example")
+      user.update_columns(
+        employment_title: "SEO",
+        employer_name: "DEV",
+        employer_url: "www.dev.to",
+        currently_learning: "Preact",
+        mostly_work_with: "Ruby",
+        currently_hacking_on: "JSON-LD",
+        mastodon_url: "www.example.com",
+        facebook_url: "www.facebook.com/example",
+        linkedin_url: "www.linkedin.com/company/example/",
+        youtube_url: "www.youtube.com/example",
+        behance_url: "www.behance.com/example",
+        stackoverflow_url: "www.stackoverflow.com/example",
+        dribbble_url: "www.dribbble.com/example",
+        medium_url: "www.medium.com/example",
+        gitlab_url: "www.gitlab.com/example",
+        instagram_url: "www.instagram.com/example",
+        twitch_username: "Example007",
+        website_url: "www.example.com/example",
+      )
       get user.path
     end
 

--- a/spec/requests/user/user_show_spec.rb
+++ b/spec/requests/user/user_show_spec.rb
@@ -1,11 +1,48 @@
 require "rails_helper"
 
 RSpec.describe "UserShow", type: :request do
-  let_it_be(:user) { create(:user, email_public: true, currently_hacking_on: "JSON-LD", education: "DEV University") }
+  let_it_be(:user) { create(:user, email_public: true, education: "DEV University") }
+  let(:doc) { Nokogiri::HTML(response.body) }
+  let(:text) { doc.at('script[type="application/ld+json"]').text }
+  let(:response_json) { JSON.parse(text) }
+  let(:main_entity_of_page) { { "@type" => "WebPage", "@id" => URL.user(user) } }
+  let(:same_as) do
+    [
+      "https://twitter.com/#{user.twitter_username}",
+      "https://github.com/#{user.github_username}",
+      user.mastodon_url,
+      user.facebook_url,
+      user.youtube_url,
+      user.linkedin_url,
+      user.behance_url,
+      user.stackoverflow_url,
+      user.dribbble_url,
+      user.medium_url,
+      user.gitlab_url,
+      user.instagram_url,
+      user.twitch_username,
+      user.website_url,
+    ]
+  end
+
+  let(:disambiguating_description) do
+    [
+      user.mostly_work_with,
+      user.currently_hacking_on,
+      user.currently_learning,
+    ]
+  end
+
+  let(:works_for) { [{ "@type" => "Organization", "name" => user.employer_name, "url" => user.employer_url }] }
 
   describe "GET /:slug (user)" do
     before do
-      user.update_columns(employment_title: "SEO", employer_name: "DEV", linkedin_url: "www.linkedin.com/company/example/")
+      user.update_columns(employment_title: "SEO", employer_name: "DEV", employer_url: "www.dev.to")
+      user.update_columns(currently_learning: "Preact", mostly_work_with: "Ruby", currently_hacking_on: "JSON-LD")
+      user.update_columns(mastodon_url: "www.example.com", facebook_url: "www.facebook.com/example", linkedin_url: "www.linkedin.com/company/example/")
+      user.update_columns(youtube_url: "www.youtube.com/example", behance_url: "www.behance.com/example", stackoverflow_url: "www.stackoverflow.com/example")
+      user.update_columns(dribbble_url: "www.dribbble.com/example", medium_url: "www.medium.com/example", gitlab_url: "www.gitlab.com/example")
+      user.update_columns(instagram_url: "www.instagram.com/example", twitch_username: "Example007", website_url: "www.example.com/example")
       get user.path
     end
 
@@ -13,40 +50,22 @@ RSpec.describe "UserShow", type: :request do
       expect(response).to have_http_status(:ok)
     end
 
-    it "renders the proper username for a user" do
-      expect(response.body).to include CGI.escapeHTML(user.username)
-    end
-
-    it "renders the proper bio for a user" do
-      expect(response.body).to include CGI.escapeHTML(user.summary)
-    end
-
-    it "renders the proper education for a user" do
-      expect(response.body).to include CGI.escapeHTML(user.education)
-    end
-
-    it "renders the proper currently hacking on info for a user" do
-      expect(response.body).to include CGI.escapeHTML(user.currently_hacking_on)
-    end
-
-    it "renders the proper job title for a user" do
-      expect(response.body).to include CGI.escapeHTML(user.employment_title)
-    end
-
-    it "renders the proper employer name for a user" do
-      expect(response.body).to include CGI.escapeHTML(user.employer_name)
-    end
-
-    it "renders the proper linkedin url for a user" do
-      expect(response.body).to include CGI.escapeHTML(user.linkedin_url)
-    end
-
-    it "renders the proper additional username for a user when one is present" do
-      expect(response.body).to include CGI.escapeHTML(user.github_username)
-    end
-
-    it "renders the proper email for a user when one is public and present" do
-      expect(response.body).to include CGI.escapeHTML(user.email)
+    it "renders the proper JSON-LD for a user" do
+      expect(response_json).to include(
+        "@context" => "http://schema.org",
+        "@type" => "Person",
+        "mainEntityOfPage" => main_entity_of_page,
+        "url" => URL.user(user),
+        "sameAs" => same_as,
+        "image" => ProfileImage.new(user).get(width: 320),
+        "name" => user.name,
+        "email" => user.email,
+        "jobTitle" => user.employment_title,
+        "description" => user.summary,
+        "disambiguatingDescription" => disambiguating_description,
+        "worksFor" => works_for,
+        "alumniOf" => user.education,
+      )
     end
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
While the original implementation worked, this PR refactors the `user_show_spec.rb` to better test the JSON-LD data within the `Stories::Controller`. 

Rather than having multiple single-line expectations, the spec now tests against the JSON-LD in one test. In addition to being more concise, the spec now tests for more data and does so against the actual data structure by parsing the data after grabbing the `response.body` with Nokogiri.

These improvements should make refactoring the actual JSON-LD (see issue #7495 ) within the `Stories::Controller` easier and should overall make the `user_show_spec.rb` stronger.

## Related Tickets & Documents
Relates to #7495 - this is the initial refactor needed to ensure further refactoring is accurate

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![Cats Cleaning](https://media.giphy.com/media/WdIaMQ6bLlvtm/giphy.gif)
