### PR TITLE
Remove User#destroy_empty_dm_channels callback

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -166,7 +166,6 @@ class User < ApplicationRecord
   before_validation :set_config_input
   before_validation :downcase_email
   before_validation :check_for_username_change
-  before_destroy :destroy_empty_dm_channels, prepend: true
   before_destroy :destroy_follows, prepend: true
   before_destroy :unsubscribe_from_newsletters, prepend: true
 
@@ -595,15 +594,6 @@ class User < ApplicationRecord
     counts_score = (articles_count + comments_count + reactions_count + badge_achievements_count) * 10
     score = (counts_score + tag_keywords_for_search.size) * reputation_modifier
     score.to_i
-  end
-
-  def destroy_empty_dm_channels
-    return if chat_channels.empty? ||
-      chat_channels.where(channel_type: "direct").empty?
-
-    empty_dm_channels = chat_channels.where(channel_type: "direct").
-      select { |chat_channel| chat_channel.messages.empty? }
-    empty_dm_channels.destroy_all
   end
 
   def destroy_follows


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

I noticed this accidentally as users are rightly deleted with `Users::DeleteWorker` both in the frontend and the backend. If you try to delete manually a user in the console with `user.destroy`, `empty_dm_channels.destroy_all` will fail as it's an array, not an ActiveRecord relation.

That got me thinking and I realized this is not needed nor activated normally, as direct message channels are deleted already in 

https://github.com/thepracticaldev/dev.to/blob/decae056f10fe9740769d3154fde08c8794347c8/app/services/users/delete_activity.rb#L49

which calls

https://github.com/thepracticaldev/dev.to/blob/decae056f10fe9740769d3154fde08c8794347c8/app/services/users/cleanup_chat_channels.rb#L4-L6

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
