### PR TITLE
Add org credit management to org mod page

### DIFF
--- a/app/controllers/internal/organizations_controller.rb
+++ b/app/controllers/internal/organizations_controller.rb
@@ -1,8 +1,13 @@
 class Internal::OrganizationsController < Internal::ApplicationController
   layout "internal"
 
+  CREDIT_ACTIONS = {
+    add: :add_to_org,
+    remove: :remove_from_org
+  }.with_indifferent_access.freeze
+
   def index
-    @organizations = Organization.order("name DESC").page(params[:page]).per(50)
+    @organizations = Organization.order(name: :desc).page(params[:page]).per(50)
 
     return if params[:search].blank?
 
@@ -14,5 +19,29 @@ class Internal::OrganizationsController < Internal::ApplicationController
 
   def show
     @organization = Organization.find(params[:id])
+  end
+
+  def update_org_credits
+    org = Organization.find(params[:id])
+    amount = params[:credits].to_i
+    update_action = CREDIT_ACTIONS.fetch(params[:credit_action])
+
+    Credit.public_send(update_action, org, amount)
+    add_note(org)
+
+    flash[:notice] = "Sucessfully updated credits"
+    redirect_to internal_organization_path(org)
+  end
+
+  private
+
+  def add_note(org)
+    Note.create(
+      author_id: current_user.id,
+      noteable_id: org.id,
+      noteable_type: "Organization",
+      reason: "misc_note",
+      content: params[:note],
+    )
   end
 end

--- a/app/helpers/organization_helper.rb
+++ b/app/helpers/organization_helper.rb
@@ -1,0 +1,8 @@
+module OrganizationHelper
+  def orgs_with_credits(organizations)
+    options = organizations.map do |org|
+      ["#{org.name} (#{org.unspent_credits_count})", org.id]
+    end
+    options_for_select(options)
+  end
+end

--- a/app/views/internal/organizations/show.html.erb
+++ b/app/views/internal/organizations/show.html.erb
@@ -30,6 +30,28 @@
       <% end %>
     </dl>
   </div>
+  <div class="col-12">
+    <% current_credits = @organization.unspent_credits_count %>
+    <h2>Credits (currrent: <%= current_credits %>)</h2>
+    <%= form_tag update_org_credits_internal_organization_path(@organization), method: :patch, class: "form-inline justify-content-between mb-2" do %>
+      <div class="form-group">
+        <%= hidden_field_tag :credit_action, :add %>
+        <%= number_field_tag :credits, nil, in: 1...100000, required: true, class: "form-control mr-3", size: 5 %>
+        <%= text_field_tag :note, "", placeholder: "Why are you adding these credits?", size: 50, required: true, class: "form-control mr-3" %>
+      </div>
+      <%= submit_tag "Add Org Credits", class: "btn btn-primary" %>
+    <% end %>
+    <% if current_credits.positive? %>
+      <%= form_tag update_org_credits_internal_organization_path(@organization), method: :patch, class: "form-inline justify-content-between mb-2" do %>
+        <div class="form-group">
+          <%= hidden_field_tag :credit_action, :remove %>
+          <%= number_field_tag :credits, nil, in: 1..current_credits, required: true, class: "form-control mr-3", size: 5 %>
+          <%= text_field_tag :note, "", placeholder: "Why are you removing these credits?", size: 50, required: true, class: "form-control mr-3" %>
+        </div>
+        <%= submit_tag "Remove Org Credits", class: "btn btn-danger" %>
+      <% end %>
+    <% end %>
+  </div>
 </div>
 
 <%= render "activity" %>

--- a/app/views/internal/users/_credits.erb
+++ b/app/views/internal/users/_credits.erb
@@ -3,41 +3,46 @@
     <h2>Credits</h2>
     <hr>
     <h4 class="mt-3"><%= @user.username %></h4>
-    <p>Available User Credits: <%= @user.unspent_credits_count %></p>
+    <% current_credits = @user.unspent_credits_count %>
+    <p>Available User Credits: <%= current_credits %></p>
     <%= form_with scope: :user, url: internal_user_path(@user), method: :patch, local: true, html: { class: "form-inline justify-content-between mb-2" } do |f| %>
       <div class="form-group">
-        <%= f.text_field :add_credits, placeholder: "#", size: 5, class: "form-control mr-3" %>
+        <%= f.number_field :add_credits, in: 1...10000, required: true, class: "form-control mr-3", size: 5 %>
         <%= f.text_field :new_note, placeholder: "Why are you adding these credits?", size: 50, required: true, class: "form-control" %>
       </div>
       <%= f.submit "Add Credits", class: "btn btn-primary" %>
     <% end %>
