### PR TITLE
Handle negative reactions on comments

### DIFF
--- a/app/views/internal/negative_reactions/index.html.erb
+++ b/app/views/internal/negative_reactions/index.html.erb
@@ -26,6 +26,7 @@
     <tr>
       <th scope="col">ID</th>
       <th scope="col">User</th>
+      <th scope="col">Type</th>
       <th scope="col">Action</th>
       <th scope="col">Content</th>
       <th scope="col">Date</th>
@@ -36,12 +37,15 @@
       <tr>
         <td><%= reaction.id %></td>
         <td><%= link_to reaction.user.username, internal_user_path(reaction.user_id) %></td>
+        <td><%= reaction.reactable_type %></td>
         <td><%= reaction.category %></td>
         <td>
           <% if reaction.reactable_type == "Article" %>
             <%= link_to reaction.reactable.title, reaction.reactable.path %>
-          <% else %>
+          <% elsif reaction.reactable_type == "User" %>
             <%= link_to reaction.reactable.username, reaction.reactable.path %>
+          <% elsif reaction.reactable_type == "Comment" %>
+            <%= link_to "#{reaction.reactable.user.username}'s Comment", reaction.reactable.path %>
           <% end %>
         </td>
         <td><%= reaction.created_at %></td>

--- a/spec/factories/reactions.rb
+++ b/spec/factories/reactions.rb
@@ -29,5 +29,9 @@ FactoryBot.define do
     trait :user do
       association :reactable, factory: :user
     end
+
+    trait :comment do
+      association :reactable, factory: :comment
+    end
   end
 end

--- a/spec/requests/internal/negative_reactions_spec.rb
+++ b/spec/requests/internal/negative_reactions_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe "/internal/negative_reactions", type: :request do
     let(:admin)              { create(:user, :admin) }
     let(:moderator)          { create(:user, :trusted) }
     let!(:user_reaction)     { create(:vomit_reaction, :user, user: moderator) }
+    let!(:comment_reaction)  { create(:vomit_reaction, :comment, user: moderator) }
     let!(:article_reaction)  { create(:vomit_reaction, user: moderator) }
 
     before do
@@ -46,6 +47,7 @@ RSpec.describe "/internal/negative_reactions", type: :request do
         get "/internal/negative_reactions"
         expect(response.body).to include(moderator.username)
         expect(response.body).to include(user_reaction.reactable.username)
+        expect(response.body).to include(comment_reaction.reactable.user.username)
         expect(response.body).to include(CGI.escapeHTML(article_reaction.reactable.title))
       end
     end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

It totally slipped my mind that we can create negative reactions on
comments. This PR accounts for that in the internal view that renders
negative reactions.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![external-content duckduckgo com](https://user-images.githubusercontent.com/11466782/81740248-44312a00-9462-11ea-9189-fdb3d3793c19.gif)

