### PR TITLE
Limit User Updates

### DIFF
--- a/app/helpers/rate_limit_checker_helper.rb
+++ b/app/helpers/rate_limit_checker_helper.rb
@@ -2,8 +2,13 @@ module RateLimitCheckerHelper
   CONFIGURABLE_RATES = {
     rate_limit_article_update: {
       min: 1,
-      placeholder: 150,
+      placeholder: 30,
       description: "The number of article updates a user can make in 30 seconds"
+    },
+    rate_limit_user_update: {
+      min: 1,
+      placeholder: 5,
+      description: "The number of user updates a user can make in 30 seconds"
     },
     rate_limit_feedback_message_creation: {
       min: 1,

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -81,9 +81,10 @@ class SiteConfig < RailsSettings::Base
   field :rate_limit_reaction_creation, type: :integer, default: 10
   field :rate_limit_image_upload, type: :integer, default: 9
   field :rate_limit_email_recipient, type: :integer, default: 5
-  field :rate_limit_article_update, type: :integer, default: 150
+  field :rate_limit_article_update, type: :integer, default: 30
   field :rate_limit_send_email_confirmation, type: :integer, default: 2
   field :rate_limit_feedback_message_creation, type: :integer, default: 5
+  field :rate_limit_user_update, type: :integer, default: 5
 
   # Google Analytics Reporting API v4
   # <https://developers.google.com/analytics/devguides/reporting/core/v4>

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -140,6 +140,7 @@ class User < ApplicationRecord
   validate :validate_feed_url, if: :feed_url_changed?
   validate :validate_mastodon_url
   validate :can_send_confirmation_email
+  validate :update_rate_limit
 
   alias_attribute :positive_reactions_count, :reactions_count
   alias_attribute :subscribed_to_welcome_notifications?, :welcome_notifications
@@ -623,5 +624,14 @@ class User < ApplicationRecord
     rate_limiter.check_limit!(:send_email_confirmation)
   rescue RateLimitChecker::LimitReached => e
     errors.add(:email, "confirmation could not be sent. #{e.message}")
+  end
+
+  def update_rate_limit
+    return unless persisted?
+
+    rate_limiter.track_limit_by_action(:user_update)
+    rate_limiter.check_limit!(:user_update)
+  rescue RateLimitChecker::LimitReached => e
+    errors.add(:base, "User could not be saved. #{e.message}")
   end
 end

--- a/app/services/rate_limit_checker.rb
+++ b/app/services/rate_limit_checker.rb
@@ -4,13 +4,14 @@ class RateLimitChecker
   # retry_after values are the seconds until a user can retry an action
   ACTION_LIMITERS = {
     article_update: { retry_after: 30 },
-    send_email_confirmation: { retry_after: 120 },
     feedback_message_creation: { retry_after: 300 },
     image_upload: { retry_after: 30 },
     listing_creation: { retry_after: 60 },
-    published_article_creation: { retry_after: 30 },
     organization_creation: { retry_after: 300 },
-    reaction_creation: { retry_after: 30 }
+    published_article_creation: { retry_after: 30 },
+    reaction_creation: { retry_after: 30 },
+    send_email_confirmation: { retry_after: 120 },
+    user_update: { retry_after: 30 }
   }.with_indifferent_access.freeze
 
   def initialize(user = nil)


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Limit the number of times a user can update themselves and make it configurable. Default to 5 times in 30 seconds

## Added tests?
- [x] yes

![alt_text](https://media1.giphy.com/media/fatcd1PnHPTDW/giphy.gif?cid=ecf05e47f892654947d7b031b0136d9e1f8064fe0c51a6f6&rid=giphy.gif)
