### PR TITLE
Gracefully handle missing linked users from comments

### DIFF
--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -92,7 +92,7 @@ class UserDecorator < ApplicationDecorator
       },
     ]
     colors |= WHITE_TEXT_COLORS
-    colors[id % 10]
+    colors[(id || rand(100)) % 10]
   end
 
   # returns true if the user has been suspended and has no content

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,10 +2,7 @@ module ApplicationHelper
   # rubocop:disable Performance/OpenStruct
   DELETED_USER = OpenStruct.new(
     id: nil,
-    darker_color: HexComparer.new({
-                                    bg: "#19063A",
-                                    text: "#dce9f3"
-                                  }).brightness,
+    darker_color: HexComparer.new(bg: "#19063A", text: "#dce9f3").brightness,
     username: "[deleted user]",
     name: "[Deleted User]",
     summary: nil,

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,6 @@
 module ApplicationHelper
+  DELETED_USER = User.new(username: "[deleted user]", name: "[Deleted User]")
+
   def user_logged_in_status
     user_signed_in? ? "logged-in" : "logged-out"
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,18 @@
 module ApplicationHelper
-  DELETED_USER = User.new(username: "[deleted user]", name: "[Deleted User]")
+  # rubocop:disable Performance/OpenStruct
+  DELETED_USER = OpenStruct.new(
+    id: nil,
+    darker_color: HexComparer.new({
+                                    bg: "#19063A",
+                                    text: "#dce9f3"
+                                  }).brightness,
+    username: "[deleted user]",
+    name: "[Deleted User]",
+    summary: nil,
+    twitter_username: nil,
+    github_username: nil,
+  )
+  # rubocop:enable Performance/OpenStruct
 
   def user_logged_in_status
     user_signed_in? ? "logged-in" : "logged-out"
@@ -115,6 +128,8 @@ module ApplicationHelper
   end
 
   def follow_button(followable, style = "full")
+    return if followable == DELETED_USER
+
     tag :button, # Yikes
         class: "cta follow-action-button",
         data: {
@@ -129,6 +144,8 @@ module ApplicationHelper
   end
 
   def user_colors(user)
+    return { bg: "#19063A", text: "#dce9f3" } if user == DELETED_USER
+
     user.decorate.enriched_colors
   end
 

--- a/app/liquid_tags/user_tag.rb
+++ b/app/liquid_tags/user_tag.rb
@@ -13,7 +13,7 @@ class UserTag < LiquidTagBase
     ActionController::Base.new.render_to_string(
       partial: PARTIAL,
       locals: {
-        user: @user.decorate,
+        user: user_object_for_partial(@user),
         follow_button: @follow_button,
         user_colors: @user_colors,
         user_path: path_to_profile(@user)
@@ -29,6 +29,10 @@ class UserTag < LiquidTagBase
 
   def path_to_profile(user)
     user == DELETED_USER ? nil : user.path
+  end
+
+  def user_object_for_partial(user)
+    user == DELETED_USER ? user : user.decorate
   end
 end
 

--- a/app/liquid_tags/user_tag.rb
+++ b/app/liquid_tags/user_tag.rb
@@ -21,18 +21,14 @@ class UserTag < LiquidTagBase
     )
   end
 
-  def parse_username_to_user(user)
-    User.find_by(username: user) || deleted_user
-  end
-
   private
 
-  def deleted_user
-    User.new(username: "[deleted user]", name: "[Deleted User]")
+  def parse_username_to_user(user)
+    User.find_by(username: user) || User::DELETED_USER
   end
 
   def path_to_profile(user)
-    user.username == "[deleted user]" ? nil : user.path
+    user == User::DELETED_USER ? nil : user.path
   end
 end
 

--- a/app/liquid_tags/user_tag.rb
+++ b/app/liquid_tags/user_tag.rb
@@ -24,11 +24,11 @@ class UserTag < LiquidTagBase
   private
 
   def parse_username_to_user(user)
-    User.find_by(username: user) || User::DELETED_USER
+    User.find_by(username: user) || DELETED_USER
   end
 
   def path_to_profile(user)
-    user == User::DELETED_USER ? nil : user.path
+    user == DELETED_USER ? nil : user.path
   end
 end
 

--- a/app/liquid_tags/user_tag.rb
+++ b/app/liquid_tags/user_tag.rb
@@ -15,16 +15,24 @@ class UserTag < LiquidTagBase
       locals: {
         user: @user.decorate,
         follow_button: @follow_button,
-        user_colors: @user_colors
+        user_colors: @user_colors,
+        user_path: path_to_profile(@user)
       },
     )
   end
 
   def parse_username_to_user(user)
-    user = User.find_by(username: user)
-    raise StandardError, "Invalid username" if user.nil?
+    User.find_by(username: user) || deleted_user
+  end
 
-    user
+  private
+
+  def deleted_user
+    User.new(username: "[deleted user]", name: "[Deleted User]")
+  end
+
+  def path_to_profile(user)
+    user.username == "[deleted user]" ? nil : user.path
   end
 end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,8 +40,6 @@ class User < ApplicationRecord
   SEARCH_CLASS = Search::User
   DATA_SYNC_CLASS = DataSync::Elasticsearch::User
 
-  DELETED_USER = User.new(username: "[deleted user]", name: "[Deleted User]")
-
   acts_as_followable
   acts_as_follower
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,6 +40,8 @@ class User < ApplicationRecord
   SEARCH_CLASS = Search::User
   DATA_SYNC_CLASS = DataSync::Elasticsearch::User
 
+  DELETED_USER = User.new(username: "[deleted user]", name: "[Deleted User]")
+
   acts_as_followable
   acts_as_follower
 

--- a/app/views/users/_liquid.html.erb
+++ b/app/views/users/_liquid.html.erb
@@ -18,22 +18,10 @@
     </div>
   <% end %>
   <div class="ltag__user__content">
-    <h2>
-      <% if user_path.present? %>
-        <a href="<%= user_path %>" class="ltag__user__link"><%= user.name %></a><%= follow_button %>
-      <% else %>
-        <%= user.name %>
-      <% end %>
-    </h2>
+    <h2><%= link_to_if user_path.present?, user.name, user_path, class: "ltag__user__link" %><%= follow_button %></h2>
     <div class="ltag__user__summary">
-      <% if user_path.present? %>
-        <a href="<%= user_path %>" class="ltag__user__link">
-          <%= user.summary %>
-        </a>
-      <% else %>
-        <%= user.summary %>
-      <% end %>
-      </div>
+      <%= link_to_if user_path.present?, user.summary, user_path, class: "ltag__user__link" %>
+    </div>
     <p class="ltag__user__social">
       <% if !user.twitter_username.blank? %>
         <a href="https://twitter.com/<%= user.twitter_username %>" target="_blank" rel="noopener">

--- a/app/views/users/_liquid.html.erb
+++ b/app/views/users/_liquid.html.erb
@@ -6,18 +6,34 @@
       border-color: <%= user_colors[:bg].casecmp("#ffffff").zero? ? user_colors[:text] : user_colors[:bg] %> !important;
     }
   </style>
-  <a href="<%= user.path %>" class="ltag__user__link profile-image-link">
+  <% if user_path.present? %>
+    <a href="<%= user_path %>" class="ltag__user__link profile-image-link">
+      <div class="ltag__user__pic">
+        <img src="<%= ProfileImage.new(user).get(width: 150) %>" alt="<%= "#{user.username} image" %>" />
+      </div>
+    </a>
+  <% else %>
     <div class="ltag__user__pic">
       <img src="<%= ProfileImage.new(user).get(width: 150) %>" alt="<%= "#{user.username} image" %>" />
     </div>
-  </a>
+  <% end %>
   <div class="ltag__user__content">
-    <h2><a href="<%= user.path %>" class="ltag__user__link"><%= user.name %></a><%= follow_button %></h2>
+    <h2>
+      <% if user_path.present? %>
+        <a href="<%= user_path %>" class="ltag__user__link"><%= user.name %></a><%= follow_button %>
+      <% else %>
+        <%= user.name %>
+      <% end %>
+    </h2>
     <div class="ltag__user__summary">
-      <a href="<%= user.path %>" class="ltag__user__link">
+      <% if user_path.present? %>
+        <a href="<%= user_path %>" class="ltag__user__link">
+          <%= user.summary %>
+        </a>
+      <% else %>
         <%= user.summary %>
-      </a>
-    </div>
+      <% end %>
+      </div>
     <p class="ltag__user__social">
       <% if !user.twitter_username.blank? %>
         <a href="https://twitter.com/<%= user.twitter_username %>" target="_blank" rel="noopener">

--- a/spec/liquid_tags/user_tag_spec.rb
+++ b/spec/liquid_tags/user_tag_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe UserTag, type: :liquid_tag do
     end
   end
 
-  context "when given an invalid id_code" do
+  context "when given an invalid username" do
     it "renders a missing username and name", aggregate_failures: true do
       liquid = generate_user_tag("nonexistent user")
       expect(liquid.render).to include("[deleted user]")

--- a/spec/liquid_tags/user_tag_spec.rb
+++ b/spec/liquid_tags/user_tag_spec.rb
@@ -21,9 +21,11 @@ RSpec.describe UserTag, type: :liquid_tag do
     end
   end
 
-  it "rejects invalid id_code" do
-    expect do
-      generate_user_tag("this should fail")
-    end.to raise_error(StandardError)
+  context "when given an invalid id_code" do
+    it "renders a missing username and name", aggregate_failures: true do
+      liquid = generate_user_tag("nonexistent user")
+      expect(liquid.render).to include("[deleted user]")
+      expect(liquid.render).to include("[Deleted User]")
+    end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

There were issues rendering the liquid `UserTag` when the user in question had been deleted, as described in #6499. This PR fixes the bug.

There is now a `DELETED_USER` constant in the `ApplicationHelper` class, which is an `OpenStruct` object that can be passed into the template in case the user has been deleted. This can be referenced when there is a need to reference a deleted user.

I've also rendered links in the tag conditionally on whether the user is deleted or not.

## Related Tickets & Documents

#6499 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Tag for existing user:
<img width="644" alt="Screen Shot 2020-05-19 at 8 21 41 am" src="https://user-images.githubusercontent.com/5115928/82265233-d9c04280-99a9-11ea-9352-dce2358b05e9.png">

Tag for deleted user:
<img width="645" alt="Screen Shot 2020-05-19 at 8 21 28 am" src="https://user-images.githubusercontent.com/5115928/82265241-e04eba00-99a9-11ea-9139-2b7c904f70db.png">

Note: The "profile image" for the deleted user kept returning a 404 in my local environment. This wasn't a result of the changes I made.

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
