### PR TITLE
Update safe params VCL for Array params

### DIFF
--- a/config/fastly/snippets/safe_params_list.vcl
+++ b/config/fastly/snippets/safe_params_list.vcl
@@ -1,7 +1,9 @@
 import querystring;
 sub vcl_recv {
-    # return this URL with only the parameters that match this regular expression
-    if (req.url !~ "/internal/" && req.url !~ "/search/" && req.url !~ "/bulk_show") {
-      set req.url = querystring.regfilter_except(req.url, "^(a_id|args|article_id|article_ids|articles|asc|callback_url|category|chat_channel_id|client_id|code|collection_id|commentable_id|commentable_type|confirmation_token|created_at|end|filter|followable_id|followable_type|fork_id|i|key|message_offset|name|oauth_token|oauth_verifier|offset|org_id|organization_id|p|page|per_page|prefill|preview|purchaser|reactable_ids|redirect_uri|reported_url|reporter_username|response_type|scope|search|signature|sort|start|state|status|tag|tag_list|top|type_of|url|username|ut|verb)$");
-    }
+  # return this URL with only the parameters that match this regular expression
+  if (req.url !~ "/internal/" && req.url !~ "/search/") {
+    set req.http.decodeurl = urldecode(req.url);
+    set req.http.decodeurl = querystring.regfilter_except(req.http.decodeurl, "^(a_id|args|article_id|article_ids|articles|asc|callback_url|category|chat_channel_id|client_id|code|collection_id|commentable_id|commentable_type|confirmation_token|created_at|end|filter|followable_id|followable_type|fork_id|i|ids\[\]|key|message_offset|name|oauth_token|oauth_verifier|offset|org_id|organization_id|p|page|per_page|prefill|preview|purchaser|reactable_ids|redirect_uri|reported_url|reporter_username|response_type|scope|search|signature|sort|start|state|status|tag|tag_list|top|type_of|url|username|ut|verb)$");
+    set req.url = req.http.decodeurl;
+  }
 }


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Optimization

## Description
In the past, we've had issues trying to add Array parameters so the safe list in our VCL snippets in Fastly. This PR demonstrates an updated `safe_params_list.vcl` to work with Array params.

~**Next steps:** if we want to refactor this VCL, just let me know! We can go about it a few ways:~
~- Comment the params that need to be added if we remove the entire guard of `/search` and `/bulk_show` endpoints and I'll add them in and mark this ready for review.~
~- A contributor pulls this PR down and updates the list themself.~
~- Do nothing, I'll close this out and we'll have it for future reference.~

~_I'm leaving this as draft for now as it is a demonstration and not ready to be merged._~

You can see how the updates snippet works on this [Fastly fiddle](https://fiddle.fastlydemo.net/fiddle/1957a5cf) and [here](https://docs.fastly.com/vcl/functions/urldecode/) is the documentation for `urldecode()`.

This PR addresses the comments from https://github.com/thepracticaldev/dev.to/pull/7676#issuecomment-624814011 and https://github.com/thepracticaldev/dev.to/pull/7676#discussion_r421628638 by adding `ids[]` to the safe list for `/bulk_show`. By decoding the URL first, we can just add `ids\[\]` to our safe list.

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/pull/7676#issuecomment-624814011
https://github.com/thepracticaldev/dev.to/pull/7676#discussion_r421628638

## Added tests?
- [x] no, because they aren't needed
See the [fiddle](https://fiddle.fastlydemo.net/fiddle/1957a5cf) for testing.

## Added to documentation?
- [x] no documentation needed

![decoded_gif](https://media.giphy.com/media/3oz8xzFky0SbITgI8M/giphy.gif)