### PR TITLE
Fixing the markup in the badge embed code

### DIFF
--- a/app/views/pages/badges.html.erb
+++ b/app/views/pages/badges.html.erb
@@ -33,7 +33,7 @@
     <% if user_signed_in? %>
       <p>
         <a href="<%= user_url(current_user) %>">
-          <img src="https://d2fltix0v2e0sb.cloudfront.net/dev-badge.svg" alt="<%= current_user.name %>'s <%= community_name %> Profile" height="30" width="30" class="dev-badge">
+          <img src="https://d2fltix0v2e0sb.cloudfront.net/dev-badge.svg" alt="<%= current_user.name %>'s <%= community_name %> Profile" height="30" width="30" class="dev-badge" />
         </a>
       </p>
       <p>
@@ -46,7 +46,7 @@
       <pre class="embed-code">
 
 &lt;a href="<%= user_url(current_user) %>"&gt;
-  &lt;img src="https://d2fltix0v2e0sb.cloudfront.net/dev-badge.svg" alt="<%= current_user.name %>'s <%= community_name %> Profile" height="30" width="30"&gt;
+  &lt;img src="https://d2fltix0v2e0sb.cloudfront.net/dev-badge.svg" alt="<%= current_user.name %>'s <%= community_name %> Profile" height="30" width="30" /&gt;
 &lt;/a&gt;
         </pre>
       <p>You can add the <%= community_name %> badge via
@@ -64,7 +64,7 @@
       </p>
     <% else %>
       <p>
-        <img src="https://d2fltix0v2e0sb.cloudfront.net/dev-badge.svg" height="30" width="30" alt="<%= community_name %> badge" class="dev-badge">
+        <img src="https://d2fltix0v2e0sb.cloudfront.net/dev-badge.svg" height="30" width="30" alt="<%= community_name %> badge" class="dev-badge" />
       </p>
       <h2 style="text-align:center;">
         <a href="/enter">Log in to view your custom embed code</a>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

On the badges page (https://dev.to/p/badges) the `img` tag was missing the self-closing forward slash, both in the actual markup and in the embed code.

When using the embed code in JSX you get the following error:

```
Expected corresponding JSX closing tag for 'img'.ts(17002)
```
![jsx error highlight](https://user-images.githubusercontent.com/237818/81984213-637bb300-962c-11ea-8b79-4b5d337f7011.png)

I'm afraid I could not bring myself to setup a local dev environment. Not even using Docker. **So I haven't even run this once.**

I understand if you can't approve this PR but someone might want to fix this anyways.

## Related Tickets & Documents

No

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

No

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## What gif best describes this PR or how it makes you feel?

![success](https://media.giphy.com/media/uTuLngvL9p0Xe/giphy.gif)
