### PR TITLE
Decrease General Site Request Limit

### DIFF
--- a/config/initializers/rack/attack.rb
+++ b/config/initializers/rack/attack.rb
@@ -22,7 +22,7 @@ class Rack::Attack
     end
   end
 
-  throttle("site_hits", limit: 100, period: 2) do |request|
+  throttle("site_hits", limit: 20, period: 2) do |request|
     if request.env["HTTP_FASTLY_CLIENT_IP"].present?
       Honeycomb.add_field("fastly_client_ip", request.env["HTTP_FASTLY_CLIENT_IP"])
       request.env["HTTP_FASTLY_CLIENT_IP"].to_s

--- a/config/initializers/rack/attack.rb
+++ b/config/initializers/rack/attack.rb
@@ -22,7 +22,7 @@ class Rack::Attack
     end
   end
 
-  throttle("site_hits", limit: 20, period: 2) do |request|
+  throttle("site_hits", limit: 40, period: 2) do |request|
     if request.env["HTTP_FASTLY_CLIENT_IP"].present?
       Honeycomb.add_field("fastly_client_ip", request.env["HTTP_FASTLY_CLIENT_IP"])
       request.env["HTTP_FASTLY_CLIENT_IP"].to_s


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
After merging #7676 we have decreased the number of hits we make to our backend in a short period of time. After doing some poking around Honeycomb it looks like we max out around 6 req/second and those spikes are usually not sustained so I figured 20 req/2 secs would give us enough buffer for normal functionality. Let me know your thoughts!  

![alt_text](https://media1.tenor.com/images/9599475f89b3dbe73866021aa1b67277/tenor.gif?itemid=16077630)
