### PR TITLE
Return the First 300 characters for Redis Commands

### DIFF
--- a/config/initializers/honeycomb.rb
+++ b/config/initializers/honeycomb.rb
@@ -26,7 +26,7 @@ else
       # Scrub unused data to save space in Honeycomb
       config.presend_hook do |fields|
         if fields.key?("redis.command")
-          fields["redis.command"].slice!(0, 300)
+          fields["redis.command"] = fields["redis.command"].slice(0, 300)
         elsif fields.key?("sql.active_record.binds")
           fields.delete("sql.active_record.binds")
           fields.delete("sql.active_record.datadog_span")


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
`.slice!` will remove how ever many characters you want off the front, return them, and then leave your string with the rest. We want those first 300 so we need to make sure we capture those in our command field in Honeycomb and not what is leftover. 

## Added tests?
- [x] no, because they aren't needed


![alt_text](https://media1.tenor.com/images/f608c2c0c84935c8c535c87a761eda6e/tenor.gif?itemid=4575685)
