### PR TITLE
[API] Distinguish between 403 and 401

### DIFF
--- a/spec/requests/api/v0/articles_spec.rb
+++ b/spec/requests/api/v0/articles_spec.rb
@@ -453,14 +453,14 @@ RSpec.describe "Api::V0::Articles", type: :request do
 
       it "fails with the wrong api key" do
         post api_articles_path, headers: { "api-key" => "foobar", "content-type" => "application/json" }
-        expect(response).to have_http_status(:unauthorized)
+        expect(response).to have_http_status(:forbidden)
       end
 
       it "fails with a failing secure compare" do
         allow(ActiveSupport::SecurityUtils).
           to receive(:secure_compare).and_return(false)
         post api_articles_path, headers: { "api-key" => api_secret.secret, "content-type" => "application/json" }
-        expect(response).to have_http_status(:unauthorized)
+        expect(response).to have_http_status(:forbidden)
       end
 
       it "fails when oauth's access_token" do
@@ -756,14 +756,14 @@ RSpec.describe "Api::V0::Articles", type: :request do
 
       it "fails with the wrong api key" do
         put path, headers: { "api-key" => "foobar", "content-type" => "application/json" }
-        expect(response).to have_http_status(:unauthorized)
+        expect(response).to have_http_status(:forbidden)
       end
 
       it "fails with a failing secure compare" do
         allow(ActiveSupport::SecurityUtils).
           to receive(:secure_compare).and_return(false)
         put path, headers: { "api-key" => api_secret.secret, "content-type" => "application/json" }
-        expect(response).to have_http_status(:unauthorized)
+        expect(response).to have_http_status(:forbidden)
       end
 
       it "fails with oauth's access_token" do

--- a/spec/requests/api/v0/classified_listings_spec.rb
+++ b/spec/requests/api/v0/classified_listings_spec.rb
@@ -240,7 +240,7 @@ RSpec.describe "Api::V0::ClassifiedListings", type: :request do
 
       it "fails with the wrong api key" do
         post api_classified_listings_path, headers: { "api-key" => "foobar", "content-type" => "application/json" }
-        expect(response).to have_http_status(:unauthorized)
+        expect(response).to have_http_status(:forbidden)
       end
     end
 
@@ -466,7 +466,7 @@ RSpec.describe "Api::V0::ClassifiedListings", type: :request do
 
       it "fails with the wrong api key" do
         put api_classified_listing_path(listing.id), headers: { "api-key" => "foobar", "content-type" => "application/json" }
-        expect(response).to have_http_status(:unauthorized)
+        expect(response).to have_http_status(:forbidden)
       end
     end
 

--- a/spec/requests/internal/negative_reactions_spec.rb
+++ b/spec/requests/internal/negative_reactions_spec.rb
@@ -44,9 +44,9 @@ RSpec.describe "/internal/negative_reactions", type: :request do
     describe "GETS /internal/negative_reactions" do
       it "renders to appropriate page" do
         get "/internal/negative_reactions"
-        expect(response.body).to include(moderator.username)
-        expect(response.body).to include(user_reaction.reactable.username)
-        expect(response.body).to include(article_reaction.reactable.title)
+        expect(response.body).to include(CGI.escapeHTML(moderator.username)).
+          and include(CGI.escapeHTML(user_reaction.reactable.username)).
+          and include(CGI.escapeHTML(article_reaction.reactable.title))
       end
     end
   end

--- a/spec/support/api_analytics_shared_examples.rb
+++ b/spec/support/api_analytics_shared_examples.rb
@@ -1,11 +1,11 @@
 RSpec.shared_examples "GET /api/analytics/:endpoint authorization examples" do |endpoint, params|
   let(:user)              { create(:user) }
   let(:api_token)         { create(:api_secret, user: user) }
-  let(:org)               { create(:organization) }
   let(:pro_user)          { create(:user, :pro) }
   let(:pro_api_token)     { create(:api_secret, user: pro_user) }
   let(:pro_org_member)    { create(:user, :pro, :org_member) }
   let(:org_member_token)  { create(:api_secret, user: pro_org_member) }
+  let(:org)               { pro_org_member.organizations.first }
   let(:article)           { create(:article, user: user) }
   let(:pro_user_article)  { create(:article, user: pro_user) }
   let(:pro_org_article)   { create(:article, user: pro_user, organization: org) }
