### PR TITLE
Use bulk_show Endpoint for Follow Buttons on Followers Dashboard

### DIFF
--- a/app/views/dashboards/followers.html.erb
+++ b/app/views/dashboards/followers.html.erb
@@ -31,7 +31,7 @@
               <span class="dashboard-username">@<%= user.username %></span>
               <a href="#"
                 id="dashboard-follow"
-                class="cta follow-action-button dashboard-follow"
+                class="cta follow-action-button dashboard-follow follow-user"
                 data-info='{"id":<%= user.id %>,"className":"<%= user.class.name %>","style":"follow-back"}'>
                 &nbsp;
               </a>

--- a/spec/system/dashboards/user_followers_display_spec.rb
+++ b/spec/system/dashboards/user_followers_display_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe "Followers Dashboard", type: :system, js: true do
+  let(:default_per_page) { 3 }
+  let(:user) { create(:user) }
+  let(:followed_user) { create(:user) }
+  let(:following_user) { create(:user) }
+
+  before do
+    sign_in user
+  end
+
+  context "when /dashboard/user_followers is visited" do
+    it "displays correct following buttons" do
+      stub_request(:post, "http://www.google-analytics.com/collect")
+      following_user.follow(user)
+      followed_user.follow(user)
+      user.follow(followed_user)
+      visit "/dashboard/user_followers"
+
+      expect(JSON.parse(find_link("✓ FOLLOWING")["data-info"])["id"]).to eq(followed_user.id)
+      expect(JSON.parse(find_link("+ FOLLOW BACK")["data-info"])["id"]).to eq(following_user.id)
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix
- [x] Optimization

## Description
This updates the user followers Dashboard buttons to use the same bulk_show endpoint we use in our search for fetching the status for the buttons. 

## Added tests?
- [x] yes

![alt_text](https://media.giphy.com/media/3o7btQhCyT75UFca7S/giphy.gif)
