### PR TITLE
Add query-friendly article additions (Initial step)

### DIFF
--- a/app/assets/stylesheets/article-show.scss
+++ b/app/assets/stylesheets/article-show.scss
@@ -153,6 +153,17 @@ article {
         font-size: 57px;
       }
 
+      .article-title-preamble {
+        display: block;
+        color: var(--base-60);
+        font-size: 16px;
+        margin-bottom: -1.25vw;
+        @media screen and (min-width: 1600px) {
+          font-size: 17px;
+          margin-bottom: -18px;
+        }
+      }
+
       .title-block {
         display: inline-block;
       }

--- a/app/assets/stylesheets/article-show.scss
+++ b/app/assets/stylesheets/article-show.scss
@@ -156,10 +156,10 @@ article {
       .article-title-preamble {
         display: block;
         color: var(--base-60);
-        font-size: 16px;
+        font-size: calc(16px + 0.2vw);
         margin-bottom: -1.25vw;
         @media screen and (min-width: 1600px) {
-          font-size: 17px;
+          font-size: 18px;
           margin-bottom: -18px;
         }
       }

--- a/app/dashboards/article_dashboard.rb
+++ b/app/dashboards/article_dashboard.rb
@@ -15,8 +15,8 @@ class ArticleDashboard < Administrate::BaseDashboard
     organization: Field::BelongsTo,
     id: Field::Number,
     title: Field::String,
-    query_friendly_title_preamble: Field::String,
-    query_friendly_description_alternative: Field::String,
+    search_optimized_title_preamble: Field::String,
+    search_optimized_description_replacement: Field::String,
     body_html: Field::Text,
     body_markdown: Field::Text,
     slug: Field::String,
@@ -69,8 +69,8 @@ class ArticleDashboard < Administrate::BaseDashboard
     third_user_id
     organization
     title
-    query_friendly_title_preamble
-    query_friendly_description_alternative
+    search_optimized_title_preamble
+    search_optimized_description_replacement
     body_markdown
     slug
     social_image

--- a/app/dashboards/article_dashboard.rb
+++ b/app/dashboards/article_dashboard.rb
@@ -15,6 +15,8 @@ class ArticleDashboard < Administrate::BaseDashboard
     organization: Field::BelongsTo,
     id: Field::Number,
     title: Field::String,
+    query_friendly_title_preamble: Field::String,
+    query_friendly_description_alternative: Field::String,
     body_html: Field::Text,
     body_markdown: Field::Text,
     slug: Field::String,
@@ -67,6 +69,8 @@ class ArticleDashboard < Administrate::BaseDashboard
     third_user_id
     organization
     title
+    query_friendly_title_preamble
+    query_friendly_description_alternative
     body_markdown
     slug
     social_image

--- a/app/decorators/article_decorator.rb
+++ b/app/decorators/article_decorator.rb
@@ -53,7 +53,17 @@ class ArticleDecorator < ApplicationDecorator
     published_at.to_i
   end
 
+  def title_with_query_preamble(user_signed_in)
+    if query_friendly_title_preamble.present? && !user_signed_in
+      "#{query_friendly_title_preamble}: #{title}"
+    else
+      title
+    end
+  end
+
   def description_and_tags
+    return query_friendly_description_alternative if query_friendly_description_alternative.present?
+
     modified_description = description.strip
     modified_description += "." unless description.end_with?(".")
     return modified_description if cached_tag_list.blank?

--- a/app/decorators/article_decorator.rb
+++ b/app/decorators/article_decorator.rb
@@ -54,15 +54,15 @@ class ArticleDecorator < ApplicationDecorator
   end
 
   def title_with_query_preamble(user_signed_in)
-    if query_friendly_title_preamble.present? && !user_signed_in
-      "#{query_friendly_title_preamble}: #{title}"
+    if search_optimized_title_preamble.present? && !user_signed_in
+      "#{search_optimized_title_preamble}: #{title}"
     else
       title
     end
   end
 
   def description_and_tags
-    return query_friendly_description_alternative if query_friendly_description_alternative.present?
+    return search_optimized_description_replacement if search_optimized_description_replacement.present?
 
     modified_description = description.strip
     modified_description += "." unless description.end_with?(".")

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -1,4 +1,4 @@
-<% title @article.title %>
+<% title @article.title_with_query_preamble(user_signed_in?) %>
 
 <%= render "shared/webcomponents_loader_script" %>
 <%= javascript_packs_with_chunks_tag "clipboardCopy", "webShare", "articlePage", defer: true %>
@@ -115,6 +115,9 @@
           </a>
         <% end %>
         <h1 class="<%= @article.title_length_classification %>">
+          <% if @article.query_friendly_title_preamble.present? && !user_signed_in? %>
+            <span class="article-title-preamble"><%= @article.query_friendly_title_preamble %></span>
+          <% end %>
           <%= @article.title %>
         </h1>
         <h3>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -115,8 +115,8 @@
           </a>
         <% end %>
         <h1 class="<%= @article.title_length_classification %>">
-          <% if @article.query_friendly_title_preamble.present? && !user_signed_in? %>
-            <span class="article-title-preamble"><%= @article.query_friendly_title_preamble %></span>
+          <% if @article.search_optimized_title_preamble.present? && !user_signed_in? %>
+            <span class="article-title-preamble"><%= @article.search_optimized_title_preamble %></span>
           <% end %>
           <%= @article.title %>
         </h1>

--- a/db/migrate/20200511224704_add_query_friendly_admin_fields_to_articles.rb
+++ b/db/migrate/20200511224704_add_query_friendly_admin_fields_to_articles.rb
@@ -1,0 +1,6 @@
+class AddQueryFriendlyAdminFieldsToArticles < ActiveRecord::Migration[5.2]
+  def change
+    add_column :articles, :query_friendly_title_preamble, :string
+    add_column :articles, :query_friendly_description_alternative, :string
+  end
+end

--- a/db/migrate/20200511224704_add_query_friendly_admin_fields_to_articles.rb
+++ b/db/migrate/20200511224704_add_query_friendly_admin_fields_to_articles.rb
@@ -1,6 +1,6 @@
 class AddQueryFriendlyAdminFieldsToArticles < ActiveRecord::Migration[5.2]
   def change
-    add_column :articles, :query_friendly_title_preamble, :string
-    add_column :articles, :query_friendly_description_alternative, :string
+    add_column :articles, :search_optimized_title_preamble, :string
+    add_column :articles, :search_optimized_description_replacement, :string
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -98,8 +98,8 @@ ActiveRecord::Schema.define(version: 2020_05_11_224704) do
     t.boolean "published", default: false
     t.datetime "published_at"
     t.boolean "published_from_feed", default: false
-    t.string "query_friendly_description_alternative"
-    t.string "query_friendly_title_preamble"
+    t.string "search_optimized_description_replacement"
+    t.string "search_optimized_title_preamble"
     t.integer "rating_votes_count", default: 0, null: false
     t.integer "reactions_count", default: 0, null: false
     t.integer "reading_time", default: 0

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_04_075409) do
+ActiveRecord::Schema.define(version: 2020_05_11_224704) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -98,6 +98,8 @@ ActiveRecord::Schema.define(version: 2020_05_04_075409) do
     t.boolean "published", default: false
     t.datetime "published_at"
     t.boolean "published_from_feed", default: false
