### PR TITLE
Raise an Error If Trying to Rate Limit with a Missing User ID

### DIFF
--- a/app/services/rate_limit_checker.rb
+++ b/app/services/rate_limit_checker.rb
@@ -66,6 +66,8 @@ class RateLimitChecker
   end
 
   def limit_cache_key(action)
+    raise "Invalid Cache Key: user ID can't be blank" unless @user.id
+
     "#{@user.id}_#{action}"
   end
 

--- a/spec/services/rate_limit_checker_spec.rb
+++ b/spec/services/rate_limit_checker_spec.rb
@@ -14,8 +14,14 @@ RSpec.describe RateLimitChecker, type: :service do
       expect(rate_limit_checker.limit_by_action("random-nothing")).to be(false)
     end
 
+    it "raises an error if user does not have an ID" do
+      action = described_class::ACTION_LIMITERS.keys.first
+      limiter = described_class.new(build(:user))
+      expect { limiter.limit_by_action(action) }.to raise_error("Invalid Cache Key: user ID can't be blank")
+    end
+
     # published_article_creation limit we check against the database rather than our cache
-    RateLimitChecker::ACTION_LIMITERS.except(:published_article_creation).each do |action, _options|
+    described_class::ACTION_LIMITERS.except(:published_article_creation).each do |action, _options|
       it "returns true if #{action} limit has been reached" do
         allow(Rails.cache).to receive(:read).with(
           cache_key(action),


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Save us from ourselves Feature

## Description
To prevent generic cache keys from incorrectly being made if an unpersisted user is passed to the RateLimitChecker we will raise an error if the user ID is not present when creating the cache key.

## Added tests?
- [x] yes

![alt_text](https://media1.tenor.com/images/c3d942614471e2978d065b29120d0621/tenor.gif?itemid=13476334)
