### PR TITLE
Change string concatenation to interpolation

### DIFF
--- a/app/controllers/concerns/valid_request.rb
+++ b/app/controllers/concerns/valid_request.rb
@@ -22,12 +22,12 @@ module ValidRequest
     case options
     # Yet another monkeypatch required to send proper protocol out.
     # In this case we make sure the redirect ends in the app protocol.
-    # This is the same as the base Rails method except ApplicationConfig["APP_PROTOCOL"]
+    # This is the same as the base Rails method except URL.protocol
     # is used instead of request.protocol.
     when /\A([a-z][a-z\d\-+\.]*:|\/\/).*/i
       options
     when String
-      (URL.protocol || request.protocol) + request.host_with_port + options
+      "#{(URL.protocol || request.protocol)}#{request.host_with_port}#{options}"
     when Proc
       _compute_redirect_to_location request, instance_eval(&options)
     else

--- a/app/controllers/concerns/valid_request.rb
+++ b/app/controllers/concerns/valid_request.rb
@@ -10,7 +10,7 @@ module ValidRequest
     return if Rails.env.test?
 
     if request.referer.present?
-      request.referer.start_with?(ApplicationConfig["APP_PROTOCOL"].to_s + ApplicationConfig["APP_DOMAIN"].to_s)
+      request.referer.start_with?(URL.url)
     else
       raise ::ActionController::InvalidAuthenticityToken, ::ApplicationController::NULL_ORIGIN_MESSAGE if request.origin == "null"
 
@@ -27,7 +27,7 @@ module ValidRequest
     when /\A([a-z][a-z\d\-+\.]*:|\/\/).*/i
       options
     when String
-      (ApplicationConfig["APP_PROTOCOL"] || request.protocol) + request.host_with_port + options
+      (URL.protocol || request.protocol) + request.host_with_port + options
     when Proc
       _compute_redirect_to_location request, instance_eval(&options)
     else

