### PR TITLE
Ensure Users are Authorized Before Checking Reaction Rate Limit

### DIFF
--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -1,6 +1,6 @@
 class ReactionsController < ApplicationController
   before_action :set_cache_control_headers, only: [:index], unless: -> { current_user }
-  before_action :check_limit, only: [:create]
+  before_action :authorize_for_reaction, :check_limit, only: [:create]
   after_action :verify_authorized
 
   def index
@@ -49,8 +49,6 @@ class ReactionsController < ApplicationController
   end
 
   def create
-    authorize Reaction
-
     Rails.cache.delete "count_for_reactable-#{params[:reactable_type]}-#{params[:reactable_id]}"
 
     category = params[:category] || "like"
@@ -135,5 +133,9 @@ class ReactionsController < ApplicationController
 
   def check_limit
     rate_limit!(:reaction_creation)
+  end
+
+  def authorize_for_reaction
+    authorize Reaction
   end
 end

--- a/spec/requests/reactions_spec.rb
+++ b/spec/requests/reactions_spec.rb
@@ -261,5 +261,11 @@ RSpec.describe "Reactions", type: :request do
         expect(Users::RecordFieldTestEventWorker).to have_received(:perform_async).with(user.id, :user_home_feed, "user_creates_reaction")
       end
     end
+
+    context "when signed out" do
+      it "returns an unauthorized error" do
+        expect { post "/reactions", params: article_params }.to raise_error(Pundit::NotAuthorizedError)
+      end
+    end
   end
 end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
We need to authorize a user before we attempt to rate limit them since rate limiting requires a user. Without one we end up with this error: https://app.honeybadger.io/fault/66984/320e664c50618130dca15f99f128093e. This PR authorizes the user in a before_action executed before the rate limiter action. 

## Related Tickets & Documents
Fixes: https://app.honeybadger.io/fault/66984/320e664c50618130dca15f99f128093e

## Added tests?
- [x] yes

![alt_text](https://media.tenor.com/images/4d8a6c975dd4dbf66a3fe3d52edc817b/tenor.gif)
