### PR TITLE
Track IPs and API Tokens for Throttled Requets, Send Retry After Header

### DIFF
--- a/config/initializers/rack/attack.rb
+++ b/config/initializers/rack/attack.rb
@@ -1,37 +1,38 @@
+Rack::Attack.throttled_response_retry_after_header = true
+
 class Rack::Attack
   throttle("search_throttle", limit: 5, period: 1) do |request|
     if request.path.starts_with?("/search/") && request.env["HTTP_FASTLY_CLIENT_IP"].present?
+      Honeycomb.add_field("fastly_client_ip", request.env["HTTP_FASTLY_CLIENT_IP"])
       request.env["HTTP_FASTLY_CLIENT_IP"].to_s
     end
   end
 
   throttle("api_throttle", limit: 3, period: 1) do |request|
     if request.path.starts_with?("/api/") && request.get? && request.env["HTTP_FASTLY_CLIENT_IP"].present?
+      Honeycomb.add_field("fastly_client_ip", request.env["HTTP_FASTLY_CLIENT_IP"])
       request.env["HTTP_FASTLY_CLIENT_IP"].to_s
     end
   end
 
   throttle("api_write_throttle", limit: 1, period: 1) do |request|
     if request.path.starts_with?("/api/") && (request.put? || request.post? || request.delete?)
+      Honeycomb.add_field("user_api_key", request.env["HTTP_API_KEY"])
       request.env["HTTP_API_KEY"]
     end
   end
 
   throttle("site_hits", limit: 100, period: 2) do |request|
     if request.env["HTTP_FASTLY_CLIENT_IP"].present?
+      Honeycomb.add_field("fastly_client_ip", request.env["HTTP_FASTLY_CLIENT_IP"])
       request.env["HTTP_FASTLY_CLIENT_IP"].to_s
     end
   end
 
   throttle("message_throttle", limit: 2, period: 1) do |request|
     if request.path.starts_with?("/messages") && request.post? && request.env["HTTP_FASTLY_CLIENT_IP"].present?
-      request.env["HTTP_FASTLY_CLIENT_IP"].to_s
-    end
-  end
-
-  track("request_tracking") do |request|
-    if request.env["HTTP_FASTLY_CLIENT_IP"].present?
       Honeycomb.add_field("fastly_client_ip", request.env["HTTP_FASTLY_CLIENT_IP"])
+      request.env["HTTP_FASTLY_CLIENT_IP"].to_s
     end
   end
 end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
I noticed after merging #7730 that we will only record client IPs for successful requests. Anything that is throttled we will not have the client IP bc we will bail before we get to the tracking. Here is how [rack-attack works](https://github.com/kickstarter/rack-attack#how-it-works) and because of that I added the tracking to the throttles. It's not pretty but it will get the job done and since we are simply adding a key to a hash I am not worried about any performance issues from possibly doing it multiple times. 
```ruby
def call(env)
  req = Rack::Attack::Request.new(env)

  if safelisted?(req)
    @app.call(env)
  elsif blocklisted?(req)
    self.class.blocklisted_callback.call(req)
  elsif throttled?(req)
    self.class.throttled_response.call(env)
    self.class.throttled_callback.call(req)
  else
    tracked?(req)
    @app.call(env)
  end
end
```
ALSO I turned on [returning the Retry-After header](https://github.com/kickstarter/rack-attack#ratelimit-headers-for-well-behaved-clients) so if well behaved clients hit this they know how long to wait before retrying. 

## Added tests?
- [x] yes

![alt_text](https://media.giphy.com/media/IMOH7KL8x6aC4/200.gif)
