### PR TITLE
Delay RemoveFromIndex Job to Fix Callback Race Conditions

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -22,32 +22,37 @@ class Comment < ApplicationRecord
   has_many :notifications, as: :notifiable, inverse_of: :notifiable, dependent: :delete_all
   has_many :notification_subscriptions, as: :notifiable, inverse_of: :notifiable, dependent: :destroy
 
+  before_validation :evaluate_markdown, if: -> { body_markdown }
+  validate :permissions, if: :commentable
   validates :body_markdown, presence: true, length: { in: BODY_MARKDOWN_SIZE_RANGE }
   validates :body_markdown, uniqueness: { scope: BODY_MARKDOWN_UNIQUENESS_SCOPES }
   validates :commentable_id, presence: true
   validates :commentable_type, inclusion: { in: COMMENTABLE_TYPES }
   validates :user_id, presence: true
 
+  before_create :adjust_comment_parent_based_on_depth
+  before_save :set_markdown_character_count, if: :body_markdown
+
   after_create :notify_slack_channel_about_warned_users
   after_create :after_create_checks
   after_create_commit :record_field_test_event
-  after_commit :calculate_score, on: %i[create update]
-  after_update_commit :update_notifications, if: proc { |comment| comment.saved_changes.include? "body_markdown" }
-  after_save     :bust_cache
-  after_save     :synchronous_bust
-  after_destroy  :after_destroy_actions
-  before_destroy :before_destroy_actions
   after_create_commit :send_email_notification, if: :should_send_email_notification?
   after_create_commit :create_first_reaction
   after_create_commit :send_to_moderator
+
+  after_commit :calculate_score, on: %i[create update]
   after_commit :index_to_elasticsearch, on: %i[create update]
+
+  after_save :bust_cache
+  after_save :synchronous_bust
+
+  after_update :remove_notifications, if: :deleted
+  after_update :update_descendant_notifications, if: :deleted
+  after_update_commit :update_notifications, if: proc { |comment| comment.saved_changes.include? "body_markdown" }
+
+  after_destroy  :after_destroy_actions
+  before_destroy :before_destroy_actions
   after_commit :remove_from_elasticsearch, on: [:destroy]
-  before_save    :set_markdown_character_count, if: :body_markdown
-  before_create  :adjust_comment_parent_based_on_depth
-  after_update   :remove_notifications, if: :deleted
-  after_update   :update_descendant_notifications, if: :deleted
-  before_validation :evaluate_markdown, if: -> { body_markdown }
-  validate :permissions, if: :commentable
 
   scope :eager_load_serialized_data, -> { includes(:user, :commentable) }
 

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -13,7 +13,7 @@ module Searchable
 
   def remove_from_elasticsearch
     # Callbacks can cause index and removal jobs to be enqueued at the same time
-    # to avoid indexing a document after removing it we delay the removal job by 5 seconds to 
+    # to avoid indexing a document after removing it we delay the removal job by 5 seconds to
     # ensure it is run last
     Search::RemoveFromIndexWorker.perform_in(5.seconds, self.class::SEARCH_CLASS.to_s, search_id)
   end

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -12,7 +12,7 @@ module Searchable
   end
 
   def remove_from_elasticsearch
-    Search::RemoveFromIndexWorker.perform_async(self.class::SEARCH_CLASS.to_s, search_id)
+    Search::RemoveFromIndexWorker.perform_in(5.seconds, self.class::SEARCH_CLASS.to_s, search_id)
   end
 
   def serialized_search_hash

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -12,6 +12,9 @@ module Searchable
   end
 
   def remove_from_elasticsearch
+    # Callbacks can cause index and removal jobs to be enqueued at the same time
+    # to avoid indexing a document after removing it we delay the removal job by 5 seconds to 
+    # ensure it is run last
     Search::RemoveFromIndexWorker.perform_in(5.seconds, self.class::SEARCH_CLASS.to_s, search_id)
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Bug Fix

## Description
We recently had two incidents where an Article and a Comment were updated and then right after deleted. This led to index and removal from index jobs to be enqueued close enough together that the removal job finished before the indexing jobs causing the records to still be in Elasticsearch even though they are no longer in Postgres. A big reason for this is our callbacks which ideally we should get rid of. However, that is a huge undertaking so **my "hack" to solve this problem for now is to put a small delay on the removal job of 5 seconds.**

While trying to make heads and tails of our callbacks I went ahead and organized the comment callbacks which were kinda haphazardly thrown together. 

## Added tests?
- [x] no, because they aren't needed

![alt_text](https://media1.tenor.com/images/45d5bf50cfd846015d36b902d0037861/tenor.gif?itemid=10449773)
