### PR TITLE
Add 403 to API docs

### DIFF
--- a/docs/api_v0.yml
+++ b/docs/api_v0.yml
@@ -1026,6 +1026,10 @@ components:
       value:
         error: not enough available credits
         status: 402
+    ErrorForbidden:
+      value:
+        error: forbidden
+        status: 403
     ErrorUnprocessableEntity:
       value:
         error: "param is missing or the value is empty: article"
@@ -1739,6 +1743,15 @@ paths:
               examples:
                 error-unauthorized:
                   $ref: "#/components/examples/ErrorUnauthorized"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/APIError"
+              examples:
+                error-forbidden:
+                  $ref: "#/components/examples/ErrorForbidden"
         "422":
           description: Unprocessable Entity
           content:
@@ -1891,6 +1904,15 @@ paths:
               examples:
                 error-unauthorized:
                   $ref: "#/components/examples/ErrorUnauthorized"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/APIError"
+              examples:
+                error-forbidden:
+                  $ref: "#/components/examples/ErrorForbidden"
         "422":
           description: Unprocessable Entity
           content:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Documentation Update

## Description
Oauth with an insufficient scope will receive 403 instead of 401. Updating the docs to reflect that.

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/pull/7834
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
n/a
## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] yes docs.dev.to

## [optional] Are there any post deployment tasks we need to perform?
n/a