### PR TITLE
Fix profile page rendering when a username contains spaces

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -59,8 +59,7 @@ class UsersController < ApplicationController
       @user.touch(:profile_updated_at)
       redirect_to "/settings/#{@tab}"
     else
-      Honeycomb.add_field("error",
-                          @user.errors.messages.reject { |_, v| v.empty? })
+      Honeycomb.add_field("error", @user.errors.messages.reject { |_, v| v.empty? })
       Honeycomb.add_field("errored", true)
       render :edit, status: :bad_request
     end

--- a/app/lib/url.rb
+++ b/app/lib/url.rb
@@ -60,6 +60,8 @@ module URL
   # @param user [User] the user to create the URL for
   def self.user(user)
     url(user.username)
+  rescue URI::InvalidURIError # invalid username containing spaces will result in an error
+    nil
   end
 
   def self.organization(organization)

--- a/app/views/users/_profile.html.erb
+++ b/app/views/users/_profile.html.erb
@@ -4,7 +4,7 @@
 
 <div class="crayons-card mb-6 p-6 grid gap-6">
   <div class="flex items-center">
-    <a href="<%= app_url(current_user.username) %>" aria-label="Go to your profile page" class="mr-2">
+    <a href="<%= user_url(current_user) || '#' %>" aria-label="Go to your profile page" class="mr-2">
       <img src="https://d2fltix0v2e0sb.cloudfront.net/dev-badge.svg" alt="<%= community_name %> badge" height="32" width="32" class="dev-badge crayons-icon" />
     </a>
     <p>Add the <%= community_name %> badge to your personal site. <a href="/p/badges">Click here for the code</a>.</p>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -49,7 +49,7 @@
         </h1>
       <% else %>
         <h1 class="fs-xl s:fs-3xl">
-          Settings for <a href="<%= user_url(@user) %>">@<%= @user.username.truncate(User::USERNAME_MAX_LENGTH) %></a>
+          Settings for <a href="<%= user_url(@user) || '#' %>">@<%= @user.username.truncate(User::USERNAME_MAX_LENGTH) %></a>
         </h1>
       <% end %>
     </header>

--- a/spec/system/user/user_edits_profile_spec.rb
+++ b/spec/system/user/user_edits_profile_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe "User edits their profile", type: :system do
+  let(:user) { create(:user, saw_onboarding: true) }
+
+  before do
+    sign_in user
+  end
+
+  describe "visiting /settings/profile" do
+    it "renders an error if the username contains spaces and thus is invalid" do
+      visit "/settings/profile"
+
+      fill_in "user[username]", with: "a b c"
+      click_button "Save"
+
+      expect(page).to have_text("Username is invalid")
+    end
+  end
+end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When a username is invalid and contains spaces, the profile page that is supposed to render the errors will break due to URI parsing. 

Fixes https://github.com/thepracticaldev/dev.to/issues/7758

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
