### PR TITLE
Mod Actions Panel: Prevent nonsensical reaction pairs

### DIFF
--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -2,6 +2,8 @@ class ReactionsController < ApplicationController
   before_action :set_cache_control_headers, only: [:index], unless: -> { current_user }
   after_action :verify_authorized
 
+  NEG_ARTICLE_REACTIONS = %w[thumbsdown vomit].freeze
+
   def index
     skip_authorization
 
@@ -72,13 +74,7 @@ class ReactionsController < ApplicationController
 
     # if the reaction already exists, destroy it
     if reaction
-      result = destroy_reaction(reaction)
-
-      if reaction.negative? && current_user.auditable?
-        updated_params = params.dup
-        updated_params[:action] = "destroy"
-        Audit::Logger.log(:moderator, current_user, updated_params)
-      end
+      handle_existing_reaction(reaction)
     else
       reaction = build_reaction(category)
 
@@ -144,9 +140,21 @@ class ReactionsController < ApplicationController
   def clear_article_reactions(id, type, mod, category)
     reactions = if category == "thumbsup"
                   Reaction.where(reactable_id: id, reactable_type: type, user: mod).where.not(category: category)
-                elsif %w[thumbsdown vomit].include?(category)
+                elsif category.in?(NEG_ARTICLE_REACTIONS)
                   Reaction.where(reactable_id: id, reactable_type: type, user: mod, category: "thumbsup")
                 end
     reactions.each { |reaction| destroy_reaction(reaction) }
+  end
+
+  def handle_existing_reaction(reaction)
+    result = destroy_reaction(reaction)
+
+    if reaction.negative? && current_user.auditable?
+      updated_params = params.dup
+      updated_params[:action] = "destroy"
+      Audit::Logger.log(:moderator, current_user, updated_params)
+    end
+
+    result
   end
 end

--- a/app/javascript/actionsPanel/actionsPanel.js
+++ b/app/javascript/actionsPanel/actionsPanel.js
@@ -32,6 +32,19 @@ function toggleDropdown(type) {
   }
 }
 
+function correctReactedClasses(category) {
+  const upVote = document.querySelector("[data-category='thumbsup']");
+  const downVote = document.querySelector("[data-category='thumbsdown']");
+  const vomitVote = document.querySelector("[data-category='vomit']");
+
+  if (category === 'thumbsup'){
+    downVote.classList.remove('reacted');
+    vomitVote.classList.remove('reacted');
+  } else {
+    upVote.classList.remove('reacted');
+  }
+}
+
 function addReactionButtonListeners() {
   const butts = Array.from(
     document.querySelectorAll('.reaction-button, .reaction-vomit-button'),
@@ -40,16 +53,14 @@ function addReactionButtonListeners() {
   butts.forEach((butt) => {
     butt.addEventListener('click', (event) => {
       event.preventDefault();
-      // if (butt.dataset.category === 'thumbsup') {
-      //   butts.forEach(item => item.classList.remove('reacted'));
-      // }
-      butt.classList.toggle('reacted');
-
       const {
         reactableType: reactable_type,
         category,
         reactableId: reactable_id,
       } = butt.dataset;
+
+      correctReactedClasses(category);
+      butt.classList.toggle('reacted');
 
       request('/reactions', {
         method: 'POST',

--- a/app/javascript/actionsPanel/actionsPanel.js
+++ b/app/javascript/actionsPanel/actionsPanel.js
@@ -40,12 +40,16 @@ function addReactionButtonListeners() {
   butts.forEach((butt) => {
     butt.addEventListener('click', (event) => {
       event.preventDefault();
-      this.classList.add('reacted');
+      // if (butt.dataset.category === 'thumbsup') {
+      //   butts.forEach(item => item.classList.remove('reacted'));
+      // }
+      butt.classList.toggle('reacted');
+
       const {
         reactableType: reactable_type,
         category,
         reactableId: reactable_id,
-      } = this.dataset;
+      } = butt.dataset;
 
       request('/reactions', {
         method: 'POST',

--- a/app/views/moderations/actions_panel.html.erb
+++ b/app/views/moderations/actions_panel.html.erb
@@ -16,8 +16,6 @@
       <%= inline_svg_tag("chevron-right.svg", aria: false) %>
     </button>
   </header>
-  <% reaction = Reaction.where(reactable_id: @moderatable.id, reactable_type: @moderatable.class.name, user: current_user) %>
-  <%= reaction.inspect %>
   <div class="reactions-container">
     <div class="thumb-reactions-container">
       <button class="reaction-button <%= Reaction.cached_any_reactions_for?(@moderatable, current_user, "thumbsup") ? "reacted" : "" %>"

--- a/app/views/moderations/actions_panel.html.erb
+++ b/app/views/moderations/actions_panel.html.erb
@@ -16,6 +16,8 @@
       <%= inline_svg_tag("chevron-right.svg", aria: false) %>
     </button>
   </header>
+  <% reaction = Reaction.where(reactable_id: @moderatable.id, reactable_type: @moderatable.class.name, user: current_user) %>
+  <%= reaction.inspect %>
   <div class="reactions-container">
     <div class="thumb-reactions-container">
       <button class="reaction-button <%= Reaction.cached_any_reactions_for?(@moderatable, current_user, "thumbsup") ? "reacted" : "" %>"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
In production, we are able to select **both** a 'thumbs-down' and a 'vomit' reaction. Now that we have a 'thumbs-up' reaction, it does not make sense to be able to select both 'thumbs-up' and 'thumbs-down' reactions (or 'thumbs-up' and 'vomit' reactions). This PR prevents the selection of these nonsensical reaction pairs.

## Related Tickets & Documents
None

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [ ] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
- [X] no, not yet

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
None