### PR TITLE
Bug Fix: Only Throttle Confirmation Emails for Existing Users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -611,7 +611,7 @@ class User < ApplicationRecord
   end
 
   def can_send_confirmation_email
-    return if changes[:email].blank?
+    return if changes[:email].blank? || id.blank?
 
     rate_limiter.track_limit_by_action(:send_email_confirmation)
     rate_limiter.check_limit!(:send_email_confirmation)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -201,11 +201,12 @@ RSpec.describe User, type: :model do
       expect(user.errors[:username].to_s).to include("taken")
     end
 
-    it "validates can_send_confirmation_email" do
-      user = build(:user)
+    it "validates can_send_confirmation_email for existing user" do
+      user = create(:user)
       limiter = RateLimitChecker.new(user)
       allow(user).to receive(:rate_limiter).and_return(limiter)
       allow(limiter).to receive(:limit_by_action).and_return(true)
+      user.update(email: "new_email@yo.com")
       expect(user).not_to be_valid
       expect(user.errors[:email].to_s).to include("confirmation could not be sent. Rate limit reached")
     end


### PR DESCRIPTION


## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
We will try to validate this confirmation sending rate limit for new users which we should not be doing. I added an additional check to the guard clause to look for an id indicating an existing user. I have a loop clearing the generic cache keys right now. 

Following this, I will issue a PR to raise an error in the RateLimitCheck if user.id is nil bc that should never happen. 

## Added tests?
- [x] yes

![alt_text](https://media1.tenor.com/images/157df44bdeda788946c236a9836277fc/tenor.gif?itemid=4586958)