+    t.string "query_friendly_description_alternative"
+    t.string "query_friendly_title_preamble"
     t.integer "rating_votes_count", default: 0, null: false
     t.integer "reactions_count", default: 0, null: false
     t.integer "reading_time", default: 0

--- a/spec/decorators/article_decorator_spec.rb
+++ b/spec/decorators/article_decorator_spec.rb
@@ -174,5 +174,12 @@ RSpec.describe ArticleDecorator, type: :decorator do
       parsed_post_by_string += "." unless created_article.user.name.end_with?(".")
       expect(created_article.description_and_tags).to eq("#{parsed_post_by_string} Tagged with heytag.")
     end
+
+    it "returns query_friendly_description_alternative if it is present" do
+      body_markdown = "---\ntitle: Title\npublished: false\ndescription:\ntags: heytag\n---\n\nHey this is the article"
+      query_friendly_description_alternative = "Hey this is the expected result"
+      expect(create_article(body_markdown: body_markdown, query_friendly_description_alternative: query_friendly_description_alternative).
+        description_and_tags).to eq(query_friendly_description_alternative)
+    end
   end
 end

--- a/spec/decorators/article_decorator_spec.rb
+++ b/spec/decorators/article_decorator_spec.rb
@@ -175,11 +175,11 @@ RSpec.describe ArticleDecorator, type: :decorator do
       expect(created_article.description_and_tags).to eq("#{parsed_post_by_string} Tagged with heytag.")
     end
 
