### PR TITLE
Remove Unnecessary User Touch From Stripe Controller

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -87,10 +87,6 @@ class ApplicationController < ActionController::Base
     response.headers["Expires"] = "Fri, 01 Jan 1990 00:00:00 GMT"
   end
 
-  def touch_current_user
-    current_user.touch
-  end
-
   def rate_limit!(action)
     rate_limiter.check_limit!(action)
   end

--- a/app/controllers/stripe_active_cards_controller.rb
+++ b/app/controllers/stripe_active_cards_controller.rb
@@ -1,6 +1,5 @@
 class StripeActiveCardsController < ApplicationController
   before_action :authenticate_user!
-  before_action :touch_current_user
 
   def create
     authorize :stripe_active_card


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
Saving a user here seems to be completely unnecessary so I am removing it. When we save a user we kick off a bunch of background jobs that waste resources so we should avoid saving them when we don't need to. 

I thought maybe the reason for this was cache-busting but we do that all async so it wouldn't even matter. 

## Added tests?
- [x] no, because they aren't needed

![alt_text](https://media0.giphy.com/media/1vZcEjlUbXMgOz8ZyD/giphy.gif?cid=ecf05e47098b5bd8373a23518bcaa1d36ffde82aad53a12a&rid=giphy.gif)
