### PR TITLE
Enforce Uniq Abuse Reports from Reporters

### DIFF
--- a/app/models/feedback_message.rb
+++ b/app/models/feedback_message.rb
@@ -17,6 +17,7 @@ class FeedbackMessage < ApplicationRecord
             inclusion: {
               in: %w[Open Invalid Resolved]
             }
+  validates :reporter_id, uniqueness: { scope: %i[reported_url feedback_type] }, if: :abuse_report? && :reporter_id
 
   def abuse_report?
     feedback_type == "abuse-reports"

--- a/spec/factories/feedback_messages.rb
+++ b/spec/factories/feedback_messages.rb
@@ -21,6 +21,6 @@ FactoryBot.define do
   trait :bug_report do
     feedback_type { "bug-reports" }
     message { "i clicked something and this happened" }
-    category { "bugs" }
+    category { "bug" }
   end
 end

--- a/spec/models/feedback_message_spec.rb
+++ b/spec/models/feedback_message_spec.rb
@@ -1,44 +1,41 @@
 require "rails_helper"
 
 RSpec.describe FeedbackMessage, type: :model do
+  subject(:feedback_message) { create(:feedback_message) }
+
+  it { is_expected.to validate_presence_of(:feedback_type) }
+  it { is_expected.to validate_presence_of(:message) }
+  it { is_expected.to validate_length_of(:reported_url).is_at_most(250) }
+  it { is_expected.to validate_length_of(:message).is_at_most(2500) }
+
+  it do
+    expect(feedback_message).to validate_inclusion_of(:category).
+      in_array(["spam", "other", "rude or vulgar", "harassment", "bug"])
+  end
+
+  it do
+    expect(feedback_message).to validate_inclusion_of(:status).
+      in_array(%w[Open Invalid Resolved])
+  end
+
   describe "validations for an abuse report" do
-    subject(:feedback_message) do
-      described_class.new(
-        feedback_type: "abuse-reports",
-        reported_url: "https://dev.to",
-        category: "spam",
-        message: "something",
-      )
-    end
+    subject(:feedback_message) { create(:feedback_message, :abuse_report) }
 
-    it { is_expected.to validate_presence_of(:feedback_type) }
     it { is_expected.to validate_presence_of(:reported_url) }
-    it { is_expected.to validate_presence_of(:message) }
+    it { is_expected.to validate_uniqueness_of(:reporter_id).scoped_to(%i[reported_url feedback_type]) }
     it { is_expected.to validate_length_of(:reported_url).is_at_most(250) }
-    it { is_expected.to validate_length_of(:message).is_at_most(2500) }
-
-    it do
-      expect(feedback_message).to validate_inclusion_of(:category).
-        in_array(["spam", "other", "rude or vulgar", "harassment", "bug"])
-    end
+    it { is_expected.to validate_presence_of(:category) }
   end
 
   describe "validations for a bug report" do
-    subject(:feedback_message) do
-      described_class.new(
-        feedback_type: "bug-reports",
-        category: "bug",
-        message: "something",
-      )
-    end
+    subject(:feedback_message) { create(:feedback_message, :bug_report) }
 
-    it { is_expected.to validate_presence_of(:feedback_type) }
-    it { is_expected.to validate_presence_of(:message) }
     it { is_expected.not_to validate_presence_of(:reported_url) }
+  end
 
-    it do
-      expect(feedback_message).to validate_inclusion_of(:category).
-        in_array(["spam", "other", "rude or vulgar", "harassment", "bug"])
-    end
+  describe "validations without a reporter_id" do
+    subject(:feedback_message) { build(:feedback_message, :abuse_report, reporter_id: nil) }
+
+    it { is_expected.not_to validate_uniqueness_of(:reporter_id).scoped_to(%i[reported_url feedback_type]) }
   end
 end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
Enforce uniqueness between reported_url and feedback type when reporting abuse and reporter_id is present to avoid duplicate reports. 

## Added tests?
- [x] yes and cleaned them up to use Rspec conventions

![alt_text](https://media1.tenor.com/images/997010422dfbef6a7e9d6b6968adbba0/tenor.gif?itemid=4802460)
