### PR TITLE
Add Feature Search Tests for Users and Articles

### DIFF
--- a/spec/support/elasticsearch_helpers.rb
+++ b/spec/support/elasticsearch_helpers.rb
@@ -1,8 +1,12 @@
 # Only included in specs with elasticsearch: true
 module ElasticsearchHelpers
   def index_documents(resources)
-    Array.wrap(resources).each(&:index_to_elasticsearch_inline)
-    described_class.refresh_index
+    index_documents_for_search_class(Array.wrap(resources), described_class)
+  end
+
+  def index_documents_for_search_class(records, search_class)
+    records.each(&:index_to_elasticsearch_inline)
+    search_class.refresh_index
   end
 
   def clear_elasticsearch_data(search_class)

--- a/spec/system/search/display_articles_search_spec.rb
+++ b/spec/system/search/display_articles_search_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe "Display articles search spec", type: :system, js: true, elasticsearch: "FeedContent" do
+  let(:found_article_one) { create(:article) }
+  let(:found_article_two) { create(:article) }
+  let(:not_found_article) { create(:article) }
+
+  before do
+    stub_request(:post, "http://www.google-analytics.com/collect")
+  end
+
+  it "returns correct results for a search" do
+    found_article_one.tags << create(:tag, name: "ruby")
+    allow(found_article_two).to receive(:body_text).and_return("Ruby Tuesday")
+    allow(not_found_article).to receive(:body_text).and_return("Python All Day Long")
+    articles = [found_article_one, found_article_two, not_found_article]
+    index_documents_for_search_class(articles, Search::FeedContent)
+    visit "/search?q=ruby&filters=class_name:Article"
+
+    expect(page).to have_content(found_article_one.title)
+    expect(page).to have_content(found_article_two.title)
+    expect(page).not_to have_content(not_found_article.title)
+  end
+
+  it "returns all expected article fields" do
+    allow(found_article_one).to receive(:reading_time).and_return(5)
+    allow(found_article_one).to receive(:comments_count).and_return(2)
+    found_article_one.tags << create(:tag, name: "ruby")
+    index_documents_for_search_class([found_article_one], Search::FeedContent)
+    visit "/search?q=ruby&filters=class_name:Article"
+
+    expect(page).to have_content(found_article_one.title)
+    expect(find("#article-link-#{found_article_one.id}")["href"]).to include(found_article_one.path)
+    expect(find_button("SAVE")["data-reactable-id"].to_i).to eq(found_article_one.id)
+    expect(find_link("5 min read")).to be_present
+    expect(find_link("#ruby")["href"]).to include("/t/ruby")
+    expect(find_link(found_article_one.user.name)["href"]).to include(found_article_one.username)
+    expect(find(".engagement-count-number").text.to_i).to eq(2)
+  end
+end

--- a/spec/system/search/display_users_search_spec.rb
+++ b/spec/system/search/display_users_search_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe "Display users search spec", type: :system, js: true, elasticsearch: "User" do
+  let(:current_user) { create(:user, username: "ironman", name: "Iron Man") }
+  let(:found_user) { create(:user, username: "janedoe", name: "Jane Doe") }
+  let(:found_two_user) { create(:user, username: "doejane", name: "Doe Jane") }
+  let(:not_found_user) { create(:user, username: "batman", name: "Batman") }
+
+  before do
+    stub_request(:post, "http://www.google-analytics.com/collect")
+  end
+
+  it "returns correct results for name search" do
+    users = [current_user, found_user, found_two_user, not_found_user]
+    index_documents_for_search_class(users, Search::User)
+    visit "/search?q=jane&filters=class_name:User"
+
+    expect(page).to have_content(found_user.name)
+    expect(page).to have_content(found_two_user.name)
+    expect(page).not_to have_content(current_user.name)
+    expect(page).not_to have_content(not_found_user.name)
+  end
+
+  it "returns all expected user fields" do
+    sign_in current_user
+    index_documents_for_search_class([found_user], Search::User)
+    visit "/search?q=jane&filters=class_name:User"
+
+    expect(page).to have_content(found_user.name)
+    expect(find(".tag-identifier").text).to eq("person")
+    expect(find(:xpath, "//img[@alt='#{found_user.username} profile']")["src"]).to include(found_user.profile_image_90)
+    expect(JSON.parse(find_button("+ FOLLOW")["data-info"])["id"]).to eq(found_user.id)
+  end
+end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Feature Specs

## Description
These two specs test that when we load users and articles from Elasticsearch they have all the data necessary to correctly display on the page. I plan to do this as well for podcasts and comments. We can further expand on these with many scenarios but I thought this was a good base to get us going. 

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/6#card-36667928

## Added tests?
- [x] yes

![alt_text](https://media0.giphy.com/media/KfHsIMXCITLQhh1MA4/giphy.gif)
