### PR TITLE
replace hardcoded twitter hashtag

### DIFF
--- a/app/controllers/buffer_updates_controller.rb
+++ b/app/controllers/buffer_updates_controller.rb
@@ -55,10 +55,10 @@ class BufferUpdatesController < ApplicationController
     @user = @article.user
     if @user.twitter_username.present?
       params[:buffer_update][:body_text] +
-        "\n\n{ author: @#{@user.twitter_username} } #DEVCommunity\n#{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}#{@article.path}"
+        "\n\n{ author: @#{@user.twitter_username} } ##{SiteConfig.twitter_hashtag}\n#{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}#{@article.path}"
     else
       params[:buffer_update][:body_text] +
-        " #DEVCommunity\n#{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}#{@article.path}"
+        " ##{SiteConfig.twitter_hashtag}\n#{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}#{@article.path}"
     end
   end
 end

--- a/app/controllers/buffer_updates_controller.rb
+++ b/app/controllers/buffer_updates_controller.rb
@@ -55,10 +55,10 @@ class BufferUpdatesController < ApplicationController
     @user = @article.user
     if @user.twitter_username.present?
       params[:buffer_update][:body_text] +
-        "\n\n{ author: @#{@user.twitter_username} } ##{SiteConfig.twitter_hashtag}\n#{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}#{@article.path}"
+        "\n\n{ author: @#{@user.twitter_username} } #{SiteConfig.twitter_hashtag}\n#{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}#{@article.path}"
     else
       params[:buffer_update][:body_text] +
-        " ##{SiteConfig.twitter_hashtag}\n#{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}#{@article.path}"
+        " #{SiteConfig.twitter_hashtag}\n#{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}#{@article.path}"
     end
   end
 end

--- a/app/labor/bufferizer.rb
+++ b/app/labor/bufferizer.rb
@@ -17,7 +17,7 @@ class Bufferizer
       next if tag.buffer_profile_id_code.blank?
 
       text = twitter_buffer_text
-      text = text.gsub(" #DEVCommunity", " #DEVCommunity ##{tag.name}") if text.length < 250
+      text = text.gsub(" ##{SiteConfig.twitter_hashtag}", " ##{SiteConfig.twitter_hashtag} ##{tag.name}") if text.length < 250
       BufferUpdate.buff!(@article.id, text, tag.buffer_profile_id_code, "twitter", tag.id, @admin_id)
     end
     @article.update(last_buffered: Time.current)

--- a/app/labor/bufferizer.rb
+++ b/app/labor/bufferizer.rb
@@ -17,7 +17,7 @@ class Bufferizer
       next if tag.buffer_profile_id_code.blank?
 
       text = twitter_buffer_text
-      text = text.gsub(" ##{SiteConfig.twitter_hashtag}", " ##{SiteConfig.twitter_hashtag} ##{tag.name}") if text.length < 250
+      text = text.gsub(" #{SiteConfig.twitter_hashtag}", " #{SiteConfig.twitter_hashtag} ##{tag.name}") if text.length < 250
       BufferUpdate.buff!(@article.id, text, tag.buffer_profile_id_code, "twitter", tag.id, @admin_id)
     end
     @article.update(last_buffered: Time.current)

--- a/app/models/buffer_update.rb
+++ b/app/models/buffer_update.rb
@@ -43,7 +43,7 @@ class BufferUpdate < ApplicationRecord
   end
 
   def self.twitter_default_text(article)
