### PR TITLE
Move functionality to public rxn count

### DIFF
--- a/app/assets/javascripts/initializers/initScrolling.js.erb
+++ b/app/assets/javascripts/initializers/initScrolling.js.erb
@@ -226,7 +226,7 @@ function paginate(tag, params, requiresApproval) {
   } else {
     searchHash.class_name = "Article";
     searchHash["published_at[gte]"] = homeEl.dataset.articlesSince;
-    searchHash.sort_by = "positive_reactions_count";
+    searchHash.sort_by = "public_reactions_count";
   }
 
   // Brute force copying code from a utlity for quick fix

--- a/app/assets/javascripts/utilities/buildArticleHTML.js.erb
+++ b/app/assets/javascripts/utilities/buildArticleHTML.js.erb
@@ -51,7 +51,7 @@ function buildArticleHTML(article) {
       flareTag = "<span class='crayons-story__flare-tag' style='background:#5874d9;color:white;'>person</span>"
     }
 
-    var rc = article.positive_reactions_count
+    var rc = article.public_reactions_count
     var reactionsCount = (rc || '0')
     var reactionsDisplay = '';
 

--- a/app/assets/javascripts/utilities/buildCommentHTML.js.erb
+++ b/app/assets/javascripts/utilities/buildCommentHTML.js.erb
@@ -108,6 +108,6 @@ function reactions(comment) {
     return '<button style="background:white" class="reaction-button '+ reactedClass +'" id="button-for-comment-'+comment.id+'" data-comment-id="'+comment.id+'">\
               <img src="<%= asset_path("favorite-heart-outline-button.svg") %>" alt="Favorite heart outline button">\
               <img class="voted-heart" src="<%= asset_path("emoji/emoji-one-heart.png") %>" alt="Favorite heart button">\
-              <span class="reactions-count" id="reactions-count-'+comment.id+'">'+comment.positive_reactions_count+'</span></button>';
+              <span class="reactions-count" id="reactions-count-'+comment.id+'">'+comment.public_reactions_count+'</span></button>';
   }
 }

--- a/app/controllers/api/v0/articles_controller.rb
+++ b/app/controllers/api/v0/articles_controller.rb
@@ -76,7 +76,7 @@ module Api
         id user_id organization_id collection_id
         title description main_image published_at crossposted_at social_image
         cached_tag_list slug path canonical_url comments_count
-        positive_reactions_count created_at edited_at last_comment_at published
+        public_reactions_count created_at edited_at last_comment_at published
         updated_at video_thumbnail_url
       ].freeze
       private_constant :INDEX_ATTRIBUTES_FOR_SERIALIZATION
@@ -89,7 +89,7 @@ module Api
       ME_ATTRIBUTES_FOR_SERIALIZATION = %i[
         id user_id organization_id
         title description main_image published published_at cached_tag_list
-        slug path canonical_url comments_count positive_reactions_count
+        slug path canonical_url comments_count public_reactions_count
         page_views_count crossposted_at body_markdown updated_at
       ].freeze
       private_constant :ME_ATTRIBUTES_FOR_SERIALIZATION

--- a/app/controllers/internal/articles_controller.rb
+++ b/app/controllers/internal/articles_controller.rb
@@ -54,7 +54,7 @@ class Internal::ArticlesController < Internal::ApplicationController
       where("published_at > ? OR crossposted_at > ?", days_ago.days.ago, days_ago.days.ago).
       includes(:user).
       limited_columns_internal_select.
-      order("positive_reactions_count DESC").
+      order("public_reactions_count DESC").
       page(params[:page]).
       per(50)
   end
@@ -64,7 +64,7 @@ class Internal::ArticlesController < Internal::ApplicationController
       where("published_at > ?", months_ago).
       includes(user: [:notes]).
       limited_columns_internal_select.
-      order("positive_reactions_count DESC").
+      order("public_reactions_count DESC").
       page(params[:page]).
       per(50)
   end

--- a/app/controllers/internal/comments_controller.rb
+++ b/app/controllers/internal/comments_controller.rb
@@ -6,7 +6,7 @@ class Internal::CommentsController < Internal::ApplicationController
                   Comment.
                     includes(:user).
                     includes(:commentable).
-                    order("positive_reactions_count DESC").
+                    order("public_reactions_count DESC").
                     where("created_at > ?", params[:state].split("-").last.to_i.days.ago).
                     page(params[:page] || 1).per(50)
                 else

--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -24,10 +24,10 @@ class ReactionsController < ApplicationController
     else
       comments = Comment.
         where(commentable_id: params[:commentable_id], commentable_type: params[:commentable_type]).
-        select(%i[id positive_reactions_count])
+        select(%i[id public_reactions_count])
 
       reaction_counts = comments.map do |comment|
