### PR TITLE
Use User reactions_count for Reaction Cache Keys

### DIFF
--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -96,7 +96,7 @@ class ReactionsController < ApplicationController
   end
 
   def cached_user_positive_reactions(user)
-    Rails.cache.fetch("cached_user_reactions-#{user.id}-#{user.updated_at}", expires_in: 24.hours) do
+    Rails.cache.fetch("cached_user_reactions-#{user.id}-#{user.positive_reactions_count}", expires_in: 24.hours) do
       user.reactions.positive
     end
   end
@@ -115,7 +115,6 @@ class ReactionsController < ApplicationController
   end
 
   def destroy_reaction(reaction)
-    current_user.touch
     reaction.destroy
     Moderator::SinkArticles.call(reaction.reactable_id) if reaction.vomit_on_user?
     Notification.send_reaction_notification_without_delay(reaction, reaction.target_user)

--- a/app/labor/reading_list.rb
+++ b/app/labor/reading_list.rb
@@ -14,7 +14,7 @@ class ReadingList
   end
 
   def cached_ids_of_articles
-    Rails.cache.fetch("reading_list_ids_of_articles_#{user.id}_#{user.updated_at.rfc3339}") do
+    Rails.cache.fetch("reading_list_ids_of_articles_#{user.id}_#{user.positive_reactions_count}") do
       ids_of_articles
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
We update users A LOT. We also use `user.updated_at` in a few of our reaction cache keys which is why we have to touch the user after we create and destroy a reaction. However, the majority of the time we update a user we probably don't need to be busting our reaction keys. This switches the reaction based cache keys to use `user.reactions_count` rather than updated_at. Because reaction_counts are updated automatically every time a reaction is created or destroyed there is no longer a need to touch a user to update `updated_at`. This should save us quite a bit of work when creating and destroying reactions.

**TL;DR: I removed a callback!!!! 🙌** 

## Added tests?
- [x] yes

![alt_text](https://media1.tenor.com/images/870360834c3f79c02cac04ca3e8de20d/tenor.gif?itemid=12706870)
