### PR TITLE
Fix flaky organization helper spec

### DIFF
--- a/spec/helpers/organization_helper_spec.rb
+++ b/spec/helpers/organization_helper_spec.rb
@@ -1,13 +1,13 @@
 require "rails_helper"
 
 describe OrganizationHelper, type: :helper do
-  it "display the correct options" do
-    org1 = create(:organization)
-    org2 = create(:organization)
+  it "displays the correct options" do
+    org1 = create(:organization, name: "ACME")
+    org2 = create(:organization, name: "Pied Piper")
     allow(org1).to receive(:unspent_credits_count).and_return(1)
 
     options = helper.orgs_with_credits([org1, org2])
-    expect(options).to include("#{org1.name} (1)")
-    expect(options).to include("#{org2.name} (0)")
+    expect(options).to include("ACME (1)")
+    expect(options).to include("Pied Piper (0)")
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Description

A spec introducd in #7761 is flaky:

```
  1) OrganizationHelper display the correct options
     Failure/Error: expect(options).to include("#{org1.name} (1)")
       expected "<option value=\"14\">Murray, Dickinson and D&#39;Amore (1)</option>\n<option value=\"15\">Krajcik-Kozey (0)</option>" to include "Murray, Dickinson and D'Amore (1)"
       Diff:
       @@ -1,2 +1,3 @@
       -Murray, Dickinson and D'Amore (1)
       +<option value="14">Murray, Dickinson and D&#39;Amore (1)</option>
       +<option value="15">Krajcik-Kozey (0)</option>
```

The Rails tag helpers encode entitities such as `&` or `'`, but rather than duplicating that on the expectations and re-testing Rails I switched to hard-coded org names.

## Related Tickets & Documents

n/a

## Added tests?

- [X] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [X] no documentation needed
