### PR TITLE
Limit Reactions Created in a 30 second Timeframe

### DIFF
--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -76,6 +76,7 @@ class SiteConfig < RailsSettings::Base
   field :rate_limit_comment_creation, type: :integer, default: 9
   field :rate_limit_published_article_creation, type: :integer, default: 9
   field :rate_limit_organization_creation, type: :integer, default: 1
+  field :rate_limit_reaction_creation, type: :integer, default: 10
   field :rate_limit_image_upload, type: :integer, default: 9
   field :rate_limit_email_recipient, type: :integer, default: 5
   field :rate_limit_article_update, type: :integer, default: 150

--- a/app/services/rate_limit_checker.rb
+++ b/app/services/rate_limit_checker.rb
@@ -6,7 +6,8 @@ class RateLimitChecker
     article_update: { retry_after: 30 },
     image_upload: { retry_after: 30 },
     published_article_creation: { retry_after: 30 },
-    organization_creation: { retry_after: 300 }
+    organization_creation: { retry_after: 300 },
+    reaction_creation: { retry_after: 30 }
   }.with_indifferent_access.freeze
 
   CONFIGURABLE_RATES = {
@@ -15,7 +16,8 @@ class RateLimitChecker
     rate_limit_published_article_creation: { min: 0, placeholder: 9, description: "The number of articles a user can create within 30 seconds" },
     rate_limit_image_upload: { min: 0, placeholder: 9, description: "The number of images a user can upload within 30 seconds" },
     rate_limit_email_recipient: { min: 0, placeholder: 5, description: "The number of emails we send to a user within 2 minutes" },
-    rate_limit_organization_creation: { min: 1, placeholder: 1, description: "The number of organizations a user can create within a 5 minute period" }
+    rate_limit_organization_creation: { min: 1, placeholder: 1, description: "The number of organizations a user can create within a 5 minute period" },
+    rate_limit_reaction_creation: { min: 1, placeholder: 10, description: "The number of times a user can react in a 30 second period" }
   }.freeze
 
   def initialize(user = nil)


### PR DESCRIPTION


## What type of PR is this? (check all applicable)
- [x] Feature
- [x] Optimization

## Description
Limit the number of reactions created in a 30 second window, default to 10, and allow it to be configurable. 

## Added tests?
- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

![alt_text](https://media1.tenor.com/images/5d4491a55e9ba0b471bc390a1643d9c7/tenor.gif?itemid=9802682)