-    it "returns query_friendly_description_alternative if it is present" do
+    it "returns search_optimized_description_replacement if it is present" do
       body_markdown = "---\ntitle: Title\npublished: false\ndescription:\ntags: heytag\n---\n\nHey this is the article"
-      query_friendly_description_alternative = "Hey this is the expected result"
-      expect(create_article(body_markdown: body_markdown, query_friendly_description_alternative: query_friendly_description_alternative).
-        description_and_tags).to eq(query_friendly_description_alternative)
+      search_optimized_description_replacement = "Hey this is the expected result"
+      expect(create_article(body_markdown: body_markdown, search_optimized_description_replacement: search_optimized_description_replacement).
+        description_and_tags).to eq(search_optimized_description_replacement)
     end
   end
 end

--- a/spec/requests/stories_show_spec.rb
+++ b/spec/requests/stories_show_spec.rb
@@ -31,40 +31,40 @@ RSpec.describe "StoriesShow", type: :request do
       expect(response.body).to include "<title>#{CGI.escapeHTML(article.title)} - #{community_name}</title>"
     end
 
-    # query_friendly_title_preamble
+    # search_optimized_title_preamble
 
-    it "renders title tag with query_friendly_title_preamble if set and not signed in" do
-      article.update_column(:query_friendly_title_preamble, "Hey this is a test")
+    it "renders title tag with search_optimized_title_preamble if set and not signed in" do
+      article.update_column(:search_optimized_title_preamble, "Hey this is a test")
       get article.reload.path
       expect(response.body).to include "<title>Hey this is a test: #{CGI.escapeHTML(article.title)} - #{community_name}</title>"
     end
 
-    it "does not render title tag with query_friendly_title_preamble if set and not signed in" do
+    it "does not render title tag with search_optimized_title_preamble if set and not signed in" do
       sign_in user
-      article.update_column(:query_friendly_title_preamble, "Hey this is a test")
+      article.update_column(:search_optimized_title_preamble, "Hey this is a test")
       get article.path
       expect(response.body).to include "<title>#{CGI.escapeHTML(article.title)} - #{community_qualified_name} 👩‍💻👨‍💻</title>"
     end
 
-    it "does not render preamble with query_friendly_title_preamble not signed in but query_friendly_title_preamble not set" do
+    it "does not render preamble with search_optimized_title_preamble not signed in but search_optimized_title_preamble not set" do
       get article.path
       expect(response.body).to include "#{CGI.escapeHTML(article.title)} - #{community_name}</title>"
     end
 
-    it "renders title preamble with query_friendly_title_preamble if set and not signed in" do
-      article.update_column(:query_friendly_title_preamble, "Hey this is a test")
+    it "renders title preamble with search_optimized_title_preamble if set and not signed in" do
+      article.update_column(:search_optimized_title_preamble, "Hey this is a test")
       get article.reload.path
       expect(response.body).to include "<span class=\"article-title-preamble\">Hey this is a test</span>"
     end
 
-    it "does not render preamble with query_friendly_title_preamble if set and signed in" do
+    it "does not render preamble with search_optimized_title_preamble if set and signed in" do
       sign_in user
