### PR TITLE
Now pointer cursor is only on feed posts.

### DIFF
--- a/app/assets/stylesheets/components/stories.scss
+++ b/app/assets/stylesheets/components/stories.scss
@@ -2,7 +2,6 @@
 @import '../config/import';
 
 .crayons-story {
-  cursor: pointer; // since the whole card is clickable now.
   background: var(--card-bg);
   font-size: $fs-base; // Todo: remove when ready.
   box-shadow: $bold-shadow; // we will kill it at some point, don't worry. just not yet.

--- a/app/javascript/articles/Article.jsx
+++ b/app/javascript/articles/Article.jsx
@@ -28,7 +28,9 @@ export const Article = ({
 
   return (
     <article
-      className={`crayons-story ${isFeatured && 'crayons-story--featured'}`}
+      className={`crayons-story cursor-pointer ${
+        isFeatured && 'crayons-story--featured'
+      }`}
       id={isFeatured && 'featured-story-marker'}
       data-featured-article={`articles-${article.id}`}
       data-content-user-id={article.user_id}


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Currently feed cards are completely clickable, but only in the feed. Posts in tag pages or search results do not currently support this (future TODO). This PR adds the cursor pointer to only home page feed posts.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![Someone saying "No deed is too small"](https://media.giphy.com/media/jQVZSl5zTFxoy3mLUq/giphy.gif)
