### PR TITLE
Adjust overflow in comments and revert inline css

### DIFF
--- a/app/assets/stylesheets/components/comments.scss
+++ b/app/assets/stylesheets/components/comments.scss
@@ -16,17 +16,32 @@
   &__body {
     margin-top: calc(var(--su-1) * -1);
     padding-left: var(--su-7);
+    padding-bottom: var(--su-2);
+    max-height:330px;
+    overflow: hidden;
 
     a:hover {
       text-decoration: underline; //todo: default for all in-content links
     }
 
-    p {
+    p, div.highlight {
+      margin: 6px auto;
+    }
+
+    * {
       display: -webkit-box;
-      -webkit-line-clamp: 2;
       -webkit-box-orient: vertical;
       overflow: hidden;
+      max-width: 100%;
+      width: auto;
+      object-fit: contain; 
     }
+  }
+
+  &__footer {
+    box-shadow: 0px 0px var(--su-2) var(--su-2) #f9fafa;
+    z-index: 5;
+    position: relative;
   }
 
   & + & {

--- a/app/assets/stylesheets/components/comments.scss
+++ b/app/assets/stylesheets/components/comments.scss
@@ -39,7 +39,7 @@
   }
 
   &__footer {
-    box-shadow: 0px 0px var(--su-2) var(--su-2) #f9fafa;
+    box-shadow: 0px 0px var(--su-2) var(--su-2) var(--story-comments-bg);
     z-index: 5;
     position: relative;
   }

--- a/app/assets/stylesheets/components/stories.scss
+++ b/app/assets/stylesheets/components/stories.scss
@@ -174,7 +174,8 @@
 
     &__actions {
       padding-left: calc(var(--su-6) + var(--su-4));
-      padding-top: var(--su-4);
+      z-index: 6;
+      position:relative;
     }
   }
 

--- a/app/javascript/articles/__tests__/__snapshots__/Article.test.jsx.snap
+++ b/app/javascript/articles/__tests__/__snapshots__/Article.test.jsx.snap
@@ -1285,6 +1285,9 @@ exports[`<Article /> component should render as saved on reading list 1`] = `
             }
           }
         />
+        <div
+          class="crayons-comment__footer"
+        />
       </div>
       <div
         class="crayons-story__comments__actions"
@@ -2085,6 +2088,9 @@ exports[`<Article /> component should render with comments 1`] = `
 ",
             }
           }
+        />
+        <div
+          class="crayons-comment__footer"
         />
       </div>
       <div

--- a/app/javascript/articles/components/CommentListItem.jsx
+++ b/app/javascript/articles/components/CommentListItem.jsx
@@ -46,6 +46,7 @@ export const CommentListItem = ({ comment }) => (
       // eslint-disable-next-line react/no-danger
       dangerouslySetInnerHTML={{ __html: comment.safe_processed_html }}
     />
+    <div className="crayons-comment__footer" />
   </div>
 );
 

--- a/app/javascript/articles/components/__tests__/__snapshots__/CommentsList.test.jsx.snap
+++ b/app/javascript/articles/components/__tests__/__snapshots__/CommentsList.test.jsx.snap
@@ -46,6 +46,9 @@ exports[`<CommentsList /> should not render "See all comments" button when there
         }
       }
     />
+    <div
+      class="crayons-comment__footer"
+    />
   </div>
   <div
     class="crayons-comment pl-2 cursor-pointer"
@@ -88,6 +91,9 @@ exports[`<CommentsList /> should not render "See all comments" button when there
 ",
         }
       }
+    />
+    <div
+      class="crayons-comment__footer"
     />
   </div>
 </div>
@@ -138,6 +144,9 @@ exports[`<CommentsList /> should not render "See all comments" button when there
 ",
         }
       }
+    />
+    <div
+      class="crayons-comment__footer"
     />
   </div>
 </div>
@@ -193,6 +202,9 @@ exports[`<CommentsList /> should render "See all comments" button when there are
         }
       }
     />
+    <div
+      class="crayons-comment__footer"
+    />
   </div>
   <div
     class="crayons-comment pl-2 cursor-pointer"
@@ -235,6 +247,9 @@ exports[`<CommentsList /> should render "See all comments" button when there are
 ",
         }
       }
+    />
+    <div
+      class="crayons-comment__footer"
     />
   </div>
   <div
@@ -296,6 +311,9 @@ exports[`<CommentsList /> should render comments 1`] = `
         }
       }
     />
+    <div
+      class="crayons-comment__footer"
+    />
   </div>
   <div
     class="crayons-comment pl-2 cursor-pointer"
@@ -338,6 +356,9 @@ exports[`<CommentsList /> should render comments 1`] = `
 ",
         }
       }
+    />
+    <div
+      class="crayons-comment__footer"
     />
   </div>
   <div

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -24,14 +24,6 @@
   <%= auto_discovery_link_tag(:rss, app_url("feed"), title: "#{community_name} RSS Feed") %>
 <% end %>
 
-<% cache "included-crayons_#{ApplicationConfig['HEROKU_SLUG_COMMIT']}", expires_in: 8.hours do %>
-  <%# This is a temporary inclusion of crayons on the page while new styles may not be included in shell %>
-  <%# provides redundency to make sure new styles are included during major transition %>
-  <style>
-    <% Rails.application.config.assets.compile = true %>
-    <%= Rails.application.assets["crayons.css"].to_s.html_safe %>
-  </style>
-<% end %>
 <%= javascript_packs_with_chunks_tag "homePage", defer: true %>
 
 <% cache(cache_key_heroku_slug("main-stories-index-#{params}-#{user_signed_in?}"), expires_in: 90.seconds) do %>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This makes an adjustment so longer comments subtly fade away... Maybe not the permanent solution but I think it works...

<img width="676" alt="Screen Shot 2020-05-12 at 12 12 25 PM" src="https://user-images.githubusercontent.com/3102842/81718544-daa52180-9449-11ea-89e2-61bda95aea9a.png">

This also fixes the ill-fated inlined `<style>`