### PR TITLE
Refactoring GitHub Repos functionality - step 1

### DIFF
--- a/app/assets/stylesheets/settings.scss
+++ b/app/assets/stylesheets/settings.scss
@@ -29,7 +29,7 @@ $input-width: 650px;
         background: #a8f1e9;
       }
     }
-    &.github-repo-row-selected {
+    &.github-repo-row-featured {
       background: $light-green;
       color: #0f0f0f;
     }

--- a/app/controllers/github_repos_controller.rb
+++ b/app/controllers/github_repos_controller.rb
@@ -20,8 +20,11 @@ class GithubReposController < ApplicationController
 
   def create
     authorize GithubRepo
-    @repo = GithubRepo.find_or_create(fetched_repo_params(fetch_repo))
+
+    @repo = GithubRepo.upsert(current_user, fetched_repo_params(fetch_repo))
+
     current_user.touch(:github_repos_updated_at)
+
     if @repo.valid?
       redirect_to "/settings/integrations", notice: "GitHub repo added"
     else
@@ -52,7 +55,7 @@ class GithubReposController < ApplicationController
       return
     end
 
-    repo = GithubRepo.find_or_create(fetched_repo_params(fetched_repo))
+    repo = GithubRepo.upsert(current_user, fetched_repo_params(fetched_repo))
 
     current_user.touch(:github_repos_updated_at)
 
@@ -75,7 +78,6 @@ class GithubReposController < ApplicationController
   def fetched_repo_params(fetched_repo)
     {
       github_id_code: fetched_repo.id,
-      user_id: current_user.id,
       name: fetched_repo.name,
       description: fetched_repo.description,
       language: fetched_repo.language,

--- a/app/controllers/github_repos_controller.rb
+++ b/app/controllers/github_repos_controller.rb
@@ -14,33 +14,6 @@ class GithubReposController < ApplicationController
     render json: { error: "GitHub Unauthorized: #{e.message}", status: 401 }, status: :unauthorized
   end
 
-  def create
-    authorize GithubRepo
-
-    @repo = GithubRepo.upsert(current_user, fetched_repo_params(fetch_repo))
-
-    current_user.touch(:github_repos_updated_at)
-
-    if @repo.valid?
-      redirect_to "/settings/integrations", notice: "GitHub repo added"
-    else
-      redirect_to "/settings/integrations",
-                  error: "There was an error adding your Github repo"
-    end
-  end
-
-  def update
-    @repo = GithubRepo.find(params[:id])
-    current_user.touch(:github_repos_updated_at)
-    authorize @repo
-    if @repo.update(featured: false)
-      redirect_to "/settings/integrations", notice: "GitHub repo added"
-    else
-      redirect_to "/settings/integrations",
-                  error: "There was an error removing your Github repo"
-    end
-  end
-
   def update_or_create
     authorize GithubRepo
 

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -207,8 +207,11 @@ class StoriesController < ApplicationController
     redirect_if_view_param
     return if performed?
 
+    assign_user_github_repositories
+
     set_surrogate_key_header "articles-user-#{@user.id}"
     set_user_json_ld
+
     render template: "users/show"
   end
 
@@ -308,6 +311,15 @@ class StoriesController < ApplicationController
       limited_column_select.
       where.not(id: @pinned_stories.pluck(:id)).
       order("published_at DESC").page(@page).per(user_signed_in? ? 2 : SIGNED_OUT_RECORD_COUNT))
+  end
+
+  def assign_user_github_repositories
+    @github_repositories = if @user.authenticated_through?(:github)
+                             @user.github_repos.featured.
+                               order(stargazers_count: :desc, name: :asc)
+                           else
+                             GithubRepo.none
+                           end
   end
 
   def stories_by_timeframe

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -314,12 +314,7 @@ class StoriesController < ApplicationController
   end
 
   def assign_user_github_repositories
-    @github_repositories = if @user.authenticated_through?(:github)
-                             @user.github_repos.featured.
-                               order(stargazers_count: :desc, name: :asc)
-                           else
-                             GithubRepo.none
-                           end
+    @github_repositories = @user.github_repos.featured.order(stargazers_count: :desc, name: :asc)
   end
 
   def stories_by_timeframe

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -315,10 +315,7 @@ class UsersController < ApplicationController
   end
 
   def handle_integrations_tab
-    return unless current_user.identities.where(provider: "github").any?
-
-    @client = Octokit::Client.
-      new(access_token: current_user.identities.where(provider: "github").last.token)
+    @github_repositories_show = current_user.authenticated_through?(:github)
   end
 
   def handle_billing_tab

--- a/app/javascript/githubRepos/__tests__/__snapshots__/singleRepo.test.jsx.snap
+++ b/app/javascript/githubRepos/__tests__/__snapshots__/singleRepo.test.jsx.snap
@@ -25,7 +25,27 @@ exports[`<SingleRepo /> when it is a fork should render and match the snapshot 1
 </div>
 `;
 
-exports[`<SingleRepo /> when it is not already selected should render and match the snapshot 1`] = `
+exports[`<SingleRepo /> when it is featured should render and match the snapshot 1`] = `
+<div
+  class="github-repo-row github-repo-row-featured"
+>
+  <div
+    class="github-repo-row-name"
+  >
+    <button
+      class="cta"
+      id="github-repo-button-123"
+      onClick={[Function]}
+      type="button"
+    >
+      REMOVE
+    </button>
+    dev.to
+  </div>
+</div>
+`;
+
+exports[`<SingleRepo /> when it is not already featured should render and match the snapshot 1`] = `
 <div
   class="github-repo-row"
 >
@@ -39,26 +59,6 @@ exports[`<SingleRepo /> when it is not already selected should render and match 
       type="button"
     >
       SELECT
-    </button>
-    dev.to
-  </div>
-</div>
-`;
-
-exports[`<SingleRepo /> when it is selected should render and match the snapshot 1`] = `
-<div
-  class="github-repo-row github-repo-row-selected"
->
-  <div
-    class="github-repo-row-name"
-  >
-    <button
-      class="cta"
-      id="github-repo-button-123"
-      onClick={[Function]}
-      type="button"
-    >
-      REMOVE
     </button>
     dev.to
   </div>

--- a/app/javascript/githubRepos/__tests__/singleRepo.test.jsx
+++ b/app/javascript/githubRepos/__tests__/singleRepo.test.jsx
@@ -7,13 +7,13 @@ import { SingleRepo } from '../singleRepo';
 global.fetch = fetch;
 
 describe('<SingleRepo />', () => {
-  describe('when it is not already selected', () => {
+  describe('when it is not already featured', () => {
     const subject = (
       <SingleRepo
         githubIdCode={123}
         name="dev.to"
         fork={false}
-        selected={false}
+        featured={false}
       />
     );
 
@@ -22,30 +22,30 @@ describe('<SingleRepo />', () => {
       expect(tree).toMatchSnapshot();
     });
 
-    it('should have a state of { selected: false }', () => {
+    it('should have a state of { featured: false }', () => {
       const context = shallow(subject);
-      expect(context.state()).toEqual({ selected: false });
+      expect(context.state()).toEqual({ featured: false });
     });
   });
 
-  describe('when it is selected', () => {
+  describe('when it is featured', () => {
     const subject = (
-      <SingleRepo githubIdCode={123} name="dev.to" fork={false} selected />
+      <SingleRepo githubIdCode={123} name="dev.to" fork={false} featured />
     );
     it('should render and match the snapshot', () => {
       const tree = render(subject);
       expect(tree).toMatchSnapshot();
     });
 
-    it('should have a state of { selected: true }', () => {
+    it('should have a state of { featured: true }', () => {
       const context = shallow(subject);
-      expect(context.state()).toEqual({ selected: true });
+      expect(context.state()).toEqual({ featured: true });
     });
   });
 
   describe('when it is a fork', () => {
     const subject = (
-      <SingleRepo githubIdCode={123} name="dev.to" fork selected={false} />
+      <SingleRepo githubIdCode={123} name="dev.to" fork featured={false} />
     );
 
     it('should render and match the snapshot', () => {

--- a/app/javascript/githubRepos/githubRepos.jsx
+++ b/app/javascript/githubRepos/githubRepos.jsx
@@ -19,8 +19,8 @@ export class GithubRepos extends Component {
       },
       credentials: 'same-origin',
     })
-      .then(response => response.json())
-      .then(json => {
+      .then((response) => response.json())
+      .then((json) => {
         this.setState({ repos: json });
       })
       .catch(() => {
@@ -30,12 +30,12 @@ export class GithubRepos extends Component {
 
   render() {
     const { repos, erroredOut } = this.state;
-    const allRepos = repos.map(repo => (
+    const allRepos = repos.map((repo) => (
       <SingleRepo
         githubIdCode={repo.github_id_code}
         name={repo.name}
         fork={repo.fork}
-        selected={repo.selected}
+        featured={repo.featured}
       />
     ));
 
@@ -55,4 +55,4 @@ export class GithubRepos extends Component {
   }
 }
 
-GithubRepos.displayName = 'GitHub Repos Wrapper';
+GithubRepos.displayName = 'GitHub Repositories Wrapper';

--- a/app/javascript/githubRepos/singleRepo.jsx
+++ b/app/javascript/githubRepos/singleRepo.jsx
@@ -4,8 +4,8 @@ import PropTypes from 'prop-types';
 export class SingleRepo extends Component {
   constructor(props) {
     super(props);
-    const { selected } = this.props;
-    this.state = { selected };
+    const { featured } = this.props;
+    this.state = { featured };
   }
 
   forkLabel = () => {
@@ -17,7 +17,7 @@ export class SingleRepo extends Component {
   };
 
   submitRepo = () => {
-    const { selected } = this.state;
+    const { featured } = this.state;
     const { githubIdCode } = this.props;
 
     const submitButton = document.getElementById(
@@ -30,7 +30,7 @@ export class SingleRepo extends Component {
     const formData = new FormData();
     const formAttributes = {
       github_id_code: githubIdCode,
-      featured: !selected,
+      featured: !featured,
     };
     formData.append('github_repo', JSON.stringify(formAttributes));
 
@@ -42,23 +42,23 @@ export class SingleRepo extends Component {
       body: formData,
       credentials: 'same-origin',
     })
-      .then(response => response.json())
-      .then(json => {
+      .then((response) => response.json())
+      .then((json) => {
         submitButton.disabled = false;
-        this.setState({ selected: json.featured });
+        this.setState({ featured: json.featured });
       });
   };
 
   githubRepoClassName = () => {
-    const { selected } = this.state;
-    if (selected) {
-      return 'github-repo-row github-repo-row-selected';
+    const { featured } = this.state;
+    if (featured) {
+      return 'github-repo-row github-repo-row-featured';
     }
     return 'github-repo-row';
   };
 
   render() {
-    const { selected } = this.state;
+    const { featured } = this.state;
     const { name, githubIdCode } = this.props;
     return (
       <div className={this.githubRepoClassName()}>
@@ -69,7 +69,7 @@ export class SingleRepo extends Component {
             id={`github-repo-button-${githubIdCode}`}
             onClick={this.submitRepo}
           >
-            {selected ? 'REMOVE' : 'SELECT'}
+            {featured ? 'REMOVE' : 'SELECT'}
           </button>
           {name}
           {this.forkLabel()}
@@ -85,5 +85,5 @@ SingleRepo.propTypes = {
   name: PropTypes.string.isRequired,
   githubIdCode: PropTypes.number.isRequired,
   fork: PropTypes.bool.isRequired,
-  selected: PropTypes.bool.isRequired,
+  featured: PropTypes.bool.isRequired,
 };

--- a/app/models/github_repo.rb
+++ b/app/models/github_repo.rb
@@ -26,14 +26,8 @@ class GithubRepo < ApplicationRecord
     repo
   end
 
-  # select user_id, count(*) as count from github_repos group by user_id order by count desc;
   def self.update_to_latest
     where("updated_at < ?", 1.day.ago).find_each do |repo|
-      # NOTE: repos could change ownership in time, tying them to the user_id
-      # for the token it's an issue
-
-      # maybe keep the user token but use pagination and iterate through
-      # repos known grouped by user_id
       user_token = User.find_by(id: repo.user_id).identities.where(provider: "github").last.token
       client = Octokit::Client.new(access_token: user_token)
       begin

--- a/app/models/github_repo.rb
+++ b/app/models/github_repo.rb
@@ -7,6 +7,8 @@ class GithubRepo < ApplicationRecord
   validates :url, url: true, uniqueness: true
   validates :github_id_code, uniqueness: true
 
+  scope :featured, -> { where(featured: true) }
+
   after_save :clear_caches
   before_destroy :clear_caches
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -455,6 +455,13 @@ class User < ApplicationRecord
     RateLimitChecker.new(self)
   end
 
+  def authenticated_through?(provider_name)
+    return false unless Authentication::Providers.available?(provider_name)
+    return false unless Authentication::Providers.enabled?(provider_name)
+
+    identities.exists?(provider: provider_name)
+  end
+
   private
 
   def estimate_default_language

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -451,15 +451,15 @@ class User < ApplicationRecord
     search_score
   end
 
-  def rate_limiter
-    RateLimitChecker.new(self)
-  end
-
   def authenticated_through?(provider_name)
     return false unless Authentication::Providers.available?(provider_name)
     return false unless Authentication::Providers.enabled?(provider_name)
 
     identities.exists?(provider: provider_name)
+  end
+
+  def rate_limiter
+    RateLimitChecker.new(self)
   end
 
   private

--- a/app/policies/github_repo_policy.rb
+++ b/app/policies/github_repo_policy.rb
@@ -3,14 +3,6 @@ class GithubRepoPolicy < ApplicationPolicy
     user.authenticated_through?(:github) && !user_is_banned?
   end
 
-  def create?
-    user.authenticated_through?(:github) && !user_is_banned?
-  end
-
-  def update?
-    user.authenticated_through?(:github) && !user_is_banned? && user_is_owner?
-  end
-
   def update_or_create?
     user.authenticated_through?(:github) && !user_is_banned?
   end

--- a/app/policies/github_repo_policy.rb
+++ b/app/policies/github_repo_policy.rb
@@ -1,18 +1,18 @@
 class GithubRepoPolicy < ApplicationPolicy
   def index?
-    !user_is_banned?
+    user.authenticated_through?(:github) && !user_is_banned?
   end
 
   def create?
-    !user_is_banned?
+    user.authenticated_through?(:github) && !user_is_banned?
   end
 
   def update?
-    !user_is_banned? && user_is_owner?
+    user.authenticated_through?(:github) && !user_is_banned? && user_is_owner?
   end
 
   def update_or_create?
-    !user_is_banned?
+    user.authenticated_through?(:github) && !user_is_banned?
   end
 
   def permitted_attributes

--- a/app/policies/github_repo_policy.rb
+++ b/app/policies/github_repo_policy.rb
@@ -1,19 +1,13 @@
 class GithubRepoPolicy < ApplicationPolicy
   def index?
-    user.authenticated_through?(:github) && !user_is_banned?
+    !user_is_banned? && user.authenticated_through?(:github)
   end
 
   def update_or_create?
-    user.authenticated_through?(:github) && !user_is_banned?
+    !user_is_banned? && user.authenticated_through?(:github)
   end
 
   def permitted_attributes
     %i[github_id_code featured]
-  end
-
-  private
-
-  def user_is_owner?
-    record.user_id == user.id
   end
 end

--- a/app/services/github/client.rb
+++ b/app/services/github/client.rb
@@ -86,7 +86,6 @@ module Github
           builder.use Octokit::Response::RaiseError
           builder.use Octokit::Response::FeedParser
 
-          builder.response :logger
           builder.adapter :patron
         end
       end

--- a/app/services/github/client.rb
+++ b/app/services/github/client.rb
@@ -86,6 +86,7 @@ module Github
           builder.use Octokit::Response::RaiseError
           builder.use Octokit::Response::FeedParser
 
+          builder.response :logger
           builder.adapter :patron
         end
       end

--- a/app/views/github_repos/index.json.jbuilder
+++ b/app/views/github_repos/index.json.jbuilder
@@ -1,5 +1,5 @@
 json.array! @repos.each do |repo|
   json.github_id_code repo.id
 
-  json.extract!(repo, :name, :fork, :selected)
+  json.extract!(repo, :name, :fork, :featured)
 end

--- a/app/views/users/_github_repositories_area.html.erb
+++ b/app/views/users/_github_repositories_area.html.erb
@@ -1,0 +1,21 @@
+<% repositories.each do |repo| %>
+  <a class="widget" href="<%= repo.url %>" target="_blank" rel="noopener">
+    <header>
+      <h4><span class="emoji"><img src="<%= asset_path("github-logo.svg") %>" alt="github logo"></span><%= repo.name %></h4>
+    </header>
+    <div class="widget-body">
+      <% if repo.description.present? %>
+        <%= EmojiConverter.call(repo.description) %>
+      <% end %>
+      <div class="widget-footer">
+        <% if repo.fork %>
+          <span class="widget-accent">fork</span>
+        <% end %>
+        <%= repo.language %>
+        <% if repo.stargazers_count.to_i > 0 %>
+          <img src="<%= asset_path("star.svg") %>" alt="star icon"> <%= repo.stargazers_count %>
+        <% end %>
+      </div>
+    </div>
+  </a>
+<% end %>

--- a/app/views/users/_integrations.html.erb
+++ b/app/views/users/_integrations.html.erb
@@ -1,13 +1,4 @@
-<div class="crayons-card grid gap-6 p-6 mb-6">
-  <h3>Pin a few of your GitHub repos to your profile</h3>
-  <% if @client %>
-    <div id="github-repos-container">
-      <div class="github-repos loading-repos">
-      </div>
-    </div>
-    <%= javascript_packs_with_chunks_tag "githubRepos", defer: true %>
-  <% end %>
-</div>
+<%= render partial: "users/integrations_github_repositories", locals: { show_integration: @github_repositories_show } %>
 
 <div class="crayons-card grid gap-6 p-6 mb-6">
   <h3>Generate a personal blog from your <%= community_name %> posts</h3>

--- a/app/views/users/_integrations_github_repositories.html.erb
+++ b/app/views/users/_integrations_github_repositories.html.erb
@@ -1,0 +1,12 @@
+<% if show_integration %>
+  <div class="crayons-card grid gap-6 p-6 mb-6">
+    <h3>Pin a few of your GitHub repositories to your profile</h3>
+
+    <div id="github-repos-container">
+      <div class="github-repos loading-repos">
+      </div>
+    </div>
+
+    <%= javascript_packs_with_chunks_tag "githubRepos", defer: true %>
+  </div>
+<% end %>

--- a/app/views/users/_response_templates.html.erb
+++ b/app/views/users/_response_templates.html.erb
@@ -8,7 +8,7 @@
     <div class="github-repos-container -mt-4">
       <div class="github-repos">
       <% @response_templates.each do |response_template| %>
-        <div class="github-repo-row <%= "github-repo-row-selected" if response_template.id == params[:id].to_i %>">
+        <div class="github-repo-row <%= "github-repo-row-featured" if response_template.id == params[:id].to_i %>">
           <div class="github-repo-row-name flex items-center crayons-card crayons-card--secondary p-2 pl-4 mt-2">
             <div class="flex-1">
               <%= response_template.title %>

--- a/app/views/users/_sidebar_additional.html.erb
+++ b/app/views/users/_sidebar_additional.html.erb
@@ -1,28 +1,10 @@
 <div id="sidebar-wrapper-right" class="sidebar-wrapper sidebar-wrapper-right">
-  <div class="sidebar-bg" id="sidebar-bg-right"></div>
+  <div class="sidebar-bg" id="sidebar-bg-right">
+  </div>
+
   <div class="side-bar sidebar-additional showing" id="sidebar-additional">
     <%= render "users/organizations_area" %>
-    <% @user.github_repos.where(featured: true).order(stargazers_count: :desc, name: :asc).each do |repo| %>
-      <a class="widget" href="<%= repo.url %>" target="_blank" rel="noopener">
-        <header>
-          <h4><span class="emoji"><img src="<%= asset_path("github-logo.svg") %>" alt="github logo"></span><%= repo.name %></h4>
-        </header>
-        <div class="widget-body">
-          <% if repo.description.present? %>
-            <%= EmojiConverter.call(repo.description) %>
-          <% end %>
-          <div class="widget-footer">
-            <% if repo.fork %>
-              <span class="widget-accent">fork</span>
-            <% end %>
-            <%= repo.language %>
-            <% if repo.stargazers_count.to_i > 0 %>
-              <img src="<%= asset_path("star.svg") %>" alt="star icon"> <%= repo.stargazers_count %>
-            <% end %>
-          </div>
-        </div>
-      </a>
-    <% end %>
+    <%= render partial: "users/github_repositories_area", locals: { repositories: repositories } %>
     <%= render "articles/badges_area" %>
   </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -206,7 +206,7 @@
     </div>
   </div>
   <% cache "user-profile-sidebar-additional-#{@user.id}-#{@user.github_repos_updated_at}-#{@user.badge_achievements_count}-#{@user.organization_info_updated_at}", expires_in: 2.days do %>
-    <%= render "users/sidebar_additional" %>
+    <%= render partial: "users/sidebar_additional", locals: { repositories: @github_repositories } %>
   <% end %>
 </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -195,7 +195,7 @@ Rails.application.routes.draw do
   end
   resources :stripe_active_cards, only: %i[create update destroy]
   resources :live_articles, only: [:index]
-  resources :github_repos, only: %i[index create update] do
+  resources :github_repos, only: %i[index] do
     collection do
       post "/update_or_create", to: "github_repos#update_or_create"
     end

--- a/spec/models/github_repo_spec.rb
+++ b/spec/models/github_repo_spec.rb
@@ -2,34 +2,79 @@ require "rails_helper"
 
 RSpec.describe GithubRepo, type: :model do
   let(:user) { create(:user, :with_identity, identities: ["github"]) }
-  let(:repo) { build(:github_repo, user_id: user.id) }
+  let(:repo) { create(:github_repo, user: user) }
 
-  before { omniauth_mock_github_payload }
-
-  it { is_expected.to validate_presence_of(:name) }
-  it { is_expected.to validate_presence_of(:url) }
-  it { is_expected.to validate_uniqueness_of(:url) }
-  it { is_expected.to validate_uniqueness_of(:github_id_code) }
-
-  it "saves" do
-    repo.save
-    expect(repo).to be_valid
+  before do
+    omniauth_mock_github_payload
   end
 
-  describe "::find_or_create" do
-    it "creates a new object if one doesn't already exists" do
-      params = { name: Faker::Book.title, user_id: user.id, github_id_code: rand(1000),
-                 url: Faker::Internet.url }
-      described_class.find_or_create(params)
-      expect(described_class.count).to eq(1)
+  describe "validations" do
+    describe "builtin validations" do
+      subject { repo }
+
+      it { is_expected.to validate_presence_of(:github_id_code) }
+      it { is_expected.to validate_presence_of(:name) }
+      it { is_expected.to validate_presence_of(:url) }
+      it { is_expected.to validate_uniqueness_of(:github_id_code) }
+      it { is_expected.to validate_uniqueness_of(:url) }
+      it { is_expected.to validate_url_of(:url) }
+    end
+  end
+
+  context "when callbacks are triggered after save" do
+    let(:repo) { build(:github_repo, user: user) }
+
+    describe "clearing caches" do
+      it "updates the user's updated_at" do
+        old_updated_at = user.updated_at
+
+        Timecop.travel(1.minute.from_now) do
+          repo.save
+        end
+
+        expect(user.reload.updated_at.to_i > old_updated_at.to_i).to be(true)
+      end
+
+      it "busts the correct caches" do
+        allow(CacheBuster).to receive(:bust)
+
+        repo.save
+
+        expect(CacheBuster).to have_received(:bust).with(user.path)
+        expect(CacheBuster).to have_received(:bust).with("#{user.path}?i=i")
+        expect(CacheBuster).to have_received(:bust).with("#{user.path}/?i=i")
+      end
+    end
+  end
+
+  describe ".upsert" do
+    let(:params) do
+      {
+        github_id_code: rand(1000),
+        name: Faker::Book.title,
+        url: Faker::Internet.url
+      }
     end
 
-    it "returns existing object if it already exists" do
-      repo.save
-      before_update_id = repo.id
-      params = { github_id_code: repo.github_id_code }
-      updated_repo = described_class.find_or_create(params)
-      expect(updated_repo.id).to eq(before_update_id)
+    it "creates a new repo" do
+      expect do
+        described_class.upsert(user, params)
+      end.to change(described_class, :count).by(1)
+    end
+
+    it "creates a repo for the given user" do
+      repo = described_class.upsert(user, params)
+
+      expect(repo.user_id).to eq(user.id)
+    end
+
+    it "returns an existing repo updated with new params" do
+      new_name = Faker::Book.title
+
+      new_repo = described_class.upsert(user, url: repo.url, name: new_name)
+
+      expect(new_repo.id).to eq(repo.id)
+      expect(repo.reload.name).to eq(new_name)
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1123,4 +1123,28 @@ RSpec.describe User, type: :model do
       expect(described_class.mascot_account).to eq(user)
     end
   end
+
+  describe "#authenticated_through?" do
+    let(:provider) { Authentication::Providers.available.first }
+
+    it "returns false if provider is not known" do
+      expect(user.authenticated_through?(:unknown)).to be(false)
+    end
+
+    it "returns false if provider is not enabled" do
+      providers = Authentication::Providers.available - [provider]
+      allow(Authentication::Providers).to receive(:enabled).and_return(providers)
+
+      expect(user.authenticated_through?(provider)).to be(false)
+    end
+
+    it "returns false if the user has no related identity" do
+      expect(user.authenticated_through?(provider)).to be(false)
+    end
+
+    it "returns true if the user has related identity" do
+      user = create(:user, :with_identity, identities: [provider])
+      expect(user.authenticated_through?(provider)).to be(true)
+    end
+  end
 end

--- a/spec/requests/github_repos_spec.rb
+++ b/spec/requests/github_repos_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe "GithubRepos", type: :request do
 
     allow(Octokit::Client).to receive(:new).and_return(my_octokit_client)
     allow(my_octokit_client).to receive(:repositories) { stubbed_github_repos }
+    allow(my_octokit_client).to receive(:repository) { stubbed_github_repos.first }
   end
 
   describe "GET /github_repos" do
@@ -85,10 +86,10 @@ RSpec.describe "GithubRepos", type: :request do
       expect(response.content_type).to eq("application/json")
     end
 
-    it "returns 404 and json response on error" do
-      allow(my_octokit_client).to receive(:repositories).and_return([])
+    it "returns 404 if no repository is found" do
+      allow(my_octokit_client).to receive(:repository).and_raise(Octokit::NotFound)
 
-      params = { github_repo: "{}" }
+      params = { github_repo: github_repo.to_json }
       post update_or_create_github_repos_path(params), headers: headers
       expect(response).to have_http_status(:not_found)
     end

--- a/spec/requests/github_repos_spec.rb
+++ b/spec/requests/github_repos_spec.rb
@@ -72,41 +72,6 @@ RSpec.describe "GithubRepos", type: :request do
     end
   end
 
-  describe "POST /github_repos" do
-    before { sign_in user }
-
-    it "returns a 302" do
-      params = { github_repo: { github_id_code: repo.github_id_code } }
-      post github_repos_path, params: params
-
-      expect(response).to have_http_status(:found)
-    end
-
-    it "creates a new GithubRepo object" do
-      params = { github_repo: { github_id_code: repo.github_id_code } }
-      expect do
-        post github_repos_path, params: params
-      end.to change(GithubRepo, :count).by(1)
-    end
-  end
-
-  describe "PUT /github_repos/:id" do
-    before do
-      repo.save
-      sign_in user
-    end
-
-    it "returns a 302" do
-      put "/github_repos/#{repo.id}"
-      expect(response).to have_http_status(:found)
-    end
-
-    it "unfeatures the requested GithubRepo" do
-      put "/github_repos/#{repo.id}"
-      expect(GithubRepo.first.featured).to eq(false)
-    end
-  end
-
   describe "POST /github_repos/update_or_create" do
     before { sign_in user }
 

--- a/spec/requests/github_repos_spec.rb
+++ b/spec/requests/github_repos_spec.rb
@@ -126,7 +126,6 @@ RSpec.describe "GithubRepos", type: :request do
       params = { github_repo: "{}" }
       post update_or_create_github_repos_path(params), headers: headers
       expect(response).to have_http_status(:not_found)
-      expect(response.body).to include("Could not find Github repo")
     end
 
     it "updates the current user github_repos_updated_at" do
@@ -135,7 +134,7 @@ RSpec.describe "GithubRepos", type: :request do
       Timecop.travel(5.minutes.from_now) do
         params = { github_repo: github_repo.to_json }
         post update_or_create_github_repos_path(params), headers: headers
-        expect(user.reload.github_repos_updated_at > previous_date).to be(true)
+        expect(user.reload.github_repos_updated_at.to_i > previous_date.to_i).to be(true)
       end
     end
 

--- a/spec/requests/internal/negative_reactions_spec.rb
+++ b/spec/requests/internal/negative_reactions_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "/internal/negative_reactions", type: :request do
         get "/internal/negative_reactions"
         expect(response.body).to include(moderator.username)
         expect(response.body).to include(user_reaction.reactable.username)
-        expect(response.body).to include(article_reaction.reactable.title)
+        expect(response.body).to include(CGI.escapeHTML(article_reaction.reactable.title))
       end
     end
   end

--- a/spec/requests/user/user_settings_spec.rb
+++ b/spec/requests/user/user_settings_spec.rb
@@ -150,6 +150,23 @@ RSpec.describe "UserSettings", type: :request do
         expect(response.body).to include("Connect GitHub Account")
       end
     end
+
+    describe ":integrations" do
+      it "renders the repositories container if the user has authenticated through GitHub" do
+        user = create(:user, :with_identity, identities: [:github])
+        sign_in user
+
+        get user_settings_path(tab: :integrations)
+        expect(response.body).to include("github-repos-container")
+      end
+
+      it "does not render anything if the user has not authenticated through GitHub" do
+        sign_in user
+
+        get user_settings_path(tab: :integrations)
+        expect(response.body).not_to include("github-repos-container")
+      end
+    end
   end
 
   describe "PUT /update/:id" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

In this PR I tried to start refactoring the functionality around displaying GitHub repositories in one's profile.

It contains:

- a "flag" which hides the integration in setting if the user hasn't signed in through GitHub (we use their user's token to fetch repositories)
- `User.authenticated_through?(provider_name)` as a generalized boolean check to see if the user has that particular authentication.
- various cleanups in the code
- "select/remove" of repos doesn't call GitHub by fetching _all_ repositories, but only fetches the one we need

In future installments I plan to address #212 and #7751 by changing the logic we use to fetch/retrieve/update but it'd make this PR too big so I stopped before that.

I haven't replaced the custom Octokit client with our `Github::Client` as well, will see what we can do in a future PR.

I also removed some dead code.

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
