### PR TITLE
Drop Elasticsearch Indexes When Database is Dropped in Development

### DIFF
--- a/lib/tasks/search.rake
+++ b/lib/tasks/search.rake
@@ -18,4 +18,8 @@ namespace :search do
 
     Search::Cluster.delete_indexes
   end
+
+  if %(development).include?(Rails.env)
+    Rake::Task["db:drop"].enhance(["search:destroy"])
+  end
 end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
When the database is dropped in development also drop Elasticsearch

## Added tests?
- [x] no, because they aren't needed

![alt_text](https://media0.giphy.com/media/avkW4UabDdJFS/giphy.gif)
