### PR TITLE
Use actions panel for /mod page

### DIFF
--- a/app/assets/stylesheets/moderators.scss
+++ b/app/assets/stylesheets/moderators.scss
@@ -139,12 +139,16 @@
     }
     .mod-index-row-iframes {
       padding: 5px 0px;
+      display: flex;
       iframe {
         height: calc(100vh - 100px);
         max-height: 800px;
-        width: 49%;
+        width: 100%;
         border: 0px;
         display: inline-block;
+      }
+      .actions-panel {
+        width: 40%;
       }
     }
   }

--- a/app/javascript/packs/loadActionsPanelButton.js
+++ b/app/javascript/packs/loadActionsPanelButton.js
@@ -1,5 +1,7 @@
 import { initializeActionsPanel } from '../actionsPanel/initializeActionsPanelToggle';
 import { initializeFlagUserModal } from './flagUserModal';
 
-initializeActionsPanel();
-initializeFlagUserModal();
+if (!window.parent.document.location.pathname.endsWith('/mod')) {
+  initializeActionsPanel();
+  initializeFlagUserModal();
+}

--- a/app/views/moderations/index.html.erb
+++ b/app/views/moderations/index.html.erb
@@ -80,7 +80,7 @@
       if (el.innerHTML.length > 10) {
         el.innerHTML = ''
       } else {
-        el.innerHTML = '<div class="mod-index-row-iframes"><iframe src="' + path + '"></iframe><iframe src="' + path + '/mod"></iframe></div>'
+        el.innerHTML = '<div class="mod-index-row-iframes"><iframe src="' + path + '"></iframe><iframe class="actions-panel" src="' + path + '/actions_panel"></iframe></div>'
       }
     }
   }


### PR DESCRIPTION
Fixes `dev.to/mod` to use `/:article/actions_panel` over `/:article/mod`

![Screen Shot 2020-05-11 at 1 20 42 PM](https://user-images.githubusercontent.com/17884966/81591314-3d36e880-938a-11ea-98c6-13aa53930b9a.png)
