### PR TITLE
Fix comment container width issue in comment permalink

### DIFF
--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -129,6 +129,8 @@ a.header-link {
   margin-bottom: 100px;
   text-align: left;
   &.comments-dedicated-page-container {
+    width: 800px;
+    max-width: 98%;
     min-height: calc(97vh - 200px);
   }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This fixes the width of a comment's permalink page.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

**Article show page**

![Screen Shot 2020-05-05 at 3 05 43 PM](https://user-images.githubusercontent.com/17884966/81105644-3c153f80-8ee2-11ea-86b1-75668ca3150f.png)

**Comment permalink page**

![Screen Shot 2020-05-05 at 3 05 49 PM](https://user-images.githubusercontent.com/17884966/81105649-3cadd600-8ee2-11ea-9bbc-82a4ccb1c228.png)


## Added tests?
- [x] no, because they aren't needed