@@ -100,8 +100,11 @@ RSpec.shared_examples "GET /api/analytics/:endpoint authorization examples" do |
 
   context "when viewing your own organizaiton's single article's analytics" do
     it "responds with status 200 OK" do
+      org_param = "&organization_id=#{pro_org_article.organization.id}"
+
       sign_in pro_org_member
-      get "/api/analytics/#{endpoint}?article_id=#{pro_org_article.id}#{params}"
+      get "/api/analytics/#{endpoint}?article_id=#{pro_org_article.id}#{params}#{org_param}"
+      expect(response).to have_http_status(:ok)
     end
   end
 end

--- a/spec/support/api_analytics_shared_examples.rb
+++ b/spec/support/api_analytics_shared_examples.rb
@@ -14,11 +14,11 @@ RSpec.shared_examples "GET /api/analytics/:endpoint authorization examples" do |
     before { get "/api/analytics/#{endpoint}?#{params}", headers: { "api-key" => "abadskajdlsak" } }
 
     it "renders an error message: 'unauthorized' in JSON" do
-      expect(JSON.parse(response.body)["error"]).to eq "unauthorized"
+      expect(response.parsed_body).to include("error" => "forbidden")
     end
 
     it "has a status 401" do
-      expect(response.status).to eq 401
+      expect(response).to have_http_status(:forbidden)
     end
   end
 
@@ -26,11 +26,11 @@ RSpec.shared_examples "GET /api/analytics/:endpoint authorization examples" do |
     before { get "/api/analytics/#{endpoint}?#{params}", headers: { "api-key" => api_token.secret } }
 
     it "renders an error message: 'unauthorized' in JSON" do
-      expect(JSON.parse(response.body)["error"]).to eq "unauthorized"
+      expect(response.parsed_body).to include("error" => "unauthorized")
     end
 
     it "has a status 401" do
-      expect(response.status).to eq 401
+      expect(response).to have_http_status(:unauthorized)
     end
   end
 
@@ -48,11 +48,11 @@ RSpec.shared_examples "GET /api/analytics/:endpoint authorization examples" do |
     end
 
     it "renders an error message: 'unauthorized' in JSON" do
-      expect(JSON.parse(response.body)["error"]).to eq "unauthorized"
+      expect(response.parsed_body).to include("error" => "unauthorized")
     end
 
     it "has a status 401" do
-      expect(response.status).to eq 401
+      expect(response).to have_http_status(:unauthorized)
     end
   end
 
@@ -71,14 +71,14 @@ RSpec.shared_examples "GET /api/analytics/:endpoint authorization examples" do |
     it "responds with status 401 unauthorized" do
       org = create(:organization)
       get "/api/analytics/#{endpoint}?organization_id=#{org.id}#{params}", headers: { "api-key" => org_member_token.secret }
-      expect(response.status).to eq 401
+      expect(response).to have_http_status(:unauthorized)
     end
   end
 
   context "when attempting to view someone else's article analytics" do
     it "responds with status 401 unauthorized" do
       get "/api/analytics/#{endpoint}?article_id=#{article.id}#{params}"
-      expect(response.status).to eq 401
+      expect(response).to have_http_status(:unauthorized)
     end
   end
 
@@ -86,7 +86,7 @@ RSpec.shared_examples "GET /api/analytics/:endpoint authorization examples" do |
     it "responds with status 200 OK" do
       sign_in pro_user
       get "/api/analytics/#{endpoint}?#{params}"
-      expect(response.status).to eq 200
+      expect(response).to have_http_status(:ok)
     end
   end
 
@@ -94,7 +94,7 @@ RSpec.shared_examples "GET /api/analytics/:endpoint authorization examples" do |
     it "responds with status 200 OK" do
       sign_in pro_user
       get "/api/analytics/#{endpoint}?article_id=#{pro_user_article.id}#{params}"
-      expect(response.status).to eq 200
+      expect(response).to have_http_status(:ok)
     end
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Feature

## Description
When interacting with API, it's best we serve 403 instead of 401 wherever appropriate so our developers are properly informed.

Also
- Some light refactor.
- Added a missing expectation.
## Related Tickets & Documents
n/a
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
n/a
## Added tests?
- [x] updated

## Added to documentation?
- [x] no documentation needed