### PR TITLE
Limit Response Template Count for Users

### DIFF
--- a/app/models/response_template.rb
+++ b/app/models/response_template.rb
@@ -36,7 +36,7 @@ class ResponseTemplate < ApplicationRecord
 
   def template_count
     return unless user
-    return if user.trusted || user.response_templates.count < 30
+    return if user.trusted || user.response_templates.count <= 30
 
     errors.add(:user, "Response template limit of 30 per user has been reached")
   end

--- a/app/models/response_template.rb
+++ b/app/models/response_template.rb
@@ -24,10 +24,20 @@ class ResponseTemplate < ApplicationRecord
             inclusion: { in: EMAIL_CONTENT_TYPES, message: EMAIL_VALIDATION_MSG },
             if: -> { type_of&.include?("email") }
   validate :user_nil_only_for_user_nil_types
+  validate :template_count
+
+  private
 
   def user_nil_only_for_user_nil_types
     return unless user_id.present? && USER_NIL_TYPE_OF_TYPES.include?(type_of)
 
     errors.add(:type_of, USER_NIL_TYPE_OF_MSG)
+  end
+
+  def template_count
+    return unless user
+    return if user.trusted || user.response_templates.count < 30
+
+    errors.add(:user, "Response template limit of 30 per user has been reached")
   end
 end

--- a/spec/models/response_template_spec.rb
+++ b/spec/models/response_template_spec.rb
@@ -27,4 +27,22 @@ RSpec.describe ResponseTemplate, type: :model do
       end
     end
   end
+
+  describe "user validation" do
+    it "validates the number of templates for a normal user" do
+      user = create(:user)
+      create_list(:response_template, 29, user_id: user.id)
+      invalid_template = create(:response_template, user_id: user.id)
+
+      expect(invalid_template).not_to be_valid
+      expect(invalid_template.errors.full_messages.join).to include("limit of 30 per user has been reached")
+    end
+
+    it "allows trusted users to have unlimited templates" do
+      user = create(:user, :trusted)
+      create_list(:response_template, 31, user_id: user.id)
+
+      expect(user.response_templates.all?(&:valid?)).to be(true)
+    end
+  end
 end

--- a/spec/models/response_template_spec.rb
+++ b/spec/models/response_template_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe ResponseTemplate, type: :model do
   describe "user validation" do
     it "validates the number of templates for a normal user" do
       user = create(:user)
-      create_list(:response_template, 29, user_id: user.id)
+      create_list(:response_template, 30, user_id: user.id)
       invalid_template = create(:response_template, user_id: user.id)
 
       expect(invalid_template).not_to be_valid


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Limit the number of templates a user can make to 30 unless they are a trusted user. I choose to exclude trusted users since many of those are mods who might need more templates. As it stands the user with the most templates(who is a mod actually) has 19. I figured a normal user would likely have much less and figured 30 was more than enough to cover them

![Screen Shot 2020-05-15 at 1 05 53 PM](https://user-images.githubusercontent.com/1813380/82083946-22c57d80-96b0-11ea-8a97-a18fae93fd70.png)

## Added tests?
- [x] yes

![alt_text](https://media.tenor.com/images/e1b3ce2f85e183f7903dc5be79c0be99/tenor.gif)
