### PR TITLE
Force Unique Jobs for User Initiated Jobs and Cache Jobs

### DIFF
--- a/app/workers/articles/bust_cache_worker.rb
+++ b/app/workers/articles/bust_cache_worker.rb
@@ -1,9 +1,5 @@
 module Articles
-  class BustCacheWorker
-    include Sidekiq::Worker
-
-    sidekiq_options queue: :high_priority, retry: 10, lock: :until_executing
-
+  class BustCacheWorker < BustCacheBaseWorker
     def perform(article_id, cache_buster = "CacheBuster")
       article = Article.find_by(id: article_id)
 

--- a/app/workers/articles/score_calc_worker.rb
+++ b/app/workers/articles/score_calc_worker.rb
@@ -2,7 +2,7 @@ module Articles
   class ScoreCalcWorker
     include Sidekiq::Worker
 
-    sidekiq_options queue: :medium_priority
+    sidekiq_options queue: :medium_priority, lock: :until_executing
 
     def perform(article_id)
       article = Article.find_by(id: article_id)

--- a/app/workers/articles/update_analytics_worker.rb
+++ b/app/workers/articles/update_analytics_worker.rb
@@ -2,7 +2,7 @@ module Articles
   class UpdateAnalyticsWorker
     include Sidekiq::Worker
 
-    sidekiq_options queue: :low_priority, retry: 15
+    sidekiq_options queue: :low_priority, retry: 15, lock: :until_executing
 
     def perform(user_id)
       user = User.find_by(id: user_id)

--- a/app/workers/articles/update_main_image_background_hex_worker.rb
+++ b/app/workers/articles/update_main_image_background_hex_worker.rb
@@ -2,7 +2,7 @@ module Articles
   class UpdateMainImageBackgroundHexWorker
     include Sidekiq::Worker
 
-    sidekiq_options queue: :high_priority, retry: 10
+    sidekiq_options queue: :high_priority, retry: 10, lock: :until_executing
 
     def perform(article_id)
       article = Article.find_by(id: article_id)

--- a/app/workers/bust_cache_base_worker.rb
+++ b/app/workers/bust_cache_base_worker.rb
@@ -1,0 +1,5 @@
+class BustCacheBaseWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :high_priority, retry: 15, lock: :until_executing
+end

--- a/app/workers/classified_listings/bust_cache_worker.rb
+++ b/app/workers/classified_listings/bust_cache_worker.rb
@@ -1,9 +1,5 @@
 module ClassifiedListings
-  class BustCacheWorker
-    include Sidekiq::Worker
-
-    sidekiq_options queue: :high_priority, retry: 10
-
+  class BustCacheWorker < BustCacheBaseWorker
     def perform(classified_listing_id)
       classified_listing = ClassifiedListing.find_by(id: classified_listing_id)
       return unless classified_listing

--- a/app/workers/comments/bust_cache_worker.rb
+++ b/app/workers/comments/bust_cache_worker.rb
@@ -1,9 +1,5 @@
 module Comments
-  class BustCacheWorker
-    include Sidekiq::Worker
-
-    sidekiq_options queue: :high_priority
-
+  class BustCacheWorker < BustCacheBaseWorker
     def perform(comment_id)
       comment = Comment.find_by(id: comment_id)
       return unless comment&.commentable

--- a/app/workers/events/bust_cache_worker.rb
+++ b/app/workers/events/bust_cache_worker.rb
@@ -1,7 +1,6 @@
 module Events
-  class BustCacheWorker
-    include Sidekiq::Worker
-    sidekiq_options queue: :low_priority, retry: 10
+  class BustCacheWorker < BustCacheBaseWorker
+    sidekiq_options queue: :low_priority
 
     def perform
       CacheBuster.bust_events

--- a/app/workers/export_content_worker.rb
+++ b/app/workers/export_content_worker.rb
@@ -1,7 +1,7 @@
 class ExportContentWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: :medium_priority, retry: 10
+  sidekiq_options queue: :medium_priority, retry: 10, lock: :until_executed
 
   def perform(user_id)
     user = User.find_by(id: user_id)

--- a/app/workers/organizations/bust_cache_worker.rb
+++ b/app/workers/organizations/bust_cache_worker.rb
@@ -1,9 +1,5 @@
 module Organizations
