### PR TITLE
Track and Limit API writes by IP Address + Rack Attack Refactor 

### DIFF
--- a/config/initializers/rack/attack.rb
+++ b/config/initializers/rack/attack.rb
@@ -2,37 +2,45 @@ Rack::Attack.throttled_response_retry_after_header = true
 
 class Rack::Attack
   throttle("search_throttle", limit: 5, period: 1) do |request|
-    if request.path.starts_with?("/search/") && request.env["HTTP_FASTLY_CLIENT_IP"].present?
-      Honeycomb.add_field("fastly_client_ip", request.env["HTTP_FASTLY_CLIENT_IP"])
-      request.env["HTTP_FASTLY_CLIENT_IP"].to_s
+    return if request.env["HTTP_FASTLY_CLIENT_IP"].blank?
+
+    if request.path.starts_with?("/search/")
+      track_and_return_ip(request.env["HTTP_FASTLY_CLIENT_IP"])
     end
   end
 
   throttle("api_throttle", limit: 3, period: 1) do |request|
-    if request.path.starts_with?("/api/") && request.get? && request.env["HTTP_FASTLY_CLIENT_IP"].present?
-      Honeycomb.add_field("fastly_client_ip", request.env["HTTP_FASTLY_CLIENT_IP"])
-      request.env["HTTP_FASTLY_CLIENT_IP"].to_s
+    return if request.env["HTTP_FASTLY_CLIENT_IP"].blank?
+
+    if request.path.starts_with?("/api/") && request.get?
+      track_and_return_ip(request.env["HTTP_FASTLY_CLIENT_IP"])
     end
   end
 
   throttle("api_write_throttle", limit: 1, period: 1) do |request|
+    return if request.env["HTTP_FASTLY_CLIENT_IP"].blank?
+
     if request.path.starts_with?("/api/") && (request.put? || request.post? || request.delete?)
-      Honeycomb.add_field("user_api_key", request.env["HTTP_API_KEY"])
-      request.env["HTTP_API_KEY"]
+      track_and_return_ip(request.env["HTTP_FASTLY_CLIENT_IP"])
     end
   end
 
   throttle("site_hits", limit: 40, period: 2) do |request|
-    if request.env["HTTP_FASTLY_CLIENT_IP"].present?
-      Honeycomb.add_field("fastly_client_ip", request.env["HTTP_FASTLY_CLIENT_IP"])
-      request.env["HTTP_FASTLY_CLIENT_IP"].to_s
-    end
+    return if request.env["HTTP_FASTLY_CLIENT_IP"].blank?
+
+    track_and_return_ip(request.env["HTTP_FASTLY_CLIENT_IP"])
   end
 
   throttle("message_throttle", limit: 2, period: 1) do |request|
-    if request.path.starts_with?("/messages") && request.post? && request.env["HTTP_FASTLY_CLIENT_IP"].present?
-      Honeycomb.add_field("fastly_client_ip", request.env["HTTP_FASTLY_CLIENT_IP"])
-      request.env["HTTP_FASTLY_CLIENT_IP"].to_s
+    return if request.env["HTTP_FASTLY_CLIENT_IP"].blank?
+
+    if request.path.starts_with?("/messages") && request.post?
+      track_and_return_ip(request.env["HTTP_FASTLY_CLIENT_IP"])
     end
+  end
+
+  def self.track_and_return_ip(ip_address)
+    Honeycomb.add_field("fastly_client_ip", ip_address)
+    ip_address.to_s
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Bug Fix

## Description
Since merging #7834 we may no longer have an API token when an Oauth user uses the API to update or create Articles. With that API key our current throttling will no longer work.  This updates the API write throttle to us IP address like the rest of the throttles. 

On my TODO list I want to extract the fastly env variable and make it configurable so in the future, a community doesn't need a fastly client IP to rate limit. 

## Added tests?
- [x] yes

![alt_text](https://media1.giphy.com/media/MF1aaZpwtmqUa2FoCa/200.gif)
