### PR TITLE
Add public reactions count columns

### DIFF
--- a/db/migrate/20200514212601_add_public_reactions_count_columns.rb
+++ b/db/migrate/20200514212601_add_public_reactions_count_columns.rb
@@ -1,0 +1,8 @@
+class AddPublicReactionsCountColumns < ActiveRecord::Migration[5.2]
+  def change
+    add_column :articles, :public_reactions_count, :integer, default: 0, null: false
+    add_column :articles, :previous_public_reactions_count, :integer, default: 0, null: false
+
+    add_column :comments, :public_reactions_count, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -93,7 +93,9 @@ ActiveRecord::Schema.define(version: 2020_05_15_085746) do
     t.string "path"
     t.integer "positive_reactions_count", default: 0, null: false
     t.integer "previous_positive_reactions_count", default: 0
+    t.integer "previous_public_reactions_count", default: 0, null: false
     t.text "processed_html"
+    t.integer "public_reactions_count", default: 0, null: false
     t.boolean "published", default: false
     t.datetime "published_at"
     t.boolean "published_from_feed", default: false
@@ -377,6 +379,7 @@ ActiveRecord::Schema.define(version: 2020_05_15_085746) do
     t.integer "markdown_character_count"
     t.integer "positive_reactions_count", default: 0, null: false
     t.text "processed_html"
+    t.integer "public_reactions_count", default: 0, null: false
     t.integer "reactions_count", default: 0, null: false
     t.boolean "receive_notifications", default: true
     t.integer "score", default: 0


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
This adds the `public_reactions_count` columns to the articles and comments tables. This column will be replacing the `positive_reactions_count` columns soon.

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/pull/7777#issuecomment-628165795

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
Make sure to `[deploy]` this and to ensure that the migration is successful.