### PR TITLE
Fix internal category filtering for listings

### DIFF
--- a/app/controllers/internal/classified_listings_controller.rb
+++ b/app/controllers/internal/classified_listings_controller.rb
@@ -8,7 +8,7 @@ class Internal::ClassifiedListingsController < Internal::ApplicationController
         page(params[:page]).order("bumped_at DESC").per(50)
 
     @classified_listings = @classified_listings.published unless include_unpublished?
-    @classified_listings = @classified_listings.where(category: params[:filter]) if params[:filter].present?
+    @classified_listings = @classified_listings.in_category(params[:filter]) if params[:filter].present?
   end
 
   def edit

--- a/spec/requests/internal/classified_listings_spec.rb
+++ b/spec/requests/internal/classified_listings_spec.rb
@@ -1,15 +1,15 @@
 require "rails_helper"
 
 RSpec.describe "/internal/listings", type: :request do
+  let_it_be(:admin) { create(:user, :super_admin) }
+  let_it_be(:classified_listing) { create(:classified_listing, user_id: admin.id) }
+
+  before do
+    allow(CacheBuster).to receive(:bust_classified_listings)
+    sign_in admin
+  end
+
   describe "PUT /internal/listings/:id" do
-    let(:admin) { create(:user, :super_admin) }
-    let(:classified_listing) { create(:classified_listing, user_id: admin.id) }
-
-    before do
-      allow(CacheBuster).to receive(:bust_classified_listings)
-      sign_in admin
-    end
-
     it "clears listing cache" do
       put internal_listing_path(id: classified_listing.id), params: {
         classified_listing: { title: "updated" }
@@ -21,6 +21,12 @@ RSpec.describe "/internal/listings", type: :request do
     describe "GET /internal/listings" do
       let!(:unpublished_listing) { create(:classified_listing, published: false) }
 
+      it "shows published listings" do
+        get internal_listings_path
+
+        expect(response.body).to include(CGI.escapeHTML(classified_listing.title))
+      end
+
       it "filters unpublished listings by default" do
         get internal_listings_path
 
@@ -31,6 +37,12 @@ RSpec.describe "/internal/listings", type: :request do
         get internal_listings_path, params: { include_unpublished: "1" }
 
         expect(response.body).to include(CGI.escapeHTML(unpublished_listing.title))
+      end
+
+      it "filters by category" do
+        get internal_listings_path(filter: "misc")
+
+        expect(response.body).not_to include(CGI.escapeHTML(classified_listing.title))
       end
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Description

While looking into cleaning up some more things related to classified listings, I realized that the internal filtering by category was broken since one of the last refactors. This PR fixes that and also upated the specs a bit.

## Related Tickets & Documents

n/a

## Added tests?

- [X] yes

## Added to documentation?

- [X] no documentation needed
