### PR TITLE
Limit Suggestions for Social Service Posts to 3 Per Article Per Service

### DIFF
--- a/app/models/buffer_update.rb
+++ b/app/models/buffer_update.rb
@@ -2,7 +2,7 @@ class BufferUpdate < ApplicationRecord
   resourcify
 
   belongs_to :article
-  validate :validate_body_text_recent_uniqueness
+  validate :validate_body_text_recent_uniqueness, :validate_suggestion_limit
   validates :status, inclusion: { in: %w[pending sent_direct confirmed dismissed] }
 
   def self.buff!(article_id, text, buffer_profile_id_code, social_service_name = "twitter", tag_id = nil, admin_id = nil)
@@ -55,5 +55,11 @@ class BufferUpdate < ApplicationRecord
         where("created_at > ?", 2.minutes.ago).any?
       errors.add(:body_text, "\"#{body_text}\" has already been submitted very recently")
     end
+  end
+
+  def validate_suggestion_limit
+    return unless BufferUpdate.where(article_id: article_id, tag_id: tag_id, social_service_name: social_service_name).count > 2
+
+    errors.add(:article_id, "already has multiple suggestions for #{social_service_name}")
   end
 end

--- a/spec/models/buffer_update_spec.rb
+++ b/spec/models/buffer_update_spec.rb
@@ -42,4 +42,13 @@ RSpec.describe BufferUpdate, type: :model do
     described_class.buff!(create(:article).id, "twitter_buffer_text", "CODE", "twitter", 1)
     expect(described_class.all.size).to eq(2)
   end
+
+  it "does not allow more than 3 suggestions" do
+    Array.new(3) do |i|
+      described_class.buff!(article.id, "twitter_buffer_text_#{i}", "CODE", "twitter")
+    end
+    invalid_buffer = described_class.buff!(article.id, "twitter_buffer_text_4", "CODE", "twitter")
+    expect(described_class.all.size).to eq(3)
+    expect(invalid_buffer.errors.full_messages.first).to include("already has multiple suggestions")
+  end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
This limits the number of suggestions a user can make for a given social service and given article.

## Added tests?
- [x] yes


![alt_text](https://media2.giphy.com/media/l4KhWMUew1f0PsBZm/giphy.gif)
