### PR TITLE
Return if there is no ip_address from Method

### DIFF
--- a/config/initializers/rack/attack.rb
+++ b/config/initializers/rack/attack.rb
@@ -31,7 +31,7 @@ class Rack::Attack
   end
 
   def self.track_and_return_ip(ip_address)
-    return unless ip_address
+    return if ip_address.blank?
 
     Honeycomb.add_field("fastly_client_ip", ip_address)
     ip_address.to_s

--- a/config/initializers/rack/attack.rb
+++ b/config/initializers/rack/attack.rb
@@ -2,24 +2,18 @@ Rack::Attack.throttled_response_retry_after_header = true
 
 class Rack::Attack
   throttle("search_throttle", limit: 5, period: 1) do |request|
-    return if request.env["HTTP_FASTLY_CLIENT_IP"].blank?
-
     if request.path.starts_with?("/search/")
       track_and_return_ip(request.env["HTTP_FASTLY_CLIENT_IP"])
     end
   end
 
   throttle("api_throttle", limit: 3, period: 1) do |request|
-    return if request.env["HTTP_FASTLY_CLIENT_IP"].blank?
-
     if request.path.starts_with?("/api/") && request.get?
       track_and_return_ip(request.env["HTTP_FASTLY_CLIENT_IP"])
     end
   end
 
   throttle("api_write_throttle", limit: 1, period: 1) do |request|
-    return if request.env["HTTP_FASTLY_CLIENT_IP"].blank?
-
     if request.path.starts_with?("/api/") && (request.put? || request.post? || request.delete?)
       Honeycomb.add_field("user_api_key", request.env["HTTP_API_KEY"])
       track_and_return_ip(request.env["HTTP_FASTLY_CLIENT_IP"])
@@ -27,20 +21,18 @@ class Rack::Attack
   end
 
   throttle("site_hits", limit: 40, period: 2) do |request|
-    return if request.env["HTTP_FASTLY_CLIENT_IP"].blank?
-
     track_and_return_ip(request.env["HTTP_FASTLY_CLIENT_IP"])
   end
 
   throttle("message_throttle", limit: 2, period: 1) do |request|
-    return if request.env["HTTP_FASTLY_CLIENT_IP"].blank?
-
     if request.path.starts_with?("/messages") && request.post?
       track_and_return_ip(request.env["HTTP_FASTLY_CLIENT_IP"])
     end
   end
 
   def self.track_and_return_ip(ip_address)
+    return unless ip_address
+
     Honeycomb.add_field("fastly_client_ip", ip_address)
     ip_address.to_s
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Return from the throttle block [apparently causes an error locally](https://github.com/thepracticaldev/dev.to/commit/8ae486a362131fb8f6f7320bf85848511d28b2b7#r39188524)
```
08:11:38 web.1       | LocalJumpError (unexpected return)
08:11:38 web.1       | LocalJumpError (unexpected return)
08:11:38 web.1       |
```
Not sure why but this fixes it. 

![alt_text](https://media2.giphy.com/media/j3DmDANh1VZk1ED8hs/giphy.gif)