-  class BustCacheWorker
-    include Sidekiq::Worker
-
-    sidekiq_options queue: :high_priority, retry: 10
-
+  class BustCacheWorker < BustCacheBaseWorker
     def perform(organization_id, slug)
       organization = Organization.find_by(id: organization_id)
 

--- a/app/workers/pages/bust_cache_worker.rb
+++ b/app/workers/pages/bust_cache_worker.rb
@@ -1,9 +1,5 @@
 module Pages
-  class BustCacheWorker
-    include Sidekiq::Worker
-
-    sidekiq_options queue: :high_priority, retry: 10
-
+  class BustCacheWorker < BustCacheBaseWorker
     def perform(slug, cache_buster = "CacheBuster")
       return if slug.blank?
 

--- a/app/workers/podcast_episodes/bust_cache_worker.rb
+++ b/app/workers/podcast_episodes/bust_cache_worker.rb
@@ -1,9 +1,5 @@
 module PodcastEpisodes
-  class BustCacheWorker
-    include Sidekiq::Worker
-
-    sidekiq_options queue: :high_priority, retry: 10
-
+  class BustCacheWorker < BustCacheBaseWorker
     def perform(podcast_episode_id, path, podcast_slug)
       podcast_episode = PodcastEpisode.find_by(id: podcast_episode_id)
       return if podcast_episode.nil?

--- a/app/workers/podcasts/bust_cache_worker.rb
+++ b/app/workers/podcasts/bust_cache_worker.rb
@@ -1,9 +1,5 @@
 module Podcasts
-  class BustCacheWorker
-    include Sidekiq::Worker
-
-    sidekiq_options queue: :high_priority, retry: 10
-
+  class BustCacheWorker < BustCacheBaseWorker
     def perform(path)
       CacheBuster.bust_podcast(path)
     end

--- a/app/workers/rss_reader_fetch_user_worker.rb
+++ b/app/workers/rss_reader_fetch_user_worker.rb
@@ -1,7 +1,7 @@
 class RssReaderFetchUserWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: :medium_priority
+  sidekiq_options queue: :medium_priority, lock: :until_executed
 
   def perform(user_id)
     user = User.find_by(id: user_id)

--- a/app/workers/tags/bust_cache_worker.rb
+++ b/app/workers/tags/bust_cache_worker.rb
@@ -1,9 +1,5 @@
 module Tags
-  class BustCacheWorker
-    include Sidekiq::Worker
-
-    sidekiq_options queue: :high_priority, retry: 10
-
+  class BustCacheWorker < BustCacheBaseWorker
     def perform(tag_name)
       tag = Tag.find_by(name: tag_name)
       return unless tag

--- a/app/workers/users/bust_cache_worker.rb
+++ b/app/workers/users/bust_cache_worker.rb
@@ -1,9 +1,5 @@
 module Users
-  class BustCacheWorker
-    include Sidekiq::Worker
-
-    sidekiq_options queue: :high_priority, retry: 10
-
+  class BustCacheWorker < BustCacheBaseWorker
     def perform(user_id)
       user = User.find_by(id: user_id)
       return unless user

--- a/app/workers/users/resave_articles_worker.rb
+++ b/app/workers/users/resave_articles_worker.rb
@@ -2,7 +2,7 @@ module Users
   class ResaveArticlesWorker
     include Sidekiq::Worker
 
-    sidekiq_options queue: :medium_priority, retry: 10
+    sidekiq_options queue: :medium_priority, retry: 10, lock: :until_executing
 
     def perform(user_id)
       user = User.find_by(id: user_id)

--- a/app/workers/users/subscribe_to_mailchimp_newsletter_worker.rb
+++ b/app/workers/users/subscribe_to_mailchimp_newsletter_worker.rb
@@ -1,7 +1,7 @@
 module Users
   class SubscribeToMailchimpNewsletterWorker
     include Sidekiq::Worker
-    sidekiq_options queue: :low_priority, retry: 10
+    sidekiq_options queue: :low_priority, retry: 10, lock: :until_executed
 
     def perform(user_id)
       user = User.find_by(id: user_id)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
This PR introduces unique constraints to all of our CacheBustWorkers and to workers that are kicked off by user actions. These will help ensure that we are not doing duplicate unnecessary work. 

I bumped the default retry for CacheBustWorkers to 15 since 10 gives us 4 hours but I could see a service possibly having issues longer than that so I increased it. 

## Added tests?
- [x] no, because they aren't needed


![alt_text](https://media2.giphy.com/media/10tVhjcavACiBi/source.gif)
