### PR TITLE
Limit the Number of API Keys a User Can Have

### DIFF
--- a/app/models/api_secret.rb
+++ b/app/models/api_secret.rb
@@ -11,6 +11,6 @@ class ApiSecret < ApplicationRecord
   def user_api_secret_count
     return if user && user.api_secrets.count < 20
 
-    errors.add(:user, "API secret limit has been reached")
+    errors.add(:user, "API secret limit of 20 per user has been reached")
   end
 end

--- a/app/models/api_secret.rb
+++ b/app/models/api_secret.rb
@@ -4,4 +4,13 @@ class ApiSecret < ApplicationRecord
   belongs_to :user
 
   validates :description, presence: true, length: { maximum: 300 }
+  validate :user_api_secret_count
+
+  private
+
+  def user_api_secret_count
+    return if user && user.api_secrets.count < 20
+
+    errors.add(:user, "API secret limit has been reached")
+  end
 end

--- a/spec/models/api_secret_spec.rb
+++ b/spec/models/api_secret_spec.rb
@@ -2,8 +2,19 @@ require "rails_helper"
 
 RSpec.describe ApiSecret, type: :model do
   describe "validations" do
+    subject { create(:api_secret) }
+
     it { is_expected.to belong_to(:user) }
     it { is_expected.to validate_presence_of(:description) }
     it { is_expected.to validate_length_of(:description).is_at_most(300) }
+
+    it "validates the number of keys a user already has" do
+      user = create(:user)
+      create_list(:api_secret, 19, user_id: user.id)
+      invalid_secret = create(:api_secret, user_id: user.id)
+
+      expect(invalid_secret).not_to be_valid
+      expect(invalid_secret.errors.full_messages).to include("User API secret limit has been reached")
+    end
   end
 end

--- a/spec/models/api_secret_spec.rb
+++ b/spec/models/api_secret_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ApiSecret, type: :model do
       invalid_secret = create(:api_secret, user_id: user.id)
 
       expect(invalid_secret).not_to be_valid
-      expect(invalid_secret.errors.full_messages).to include("User API secret limit has been reached")
+      expect(invalid_secret.errors.full_messages.join).to include("limit of 20 per user has been reached")
     end
   end
 end

--- a/spec/queries/internal/moderators_query_spec.rb
+++ b/spec/queries/internal/moderators_query_spec.rb
@@ -13,26 +13,26 @@ RSpec.describe Internal::ModeratorsQuery, type: :query do
   describe ".call" do
     context "when no arguments are given" do
       it "returns all moderators" do
-        expect(described_class.call).to eq([user, user2, user5])
+        expect(described_class.call).to match_array([user, user2, user5])
       end
     end
 
     context "when search is set" do
       let(:options) { { search: "greg" } }
 
-      it { is_expected.to eq([user, user2]) }
+      it { is_expected.to match_array([user, user2]) }
     end
 
     context "when state is tag_moderator" do
       let(:options) { { state: "tag_moderator" } }
 
-      it { is_expected.to eq([user3]) }
+      it { is_expected.to match_array([user3]) }
     end
 
     context "when state is potential" do
       let(:options) { { state: "potential" } }
 
-      it { is_expected.to eq([user4, user6, user3]) }
+      it { is_expected.to match_array([user4, user6, user3]) }
     end
 
     context "when state does not exist" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
Prevent users from creating an unlimited number of API keys by capping it at 20. I checked the database and one user has 103 but it is a pentester. I will clean those up before this goes out. The most valid keys I found on a user was 4. The VAST majority have only 1. I figured 20 was plenty for anyone to have.

My first run hit a flaky spec where we got users in the wrong order so I threw in a fix for that.

## Added tests?
- [x] yes

![alt_text](https://media.tenor.com/images/7d883ea0ae3493fa34872434d3594dab/tenor.gif)
