### PR TITLE
Render the correct partial when updating an organization fails

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -41,6 +41,9 @@ class OrganizationsController < ApplicationController
       flash[:settings_notice] = "Your organization was successfully updated."
       redirect_to "/settings/organization"
     else
+      @org_organization_memberships = @organization.organization_memberships.includes(:user)
+      @organization_membership = OrganizationMembership.find_by(user_id: current_user.id, organization_id: @organization.id)
+
       render template: "users/edit"
     end
   end

--- a/spec/system/organization/user_updates_org_settings_spec.rb
+++ b/spec/system/organization/user_updates_org_settings_spec.rb
@@ -1,51 +1,6 @@
 require "rails_helper"
 
 RSpec.describe "Organization setting page(/settings/organization)", type: :system, js: true do
-  let(:user) { create(:user) }
-  let(:organization) { create(:organization) }
-
-  before do
-    sign_in user
-  end
-
-  it "user creates an organization" do
-    visit "/settings/organization"
-    fill_in_org_form
-    click_button "Create Organization"
-
-    expect(page).to have_text("Your organization was successfully created and you are an admin.")
-  end
-
-  it "promotes a member to an admin" do
-    create(:organization_membership, user_id: user.id, organization_id: organization.id, type_of_user: "admin")
-    user2 = create(:user, username: "newuser")
-    create(:organization_membership, user_id: user2.id, organization_id: organization.id)
-    visit "settings/organization"
-    click_button("Make admin")
-    page.driver.browser.switch_to.alert.accept
-    expect(page).to have_text("#{user2.name} is now an admin.")
-  end
-
-  it "revokes an admin's privileges" do
-    create(:organization_membership, user_id: user.id, organization_id: organization.id, type_of_user: "admin")
-    user2 = create(:user, username: "newuser")
-    create(:organization_membership, user_id: user2.id, organization_id: organization.id, type_of_user: "admin")
-    visit "settings/organization"
-    click_button("Revoke admin status")
-    page.driver.browser.switch_to.alert.accept
-    expect(page).to have_text("#{user2.name} is no longer an admin.")
-  end
-
-  it "remove user from organization" do
-    create(:organization_membership, user_id: user.id, organization_id: organization.id, type_of_user: "admin")
-    user2 = create(:user, username: "newuser")
-    create(:organization_membership, user_id: user2.id, organization_id: organization.id)
-    visit "settings/organization"
-    click_button("Remove from org")
-    page.driver.browser.switch_to.alert.accept
-    expect(page).to have_text("#{user2.name} is no longer part of your organization.")
-  end
-
   def fill_in_org_form
     fill_in "organization[name]", with: "Organization Name"
     fill_in "organization[slug]", with: "Organization"
@@ -58,5 +13,69 @@ RSpec.describe "Organization setting page(/settings/organization)", type: :syste
     fill_in "organization[url]", with: "http://company.com"
     fill_in "organization[summary]", with: "Summary"
     fill_in "organization[proof]", with: "Proof"
+  end
+
+  let(:user) { create(:user) }
+  let(:user2) { create(:user, username: "newuser") }
+  let(:organization) { create(:organization) }
+
+  before do
+    sign_in user
+  end
+
+  def join_org(user, organization, type_of_user)
+    create(
+      :organization_membership,
+      user: user,
+      organization: organization,
+      type_of_user: type_of_user,
+    )
+  end
+
+  it "user creates an organization" do
+    visit "/settings/organization"
+    fill_in_org_form
+    click_button "Create Organization"
+
+    expect(page).to have_text("Your organization was successfully created and you are an admin.")
+  end
+
+  it "promotes a member to an admin" do
+    join_org(user, organization, :admin)
+    join_org(user2, organization, :member)
+
+    visit "settings/organization"
+    click_button("Make admin")
+    page.driver.browser.switch_to.alert.accept
+    expect(page).to have_text("#{user2.name} is now an admin.")
+  end
+
+  it "revokes an admin's privileges" do
+    join_org(user, organization, :admin)
+    join_org(user2, organization, :admin)
+
+    visit "settings/organization"
+    click_button("Revoke admin status")
+    page.driver.browser.switch_to.alert.accept
+    expect(page).to have_text("#{user2.name} is no longer an admin.")
+  end
+
+  it "remove user from organization" do
+    join_org(user, organization, :admin)
+    join_org(user2, organization, :member)
+
+    visit "settings/organization"
+    click_button("Remove from org")
+    page.driver.browser.switch_to.alert.accept
+    expect(page).to have_text("#{user2.name} is no longer part of your organization.")
+  end
+
+  it "uses the update page when an update error occurs" do
+    join_org(user, organization, :admin)
+
+    visit "/settings/organization"
+    fill_in "organization[name]", with: user.name
+    click_button("Save")
+    expect(page).to have_text("Organization details")
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The `users/edit.html.erb` template uses an intricate logic to decide which partial to render. It was defaulting to the "create a new org" template, instead of of the "edit an org as the admin" template.

Fixes https://github.com/thepracticaldev/dev.to/issues/7750

## Related Tickets & Documents

#7750 

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
