### PR TITLE
Shorten page title for unauthenticated traffic

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -20,8 +20,10 @@ module ApplicationHelper
   def title(page_title)
     derived_title = if page_title.include?(community_name)
                       page_title
-                    else
+                    elsif user_signed_in?
                       "#{page_title} - #{community_qualified_name} 👩‍💻👨‍💻"
+                    else
+                      "#{page_title} - #{community_name}"
                     end
     content_for(:title) { derived_title }
     derived_title

--- a/spec/requests/stories_show_spec.rb
+++ b/spec/requests/stories_show_spec.rb
@@ -19,6 +19,19 @@ RSpec.describe "StoriesShow", type: :request do
       expect(response).to have_http_status(:moved_permanently)
     end
 
+    ## Title tag
+    it "renders signed-in title tag for signed-in user" do
+      sign_in user
+      get article.path
+      p community_qualified_name
+      expect(response.body).to include "<title>#{CGI.escapeHTML(article.title)} - #{community_qualified_name} 👩‍💻👨‍💻</title>"
+    end
+
+    it "renders signed-out title tag for signed-out user" do
+      get article.path
+      expect(response.body).to include "<title>#{CGI.escapeHTML(article.title)} - #{community_name}</title>"
+    end
+
     it "renders second and third users if present" do
       # 3rd user doesn't seem to get rendered for some reason
       user2 = create(:user)

--- a/spec/requests/stories_show_spec.rb
+++ b/spec/requests/stories_show_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe "StoriesShow", type: :request do
     it "renders signed-in title tag for signed-in user" do
       sign_in user
       get article.path
-      p community_qualified_name
       expect(response.body).to include "<title>#{CGI.escapeHTML(article.title)} - #{community_qualified_name} 👩‍💻👨‍💻</title>"
     end
 

--- a/spec/system/organization/user_views_an_organization_spec.rb
+++ b/spec/system/organization/user_views_an_organization_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Organization index", type: :system do
       end
 
       it "shows the proper title tag" do
-        expect(page).to have_title("#{organization.name} - #{ApplicationConfig['COMMUNITY_NAME']} Community 👩‍💻👨‍💻")
+        expect(page).to have_title("#{organization.name} - #{ApplicationConfig['COMMUNITY_NAME']}")
       end
     end
 

--- a/spec/system/user/view_user_index_spec.rb
+++ b/spec/system/user/view_user_index_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "User index", type: :system do
       end
 
       it "shows proper title tag" do
-        expect(page).to have_title("#{user.name} - #{ApplicationConfig['COMMUNITY_NAME']} Community 👩‍💻👨‍💻")
+        expect(page).to have_title("#{user.name} - #{ApplicationConfig['COMMUNITY_NAME']}")
       end
 
       it "shows user's articles" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This shortens the page title from `Productive and simple way to deploy Dockerized applications - DEV Community 👩‍💻👨‍💻` to just `Productive and simple way to deploy Dockerized applications - DEV` for non-signed-in traffic. Home page is still `DEV Community 👩‍💻👨‍💻`.

This is because search engines have struggled to display this consistently and moving just to DEV should help. I love the funkiness of the emojis but now that we're not using them for signed-out traffic we can be even funkier with them because we won't care about confusing the bots. We had a PR about randomizing the skin tones of the characters in the emoji and I was sort of unsure about doing that if the search engines are expecting consistency but this could free us up in that regard.