### PR TITLE
Track Client IPs to Help Block Bad Actors

### DIFF
--- a/config/initializers/rack/attack.rb
+++ b/config/initializers/rack/attack.rb
@@ -28,4 +28,10 @@ class Rack::Attack
       request.env["HTTP_FASTLY_CLIENT_IP"].to_s
     end
   end
+
+  track("request_tracking") do |request|
+    if request.env["HTTP_FASTLY_CLIENT_IP"].present?
+      Honeycomb.add_field("fastly_client_ip", request.env["HTTP_FASTLY_CLIENT_IP"])
+    end
+  end
 end

--- a/spec/initializers/rack/attack_spec.rb
+++ b/spec/initializers/rack/attack_spec.rb
@@ -96,4 +96,13 @@ describe Rack::Attack, type: :request, throttle: true do
       end
     end
   end
+
+  describe "request_tracking" do
+    it "adds fastly client IP to Honeycomb span" do
+      allow(Honeycomb).to receive(:add_field)
+      get api_articles_path, headers: { "HTTP_FASTLY_CLIENT_IP" => "5.6.7.8" }
+
+      expect(Honeycomb).to have_received(:add_field).with("fastly_client_ip", "5.6.7.8")
+    end
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
Allow us to see IPs in Honeycomb to block bad actors. Chatted with Ben about this approach and we agree it seems like a good one. 

## Added tests?
- [x] yes

![alt_text](https://thumbs.gfycat.com/FluffyImpressionableEyas-max-1mb.gif)