-        { id: comment.id, count: comment.positive_reactions_count }
+        { id: comment.id, count: comment.public_reactions_count }
       end
 
       reactions = if session_current_user_id

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -1,7 +1,7 @@
 class StoriesController < ApplicationController
   DEFAULT_HOME_FEED_ATTRIBUTES_FOR_SERIALIZATION = {
     only: %i[
-      title path id user_id comments_count positive_reactions_count organization_id
+      title path id user_id comments_count public_reactions_count organization_id
       reading_time video_thumbnail_url video video_duration_in_minutes language
       experience_level_rating experience_level_rating_distribution cached_user cached_organization
       classified_listing_category_id
@@ -320,7 +320,7 @@ class StoriesController < ApplicationController
   def stories_by_timeframe
     if %w[week month year infinity].include?(params[:timeframe])
       @stories.where("published_at > ?", Timeframer.new(params[:timeframe]).datetime).
-        order("positive_reactions_count DESC")
+        order("public_reactions_count DESC")
     elsif params[:timeframe] == "latest"
       @stories.where("score > ?", -20).order("published_at DESC")
     else

--- a/app/javascript/articles/__tests__/utilities/articleUtilities.js
+++ b/app/javascript/articles/__tests__/utilities/articleUtilities.js
@@ -127,7 +127,7 @@ export const articleWithReactions = {
   published_at: '2020-03-19T10:04:15-05:00',
   readable_publish_date: 'February 18',
   top_comments: [],
-  positive_reactions_count: 232,
+  public_reactions_count: 232,
 };
 
 export const articleWithComments = {
@@ -169,7 +169,7 @@ export const articleWithComments = {
       profile_image_90: '/images/7.png',
     },
   ],
-  positive_reactions_count: 428,
+  public_reactions_count: 428,
   comments_count: 213,
 };
 
@@ -311,7 +311,7 @@ export const userArticle = {
 export const featuredArticle = {
   ...article,
   main_image: '/images/onboarding-background.png',
-  positive_reactions_count: 428,
+  public_reactions_count: 428,
   comments_count: 213,
 };
 

--- a/app/javascript/articles/components/ReactionsCount.jsx
+++ b/app/javascript/articles/components/ReactionsCount.jsx
@@ -3,7 +3,7 @@ import { articlePropTypes } from '../../common-prop-types';
 import { Button } from '../../crayons/Button';
 
 export const ReactionsCount = ({ article }) => {
-  const totalReactions = article.positive_reactions_count || 0;
+  const totalReactions = article.public_reactions_count || 0;
   const reactionsSVG = () => (
     <svg
       className="crayons-icon"

--- a/app/javascript/common-prop-types/article-prop-types.js
+++ b/app/javascript/common-prop-types/article-prop-types.js
@@ -29,7 +29,7 @@ export const articlePropTypes = PropTypes.shape({
   }),
   organization: organizationPropType,
   highlight: articleSnippetResultPropTypes,
-  positive_reactions_count: PropTypes.number,
+  public_reactions_count: PropTypes.number,
   reactions_count: PropTypes.number,
   comments_count: PropTypes.number,
   reading_time: PropTypes.number,

--- a/app/labor/badge_rewarder.rb
+++ b/app/labor/badge_rewarder.rb
@@ -20,7 +20,7 @@ module BadgeRewarder
   def self.award_beloved_comment_badges
     # ID 3 is the proper ID in prod. We should change in future to ENV var.
     badge_id = Badge.find_by(slug: "beloved-comment")&.id || 3
-    Comment.where("positive_reactions_count > ?", 24).find_each do |comment|
+    Comment.where("public_reactions_count > ?", 24).find_each do |comment|
       message = "You're famous! [This is the comment](https://#{ApplicationConfig['APP_DOMAIN']}#{comment.path}) for which you are being recognized. 😄"
       achievement = BadgeAchievement.create(
         user_id: comment.user_id,

--- a/app/labor/cache_buster.rb
+++ b/app/labor/cache_buster.rb
@@ -77,7 +77,7 @@ module CacheBuster
     end
     TIMEFRAMES.each do |timestamp, interval|
       if Article.published.where("published_at > ?", timestamp).
-          order("positive_reactions_count DESC").limit(3).pluck(:id).include?(article.id)
+          order("public_reactions_count DESC").limit(3).pluck(:id).include?(article.id)
         bust("/top/#{interval}")
         bust("/top/#{interval}?i=i")
         bust("/top/#{interval}/?i=i")
@@ -100,7 +100,7 @@ module CacheBuster
       end
       TIMEFRAMES.each do |timestamp, interval|
         if Article.published.where("published_at > ?", timestamp).tagged_with(tag).
-            order("positive_reactions_count DESC").limit(3).pluck(:id).include?(article.id)
+            order("public_reactions_count DESC").limit(3).pluck(:id).include?(article.id)
           bust("/top/#{interval}")
           bust("/top/#{interval}?i=i")
           bust("/top/#{interval}/?i=i")

--- a/app/labor/sticky_article_collection.rb
+++ b/app/labor/sticky_article_collection.rb
@@ -23,7 +23,7 @@ class StickyArticleCollection
   def tag_articles
     @tag_articles ||= Article.published.tagged_with(article_tags, any: true).
       includes(:user).
-      where("positive_reactions_count > ? OR comments_count > ?", reaction_count_num, comment_count_num).
+      where("public_reactions_count > ? OR comments_count > ?", reaction_count_num, comment_count_num).
       where.not(id: article.id, user_id: article.user_id).
       where("featured_number > ?", 5.days.ago.to_i).
       order(Arel.sql("RANDOM()")).

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -119,7 +119,7 @@ class Article < ApplicationRecord
 
   scope :limited_column_select, lambda {
     select(:path, :title, :id, :published,
-           :comments_count, :positive_reactions_count, :cached_tag_list,
+           :comments_count, :public_reactions_count, :cached_tag_list,
            :main_image, :main_image_background_hex_color, :updated_at, :slug,
            :video, :user_id, :organization_id, :video_source_url, :video_code,
            :video_thumbnail_url, :video_closed_caption_track_url, :language,
@@ -130,7 +130,7 @@ class Article < ApplicationRecord
 
   scope :limited_columns_internal_select, lambda {
     select(:path, :title, :id, :featured, :approved, :published,
-           :comments_count, :positive_reactions_count, :cached_tag_list,
+           :comments_count, :public_reactions_count, :cached_tag_list,
            :main_image, :main_image_background_hex_color, :updated_at, :boost_states,
            :video, :user_id, :organization_id, :video_source_url, :video_code,
            :video_thumbnail_url, :video_closed_caption_track_url, :social_image,
@@ -157,7 +157,7 @@ class Article < ApplicationRecord
       case kind
       when "creation"  then :created_at
       when "views"     then :page_views_count
-      when "reactions" then :positive_reactions_count
+      when "reactions" then :public_reactions_count
       when "comments"  then :comments_count
       when "published" then :published_at
       else
@@ -339,7 +339,7 @@ class Article < ApplicationRecord
   private
 
   def search_score
-    calculated_score = hotness_score.to_i + ((comments_count * 3).to_i + positive_reactions_count.to_i * 300 * user.reputation_modifier * score.to_i)
+    calculated_score = hotness_score.to_i + ((comments_count * 3).to_i + public_reactions_count.to_i * 300 * user.reputation_modifier * score.to_i)
     calculated_score.to_i
   end
 

--- a/app/models/concerns/reactable.rb
+++ b/app/models/concerns/reactable.rb
@@ -6,6 +6,6 @@ module Reactable
   end
 
   def sync_reactions_count
-    update_column(:positive_reactions_count, reactions.positive.size)
+    update_column(:public_reactions_count, reactions.positive.size)
   end
 end

--- a/app/models/podcast_episode.rb
+++ b/app/models/podcast_episode.rb
@@ -74,7 +74,7 @@ class PodcastEpisode < ApplicationRecord
   end
   alias hotness_score zero_method
   alias search_score zero_method
-  alias positive_reactions_count zero_method
+  alias public_reactions_count zero_method
 
   def class_name
     self.class.name

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -5,6 +5,7 @@ class Reaction < ApplicationRecord
   SEARCH_CLASS = Search::Reaction
 
   CATEGORIES = %w[like readinglist unicorn thinking hands thumbsdown vomit].freeze
+  PUBLIC_CATEGORIES = %w[like readinglist unicorn thinking hands].freeze
   REACTABLE_TYPES = %w[Comment Article User].freeze
   STATUSES = %w[valid invalid confirmed archived].freeze
 
@@ -13,7 +14,7 @@ class Reaction < ApplicationRecord
 
   counter_culture :reactable,
                   column_name: proc { |model|
-                    model.points.positive? ? "positive_reactions_count" : "reactions_count"
+                    PUBLIC_CATEGORIES.include?(model.category) ? "public_reactions_count" : "reactions_count"
                   }
   counter_culture :user
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -141,7 +141,7 @@ class User < ApplicationRecord
   validate :validate_mastodon_url
   validate :can_send_confirmation_email
 
-  alias_attribute :positive_reactions_count, :reactions_count
+  alias_attribute :public_reactions_count, :reactions_count
   alias_attribute :subscribed_to_welcome_notifications?, :welcome_notifications
 
   scope :with_this_week_comments, lambda { |number|

--- a/app/serializers/search/article_serializer.rb
+++ b/app/serializers/search/article_serializer.rb
@@ -7,7 +7,7 @@ module Search
     attributes :approved, :body_text, :class_name, :cloudinary_video_url,
                :comments_count, :experience_level_rating, :experience_level_rating_distribution,
                :featured, :featured_number, :hotness_score, :language,
-               :main_image, :path, :positive_reactions_count, :published,
+               :main_image, :path, :public_reactions_count, :published,
                :published_at, :reactions_count, :reading_time, :score, :title
 
     # video_duration_in_minutes in Elasticsearch is mapped as an integer

--- a/app/serializers/search/comment_serializer.rb
+++ b/app/serializers/search/comment_serializer.rb
@@ -4,7 +4,7 @@ module Search
 
     attribute :id, &:search_id
 
-    attributes :path, :positive_reactions_count
+    attributes :path, :public_reactions_count
 
     attribute :body_text, &:body_markdown
     attribute :class_name do |comment|

--- a/app/serializers/search/podcast_episode_serializer.rb
+++ b/app/serializers/search/podcast_episode_serializer.rb
@@ -5,7 +5,7 @@ module Search
     attribute :id, &:search_id
 
     attributes :body_text, :class_name, :comments_count, :hotness_score, :path,
-               :positive_reactions_count, :published, :published_at, :quote,
+               :public_reactions_count, :published, :published_at, :quote,
                :reactions_count, :search_score, :subtitle, :summary, :title,
                :website_url
 

--- a/app/serializers/search/user_serializer.rb
+++ b/app/serializers/search/user_serializer.rb
@@ -12,7 +12,7 @@ module Search
                :mostly_work_with,
                :name,
                :path,
-               :positive_reactions_count,
+               :public_reactions_count,
                :profile_image_90,
                :reactions_count,
                :username

--- a/app/serializers/webhook/article_serializer.rb
+++ b/app/serializers/webhook/article_serializer.rb
@@ -4,7 +4,7 @@ module Webhook
 
     set_type :article
     attributes :title, :description, :readable_publish_date, :cached_tag_list, :cached_tag_list_array,
-               :slug, :path, :url, :comments_count, :positive_reactions_count, :body_markdown
+               :slug, :path, :url, :comments_count, :public_reactions_count, :body_markdown
 
     attribute :canonical_url, &:processed_canonical_url
     attribute :body_html, &:processed_html

--- a/app/services/article_api_index_service.rb
+++ b/app/services/article_api_index_service.rb
@@ -63,7 +63,7 @@ class ArticleApiIndexService
                  articles.where(approved: true).order("featured_number DESC")
                elsif top.present?
                  articles.where("published_at > ?", top.to_i.days.ago).
-                   order("positive_reactions_count DESC")
+                   order("public_reactions_count DESC")
                else
                  articles.order("hotness_score DESC")
                end
@@ -74,7 +74,7 @@ class ArticleApiIndexService
   def top_articles
     Article.published.includes(:user, :organization).
       where("published_at > ?", top.to_i.days.ago).
-      order("positive_reactions_count DESC").
+      order("public_reactions_count DESC").
       page(page).per(per_page || DEFAULT_PER_PAGE)
   end
 
@@ -83,11 +83,11 @@ class ArticleApiIndexService
 
     articles = if state == "fresh"
                  articles.where(
-                   "positive_reactions_count < ? AND featured_number > ? AND score > ?", 2, 7.hours.ago.to_i, -2
+                   "public_reactions_count < ? AND featured_number > ? AND score > ?", 2, 7.hours.ago.to_i, -2
                  )
                elsif state == "rising"
                  articles.where(
-                   "positive_reactions_count > ? AND positive_reactions_count < ? AND featured_number > ?",
+                   "public_reactions_count > ? AND public_reactions_count < ? AND featured_number > ?",
                    19, 33, 3.days.ago.to_i
                  )
                else

--- a/app/services/articles/analytics_updater.rb
+++ b/app/services/articles/analytics_updater.rb
@@ -23,7 +23,7 @@ module Articles
     def fetch_and_update_page_views_and_reaction_counts(qualified_articles)
       qualified_articles.each_slice(15) do |chunk|
         chunk.each do |article|
-          article.update_columns(previous_positive_reactions_count: article.positive_reactions_count)
+          article.update_columns(previous_public_reactions_count: article.public_reactions_count)
           # Notification.send_milestone_notification(type: "Reaction", article_id: article.id)
           # Notification.send_milestone_notification(type: "View", article_id: article.id)
         end
@@ -41,7 +41,7 @@ module Articles
     def should_fetch(article)
       return true if @context == "force"
 
-      article.positive_reactions_count > article.previous_positive_reactions_count || occasionally_force_fetch?
+      article.public_reactions_count > article.previous_public_reactions_count || occasionally_force_fetch?
     end
 
     def occasionally_force_fetch?

--- a/app/services/exporter/articles.rb
+++ b/app/services/exporter/articles.rb
@@ -53,7 +53,7 @@ module Exporter
         main_image
         main_image_background_hex_color
         path
-        positive_reactions_count
+        public_reactions_count
         processed_html
         published
         published_from_feed

--- a/app/services/exporter/comments.rb
+++ b/app/services/exporter/comments.rb
@@ -26,7 +26,7 @@ module Exporter
         edited_at
         id_code
         markdown_character_count
-        positive_reactions_count
+        public_reactions_count
         processed_html
         receive_notifications
       ]

--- a/app/services/notifications/milestone/send.rb
+++ b/app/services/notifications/milestone/send.rb
@@ -58,7 +58,7 @@ module Notifications
         if type == "View"
           last_milestone_notification.blank? && article.page_views_count > @next_milestone
         elsif type == "Reaction"
-          last_milestone_notification.blank? && article.positive_reactions_count > @next_milestone
+          last_milestone_notification.blank? && article.public_reactions_count > @next_milestone
         end
       end
 
@@ -69,7 +69,7 @@ module Notifications
           milestone_count = article.page_views_count
         when "Reaction"
           milestones = [64, 128, 256, 512, 1024, 2048, 4096, 8192]
-          milestone_count = article.positive_reactions_count
+          milestone_count = article.public_reactions_count
         end
 
         closest_number = milestones.min_by { |num| (milestone_count - num).abs }

--- a/app/services/search/query_builders/feed_content.rb
+++ b/app/services/search/query_builders/feed_content.rb
@@ -51,7 +51,7 @@ module Search
         flare_tag_hash
         main_image
         path
-        positive_reactions_count
+        public_reactions_count
         published_at
         readable_publish_date_string
         reading_time

--- a/app/services/search/user.rb
+++ b/app/services/search/user.rb
@@ -21,7 +21,7 @@ module Search
           "path" => source["path"],
           "id" => source["id"],
           "class_name" => "User",
-          "positive_reactions_count" => source["positive_reactions_count"],
+          "public_reactions_count" => source["public_reactions_count"],
           "comments_count" => source["comments_count"],
           "badge_achievements_count" => source["badge_achievements_count"],
           "last_comment_at" => source["last_comment_at"],

--- a/app/services/suggester/articles/classic.rb
+++ b/app/services/suggester/articles/classic.rb
@@ -27,7 +27,7 @@ module Suggester
             includes(user: [:pro_membership]).
             limited_column_select.
             where(featured: true).
-            where("positive_reactions_count > ?", MIN_REACTION_COUNT).
+            where("public_reactions_count > ?", MIN_REACTION_COUNT).
             where("published_at > ?", 10.months.ago).
             order(Arel.sql("RANDOM()"))
         end

--- a/app/services/suggester/articles/high_quality.rb
+++ b/app/services/suggester/articles/high_quality.rb
@@ -11,7 +11,7 @@ module Suggester
         Article.published.where(featured: true).
           includes(user: [:pro_membership]).
           limited_column_select.
-          where("positive_reactions_count > ?", MIN_HQ_REACTION_COUNT).
+          where("public_reactions_count > ?", MIN_HQ_REACTION_COUNT).
           where.not(id: @not_ids).
           order(Arel.sql("RANDOM()")).
           limit(num)

--- a/app/services/suggester/users/sidebar.rb
+++ b/app/services/suggester/users/sidebar.rb
@@ -10,7 +10,7 @@ module Suggester
         Rails.cache.fetch(generate_cache_name, expires_in: 120.hours) do
           reaction_count = Rails.env.production? ? 25 : 0
           user_ids = Article.published.tagged_with([given_tag], any: true).
-            where("positive_reactions_count > ?", reaction_count).
+            where("public_reactions_count > ?", reaction_count).
             where("published_at > ?", 4.months.ago).
             where("user_id != ?", user.id).
             where.not(user_id: user.following_by_type("User")).

--- a/app/views/additional_content_boxes/_article_content_area.html.erb
+++ b/app/views/additional_content_boxes/_article_content_area.html.erb
@@ -13,8 +13,8 @@
     <%= article.description %>
   </a>
 <div class="engagement-count">
-  <% if article.positive_reactions_count > 0 %>
-    <img src="<%= asset_path("reactions-stack.png") %>" alt="Reactions" /> <%= article.positive_reactions_count %>
+  <% if article.public_reactions_count > 0 %>
+    <img src="<%= asset_path("reactions-stack.png") %>" alt="Reactions" /> <%= article.public_reactions_count %>
   <% end %>
   <% if article.comments_count > 0 %>
     <img src="<%= asset_path("comments-bubble.png") %>" alt="Reactions" class="comments-bubble" /> <%= article.comments_count %>

--- a/app/views/api/v0/articles/_article.json.jbuilder
+++ b/app/views/api/v0/articles/_article.json.jbuilder
@@ -10,7 +10,7 @@ json.extract!(
   :path,
   :url,
   :comments_count,
-  :positive_reactions_count,
+  :public_reactions_count,
   :collection_id,
   :published_timestamp,
 )

--- a/app/views/api/v0/articles/me.json.jbuilder
+++ b/app/views/api/v0/articles/me.json.jbuilder
@@ -12,7 +12,7 @@ json.array!    @articles do |article|
     :path,
     :url,
     :comments_count,
-    :positive_reactions_count,
+    :public_reactions_count,
     :page_views_count,
     :published_timestamp,
     :body_markdown,

--- a/app/views/api/v0/articles/onboarding.json.jbuilder
+++ b/app/views/api/v0/articles/onboarding.json.jbuilder
@@ -6,7 +6,7 @@ json.array! @articles do |article|
     :description,
     :published_at,
     :comments_count,
-    :positive_reactions_count,
+    :public_reactions_count,
   )
 
   json.tag_list article.cached_tag_list

--- a/app/views/articles/_single_story.html.erb
+++ b/app/views/articles/_single_story.html.erb
@@ -1,17 +1,17 @@
 <div class="crayons-story <% if featured == true %>crayons-story--featured<% end %>" data-content-user-id="<%= story.user_id %>">
   <% if featured == true %>
-    <div id="featured-story-marker" data-featured-article="articles-<%= story.id %>"></div>
-    <a href="<%= story.path %>" class="crayons-story__cover" data-featured-article="articles-<%= story.id %>">
-      <div style="background-color: <%= story.main_image_background_hex_color %>; background-image: url(<%= cloud_cover_url(story.main_image) %>);" class="crayons-story__cover__image"></div>
-    </a>
+  <div id="featured-story-marker" data-featured-article="articles-<%= story.id %>"></div>
+  <a href="<%= story.path %>" class="crayons-story__cover" data-featured-article="articles-<%= story.id %>">
+    <div style="background-color: <%= story.main_image_background_hex_color %>; background-image: url(<%= cloud_cover_url(story.main_image) %>);" class="crayons-story__cover__image"></div>
+  </a>
   <% end %>
 
   <% if story.video.present? && story.video_thumbnail_url.present? %>
-    <a href="<%= story.path %>" class="crayons-story__video" style="background-image:url(<%= story.cloudinary_video_url %>)">
-      <span class="crayons-story__video__time">
-        <%= story.video_duration_in_minutes %>
-      </span>
-    </a>
+  <a href="<%= story.path %>" class="crayons-story__video" style="background-image:url(<%= story.cloudinary_video_url %>)">
+    <span class="crayons-story__video__time">
+      <%= story.video_duration_in_minutes %>
+    </span>
+  </a>
   <% end %>
 
   <div class="crayons-story__body">
@@ -19,9 +19,9 @@
       <div class="crayons-story__meta">
         <div class="crayons-story__author-pic">
           <% if story.cached_organization && !@organization_article_index %>
-            <a class="crayons-logo crayons-logo--l" href="/<%= story.cached_organization.slug %>">
-              <img alt="<%= story.cached_organization.name %> logo" src="<%= story.cached_organization.profile_image_90 %>" class="crayons-logo__image">
-            </a>
+          <a class="crayons-logo crayons-logo--l" href="/<%= story.cached_organization.slug %>">
+            <img alt="<%= story.cached_organization.name %> logo" src="<%= story.cached_organization.profile_image_90 %>" class="crayons-logo__image">
+          </a>
           <% end %>
 
           <a href="/<%= story.cached_user.username %>" class="crayons-avatar <% if story.cached_organization && !@organization_article_index %> crayons-avatar--s absolute -right-2 -bottom-2 border-solid border-2 border-base-inverted <% else %> crayons-avatar--l <% end %> ">
@@ -35,10 +35,10 @@
               <%= render "shared/pro_checkmark" if story.cached_user.pro %>
             </a>
             <% if story.cached_organization && !@organization_article_index %>
-              <span>
-                <span class="crayons-story__tertiary fw-normal"> for </span>
-                <a href="/<%= story.cached_organization.slug %>" class="crayons-story__secondary fw-medium"><%= story.cached_organization.name %></a>
-              </span>
+            <span>
+              <span class="crayons-story__tertiary fw-normal"> for </span>
+              <a href="/<%= story.cached_organization.slug %>" class="crayons-story__secondary fw-medium"><%= story.cached_organization.name %></a>
+            </span>
             <% end %>
           </p>
           <a href="<%= story.path %>" class="crayons-story__tertiary fs-xs"><time datetime="<%= story.published_timestamp %>"><%= story.readable_publish_date %></time><span class="time-ago-indicator-initial-placeholder" data-seconds="<%= story.published_at_int %>"></span></a>
@@ -54,34 +54,29 @@
       </h2>
       <div class="crayons-story__tags">
         <% story.cached_tag_list_array.each do |tag| %>
-          <a href="/t/<%= tag %>" class="crayons-tag"><span class="crayons-tag__prefix">#</span><%= tag %></a>
+        <a href="/t/<%= tag %>" class="crayons-tag"><span class="crayons-tag__prefix">#</span><%= tag %></a>
         <% end %>
       </div>
       <div class="crayons-story__bottom">
         <div class="crayons-story__details">
           <a href="<%= story.path %>" class="crayons-btn crayons-btn--s crayons-btn--ghost crayons-btn--icon-left" data-reaction-count data-reactable-id="<%= story.id %>">
             <%= inline_svg_tag("small-heart.svg", aria: true, width: 24, height: 24, class: "crayons-icon", title: "Reactions") %>
-            <%= story.positive_reactions_count %>
+            <%= story.public_reactions_count %>
             <span class="hidden s:inline">&nbsp;reactions</span>
           </a>
           <% if story.comments_count > 0 %>
-            <a href="<%= story.path %>#comments" class="crayons-btn crayons-btn--s crayons-btn--ghost crayons-btn--icon-left">
-              <%= inline_svg_tag("small-comment.svg", aria: true, width: 24, height: 24, class: "crayons-icon", title: "Comments") %>
-              <%= story.comments_count %>
-              <span class="hidden s:inline">&nbsp;comments</span>
-            </a>
+          <a href="<%= story.path %>#comments" class="crayons-btn crayons-btn--s crayons-btn--ghost crayons-btn--icon-left">
+            <%= inline_svg_tag("small-comment.svg", aria: true, width: 24, height: 24, class: "crayons-icon", title: "Comments") %>
+            <%= story.comments_count %>
+            <span class="hidden s:inline">&nbsp;comments</span>
+          </a>
           <% end %>
         </div>
         <div class="crayons-story__save">
           <small class="crayons-story__tertiary fs-xs mr-2">
             <%= story.reading_time < 1 ? 1 : story.reading_time %> min read
           </small>
-          <button
-            type="button"
-            class="crayons-btn crayons-btn--secondary crayons-btn--s bookmark-button"
-            data-reactable-id="<%= story.id %>"
-            aria-label="Save to reading list"
-            title="Save to reading list">
+          <button type="button" class="crayons-btn crayons-btn--secondary crayons-btn--s bookmark-button" data-reactable-id="<%= story.id %>" aria-label="Save to reading list" title="Save to reading list">
             <span class="bm-initial">Save</span>
             <span class="bm-success">Saved</span>
           </button>

--- a/app/views/dashboards/_analytics.html.erb
+++ b/app/views/dashboards/_analytics.html.erb
@@ -2,7 +2,7 @@
 
 <div class="dashboard-analytics-header-wrapper">
   <div class="dashboard-analytics-header">
-    <span><%= number_with_delimiter(@articles.sum(&:positive_reactions_count), delimeter: ",") %></span>
+    <span><%= number_with_delimiter(@articles.sum(&:public_reactions_count), delimeter: ",") %></span>
     <div class="dashboard-analytics-sub-indicator">
       <img src="<%= asset_path "emoji/emoji-one-heart.png" %>" /><img src="<%= asset_path "emoji/emoji-one-unicorn.png" %>" /><img src="<%= asset_path "emoji/emoji-one-bookmark.png" %>" />
       Total Post Reactions

--- a/app/views/dashboards/_dashboard_article.html.erb
+++ b/app/views/dashboards/_dashboard_article.html.erb
@@ -80,9 +80,9 @@
         //
         <span class="reactions-count">
           <span class="value">
-            <%= article.positive_reactions_count %>
+            <%= article.public_reactions_count %>
           </span>
-          <%= "reaction".pluralize(count: article.positive_reactions_count) %>
+          <%= "reaction".pluralize(count: article.public_reactions_count) %>
         </span>
         //
         <span class="comments-count">

--- a/app/views/internal/articles/_individual_article.html.erb
+++ b/app/views/internal/articles/_individual_article.html.erb
@@ -16,7 +16,7 @@
       <button class="btn btn-sm btn-success" data-action="article#increaseFeaturedNumber">Boost</button>
       <a class="btn btn-sm btn-secondary" href="/internal/users/<%= article.user_id %>" target="_blank" rel="noopener">Manage User</a>
       <a href="/internal/users/<%= article.user_id %>" class="badge badge-light">@<%= article.user&.username %></a>
-      <span class="badge badge-light">❤️ <%= article.positive_reactions_count %> 💬 <%= article.comments_count %></span>
+      <span class="badge badge-light">❤️ <%= article.public_reactions_count %> 💬 <%= article.comments_count %></span>
       <span class="badge badge-light">
         <% if article.published_from_feed? && !article.published? %>
           RSS Import <%= article.created_at.strftime("%b %d, %Y") %>

--- a/app/views/internal/comments/index.html.erb
+++ b/app/views/internal/comments/index.html.erb
@@ -6,7 +6,7 @@
       <div class="card">
         <div class="card-header">
           <% if comment.commentable %>
-            <a href="<%= comment.commentable.path %>">re: <%= comment.commentable.title %></a> (<%= comment.positive_reactions_count %> ❤️)
+            <a href="<%= comment.commentable.path %>">re: <%= comment.commentable.title %></a> (<%= comment.public_reactions_count %> ❤️)
           <% end %>
         </div>
         <div class="card-body">

--- a/app/views/stories/feeds/show.json.jbuilder
+++ b/app/views/stories/feeds/show.json.jbuilder
@@ -1,5 +1,5 @@
 article_attributes_to_include = %i[
-  title path id user_id comments_count positive_reactions_count organization_id
+  title path id user_id comments_count public_reactions_count organization_id
   reading_time video_thumbnail_url video video_duration_in_minutes language
   experience_level_rating experience_level_rating_distribution
 ]

--- a/config/elasticsearch/mappings/feed_content.json
+++ b/config/elasticsearch/mappings/feed_content.json
@@ -84,7 +84,7 @@
     "path": {
       "type": "keyword"
     },
-    "positive_reactions_count": {
+    "public_reactions_count": {
       "type": "integer"
     },
     "published": {

--- a/config/elasticsearch/mappings/users.json
+++ b/config/elasticsearch/mappings/users.json
@@ -38,7 +38,7 @@
     "path": {
       "type": "keyword"
     },
-    "positive_reactions_count": {
+    "public_reactions_count": {
       "type": "integer"
     },
     "profile_image_90": {

--- a/db/migrate/20200514212601_add_public_reactions_count_columns.rb
+++ b/db/migrate/20200514212601_add_public_reactions_count_columns.rb
@@ -1,0 +1,8 @@
+class AddPublicReactionsCountColumns < ActiveRecord::Migration[5.2]
+  def change
+    add_column :articles, :public_reactions_count, :integer, default: 0, null: false
+    add_column :articles, :previous_public_reactions_count, :integer, default: 0, null: false
+
+    add_column :comments, :public_reactions_count, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -93,7 +93,9 @@ ActiveRecord::Schema.define(version: 2020_05_15_085746) do
     t.string "path"
     t.integer "positive_reactions_count", default: 0, null: false
     t.integer "previous_positive_reactions_count", default: 0
+    t.integer "previous_public_reactions_count", default: 0, null: false
     t.text "processed_html"
+    t.integer "public_reactions_count", default: 0, null: false
     t.boolean "published", default: false
     t.datetime "published_at"
     t.boolean "published_from_feed", default: false
@@ -377,6 +379,7 @@ ActiveRecord::Schema.define(version: 2020_05_15_085746) do
     t.integer "markdown_character_count"
     t.integer "positive_reactions_count", default: 0, null: false
     t.text "processed_html"
+    t.integer "public_reactions_count", default: 0, null: false
     t.integer "reactions_count", default: 0, null: false
     t.boolean "receive_notifications", default: true
     t.integer "score", default: 0

--- a/docs/api_v0.yml
+++ b/docs/api_v0.yml
@@ -154,7 +154,7 @@ components:
         - url
         - canonical_url
         - comments_count
-        - positive_reactions_count
+        - public_reactions_count
         - created_at
         - edited_at
         - crossposted_at
@@ -200,7 +200,7 @@ components:
         comments_count:
           type: integer
           format: int32
-        positive_reactions_count:
+        public_reactions_count:
           type: integer
           format: int32
         created_at:
@@ -246,7 +246,7 @@ components:
         - url
         - canonical_url
         - comments_count
-        - positive_reactions_count
+        - public_reactions_count
         - created_at
         - edited_at
         - crossposted_at
@@ -294,7 +294,7 @@ components:
         comments_count:
           type: integer
           format: int32
-        positive_reactions_count:
+        public_reactions_count:
           type: integer
           format: int32
         created_at:
@@ -475,7 +475,7 @@ components:
         - url
         - canonical_url
         - comments_count
-        - positive_reactions_count
+        - public_reactions_count
         - page_views_count
         - published_timestamp
         - body_markdown
@@ -516,7 +516,7 @@ components:
         comments_count:
           type: integer
           format: int32
-        positive_reactions_count:
+        public_reactions_count:
           type: integer
           format: int32
         page_views_count:
@@ -1060,7 +1060,7 @@ components:
           url: https://dev.to/devteam/there-s-a-new-dev-theme-in-town-for-all-you-10x-hackers-out-there-plus-one-actually-useful-new-feature-2kgk
           canonical_url: https://dev.to/devteam/there-s-a-new-dev-theme-in-town-for-all-you-10x-hackers-out-there-plus-one-actually-useful-new-feature-2kgk
           comments_count: 37
-          positive_reactions_count: 142
+          public_reactions_count: 142
           collection_id:
           created_at: '2019-10-24T13:41:29Z'
           edited_at: '2019-10-24T13:56:35Z'
@@ -1103,7 +1103,7 @@ components:
         url: https://dev.to/bytesized/byte-sized-episode-2-the-creation-of-graph-theory-34g1
         canonical_url: https://dev.to/bytesized/byte-sized-episode-2-the-creation-of-graph-theory-34g1
         comments_count: 21
-        positive_reactions_count: 322
+        public_reactions_count: 322
         collection_id: 1693
         created_at: "2019-07-31T11:15:06Z"
         edited_at:

--- a/spec/labor/badge_rewarder_spec.rb
+++ b/spec/labor/badge_rewarder_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe BadgeRewarder, type: :labor do
     it "rewards beloved comment to folks who have a qualifying comment" do
       create(:badge, title: "Beloved comment", slug: "beloved-comment")
       comment = create(:comment, commentable: create(:article))
-      comment.update(positive_reactions_count: 30)
+      comment.update(public_reactions_count: 30)
       described_class.award_beloved_comment_badges
       expect(BadgeAchievement.count).to eq(1)
     end

--- a/spec/labor/email_digest_spec.rb
+++ b/spec/labor/email_digest_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe EmailDigest, type: :labor do
       before { user.follow(author) }
 
       it "send digest email when there's atleast 3 hot articles" do
-        create_list(:article, 3, user_id: author.id, positive_reactions_count: 20, score: 20)
+        create_list(:article, 3, user_id: author.id, public_reactions_count: 20, score: 20)
         described_class.send_periodic_digest_email
         expect(DigestMailer).to have_received(:digest_email).with(
           user, [instance_of(Article), instance_of(Article), instance_of(Article)]

--- a/spec/labor/email_logic_spec.rb
+++ b/spec/labor/email_logic_spec.rb
@@ -8,26 +8,26 @@ RSpec.describe EmailLogic, type: :labor do
       it "returns 0.5 for open_percentage" do
         author = create(:user)
         user.follow(author)
-        create_list(:article, 3, user_id: author.id, positive_reactions_count: 20, score: 20)
+        create_list(:article, 3, user_id: author.id, public_reactions_count: 20, score: 20)
         h = described_class.new(user).analyze
         expect(h.open_percentage).to eq(0.5)
       end
 
       it "provides top 3 articles" do
-        create_list(:article, 3, positive_reactions_count: 40, featured: true, score: 40)
+        create_list(:article, 3, public_reactions_count: 40, featured: true, score: 40)
         h = described_class.new(user).analyze
         expect(h.articles_to_send.length).to eq(3)
       end
 
       it "marks as not ready if there isn't atleast 3 articles" do
-        create_list(:article, 2, positive_reactions_count: 40, score: 40)
+        create_list(:article, 2, public_reactions_count: 40, score: 40)
         h = described_class.new(user).analyze
         expect(h.should_receive_email?).to eq(false)
       end
 
       it "marks as not ready if there isn't at least 3 email-digest-eligible articles" do
-        create_list(:article, 2, positive_reactions_count: 40, score: 40)
-        create_list(:article, 2, positive_reactions_count: 40, email_digest_eligible: false)
+        create_list(:article, 2, public_reactions_count: 40, score: 40)
+        create_list(:article, 2, public_reactions_count: 40, email_digest_eligible: false)
         h = described_class.new(user).analyze
         expect(h.should_receive_email?).to eq(false)
       end
@@ -37,7 +37,7 @@ RSpec.describe EmailLogic, type: :labor do
       before do
         author = create(:user)
         user.follow(author)
-        create_list(:article, 3, user_id: author.id, positive_reactions_count: 20, score: 20)
+        create_list(:article, 3, user_id: author.id, public_reactions_count: 20, score: 20)
         10.times do
           Ahoy::Message.create(mailer: "DigestMailer#digest_email",
                                user_id: user.id, sent_at: Time.current.utc)
@@ -57,7 +57,7 @@ RSpec.describe EmailLogic, type: :labor do
                                sent_at: Time.current.utc, opened_at: Time.current.utc)
           author = create(:user)
           user.follow(author)
-          create_list(:article, 3, user_id: author.id, positive_reactions_count: 40, score: 40)
+          create_list(:article, 3, user_id: author.id, public_reactions_count: 40, score: 40)
         end
       end
 
@@ -74,7 +74,7 @@ RSpec.describe EmailLogic, type: :labor do
     it "reflects @ready_to_receive_email" do
       author = create(:user)
       user.follow(author)
-      create_list(:article, 3, user_id: author.id, positive_reactions_count: 20, score: 20)
+      create_list(:article, 3, user_id: author.id, public_reactions_count: 20, score: 20)
       h = described_class.new(user).analyze
       expect(h.should_receive_email?).to eq(true)
     end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Notification, type: :model do
   let_it_be_readonly(:user3)           { create(:user) }
   let_it_be_readonly(:organization)    { create(:organization) }
   let_it_be_changeable(:article) do
-    create(:article, :with_notification_subscription, user: user, page_views_count: 4000, positive_reactions_count: 70)
+    create(:article, :with_notification_subscription, user: user, page_views_count: 4000, public_reactions_count: 70)
   end
   let_it_be_readonly(:user_follows_user2) { user.follow(user2) }
   let_it_be_changeable(:comment) { create(:comment, user: user2, commentable: article) }

--- a/spec/models/shared_examples/sync_reactions_count.rb
+++ b/spec/models/shared_examples/sync_reactions_count.rb
@@ -8,11 +8,11 @@ RSpec.shared_examples "#sync_reactions_count" do |reactable_type|
     end
 
     it "syncs reactions count" do
-      expect(reactable.positive_reactions_count).to eq(0)
+      expect(reactable.public_reactions_count).to eq(0)
       reactable.sync_reactions_count
       reactable.reload
       expected_count = reactable.reactions.positive.size
-      expect(reactable.positive_reactions_count).to eq(expected_count)
+      expect(reactable.public_reactions_count).to eq(expected_count)
     end
   end
 end

--- a/spec/requests/additional_content_boxes_spec.rb
+++ b/spec/requests/additional_content_boxes_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "AdditionalContentBoxes", type: :request do
   describe "GET /additional_content_boxes" do
     it "returns an article if there is a published/featured one" do
       suggestion = create(:article, published: true, published_at: 12.months.ago, featured: true, path: "blah")
-      suggestion.update(body_markdown: "foobar", title: "Title of the article", positive_reactions_count: 100)
+      suggestion.update(body_markdown: "foobar", title: "Title of the article", public_reactions_count: 100)
 
       get "/additional_content_boxes?article_id=#{regular_article.id}&state=include_sponsors"
       expect(response.body).to include(CGI.escapeHTML(suggestion.title))

--- a/spec/requests/api/v0/articles_spec.rb
+++ b/spec/requests/api/v0/articles_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Api::V0::Articles", type: :request do
 
       index_keys = %w[
         type_of id title description cover_image readable_publish_date social_image
-        tag_list tags slug path url canonical_url comments_count positive_reactions_count
+        tag_list tags slug path url canonical_url comments_count public_reactions_count
         collection_id created_at edited_at crossposted_at published_at last_comment_at
         published_timestamp user organization flare_tag
       ]
@@ -215,14 +215,14 @@ RSpec.describe "Api::V0::Articles", type: :request do
 
     context "with state param" do
       it "returns fresh articles" do
-        article.update_columns(positive_reactions_count: 1, score: 1)
+        article.update_columns(public_reactions_count: 1, score: 1)
 
         get api_articles_path(state: "fresh")
         expect(response.parsed_body.size).to eq(1)
       end
 
       it "returns rising articles" do
-        article.update_columns(positive_reactions_count: 32, score: 1, featured_number: 2.days.ago.to_i)
+        article.update_columns(public_reactions_count: 32, score: 1, featured_number: 2.days.ago.to_i)
 
         get api_articles_path(state: "rising")
         expect(response.parsed_body.size).to eq(1)
@@ -235,7 +235,7 @@ RSpec.describe "Api::V0::Articles", type: :request do
       end
 
       it "supports pagination" do
-        create_list(:article, 2, tags: "discuss", positive_reactions_count: 1, score: 1)
+        create_list(:article, 2, tags: "discuss", public_reactions_count: 1, score: 1)
 
         get api_articles_path(state: "fresh"), params: { page: 1, per_page: 2 }
         expect(response.parsed_body.length).to eq(2)
@@ -244,7 +244,7 @@ RSpec.describe "Api::V0::Articles", type: :request do
       end
 
       it "sets the correct edge caching surrogate key" do
-        article.update_columns(positive_reactions_count: 1, score: 1)
+        article.update_columns(public_reactions_count: 1, score: 1)
 
         get api_articles_path(state: "fresh")
         expected_key = ["articles", article.record_key].to_set
@@ -280,7 +280,7 @@ RSpec.describe "Api::V0::Articles", type: :request do
 
       show_keys = %w[
         type_of id title description cover_image readable_publish_date social_image
-        tag_list tags slug path url canonical_url comments_count positive_reactions_count
+        tag_list tags slug path url canonical_url comments_count public_reactions_count
         collection_id created_at edited_at crossposted_at published_at last_comment_at
         published_timestamp body_html body_markdown user organization flare_tag
       ]

--- a/spec/services/articles/analytics_updater_spec.rb
+++ b/spec/services/articles/analytics_updater_spec.rb
@@ -10,16 +10,16 @@ RSpec.describe Articles::AnalyticsUpdater, type: :service do
   end
 
   describe "#call" do
-    context "when positive_reactions_count is LOWER than previous_positive_reactions_count" do
+    context "when public_reactions_count is LOWER than previous_public_reactions_count" do
       it "does nothing " do
-        build_stubbed(:article, positive_reactions_count: 2, previous_positive_reactions_count: 3, user: user)
+        build_stubbed(:article, public_reactions_count: 2, previous_public_reactions_count: 3, user: user)
         described_class.call(user)
         expect(Notification).not_to have_received(:send_milestone_notification)
       end
     end
 
-    context "when positive_reactions_count is HIGHER than previous_positive_reactions_count" do
-      let(:article) { build_stubbed(:article, positive_reactions_count: 5, previous_positive_reactions_count: 3, user: user) }
+    context "when public_reactions_count is HIGHER than previous_public_reactions_count" do
+      let(:article) { build_stubbed(:article, public_reactions_count: 5, previous_public_reactions_count: 3, user: user) }
       let(:pageview) { {} }
       let(:counts) { 1000 }
       let(:user_articles) { double }
@@ -40,7 +40,7 @@ RSpec.describe Articles::AnalyticsUpdater, type: :service do
       end
 
       it "updates appropriate column" do
-        expect(article).to have_received(:update_columns).with(previous_positive_reactions_count: article.positive_reactions_count)
+        expect(article).to have_received(:update_columns).with(previous_public_reactions_count: article.public_reactions_count)
       end
     end
   end

--- a/spec/services/exporter/articles_spec.rb
+++ b/spec/services/exporter/articles_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Exporter::Articles, type: :service do
       main_image
       main_image_background_hex_color
       path
-      positive_reactions_count
+      public_reactions_count
       processed_html
       published
       published_at

--- a/spec/services/exporter/comments_spec.rb
+++ b/spec/services/exporter/comments_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Exporter::Comments, type: :service do
       edited_at
       id_code
       markdown_character_count
-      positive_reactions_count
+      public_reactions_count
       processed_html
       receive_notifications
       commentable_path

--- a/spec/services/notifications/milestone/send_spec.rb
+++ b/spec/services/notifications/milestone/send_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Notifications::Milestone::Send, type: :service do
   let(:user) { create(:user) }
-  let(:article) { create(:article, user_id: user.id, page_views_count: 4000, positive_reactions_count: 70) }
+  let(:article) { create(:article, user_id: user.id, page_views_count: 4000, public_reactions_count: 70) }
 
   context "when a user has never received a milestone notification" do
     it "sends the appropriate level view milestone notification" do
@@ -25,7 +25,7 @@ RSpec.describe Notifications::Milestone::Send, type: :service do
 
     def mock_previous_reaction_milestone_notification
       send_milestone_notification_reaction
-      article.update_column(:positive_reactions_count, 150)
+      article.update_column(:public_reactions_count, 150)
       send_milestone_notification_reaction
     end
 

--- a/spec/services/notifications/new_follower/send_spec.rb
+++ b/spec/services/notifications/new_follower/send_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Notifications::NewFollower::Send, type: :service do
   let(:user2)           { create(:user) }
   let(:user3)           { create(:user) }
   let(:organization)    { create(:organization) }
-  let(:article)         { create(:article, user_id: user.id, page_views_count: 4000, positive_reactions_count: 70) }
+  let(:article)         { create(:article, user_id: user.id, page_views_count: 4000, public_reactions_count: 70) }
   let!(:follow)         { user.follow(user2) }
 
   def follow_data(follow)

--- a/spec/system/dashboards/user_sorts_dashboard_articles_spec.rb
+++ b/spec/system/dashboards/user_sorts_dashboard_articles_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.describe "Sorting Dashboard Articles", type: :system, js: true do
   let(:user) { create(:user) }
-  let(:article1) { create(:article, user_id: user.id, published_at: 10.minutes.ago, created_at: 1.day.ago, positive_reactions_count: 5, page_views_count: 0, comments_count: 100) }
-  let(:article2) { create(:article, user_id: user.id, published_at: 1.minute.ago, created_at: 2.days.ago, positive_reactions_count: 1, page_views_count: 10, comments_count: 0) }
-  let(:article3) { create(:article, user_id: user.id, published_at: 5.minutes.ago, created_at: 3.days.ago, positive_reactions_count: 0, page_views_count: 1000, comments_count: 50) }
+  let(:article1) { create(:article, user_id: user.id, published_at: 10.minutes.ago, created_at: 1.day.ago, public_reactions_count: 5, page_views_count: 0, comments_count: 100) }
+  let(:article2) { create(:article, user_id: user.id, published_at: 1.minute.ago, created_at: 2.days.ago, public_reactions_count: 1, page_views_count: 10, comments_count: 0) }
+  let(:article3) { create(:article, user_id: user.id, published_at: 5.minutes.ago, created_at: 3.days.ago, public_reactions_count: 0, page_views_count: 1000, comments_count: 50) }
   let(:articles) { [article1, article2, article3] }
 
   let(:article_with_comments_count_of) do
@@ -45,7 +45,7 @@ RSpec.describe "Sorting Dashboard Articles", type: :system, js: true do
     test_article_order.call("/dashboard?sort=views-asc", [article1, article2, article3])
   end
 
-  it "shows articles sorted by positive_reactions_count ASC" do
+  it "shows articles sorted by public_reactions_count ASC" do
     test_article_order.call("/dashboard?sort=reactions-asc", [article3, article2, article1])
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
This moves the functionality from `positive_reactions_count` to `public_reactions_count`. All changes are simply renaming `positive` to `public`.

**Please do not merge this for me until we are sure that this will not break the site!!**

I think there are some concerns about caching and what not, I'm mostly making the PR right now to see the CI while I think about the caching considerations.

## Related Tickets & Documents
#7919 

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![Spongebob and Patrick are thinking very, very hard.](https://media.giphy.com/media/TPl5N4Ci49ZQY/giphy.gif)
