### PR TITLE
Add Back Tracking API-keys in Honeycomb

### DIFF
--- a/config/initializers/rack/attack.rb
+++ b/config/initializers/rack/attack.rb
@@ -21,6 +21,7 @@ class Rack::Attack
     return if request.env["HTTP_FASTLY_CLIENT_IP"].blank?
 
     if request.path.starts_with?("/api/") && (request.put? || request.post? || request.delete?)
+      Honeycomb.add_field("user_api_key", request.env["HTTP_API_KEY"])
       track_and_return_ip(request.env["HTTP_FASTLY_CLIENT_IP"])
     end
   end

--- a/spec/initializers/rack/attack_spec.rb
+++ b/spec/initializers/rack/attack_spec.rb
@@ -64,6 +64,8 @@ describe Rack::Attack, type: :request, throttle: true do
         expect(new_api_response).not_to eq(429)
         expect(Honeycomb).to have_received(:add_field).with("fastly_client_ip", "5.6.7.8").exactly(3).times
         expect(Honeycomb).to have_received(:add_field).with("fastly_client_ip", "1.1.1.1").exactly(2).times
+        expect(Honeycomb).to have_received(:add_field).with("user_api_key", api_secret.secret).exactly(2).times
+        expect(Honeycomb).to have_received(:add_field).with("user_api_key", another_api_secret.secret)
       end
     end
   end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Feature

## Description
Was going to throw this back in, in my other PR but since that was all approved I decided to push it out as is and make a separate one for this. 

I think we should still be tracking user API keys in Honeycomb. The reason is that we have no way of linking an IP to a user and I could see a case where we have a valid good-intentioned user struggling with rate limits and we might want to proactively reach out to them. Having the API key in the requests would allow us to do that. 
 
## Added tests?
- [x] yes

![alt_text](https://media3.giphy.com/media/MCpIqOWKiDfLzAbbBN/200.gif)
