### PR TITLE
Only Remove Article Reaction Count Cache Keys

### DIFF
--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -49,7 +49,7 @@ class ReactionsController < ApplicationController
   end
 
   def create
-    Rails.cache.delete "count_for_reactable-#{params[:reactable_type]}-#{params[:reactable_id]}"
+    remove_count_cache_key
 
     category = params[:category] || "like"
     reaction = Reaction.where(
@@ -137,5 +137,11 @@ class ReactionsController < ApplicationController
 
   def authorize_for_reaction
     authorize Reaction
+  end
+
+  def remove_count_cache_key
+    return unless params[:reactable_type] == "Article"
+
+    Rails.cache.delete "count_for_reactable-Article-#{params[:reactable_id]}"
   end
 end

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -42,7 +42,7 @@ class Reaction < ApplicationRecord
 
   class << self
     def count_for_article(id)
-      Rails.cache.fetch("count_for_reactable-Article-#{id}", expires_in: 1.hour) do
+      Rails.cache.fetch("count_for_reactable-Article-#{id}", expires_in: 10.hours) do
         reactions = Reaction.where(reactable_id: id, reactable_type: "Article")
         counts = reactions.group(:category).count
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
We only use the `count_for_reactable` cache key in one place in our codebase and that is for Articles. Since we don't do it for anything else skip deleting cache keys that don't exist if the reactable type is not Article. This will save us some Redis hits. 

I also increased the expiration on the reaction count cache key bc we are explicitly clearing it when we need to so we can have a longer expiration.  

## Added tests?
- [x] no, because they aren't needed


![alt_text](https://media1.tenor.com/images/7ba4ad8430bdc590e2793e8cfcc8ca3a/tenor.gif?itemid=14410605)
