### PR TITLE
Fix pluralization in FollowUsers component

### DIFF
--- a/app/javascript/onboarding/components/FollowUsers.jsx
+++ b/app/javascript/onboarding/components/FollowUsers.jsx
@@ -115,15 +115,21 @@ class FollowUsers extends Component {
 
   renderFollowToggle() {
     const { users, selectedUsers } = this.state;
-    if (users.length === 0) {
-      return '';
+    let followText = '';
+
+    if (selectedUsers.length !== users.length) {
+      if (users.length === 1) {
+        followText = `Select ${users.length} person`;
+      } else {
+        followText = `Select all ${users.length} people`;
+      }
+    } else {
+      followText = 'Deselect all';
     }
 
     return (
       <button type="button" onClick={() => this.handleSelectAll()}>
-        {selectedUsers.length !== users.length
-          ? `Select all ${users.length} people`
-          : 'Deselect all'}
+        {followText}
       </button>
     );
   }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Fixes incorrect pluralization when only one user is suggested in the `FollowUsers` component of onboarding.

## Related Tickets & Documents
N/A.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
Before this change:
<img width="822" alt="Screen_Shot_2020-04-30_at_11_24_01_AM" src="https://user-images.githubusercontent.com/6921610/82241907-cbaeeb00-98f1-11ea-8598-20263f840977.png">

After this change:
<img width="791" alt="Screen_Shot_2020-05-18_at_10_17_01_AM" src="https://user-images.githubusercontent.com/6921610/82241929-cfdb0880-98f1-11ea-846e-9f7bcb3cfa3b.png">
<img width="785" alt="Screen_Shot_2020-05-18_at_10_19_06_AM" src="https://user-images.githubusercontent.com/6921610/82241941-d2d5f900-98f1-11ea-8899-812729df34bd.png">


## Added tests?

- [ ] yes
- [x] no, because they aren't needed **(it doesn't make sense to test pluralization here, we really should just be using i18n)**
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## Are there any post deployment tasks we need to perform?
N/A

## What gif best describes this PR or how it makes you feel?

![sighing birds](https://media0.giphy.com/media/d3JtCuf3m0S1ReSc/giphy.webp?cid=5a38a5a2e4ddd24feb6e4b063d8391285a4b3718810da832&rid=giphy.webp)
