### PR TITLE
Add campaign url for sidebar link

### DIFF
--- a/app/controllers/internal/configs_controller.rb
+++ b/app/controllers/internal/configs_controller.rb
@@ -86,6 +86,7 @@ class Internal::ConfigsController < Internal::ApplicationController
       campaign_hero_html_variant_name
       campaign_sidebar_enabled
       campaign_sidebar_image
+      campaign_url
     ]
   end
 

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -69,7 +69,7 @@ class StoriesController < ApplicationController
 
   def get_latest_campaign_articles
     campaign_articles_scope = Article.tagged_with(SiteConfig.campaign_featured_tags, any: true).
-      where("published_at > ?", 2.weeks.ago).where(approved: true).
+      where("published_at > ?", 4.weeks.ago).where(approved: true).
       order("hotness_score DESC")
 
     @campaign_articles_count = campaign_articles_scope.count

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -59,6 +59,7 @@ class SiteConfig < RailsSettings::Base
   field :campaign_featured_tags, type: :array, default: %w[]
   field :campaign_sidebar_enabled, type: :boolean, default: 0
   field :campaign_sidebar_image, type: :string, default: nil
+  field :campaign_url, type: :string, default: nil
 
   # Onboarding
   field :onboarding_taskcard_image, type: :string, default: "https://practicaldev-herokuapp-com.freetls.fastly.net/assets/staggered-dev.svg"

--- a/app/views/articles/_sidebar_campaign.html.erb
+++ b/app/views/articles/_sidebar_campaign.html.erb
@@ -1,5 +1,9 @@
 <div class="widget">
-  <% if SiteConfig.campaign_sidebar_image %>
+  <% if SiteConfig.campaign_sidebar_image && SiteConfig.campaign_url %>
+    <a href="<%= SiteConfig.campaign_url %>">
+      <img src="<%= SiteConfig.campaign_sidebar_image %>" class="widget-image" style="height:116px;" />
+    </a>
+  <% elsif SiteConfig.campaign_sidebar_image %>
     <img src="<%= SiteConfig.campaign_sidebar_image %>" class="widget-image" style="height:116px;" />
   <% end %>
   <header>

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -279,6 +279,16 @@
             </div>
 
             <div class="form-group">
+              <%= f.label :campaign_url %>
+              <%= f.text_field :campaign_url,
+                               class: "form-control",
+                               value: SiteConfig.campaign_url,
+                               placeholder: "https://url.com/lander" %>
+              <div class="alert alert-info">URL campaign sidebar image will link to</div>
+            </div>
+
+
+            <div class="form-group">
               <%= f.label :campaign_featured_tags %>
               <%= f.text_field :campaign_featured_tags,
                                class: "form-control",

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -170,6 +170,13 @@ RSpec.describe "StoriesIndex", type: :request do
         get "/"
         expect(response.body).not_to include(CGI.escapeHTML("Super-puper"))
       end
+
+      it "displays sidebar url if campaign_url is set" do
+        SiteConfig.campaign_url = "https://example.com"
+        SiteConfig.campaign_sidebar_image = "https://example.com/image.png"
+        get "/"
+        expect(response.body).to include('<a href="https://example.com">')
+      end
     end
   end
 

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -172,11 +172,20 @@ RSpec.describe "StoriesIndex", type: :request do
       end
 
       it "displays sidebar url if campaign_url is set" do
-        SiteConfig.campaign_url = "https://example.com"
+        SiteConfig.campaign_sidebar_enabled = true
+        SiteConfig.campaign_url = "https://campaign-lander.com"
         SiteConfig.campaign_sidebar_image = "https://example.com/image.png"
         get "/"
-        expect(response.body).to include('<a href="https://example.com">')
+        expect(response.body).to include('<a href="https://campaign-lander.com"')
       end
+
+      it "does not display sidebar url if image is not present is set" do
+        SiteConfig.campaign_sidebar_enabled = true
+        SiteConfig.campaign_url = "https://campaign-lander.com"
+        get "/"
+        expect(response.body).not_to include('<a href="https://campaign-lander.com"')
+      end
+
     end
   end
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This features adds a `campaign_url` config which makes the sidebar image clickable...which was acutely pointed out by @maestromac as the expected behavior.

<img width="378" alt="Screen Shot 2020-05-19 at 10 10 31 AM" src="https://user-images.githubusercontent.com/3102842/82336841-0af43f00-99b9-11ea-9b38-19fa03d90546.png">
This image should link to the appropriate page for the campaign (in this case we can use the announcement post)