### PR TITLE
Added coverage threshold to jest configuration.

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,6 +11,14 @@ module.exports = {
     '!**/__tests__/**',
     '!**/__stories__/**',
   ],
+  coverageThreshold: {
+    global: {
+      statements: 39,
+      branches: 35,
+      functions: 34,
+      lines: 39,
+    },
+  },
   moduleNameMapper: {
     '\\.(svg|png)$': '<rootDir>/empty-module.js',
     '^@crayons(.*)$': '<rootDir>/app/javascript/crayons$1',


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [x] DX

## Description

We have code climate that will complain about code coverage dropping already, but this only runs on CI. This adds [thresholds](https://jestjs.io/docs/en/configuration#coveragethreshold-object) for lines, branches, functions, and statements when jest runs.

Our coverage in the frontend is improving, so let's keep it that way. 😉 

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![image](https://user-images.githubusercontent.com/833231/82330446-da100c00-99b0-11ea-8960-03a1f990531d.png)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![The word perfection being crossed out and replaced with the word progress](https://media.giphy.com/media/Tdp2QlrGJVsz1TRY1h/giphy.gif)
