### PR TITLE
Don't Touch User Twice for New Follow

### DIFF
--- a/app/controllers/follows_controller.rb
+++ b/app/controllers/follows_controller.rb
@@ -73,7 +73,6 @@ class FollowsController < ApplicationController
                 follow(followable, need_notification: need_notification)
               end
 
-    current_user.touch
     render json: { outcome: @result }
   end
 


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
When we update a follow we [automatically touch the follower](https://github.com/thepracticaldev/dev.to/blob/master/app/models/follow.rb#L32) which in the case of the controller is always going to be `current_user` so this touch is redundant. 

## Added tests?
- [x] no, because they aren't needed

![alt_text](https://media.giphy.com/media/RXlkTRLi1S1aM/giphy.gif)
