### PR TITLE
Specify background for content row in onboarding

### DIFF
--- a/app/assets/stylesheets/preact/onboarding-modal.scss
+++ b/app/assets/stylesheets/preact/onboarding-modal.scss
@@ -412,6 +412,7 @@ $onboarding-user-selected-hover: rgba(71, 85, 235, 0.2);
 
 .onboarding-body {
   .content-row {
+    background-color: var(--base-inverted); // Specify background for Safari.
     align-items: center;
     border: none;
     box-sizing: border-box;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
While trying to take some screenshots for a blog post, I found a visual bug in our onboarding flow on Safari. In the "follow users" slide, the background color of the rows of the scrollable table is all wrong:
<img width="1761" alt="Screen Shot 2020-05-12 at 12 54 18 PM" src="https://user-images.githubusercontent.com/6921610/81741253-1db7c280-9453-11ea-810d-114b7ba2e55d.png">

Notably, this does _not_ happen on Chrome. I investigated and found out that Safari was inheriting the border-bottom color from elsewhere (?). So we'll need to specify the background-color for the content row element explicitly.

## Related Tickets & Documents
N/A

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
Before this change on Safari:
<img width="1761" alt="Screen Shot 2020-05-12 at 12 54 18 PM" src="https://user-images.githubusercontent.com/6921610/81741253-1db7c280-9453-11ea-810d-114b7ba2e55d.png">

After this change on Safari:
<img width="1761" alt="Screen Shot 2020-05-12 at 1 12 41 PM" src="https://user-images.githubusercontent.com/6921610/81741237-17c1e180-9453-11ea-809f-61eeb9b8c733.png">

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## Are there any post deployment tasks we need to perform?
N/A

## [optional] What gif best describes this PR or how it makes you feel?

![](https://media1.giphy.com/media/l4JyRqcDU93S334KQ/giphy.gif?cid=5a38a5a285b23faab3320e9ae56f8bdf515e8ffabe1f813a&rid=giphy.gif)
