### PR TITLE
Create write_articles oauth scope

### DIFF
--- a/app/controllers/api/v0/articles_controller.rb
+++ b/app/controllers/api/v0/articles_controller.rb
@@ -1,9 +1,9 @@
 module Api
   module V0
     class ArticlesController < ApiController
-      before_action :authenticate_with_api_key_or_current_user!, only: %i[create update]
-      before_action :authenticate!, only: :me
+      before_action :authenticate!, only: %i[create update me]
       before_action -> { doorkeeper_authorize! :public }, only: %w[index show], if: -> { doorkeeper_token }
+      before_action -> { doorkeeper_authorize! :write_articles }, only: %w[create update], if: -> { doorkeeper_token }
 
       before_action :validate_article_param_is_hash, only: %w[create update]
 

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -211,7 +211,7 @@ Doorkeeper.configure do
   # https://doorkeeper.gitbook.io/guides/ruby-on-rails/scopes
   #
   default_scopes :public, :read_articles
-  # optional_scopes :write, :update
+  optional_scopes :public, :read_articles, :write_articles
 
   # Allows to restrict only certain scopes for grant_type.
   # By default, all the scopes will be available for all the grant types.

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -211,7 +211,7 @@ Doorkeeper.configure do
   # https://doorkeeper.gitbook.io/guides/ruby-on-rails/scopes
   #
   default_scopes :public, :read_articles
-  optional_scopes :public, :read_articles, :write_articles
+  optional_scopes :write_articles
 
   # Allows to restrict only certain scopes for grant_type.
   # By default, all the scopes will be available for all the grant types.
@@ -226,7 +226,7 @@ Doorkeeper.configure do
   # not in configuration, i.e. +default_scopes+ or +optional_scopes+.
   # (disabled by default)
   #
-  # enforce_configured_scopes
+  enforce_configured_scopes
 
   # Change the way client credentials are retrieved from the request object.
   # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then

--- a/config/locales/doorkeeper.en.yml
+++ b/config/locales/doorkeeper.en.yml
@@ -22,7 +22,7 @@ en:
     scopes:
       public: 'Access public profile data and published articles'
       read_articles: 'Access all articles including drafts'
-      write_articles: 'Write access to articles'
+      write_articles: 'Access to creating and updating articles'
 
     applications:
       confirmations:

--- a/config/locales/doorkeeper.en.yml
+++ b/config/locales/doorkeeper.en.yml
@@ -22,6 +22,7 @@ en:
     scopes:
       public: 'Access public profile data and published articles'
       read_articles: 'Access all articles including drafts'
+      write_articles: 'Write access to articles'
 
     applications:
       confirmations:

--- a/spec/requests/api/v0/articles_spec.rb
+++ b/spec/requests/api/v0/articles_spec.rb
@@ -462,14 +462,6 @@ RSpec.describe "Api::V0::Articles", type: :request do
         post api_articles_path, headers: { "api-key" => api_secret.secret, "content-type" => "application/json" }
         expect(response).to have_http_status(:unauthorized)
       end
-
-      it "fails when oauth's access_token" do
-        access_token = create(:doorkeeper_access_token, resource_owner_id: user.id)
-        headers = { "authorization" => "Bearer #{access_token.token}", "content-type" => "application/json" }
-
-        post api_articles_path, params: { article: { title: Faker::Book.title } }.to_json, headers: headers
-        expect(response).to have_http_status(:unauthorized)
-      end
     end
 
     describe "when authorized" do
@@ -479,6 +471,22 @@ RSpec.describe "Api::V0::Articles", type: :request do
         headers = { "api-key" => api_secret.secret, "content-type" => "application/json" }
         params = default_params.merge params
         post api_articles_path, params: { article: params }.to_json, headers: headers
+      end
+
+      it "returns 200 when missing the proper scope (oauth)" do
+        access_token = create(:doorkeeper_access_token, resource_owner_id: user.id, scopes: "public")
+        headers = { "authorization" => "Bearer #{access_token.token}", "content-type" => "application/json" }
+
+        post api_articles_path, params: { article: { title: Faker::Book.title } }.to_json, headers: headers
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "returns 201 with the right scope (oauth)" do
+        access_token = create(:doorkeeper_access_token, resource_owner_id: user.id, scopes: "write_articles")
+        headers = { "authorization" => "Bearer #{access_token.token}", "content-type" => "application/json" }
+
+        post api_articles_path, params: { article: { title: Faker::Book.title, body_markdown: "" } }.to_json, headers: headers
+        expect(response).to have_http_status(:created)
       end
 
       it "returns a 429 status code if the rate limit is reached" do
