### PR TITLE
Add max height to content images to ensure they can't over-eat vertical space

### DIFF
--- a/app/assets/stylesheets/article-show.scss
+++ b/app/assets/stylesheets/article-show.scss
@@ -612,6 +612,7 @@ article {
       margin: auto;
       left: -4%;
       max-width: 108%;
+      max-height: calc(50vh + 180px);
 
       @media screen and (min-width: 430px) {
         left: -6px;

--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -889,6 +889,7 @@ a.header-link {
     }
     img {
       max-width: 100%;
+      max-height: calc(50vh + 100px);
     }
     .table-wrapper-paragraph {
       width: 100%;


### PR DESCRIPTION
…al space

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Currently in comments and articles if we have an image which is _super tall_ it sometimes kind of breaks things because we default to 100% max-width. This PR adds sensible max heights to complement max width and ensure images are more easily consumed if they are super tall.

Tall images like this are now much less out of place.

<img width="1416" alt="Screen Shot 2020-05-13 at 5 25 31 PM" src="https://user-images.githubusercontent.com/3102842/81868453-61d4c100-9540-11ea-8c76-665d759ca168.png">

<img width="776" alt="Screen Shot 2020-05-13 at 5 38 02 PM" src="https://user-images.githubusercontent.com/3102842/81868588-92b4f600-9540-11ea-993b-77f5a29e350b.png">

Screenshots are probably the worst offender in that they tend to be _super tall_ and kind of ugly when blown up huge. This helps account for more types of images. Clicking still lets the user see a bigger pic (And we could close the loop on lighthouse view to really make this a slick experience).