--- a/app/liquid_tags/organization_tag.rb
+++ b/app/liquid_tags/organization_tag.rb
@@ -13,7 +13,7 @@ class OrganizationTag < LiquidTagBase
     ActionController::Base.new.render_to_string(
       partial: PARTIAL,
       locals: {
-        organization: @organization,
+        organization: @organization.decorate,
         follow_button: @follow_button,
         organization_colors: @organization_colors
       },

--- a/app/liquid_tags/user_tag.rb
+++ b/app/liquid_tags/user_tag.rb
@@ -13,7 +13,7 @@ class UserTag < LiquidTagBase
     ActionController::Base.new.render_to_string(
       partial: PARTIAL,
       locals: {
-        user: @user,
+        user: @user.decorate,
         follow_button: @follow_button,
         user_colors: @user_colors
       },

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -408,7 +408,7 @@ class Article < ApplicationRecord
   end
 
   def liquid_tags_used
-    MarkdownParser.new(body_markdown.to_s + comments_blob.to_s).tags_used
+    MarkdownParser.new("#{body_markdown}#{comments_blob}").tags_used
   rescue StandardError
     []
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -40,8 +40,8 @@ class Event < ApplicationRecord
   end
 
   def title_to_slug
-    downcase = (id.to_s + "-" + category + "-" + title).to_s
-    downcase.parameterize + "-" + starts_at.strftime("%m-%d-%Y")
+    downcase = "#{id}-#{category}-#{title}"
+    "#{downcase.parameterize}-#{starts_at.strftime('%m-%d-%Y')}"
   end
 
   def bust_cache

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -577,7 +577,7 @@ class User < ApplicationRecord
   end
 
   def tag_keywords_for_search
-    employer_name.to_s + mostly_work_with.to_s + available_for.to_s
+    "#{employer_name}#{mostly_work_with}#{available_for}"
   end
 
   def search_score

--- a/app/views/organizations/_liquid.html.erb
+++ b/app/views/organizations/_liquid.html.erb
@@ -1,4 +1,4 @@
-<div class="<%= "ltag__user ltag__user__id__" + organization.id.to_s %>" style="<%= "border-color:" + organization.decorate.darker_color + ";box-shadow: 3px 3px 0px " + organization.decorate.darker_color + ";" %>">
+<div class="<%= "ltag__user ltag__user__id__#{organization.id}" %>" style="<%= "border-color:#{organization.darker_color};box-shadow: 3px 3px 0px #{organization.darker_color};" %>">
   <style>
     .ltag__user__id__<%= organization.id %> .follow-action-button {
       background-color: <%= organization_colors[:bg] %> !important;

--- a/app/views/users/_liquid.html.erb
+++ b/app/views/users/_liquid.html.erb
@@ -1,4 +1,4 @@
-<div class="<%= "ltag__user ltag__user__id__" + user.id.to_s %>" style="<%= "border-color:" + user.decorate.darker_color + ";box-shadow: 3px 3px 0px " + user.decorate.darker_color + ";" %>">
+<div class="<%= "ltag__user ltag__user__id__#{user.id}" %>" style="<%= "border-color:#{user.darker_color};box-shadow: 3px 3px 0px #{user.darker_color};" %>">
   <style>
     .ltag__user__id__<%= user.id %> .follow-action-button {
       background-color: <%= user_colors[:bg] %> !important;
@@ -8,7 +8,7 @@
   </style>
   <a href="<%= user.path %>" class="ltag__user__link profile-image-link">
     <div class="ltag__user__pic">
-      <img src="<%= ProfileImage.new(user).get(width: 150) %>" alt="<%= user.username + " image" %>" />
+      <img src="<%= ProfileImage.new(user).get(width: 150) %>" alt="<%= "#{user.username} image" %>" />
     </div>
   </a>
   <div class="ltag__user__content">

--- a/spec/labor/cache_buster_spec.rb
+++ b/spec/labor/cache_buster_spec.rb
@@ -96,9 +96,9 @@ RSpec.describe CacheBuster, type: :labor do
     it "busts a user" do
       allow(cache_buster).to receive(:bust)
       cache_buster.bust_user(user)
-      expect(cache_buster).to have_received(:bust).with("/" + user.username.to_s)
-      expect(cache_buster).to have_received(:bust).with("/" + user.username.to_s + "/comments?i=i")
-      expect(cache_buster).to have_received(:bust).with("/feed/" + user.username.to_s)
+      expect(cache_buster).to have_received(:bust).with("/#{user.username}")
+      expect(cache_buster).to have_received(:bust).with("/#{user.username}/comments?i=i")
+      expect(cache_buster).to have_received(:bust).with("/feed/#{user.username}")
     end
   end
 end

--- a/spec/requests/page_views_spec.rb
+++ b/spec/requests/page_views_spec.rb
@@ -107,13 +107,13 @@ RSpec.describe "PageViews", type: :request do
 
       it "updates a new page view time on page by 15" do
         post "/page_views", params: { article_id: article.id }
-        put "/page_views/" + article.id.to_s
+        put "/page_views/#{article.id}"
         expect(PageView.last.time_tracked_in_seconds).to eq(30)
       end
 
       it "does not update an invalid page view" do
         invalid_id = article.id + 100
-        expect { put "/page_views/" + invalid_id.to_s }.not_to raise_error
+        expect { put "/page_views/#{invalid_id}" }.not_to raise_error
       end
     end
 
@@ -122,7 +122,7 @@ RSpec.describe "PageViews", type: :request do
         post "/page_views", params: {
           article_id: article.id
         }
-        put "/page_views/" + article.id.to_s
+        put "/page_views/#{article.id}"
         expect(PageView.last.time_tracked_in_seconds).to eq(15)
       end
     end

--- a/spec/requests/stories_show_spec.rb
+++ b/spec/requests/stories_show_spec.rb
@@ -115,13 +115,13 @@ RSpec.describe "StoriesShow", type: :request do
     it "renders canonical url when exists" do
       article = create(:article, with_canonical_url: true)
       get article.path
-      expect(response.body).to include('"canonical" href="' + article.canonical_url.to_s + '"')
+      expect(response.body).to include(%("canonical" href="#{article.canonical_url}"))
     end
 
     it "does not render canonical url when not on article model" do
       article = create(:article, with_canonical_url: false)
       get article.path
-      expect(response.body).not_to include('"canonical" href="' + article.canonical_url.to_s + '"')
+      expect(response.body).not_to include(%("canonical" href="#{article.canonical_url}"))
     end
 
     it "handles invalid slug characters" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

String interpolation is often preferred over concatenation in Ruby. While the latter may be faster for two strings, it does generate more intermediate string objects when concatenating more strings. Interpolation also calls `to_s` automatically, which simplifies the resulting code.

## Related Tickets & Documents

This is what I do for fun. I'm also great at parties.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [X] no, because they aren't needed

## Added to documentation?

- [X] no documentation needed
