### PR TITLE
Rate Limit Classified Listing Creation

### DIFF
--- a/app/controllers/classified_listings_controller.rb
+++ b/app/controllers/classified_listings_controller.rb
@@ -1,5 +1,6 @@
 class ClassifiedListingsController < ApplicationController
   include ClassifiedListingsToolkit
+  before_action :check_limit, only: [:create]
 
   JSON_OPTIONS = {
     only: %i[
@@ -117,5 +118,9 @@ class ClassifiedListingsController < ApplicationController
 
   def process_after_unpublish
     redirect_to "/listings/dashboard"
+  end
+
+  def check_limit
+    rate_limit!(:listing_creation)
   end
 end

--- a/app/controllers/concerns/classified_listings_toolkit.rb
+++ b/app/controllers/concerns/classified_listings_toolkit.rb
@@ -113,6 +113,7 @@ module ClassifiedListingsToolkit
     end
 
     if successful_transaction
+      rate_limiter.track_limit_by_action(:listing_creation)
       clear_listings_cache
       process_successful_creation
     else

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -74,6 +74,7 @@ class SiteConfig < RailsSettings::Base
   # Rate Limits
   field :rate_limit_follow_count_daily, type: :integer, default: 500
   field :rate_limit_comment_creation, type: :integer, default: 9
+  field :rate_limit_listing_creation, type: :integer, default: 1
   field :rate_limit_published_article_creation, type: :integer, default: 9
   field :rate_limit_organization_creation, type: :integer, default: 1
   field :rate_limit_image_upload, type: :integer, default: 9

--- a/app/services/rate_limit_checker.rb
+++ b/app/services/rate_limit_checker.rb
@@ -5,6 +5,7 @@ class RateLimitChecker
   ACTION_LIMITERS = {
     article_update: { retry_after: 30 },
     image_upload: { retry_after: 30 },
+    listing_creation: { retry_after: 60 },
     published_article_creation: { retry_after: 30 },
     organization_creation: { retry_after: 300 }
   }.with_indifferent_access.freeze
@@ -12,6 +13,7 @@ class RateLimitChecker
   CONFIGURABLE_RATES = {
     rate_limit_follow_count_daily: { min: 0, placeholder: 500, description: "The number of users a person can follow daily" },
     rate_limit_comment_creation: { min: 0, placeholder: 9, description: "The number of comments a user can create within 30 seconds" },
+    rate_limit_listing_creation: { min: 1, placeholder: 1, description: "The number of listings a user can create in 1 minute" },
     rate_limit_published_article_creation: { min: 0, placeholder: 9, description: "The number of articles a user can create within 30 seconds" },
     rate_limit_image_upload: { min: 0, placeholder: 9, description: "The number of images a user can upload within 30 seconds" },
     rate_limit_email_recipient: { min: 0, placeholder: 5, description: "The number of emails we send to a user within 2 minutes" },


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature
- [x] Optimization

## Description
Limit the number of Classified Listings a user can create in a single minute. Allow it to be configured, default 1.

## Added tests?
- [x] yes

![alt_text](https://media1.tenor.com/images/b5c7245822380151d00b2ff63ae9acf8/tenor.gif?itemid=16455196)