+    <% if current_credits.positive? %>
     <%= form_with scope: :user, url: internal_user_path(@user), method: :patch, local: true, html: { class: "form-inline justify-content-between mb-2" } do |f| %>
       <div class="form-group">
-        <%= f.text_field :remove_credits, placeholder: "#", size: 5, class: "form-control mr-3" %>
+        <%= f.number_field :remove_credits, in: 1..current_credits, required: true, class: "form-control mr-3", size: 5 %>
         <%= f.text_field :new_note, placeholder: "Why are you removing these credits?", size: 50, required: true, class: "form-control" %>
       </div>
       <%= f.submit "Remove Credits", class: "btn btn-danger" %>
     <% end %>
+    <% end %>
     <hr>
   </div>
+  <% if @organizations.present? %>
   <div class="col-12">
     <h4>Organizations</h4>
     <%= form_with scope: :user, url: internal_user_path(@user), method: :patch, local: true, html: { class: "form-inline justify-content-between mb-2" } do |f| %>
       <div class="form-group">
-        <%= f.text_field :add_org_credits, placeholder: "#", size: 5, class: "form-control mr-3" %>
+        <%= f.number_field :add_org_credits, in: 1...10000, required: true, class: "form-control mr-3", size: 5 %>
         <%= f.text_field :new_note, placeholder: "Why are you adding these credits?", size: 50, required: true, class: "form-control mr-3" %>
-        <%= f.collection_select :organization_id, @organizations, :id, :name, {}, { class: 'form-control' } %>
+        <%= f.select :organization_id, orgs_with_credits(@organizations), {}, { class: 'form-control' } %>
       </div>
       <%= f.submit "Add Org Credits", class: "btn btn-primary" %>
     <% end %> 
     <%= form_with scope: :user, url: internal_user_path(@user), method: :patch, local: true, html: { class: "form-inline justify-content-between mb-2" } do |f| %>
       <div class="form-group">
-        <%= f.text_field :remove_org_credits, placeholder: "#", size: 5, class: "form-control mr-3" %>
+        <%= f.number_field :remove_org_credits, in: 1...10000, required: true, class: "form-control mr-3", size: 5 %>
         <%= f.text_field :new_note, placeholder: "Why are you removing these credits?", size: 50, required: true, class: "form-control mr-3" %>
-        <%= f.collection_select :organization_id, @organizations, :id, :name, {}, { class: 'form-control' } %>
+        <%= f.select :organization_id, orgs_with_credits(@organizations), {}, { class: 'form-control' } %>
       </div>
       <%= f.submit "Remove Org Credits", class: "btn btn-danger" %>
     <% end %>
     <hr>
   </div>
+  <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,7 +89,11 @@ Rails.application.routes.draw do
       end
     end
     resources :organization_memberships, only: %i[update destroy create]
-    resources :organizations, only: %i[index show]
+    resources :organizations, only: %i[index show] do
+      member do
+        patch "update_org_credits"
+      end
+    end
     resources :sponsorships, only: %i[index edit update destroy]
     resources :welcome, only: %i[index create]
     resources :growth, only: %i[index]

--- a/spec/helpers/organization_helper_spec.rb
+++ b/spec/helpers/organization_helper_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+describe OrganizationHelper, type: :helper do
+  it "display the correct options" do
+    org1 = create(:organization)
+    org2 = create(:organization)
+    allow(org1).to receive(:unspent_credits_count).and_return(1)
+
+    options = helper.orgs_with_credits([org1, org2])
+    expect(options).to include("#{org1.name} (1)")
+    expect(options).to include("#{org2.name} (0)")
+  end
+end

--- a/spec/requests/internal/organizations_spec.rb
+++ b/spec/requests/internal/organizations_spec.rb
@@ -31,4 +31,27 @@ RSpec.describe "internal/organizations", type: :request do
       expect(response.body).to include(CGI.escapeHTML(organization.name))
     end
   end
+
+  describe "PATCH /internal" do
+    let(:organization) { create(:organiztion) }
+
+    it "adds credits to an organization" do
+      params = { credits: 1, credit_action: :add }
+
+      expect do
+        patch update_org_credits_internal_organization_path(organization),
+              params: params
+      end.to change(organization, :unspent_credits_count).by(1)
+    end
+
+    it "removes credits to an organization" do
+      Credit.add_to_org(organization, 1)
+      params = { credits: 1, credit_action: :remove }
+
+      expect do
+        patch update_org_credits_internal_organization_path(organization),
+              params: params
+      end.to change(organization, :unspent_credits_count).by(-1)
+    end
+  end
 end

