### PR TITLE
Fix podcast styling

### DIFF
--- a/app/assets/stylesheets/components/stories.scss
+++ b/app/assets/stylesheets/components/stories.scss
@@ -240,17 +240,17 @@
   margin-bottom: var(--su-4);
 
   &:last-child {
-    margin-bottom: 0;
+    margin-bottom: 4px;
   }
 
   &__cover {
-    width: var(--su-7);
-    height: var(--su-7);
+    width: var(--su-8);
+    height: var(--su-8);
     margin-right: var(--su-2);
 
     img {
-      width: 100%;
-      height: 100%;
+      width: var(--su-8);
+      min-width:var(--su-8);
       border-radius: var(--radius);
     }
   }
@@ -258,16 +258,17 @@
   &__author {
     font-size: var(--fs-s);
     color: var(--card-color-secondary);
+    margin-top: -5px;
   }
 
   &__title {
     color: var(--card-color);
     line-height: var(--lh-tight);
     margin-bottom: var(--su-1);
-    font-size: var(--fs-xl);
+    font-size: var(--fs-l);
 
     @media (min-width: $breakpoint-s) {
-      font-size: var(--fs-2xl);
+      font-size: var(--fs-xl);
     }
 
     a {

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -331,7 +331,7 @@ class StoriesController < ApplicationController
   def assign_podcasts
     return unless user_signed_in?
 
-    num_hours = Rails.env.production? ? 24 : 800
+    num_hours = Rails.env.production? ? 24 : 2400
     @podcast_episodes = PodcastEpisode.
       includes(:podcast).
       order("published_at desc").

--- a/app/javascript/podcasts/PodcastEpisode.jsx
+++ b/app/javascript/podcasts/PodcastEpisode.jsx
@@ -15,7 +15,7 @@ export const PodcastEpisode = ({ episode }) => {
         <p className="crayons-podcast-episode__author">
           {episode.podcast.title}
         </p>
-        <h2 className="crayons-story__title mb-0">
+        <h2 className="crayons-podcast-episode__title crayons-story__title mb-0">
           <a href={`/${episode.podcast.slug}/${episode.slug}`}>
             {episode.title}
           </a>

--- a/app/javascript/podcasts/__tests__/__snapshots__/PodcastEpisode.test.jsx.snap
+++ b/app/javascript/podcasts/__tests__/__snapshots__/PodcastEpisode.test.jsx.snap
@@ -20,7 +20,7 @@ exports[`<PodcastEpisode /> component should render a podcast episode 1`] = `
       Rubber local
     </p>
     <h2
-      class="crayons-story__title mb-0"
+      class="crayons-podcast-episode__title crayons-story__title mb-0"
     >
       <a
         href="/monitor-recontextualize/undefined"

--- a/app/javascript/podcasts/__tests__/__snapshots__/TodaysPodcasts.test.jsx.snap
+++ b/app/javascript/podcasts/__tests__/__snapshots__/TodaysPodcasts.test.jsx.snap
@@ -35,7 +35,7 @@ exports[`<TodaysPodcasts /> component should render a today's podcasts 1`] = `
           Rubber local
         </p>
         <h2
-          class="crayons-story__title mb-0"
+          class="crayons-podcast-episode__title crayons-story__title mb-0"
         >
           <a
             href="/monitor-recontextualize/undefined"
@@ -64,7 +64,7 @@ exports[`<TodaysPodcasts /> component should render a today's podcasts 1`] = `
           Rubber local
         </p>
         <h2
-          class="crayons-story__title mb-0"
+          class="crayons-podcast-episode__title crayons-story__title mb-0"
         >
           <a
             href="/monitor-recontextualize/undefined"
@@ -93,7 +93,7 @@ exports[`<TodaysPodcasts /> component should render a today's podcasts 1`] = `
           Rubber local
         </p>
         <h2
-          class="crayons-story__title mb-0"
+          class="crayons-podcast-episode__title crayons-story__title mb-0"
         >
           <a
             href="/monitor-recontextualize/undefined"


### PR DESCRIPTION


<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Podcast episode images are currently a little messed up and the titles don't have the proper class. I also took the liberty of downsizing the font _slightly_ even from the intended one because I think as a list they don't need to be so individually pronounced.

Mostly just a style bug fix though.