### PR TITLE
Only Allow Direct Channels Between 2 Different People

### DIFF
--- a/app/models/chat_channel.rb
+++ b/app/models/chat_channel.rb
@@ -59,7 +59,7 @@ class ChatChannel < ApplicationRecord
 
   class << self
     def create_with_users(users:, channel_type: "direct", contrived_name: "New Channel", membership_role: "member")
-      raise "Invalid direct channel" if users.size != 2 && channel_type == "direct"
+      raise "Invalid direct channel" if invalid_direct_channel?(users, channel_type)
 
       usernames = users.map(&:username).sort
       slug = channel_type == "direct" ? usernames.join("/") : contrived_name.to_s.parameterize + "-" + rand(100_000).to_s(26)
@@ -90,6 +90,10 @@ class ChatChannel < ApplicationRecord
         )
       end
       channel
+    end
+
+    def invalid_direct_channel?(users, channel_type)
+      (users.size != 2 || users.map(&:id).uniq.count < 2) && channel_type == "direct"
     end
   end
 

--- a/spec/models/chat_channel_spec.rb
+++ b/spec/models/chat_channel_spec.rb
@@ -35,6 +35,18 @@ RSpec.describe ChatChannel, type: :model do
       expect(chat_channel.active_users.size).to eq(users.size)
       expect(chat_channel.channel_users.size).to eq(users.size)
     end
+
+    context "when direct channel is invalid" do
+      it "raises an error if users are the same" do
+        user = users.first
+        expect { described_class.create_with_users(users: [user, user]) }.to raise_error("Invalid direct channel")
+      end
+
+      it "raises an error if more than 2 users" do
+        more_users = users + [create(:user)]
+        expect { described_class.create_with_users(users: more_users) }.to raise_error("Invalid direct channel")
+      end
+    end
   end
 
   describe "#active_users" do


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Somehow we are allowing people to create chat channels with themselves. When this happens we break our serialization bc the "other_user" is not present. This prevents chat channels for a single user from being created. Their ChatChannelMemberships would be invalid anyways bc we enforce uniqueness between user_id and channel_id

## Related Tickets & Documents
Fixes: https://app.honeybadger.io/fault/66984/436a2859b03e24cb43dda4036b498ab9

## Added tests?
- [x] yes

![alt_text](https://media.giphy.com/media/xUNd9YOHIn51znLRII/giphy.gif)