-      article.update_column(:query_friendly_title_preamble, "Hey this is a test")
+      article.update_column(:search_optimized_title_preamble, "Hey this is a test")
       get article.path
       expect(response.body).not_to include "<span class=\"article-title-preamble\">Hey this is a test</span>"
     end
 
-    it "does not render title tag with query_friendly_title_preamble not signed in but query_friendly_title_preamble not set" do
+    it "does not render title tag with search_optimized_title_preamble not signed in but search_optimized_title_preamble not set" do
       get article.path
       expect(response.body).not_to include "<span class=\"article-title-preamble\">Hey this is a test</span>"
     end

--- a/spec/requests/stories_show_spec.rb
+++ b/spec/requests/stories_show_spec.rb
@@ -31,6 +31,44 @@ RSpec.describe "StoriesShow", type: :request do
       expect(response.body).to include "<title>#{CGI.escapeHTML(article.title)} - #{community_name}</title>"
     end
 
+    # query_friendly_title_preamble
+
+    it "renders title tag with query_friendly_title_preamble if set and not signed in" do
+      article.update_column(:query_friendly_title_preamble, "Hey this is a test")
+      get article.reload.path
+      expect(response.body).to include "<title>Hey this is a test: #{CGI.escapeHTML(article.title)} - #{community_name}</title>"
+    end
+
+    it "does not render title tag with query_friendly_title_preamble if set and not signed in" do
+      sign_in user
+      article.update_column(:query_friendly_title_preamble, "Hey this is a test")
+      get article.path
+      expect(response.body).to include "<title>#{CGI.escapeHTML(article.title)} - #{community_qualified_name} 👩‍💻👨‍💻</title>"
+    end
+
+    it "does not render preamble with query_friendly_title_preamble not signed in but query_friendly_title_preamble not set" do
+      get article.path
+      expect(response.body).to include "#{CGI.escapeHTML(article.title)} - #{community_name}</title>"
+    end
+
+    it "renders title preamble with query_friendly_title_preamble if set and not signed in" do
+      article.update_column(:query_friendly_title_preamble, "Hey this is a test")
+      get article.reload.path
+      expect(response.body).to include "<span class=\"article-title-preamble\">Hey this is a test</span>"
+    end
+
+    it "does not render preamble with query_friendly_title_preamble if set and signed in" do
+      sign_in user
+      article.update_column(:query_friendly_title_preamble, "Hey this is a test")
+      get article.path
+      expect(response.body).not_to include "<span class=\"article-title-preamble\">Hey this is a test</span>"
+    end
+
+    it "does not render title tag with query_friendly_title_preamble not signed in but query_friendly_title_preamble not set" do
+      get article.path
+      expect(response.body).not_to include "<span class=\"article-title-preamble\">Hey this is a test</span>"
+    end
+
     it "renders second and third users if present" do
       # 3rd user doesn't seem to get rendered for some reason
       user2 = create(:user)


### PR DESCRIPTION

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This feature allows admins to add a label which helps clarify the content of a post, primarily for our own search engine as well as Google, and of course clarification for humans. For now this is just going to affect non-logged-in traffic but I could see this being pretty useful across all posts.

It puts a preamble in the `<title>` tag and on the post, but it is distinct from the actual article content—I think it is helpful and appropriate to modify things about _the page_, but not the title/body of the content itself, which is authored by the user.

This also adds an option to re-word the description, which again is part of site meta info and not necessarily part of the content itself.

Here is an example where this could be helpful: The title itself isn't enough to convey that this is a helpful post if you search "Rails 6" in our search, even though it is all about Rails 6.

<img width="716" alt="Screen Shot 2020-05-13 at 8 48 59 AM" src="https://user-images.githubusercontent.com/3102842/81814316-a471ab80-94f6-11ea-9977-7d5c13d9bc7f.png">

This PR is only the data layer, as I'd like to experiment with this a bit right now before we get into how it would fit properly into `/internal` (Or even `/mod` possibly). This is a small, but somewhat powerful tool and we want to make sure we're thinking about it the right way.