### PR TITLE
Expose Article Update Rate Limit on Config Page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -92,7 +92,5 @@ class ApplicationController < ActionController::Base
     rate_limiter.check_limit!(action)
   end
 
-  def rate_limiter
-    RateLimitChecker.new(current_user)
-  end
+  delegate :rate_limiter, to: :current_user
 end

--- a/app/helpers/rate_limit_checker_helper.rb
+++ b/app/helpers/rate_limit_checker_helper.rb
@@ -1,5 +1,10 @@
 module RateLimitCheckerHelper
   CONFIGURABLE_RATES = {
+    rate_limit_article_update: {
+      min: 1,
+      placeholder: 150,
+      description: "The number of article updates a user can make in 30 seconds"
+    },
     rate_limit_follow_count_daily: {
       min: 0,
       placeholder: 500,

--- a/app/services/articles/creator.rb
+++ b/app/services/articles/creator.rb
@@ -30,7 +30,7 @@ module Articles
     attr_reader :user, :article_params, :event_dispatcher
 
     def rate_limit!
-      RateLimitChecker.new(user).check_limit!(:published_article_creation)
+      user.rate_limiter.check_limit!(:published_article_creation)
     end
 
     def dispatch_event(article)

--- a/app/services/articles/updater.rb
+++ b/app/services/articles/updater.rb
@@ -12,7 +12,7 @@ module Articles
     end
 
     def call
-      rate_limiter.check_limit!(:article_update)
+      user.rate_limiter.check_limit!(:article_update)
 
       article = load_article
       was_published = article.published
@@ -36,7 +36,7 @@ module Articles
       article_params[:edited_at] = Time.current if update_edited_at
 
       article.update!(article_params)
-      rate_limiter.track_limit_by_action(:article_update)
+      user.rate_limiter.track_limit_by_action(:article_update)
 
       # send notification only the first time an article is published
       send_notification = article.published && article.saved_change_to_published_at.present?
@@ -56,10 +56,6 @@ module Articles
     private
 
     attr_reader :user, :article_id, :article_params, :event_dispatcher
-
-    def rate_limiter
-      RateLimitChecker.new(user)
-    end
 
     def dispatch_event(article)
       event_dispatcher.call("article_updated", article)


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Bug Fix

## Description
We were missing our configurable rate limit for article updates from our config display list in admin, this adds it. Plus I did a little refactoring with the new `user.rate_limiter` method.

## Added tests?
- [x] no, because they aren't needed

![alt_text](https://media0.giphy.com/media/l2YWsOymHDRFYqyAM/giphy.gif)
