### PR TITLE
Allow empty status option for feedback messages

### DIFF
--- a/app/views/internal/feedback_messages/index.html.erb
+++ b/app/views/internal/feedback_messages/index.html.erb
@@ -17,11 +17,11 @@
   <%= f.search_field :reporter_username_cont, placeholder: "Reporter", class: "form-control mx-3" %>
 
   <%= f.select(
-        :status_eq,
-        options_for_select([["Open"], ["Invalid"], ["Resolved"]], @q.status_eq),
-        {},
-        class: "custom-select mx-3",
-      ) %>
+    :status_eq,
+    options_for_select(["Open", "Invalid", "Resolved"], @q.status_eq),
+    { include_blank: true },
+    class: "custom-select mx-3",
+  ) %>
 
   <%= f.submit "Search", class: "btn btn-secondary" %>
 <% end %>

--- a/spec/system/internal/admin_manages_reports_spec.rb
+++ b/spec/system/internal/admin_manages_reports_spec.rb
@@ -1,16 +1,17 @@
 require "rails_helper"
 
-RSpec.describe "Admin awards badges", type: :system do
+RSpec.describe "Admin manages reports", type: :system do
   let(:admin) { create(:user, :super_admin) }
 
   def clear_search_boxes
     fill_in "q_reporter_username_cont", with: ""
     fill_in "q_reported_url_cont", with: ""
+    select "", from: "q_status_eq"
   end
 
   before do
     sign_in admin
-    visit "/internal/reports"
+    visit internal_feedback_messages_path
   end
 
   it "loads the view" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This just makes it possible to search all reports regardless of status from the feedback messages UI.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
