### PR TITLE
One Liner: Only Count Hot Stories Once Rather Than Every Iteration

### DIFF
--- a/app/services/articles/feed.rb
+++ b/app/services/articles/feed.rb
@@ -209,7 +209,8 @@ module Articles
         order("hotness_score DESC")
       featured_story = hot_stories.where.not(main_image: nil).first
       if user_signed_in
-        offset = RANDOM_OFFSET_VALUES.select { |i| i < hot_stories.count }.sample # random offset, weighted more towards zero
+        hot_story_count = hot_stories.count
+        offset = RANDOM_OFFSET_VALUES.select { |i| i < hot_story_count }.sample # random offset, weighted more towards zero
         hot_stories = hot_stories.offset(offset)
         new_stories = Article.published.
           where("score > ?", -15).


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
The `count` will actually issue a database query for every iteration. Instead lets count in the database once then store the count in a variable and use that. 

## Added tests?
- [x] no, because they aren't needed

![alt_text](https://media2.giphy.com/media/dXoVlat19IED3jySHk/200.gif)