@@ -765,17 +773,6 @@ RSpec.describe "Api::V0::Articles", type: :request do
         put path, headers: { "api-key" => api_secret.secret, "content-type" => "application/json" }
         expect(response).to have_http_status(:unauthorized)
       end
-
-      it "fails with oauth's access_token" do
-        access_token = create(:doorkeeper_access_token, resource_owner_id: user.id)
-        headers = { "authorization" => "Bearer #{access_token.token}", "content-type" => "application/json" }
-
-        title = Faker::Book.title
-        body_markdown = "foobar"
-        params = { title: title, body_markdown: body_markdown }
-        put path, params: { article: params }.to_json, headers: headers
-        expect(response).to have_http_status(:unauthorized)
-      end
     end
 
     describe "when authorized" do
@@ -784,6 +781,28 @@ RSpec.describe "Api::V0::Articles", type: :request do
       def put_article(**params)
         headers = { "api-key" => api_secret.secret, "content-type" => "application/json" }
         put path, params: { article: params }.to_json, headers: headers
+      end
+
+      it "returns 403 if user does not have the proper scope (oauth)" do
+        access_token = create(:doorkeeper_access_token, resource_owner_id: user.id)
+        headers = { "authorization" => "Bearer #{access_token.token}", "content-type" => "application/json" }
+
+        title = Faker::Book.title
+        body_markdown = "foobar"
+        params = { title: title, body_markdown: body_markdown }
+        put path, params: { article: params }.to_json, headers: headers
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "returns 200 if user does not have the proper scope (oauth)" do
+        access_token = create(:doorkeeper_access_token, resource_owner_id: user.id, scopes: "write_articles")
+        headers = { "authorization" => "Bearer #{access_token.token}", "content-type" => "application/json" }
+
+        title = Faker::Book.title
+        body_markdown = "foobar"
+        params = { title: title, body_markdown: body_markdown }
+        put path, params: { article: params }.to_json, headers: headers
+        expect(response).to have_http_status(:ok)
       end
 
       it "returns a 429 status code if the rate limit is reached" do

--- a/spec/requests/api/v0/articles_spec.rb
+++ b/spec/requests/api/v0/articles_spec.rb
@@ -473,7 +473,7 @@ RSpec.describe "Api::V0::Articles", type: :request do
         post api_articles_path, params: { article: params }.to_json, headers: headers
       end
 
-      it "returns 200 when missing the proper scope (oauth)" do
+      it "returns a 403 if :write_articles scope is missing (oauth)" do
         access_token = create(:doorkeeper_access_token, resource_owner_id: user.id, scopes: "public")
         headers = { "authorization" => "Bearer #{access_token.token}", "content-type" => "application/json" }
 
@@ -481,7 +481,7 @@ RSpec.describe "Api::V0::Articles", type: :request do
         expect(response).to have_http_status(:forbidden)
       end
 
-      it "returns 201 with the right scope (oauth)" do
+      it "returns a 201 if :write_articles scope is provided (oauth)" do
         access_token = create(:doorkeeper_access_token, resource_owner_id: user.id, scopes: "write_articles")
         headers = { "authorization" => "Bearer #{access_token.token}", "content-type" => "application/json" }
 
@@ -783,7 +783,7 @@ RSpec.describe "Api::V0::Articles", type: :request do
         put path, params: { article: params }.to_json, headers: headers
       end
 
-      it "returns 403 if user does not have the proper scope (oauth)" do
+      it "returns a 403 if :write_articles scope is missing (oauth)" do
         access_token = create(:doorkeeper_access_token, resource_owner_id: user.id)
         headers = { "authorization" => "Bearer #{access_token.token}", "content-type" => "application/json" }
 
@@ -794,7 +794,7 @@ RSpec.describe "Api::V0::Articles", type: :request do
         expect(response).to have_http_status(:forbidden)
       end
 
-      it "returns 200 if user does not have the proper scope (oauth)" do
+      it "returns a 200 if :write_articles scope is provided (oauth)" do
         access_token = create(:doorkeeper_access_token, resource_owner_id: user.id, scopes: "write_articles")
         headers = { "authorization" => "Bearer #{access_token.token}", "content-type" => "application/json" }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
This PR adds `:write_articles` scope to expand our doorkeeper capability. I've also enabled `enforce_configured_scopes` so that application can only be created with scope we provided
n/a
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![image](https://user-images.githubusercontent.com/15793250/81861567-71e7a300-9536-11ea-9305-edd49fea4045.png)
## Added tests?
- [y] yes

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a