### PR TITLE
Use raw Option When Incrementing Redis Keys

### DIFF
--- a/app/services/rate_limit_checker.rb
+++ b/app/services/rate_limit_checker.rb
@@ -50,7 +50,7 @@ class RateLimitChecker
 
   def track_limit_by_action(action)
     expires_in = ACTION_LIMITERS.dig(action, :retry_after).seconds
-    Rails.cache.increment(limit_cache_key(action), 1, expires_in: expires_in)
+    Rails.cache.increment(limit_cache_key(action), 1, expires_in: expires_in, raw: true)
   end
 
   def limit_by_email_recipient_address(address)
@@ -63,7 +63,7 @@ class RateLimitChecker
 
   ACTION_LIMITERS.each_key do |action|
     define_method("check_#{action}_limit") do
-      Rails.cache.read(limit_cache_key(action)).to_i > action_rate_limit(action)
+      Rails.cache.read(limit_cache_key(action), raw: true).to_i > action_rate_limit(action)
     end
   end
 

--- a/spec/requests/image_uploads_spec.rb
+++ b/spec/requests/image_uploads_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe "ImageUploads", type: :request do
 
       it "counts number of uploads in cache" do
         post "/image_uploads", headers: headers, params: { image: [image] }
-        expect(cache.read(cache_key).to_i).to eq(1)
+        expect(cache.read(cache_key, raw: true).to_i).to eq(1)
       end
 
       it "responds with HTTP 429 with too many uploads" do

--- a/spec/services/rate_limit_checker_spec.rb
+++ b/spec/services/rate_limit_checker_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe RateLimitChecker, type: :service do
     described_class::ACTION_LIMITERS.except(:published_article_creation).each do |action, _options|
       it "returns true if #{action} limit has been reached" do
         allow(Rails.cache).to receive(:read).with(
-          cache_key(action),
+          cache_key(action), raw: true
         ).and_return(SiteConfig.public_send("rate_limit_#{action}") + 1)
 
         expect(rate_limit_checker.limit_by_action(action)).to be(true)
@@ -38,7 +38,7 @@ RSpec.describe RateLimitChecker, type: :service do
 
       it "returns false if #{action} limit has NOT been reached" do
         allow(Rails.cache).to receive(:read).with(
-          cache_key(action),
+          cache_key(action), raw: true
         ).and_return(SiteConfig.public_send("rate_limit_#{action}"))
 
         expect(rate_limit_checker.limit_by_action(action)).to be(false)
@@ -96,7 +96,7 @@ RSpec.describe RateLimitChecker, type: :service do
 
     it "logs a rate limit hit to datadog" do
       allow(Rails.cache).
-        to receive(:read).with("#{user.id}_organization_creation").
+        to receive(:read).with("#{user.id}_organization_creation", raw: true).
         and_return(SiteConfig.rate_limit_organization_creation + 1)
       allow(DatadogStatsClient).to receive(:increment)
       described_class.new(user).limit_by_action("organization_creation")
@@ -128,7 +128,7 @@ RSpec.describe RateLimitChecker, type: :service do
 
       key = "#{user.id}_#{action}"
       expires_in = described_class::ACTION_LIMITERS.dig(action, :retry_after)
-      expect(Rails.cache).to have_received(:increment).with(key, 1, expires_in: expires_in)
+      expect(Rails.cache).to have_received(:increment).with(key, 1, expires_in: expires_in, raw: true)
     end
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Warning Fix

## Description
We have been seeing the below warnings in our specs for Rails 6
```
Using a different value for the raw option when reading and writing to a cache key is deprecated for :redis_cache_store and Rails 6.0 will stop automatically detecting the format when reading to avoid marshal loading untrusted raw strings. 
```
this implements the `:raw` option to fix this warning

Rack attack warnings still remain, there is a PR issued for that gem to fix those https://github.com/kickstarter/rack-attack/pull/482 I reviewed it so I should be notified when its merged and can update our gem accordingly 

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/9#card-38461033

## Added tests?
- [x] no, because they aren't needed

![alt_text](https://blog.sociallyin.com/hubfs/warning%20GIF-downsized_large.gif)