--- a/spec/requests/internal/organizations_spec.rb
+++ b/spec/requests/internal/organizations_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "internal/organizations", type: :request do
   end
 
   describe "PATCH /internal" do
-    let(:organization) { create(:organiztion) }
+    let(:organization) { create(:organization) }
 
     it "adds credits to an organization" do
       params = { credits: 1, credit_action: :add }
@@ -41,7 +41,7 @@ RSpec.describe "internal/organizations", type: :request do
       expect do
         patch update_org_credits_internal_organization_path(organization),
               params: params
-      end.to change(organization, :unspent_credits_count).by(1)
+      end.to change { organization.reload.unspent_credits_count }.by(1)
     end
 
     it "removes credits to an organization" do
@@ -51,7 +51,7 @@ RSpec.describe "internal/organizations", type: :request do
       expect do
         patch update_org_credits_internal_organization_path(organization),
               params: params
-      end.to change(organization, :unspent_credits_count).by(-1)
+      end.to change { organization.reload.unspent_credits_count }.by(-1)
     end
   end
 end

--- a/spec/system/internal/admin_manages_organizations_spec.rb
+++ b/spec/system/internal/admin_manages_organizations_spec.rb
@@ -4,15 +4,26 @@ RSpec.describe "Admin manages organizations", type: :system do
   let(:admin) { create(:user, :super_admin) }
   let(:organization) { create(:organization) }
 
-  before do
-    create_list :organization, 5
-    sign_in admin
-    visit "/internal/organizations"
+  before { sign_in admin }
+
+  context "when searching for organizations" do
+    it "searches for organizations" do
+      create_list :organization, 5
+      visit internal_organizations_path
+
+      fill_in "search", with: organization.name.to_s
+      click_on "Search"
+
+      expect(page.body).to have_link(organization.name)
+    end
   end
 
-  it "searches for organizations" do
-    fill_in "search", with: organization.name.to_s
-    click_on "Search"
-    expect(page.body).to have_link(organization.name)
+  context "when managing credits for a single organization" do
+    before { visit internal_organization_path(organization) }
+
+    it "does not show the remove form when there are no credits" do
+      expect(page).to have_button("Add Org Credits")
+      #expect(page).to have_no_button("Remove Org Credits")
+    end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor
- [X] Feature

## Description

As requested by @michael-tharrington in https://github.com/thepracticaldev/tech-private/issues/427, this PR adds credit management to the org mod page. It also improves the credit editing experience on the user mod page and cleans up/refactors some code.

## Related Tickets & Documents

https://github.com/thepracticaldev/tech-private/issues/427

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Org mod page:

1. The forms for managing credits are now directly on `/internal/organizations/:id` and the remove option will only be shown when there are credits to remove. You also see how many credits are currently available:
    <img width="1159" alt="Screen Shot 2020-05-08 at 11 41 09" src="https://user-images.githubusercontent.com/47985/81371128-30638c00-9121-11ea-9cc1-74fd9d91fd1c.png">
2. The inputs are now actually of type number, with the little arrows for increasing/decreasing, and all that. In the case of adding credits, values from 1 to 99999 are valid, for removing it's 1 to the number of current credits. So you can't submit the form if you try to remove more credits than an org has (indicated by the red border):
    <img width="1138" alt="Screen Shot 2020-05-08 at 11 38 19" src="https://user-images.githubusercontent.com/47985/81370968-b8956180-9120-11ea-911d-c21566fceec3.png">

User mod page:

<img width="1153" alt="Screen Shot 2020-05-11 at 10 37 42" src="https://user-images.githubusercontent.com/47985/81525591-6900a100-937f-11ea-8d19-df109088e6b1.png">

1. Remove user credits form will be hidden if user has no credits.
2. All credits inputs are now number fields. For orgs there's no error checking on the upper bound of remove though, as we don't have that readily available at that point.
3. I also hide the whole org credit management block if the user isn't in any orgs.

## Added tests?

- [X] yes

Less than I would have liked tbh, but I seem to have some trouble with my local test setup and I didn't want to sink any more time into it right now.

## Added to documentation?

- [X] no documentation needed