-    "#{article.title}\n\n#{"{ author: @#{article.user.twitter_username} } #DEVCommunity" if article.user.twitter_username?}".strip
+    "#{article.title}\n\n#{"{ author: @#{article.user.twitter_username} } ##{SiteConfig.twitter_hashtag}" if article.user.twitter_username?}".strip
   end
 
   private

--- a/app/models/buffer_update.rb
+++ b/app/models/buffer_update.rb
@@ -43,7 +43,7 @@ class BufferUpdate < ApplicationRecord
   end
 
   def self.twitter_default_text(article)
-    "#{article.title}\n\n#{"{ author: @#{article.user.twitter_username} } ##{SiteConfig.twitter_hashtag}" if article.user.twitter_username?}".strip
+    "#{article.title}\n\n#{"{ author: @#{article.user.twitter_username} } #{SiteConfig.twitter_hashtag}" if article.user.twitter_username?}".strip
   end
 
   private

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -31,7 +31,7 @@ class SiteConfig < RailsSettings::Base
     instagram: nil,
     twitch: nil
   }
-  field :twitter_hashtag, type: :string, default: "DEVCommunity"
+  field :twitter_hashtag, type: :string, default: "#DEVCommunity"
 
   # Emails
   field :email_addresses, type: :hash, default: {

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -31,7 +31,7 @@ class SiteConfig < RailsSettings::Base
     instagram: nil,
     twitch: nil
   }
-  field :twitter_hashtag, type: :string
+  field :twitter_hashtag, type: :string, default: "DEVCommunity"
 
   # Emails
   field :email_addresses, type: :hash, default: {

--- a/app/views/articles/_actions.html.erb
+++ b/app/views/articles/_actions.html.erb
@@ -24,7 +24,7 @@
       class="article-actions-tweet-button"
       rel="noopener"
       target="_blank"
-      href='https://twitter.com/intent/tweet?text="<%= u @article.title.strip %>" by <%= display_name %> %23DEVcommunity <%= article_url(@article) %>'>
+      href='https://twitter.com/intent/tweet?text="<%= u @article.title.strip %>" by <%= display_name %> %23<%= SiteConfig.twitter_hashtag %> <%= article_url(@article) %>'>
       <img src="<%= asset_path("twitter.svg") %>" alt="twitter logo">
     </a>
   <% end %>
@@ -53,7 +53,7 @@
             <a
               target="_blank"
               rel="noopener"
-              href='https://twitter.com/intent/tweet?text="<%= u @article.title.strip %>" by <%= @article.user.twitter_username ? "@" + @article.user.twitter_username : @article.user.name %> %23DEVcommunity <%= article_url(@article) %>'>
+              href='https://twitter.com/intent/tweet?text="<%= u @article.title.strip %>" by <%= @article.user.twitter_username ? "@" + @article.user.twitter_username : @article.user.name %> %23<%= SiteConfig.twitter_hashtag %> <%= article_url(@article) %>'>
               Share to Twitter
             </a>
           </div>

--- a/app/views/articles/_actions.html.erb
+++ b/app/views/articles/_actions.html.erb
@@ -24,7 +24,7 @@
       class="article-actions-tweet-button"
       rel="noopener"
       target="_blank"
-      href='https://twitter.com/intent/tweet?text="<%= u @article.title.strip %>" by <%= display_name %> %23<%= SiteConfig.twitter_hashtag %> <%= article_url(@article) %>'>
+      href='https://twitter.com/intent/tweet?text="<%= u @article.title.strip %>" by <%= display_name %> <%= u SiteConfig.twitter_hashtag %> <%= article_url(@article) %>'>
       <img src="<%= asset_path("twitter.svg") %>" alt="twitter logo">
     </a>
   <% end %>
@@ -53,7 +53,7 @@
             <a
               target="_blank"
               rel="noopener"
-              href='https://twitter.com/intent/tweet?text="<%= u @article.title.strip %>" by <%= @article.user.twitter_username ? "@" + @article.user.twitter_username : @article.user.name %> %23<%= SiteConfig.twitter_hashtag %> <%= article_url(@article) %>'>
+              href='https://twitter.com/intent/tweet?text="<%= u @article.title.strip %>" by <%= @article.user.twitter_username ? "@" + @article.user.twitter_username : @article.user.name %> <%= u SiteConfig.twitter_hashtag %> <%= article_url(@article) %>'>
               Share to Twitter
             </a>
           </div>

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -154,7 +154,7 @@
               <%= f.label :twitter_hashtag %>
               <%= f.text_field :twitter_hashtag,
                                class: "form-control",
-                               value: SiteConfig.twitter_hashtag,
+                               value: "##{SiteConfig.twitter_hashtag}",
                                placeholder: "#DEVCommunity" %>
               <div class="alert alert-info">Used as the twitter hashtag of the community</div>
             </div>

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -154,7 +154,7 @@
               <%= f.label :twitter_hashtag %>
               <%= f.text_field :twitter_hashtag,
                                class: "form-control",
-                               value: "##{SiteConfig.twitter_hashtag}",
+                               value: SiteConfig.twitter_hashtag.to_s,
                                placeholder: "#DEVCommunity" %>
               <div class="alert alert-info">Used as the twitter hashtag of the community</div>
             </div>

--- a/spec/labor/bufferizer_spec.rb
+++ b/spec/labor/bufferizer_spec.rb
@@ -19,10 +19,10 @@ RSpec.describe Bufferizer, type: :labor do
   end
 
   it "sends to buffer sattelite twitter" do
-    tweet = "test tweet ##{SiteConfig.twitter_hashtag}"
+    tweet = "test tweet #{SiteConfig.twitter_hashtag}"
     described_class.new("article", article, tweet).satellite_tweet!
     expect(article.last_buffered.utc.to_i).to be > 2.minutes.ago.to_i
-    expect(BufferUpdate.last.body_text).to include(" ##{SiteConfig.twitter_hashtag} ##{tag.name} http")
+    expect(BufferUpdate.last.body_text).to include(" #{SiteConfig.twitter_hashtag} ##{tag.name} http")
   end
 
   it "sends to buffer facebook" do

--- a/spec/labor/bufferizer_spec.rb
+++ b/spec/labor/bufferizer_spec.rb
@@ -19,10 +19,10 @@ RSpec.describe Bufferizer, type: :labor do
   end
 
   it "sends to buffer sattelite twitter" do
-    tweet = "test tweet #DEVCommunity"
+    tweet = "test tweet ##{SiteConfig.twitter_hashtag}"
     described_class.new("article", article, tweet).satellite_tweet!
     expect(article.last_buffered.utc.to_i).to be > 2.minutes.ago.to_i
-    expect(BufferUpdate.last.body_text).to include(" #DEVCommunity ##{tag.name} http")
+    expect(BufferUpdate.last.body_text).to include(" ##{SiteConfig.twitter_hashtag} ##{tag.name} http")
   end
 
   it "sends to buffer facebook" do

--- a/spec/labor/bufferizer_spec.rb
+++ b/spec/labor/bufferizer_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Bufferizer, type: :labor do
   end
 
   it "sends to buffer sattelite twitter" do
+    SiteConfig.twitter_hashtag = "#DEVCommunity"
     tweet = "test tweet #{SiteConfig.twitter_hashtag}"
     described_class.new("article", article, tweet).satellite_tweet!
     expect(article.last_buffered.utc.to_i).to be > 2.minutes.ago.to_i

--- a/spec/requests/buffer_updates_spec.rb
+++ b/spec/requests/buffer_updates_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "BufferUpdates", type: :request do
       post "/buffer_updates",
            params:
            { buffer_update: { body_text: "This is the text!!!!", tag_id: "javascript", article_id: article.id } }
-      expect(BufferUpdate.first.body_text).to include("##{SiteConfig.twitter_hashtag}")
+      expect(BufferUpdate.first.body_text).to include(SiteConfig.twitter_hashtag.to_s)
     end
 
     it "creates satellite and Facebook buffer" do

--- a/spec/requests/buffer_updates_spec.rb
+++ b/spec/requests/buffer_updates_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "BufferUpdates", type: :request do
       post "/buffer_updates",
            params:
            { buffer_update: { body_text: "This is the text!!!!", tag_id: "javascript", article_id: article.id } }
-      expect(BufferUpdate.first.body_text).to include("#DEVCommunity")
+      expect(BufferUpdate.first.body_text).to include("##{SiteConfig.twitter_hashtag}")
     end
 
     it "creates satellite and Facebook buffer" do

--- a/spec/requests/buffer_updates_spec.rb
+++ b/spec/requests/buffer_updates_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe "BufferUpdates", type: :request do
     end
 
     it "creates buffer hashtag" do
+      SiteConfig.twitter_hashtag = "#DEVCommunity"
       post "/buffer_updates",
            params:
            { buffer_update: { body_text: "This is the text!!!!", tag_id: "javascript", article_id: article.id } }

--- a/spec/requests/internal/configs_spec.rb
+++ b/spec/requests/internal/configs_spec.rb
@@ -352,7 +352,7 @@ RSpec.describe "/internal/config", type: :request do
         it "updates the twitter hashtag" do
           params["confirmation"] = confirmation_message
           post "/internal/config", params: params
-          expect("##{SiteConfig.twitter_hashtag}").to eq twitter_hashtag
+          expect(SiteConfig.twitter_hashtag.to_s).to eq twitter_hashtag
         end
       end
     end

--- a/spec/requests/internal/configs_spec.rb
+++ b/spec/requests/internal/configs_spec.rb
@@ -342,7 +342,7 @@ RSpec.describe "/internal/config", type: :request do
       end
 
       describe "twitter_hashtag" do
-        twitter_hashtag = "DEVCommunity"
+        twitter_hashtag = "#DEVCommunity"
         params = { site_config: { twitter_hashtag: twitter_hashtag }, confirmation: "Incorrect confirmation" }
 
         it "does not update the twitter hashtag" do
@@ -352,7 +352,7 @@ RSpec.describe "/internal/config", type: :request do
         it "updates the twitter hashtag" do
           params["confirmation"] = confirmation_message
           post "/internal/config", params: params
-          expect(SiteConfig.twitter_hashtag).to eq twitter_hashtag
+          expect("##{SiteConfig.twitter_hashtag}").to eq twitter_hashtag
         end
       end
     end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
In [this PR](https://github.com/thepracticaldev/dev.to/pull/7573/commits) the twitter hashtag site config variable was added. The next step was to replace all hardcoded #DEVCommunity references with w/ the dynamic `SiteConfig.twitter_hashtag` variable set to "DevCommunity" in `site_config.rb`. Tests were also updated to reflect the dynamic addition.

## Related Tickets & Documents
This PR is in direct relation to [this issue](https://github.com/thepracticaldev/dev.to/issues/7835#event-3340045458)

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?
