### PR TITLE
Include crayons style in index view for redundency

### DIFF
--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -23,6 +23,15 @@
   <meta name="twitter:card" content="summary_large_image">
   <%= auto_discovery_link_tag(:rss, app_url("feed"), title: "#{community_name} RSS Feed") %>
 <% end %>
+
+<% cache "included-crayons_#{ApplicationConfig['HEROKU_SLUG_COMMIT']}", expires_in: 8.hours do %>
+  <%# This is a temporary inclusion of crayons on the page while new styles may not be included in shell %>
+  <%# provides redundency to make sure new styles are included during major transition %>
+  <style>
+    <% Rails.application.config.assets.compile = true %>
+    <%= Rails.application.assets["crayons.css"].to_s.html_safe %>
+  </style>
+<% end %>
 <%= javascript_packs_with_chunks_tag "homePage", defer: true %>
 
 <% cache(cache_key_heroku_slug("main-stories-index-#{params}-#{user_signed_in?}"), expires_in: 90.seconds) do %>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Since the shell and index page is out of sync, this provides some redundancy of style while users are still on old styles in the cached shell.