### PR TITLE
Add config for whether campaign posts require approval

### DIFF
--- a/app/controllers/internal/configs_controller.rb
+++ b/app/controllers/internal/configs_controller.rb
@@ -87,6 +87,7 @@ class Internal::ConfigsController < Internal::ApplicationController
       campaign_sidebar_enabled
       campaign_sidebar_image
       campaign_url
+      campaign_articles_require_approval
     ]
   end
 

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -69,7 +69,7 @@ class StoriesController < ApplicationController
 
   def get_latest_campaign_articles
     campaign_articles_scope = Article.tagged_with(SiteConfig.campaign_featured_tags, any: true).
-      where("published_at > ?", 4.weeks.ago).where(approved: true).
+      where("published_at > ? AND score > ?", 4.weeks.ago, 0).where(approved: SiteConfig.campaign_articles_require_approval?).
       order("hotness_score DESC")
 
     @campaign_articles_count = campaign_articles_scope.count

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -69,9 +69,9 @@ class StoriesController < ApplicationController
 
   def get_latest_campaign_articles
     campaign_articles_scope = Article.tagged_with(SiteConfig.campaign_featured_tags, any: true).
-      where("published_at > ? AND score > ?", 4.weeks.ago, 0).where(approved: SiteConfig.campaign_articles_require_approval?).
+      where("published_at > ? AND score > ?", 4.weeks.ago, 0).
       order("hotness_score DESC")
-
+    campaign_articles_scope = campaign_articles_scope.where(approved: true) if SiteConfig.campaign_articles_require_approval?
     @campaign_articles_count = campaign_articles_scope.count
     @latest_campaign_articles = campaign_articles_scope.limit(5).pluck(:path, :title, :comments_count, :created_at)
   end

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -60,6 +60,7 @@ class SiteConfig < RailsSettings::Base
   field :campaign_sidebar_enabled, type: :boolean, default: 0
   field :campaign_sidebar_image, type: :string, default: nil
   field :campaign_url, type: :string, default: nil
+  field :campaign_articles_require_approval, type: :boolean, default: 0
 
   # Onboarding
   field :onboarding_taskcard_image, type: :string, default: "https://practicaldev-herokuapp-com.freetls.fastly.net/assets/staggered-dev.svg"

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -257,6 +257,12 @@
             </div>
 
             <div class="form-group">
+              <%= f.label :campaign_articles_require_approval %>
+              <%= f.check_box :campaign_articles_require_approval, checked: SiteConfig.campaign_articles_require_approval %>
+              <div class="alert alert-info">Campaign stories show up on sidebar with approval?</div>
+            </div>
+
+            <div class="form-group">
               <%= f.label :campaign_sidebar_enabled %>
               <%= f.check_box :campaign_sidebar_enabled, checked: SiteConfig.campaign_sidebar_enabled %>
               <div class="alert alert-info">Campaign sidebar enabled or not</div>

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -148,9 +148,9 @@ RSpec.describe "StoriesIndex", type: :request do
         SiteConfig.campaign_featured_tags = "shecoded,theycoded"
 
         a_body = "---\ntitle: Super-sheep#{rand(1000)}\npublished: true\ntags: heyheyhey,shecoded\n---\n\nHello"
-        create(:article, approved: true, body_markdown: a_body)
+        create(:article, approved: true, body_markdown: a_body, score: 1)
         u_body = "---\ntitle: Unapproved-post#{rand(1000)}\npublished: true\ntags: heyheyhey,shecoded\n---\n\nHello"
-        create(:article, approved: false, body_markdown: u_body)
+        create(:article, approved: false, body_markdown: u_body, score: 1)
       end
 
       it "doesn't display posts with the campaign tags when sidebar is disabled" do
@@ -159,10 +159,25 @@ RSpec.describe "StoriesIndex", type: :request do
         expect(response.body).not_to include(CGI.escapeHTML("Super-sheep"))
       end
 
-      it "displays posts with the campaign tags when sidebar is enabled" do
+      it "doesn't display low-score posts" do
         SiteConfig.campaign_sidebar_enabled = true
+        SiteConfig.campaign_articles_require_approval = true
         get "/"
         expect(response.body).not_to include(CGI.escapeHTML("Unapproved-post"))
+      end
+
+      it "doesn't display unapproved posts" do
+        SiteConfig.campaign_sidebar_enabled = true
+        SiteConfig.campaign_articles_require_approval = true
+        Article.last.update_column(:score, -2)
+        get "/"
+        expect(response.body).not_to include(CGI.escapeHTML("Unapproved-post"))
+      end
+
+      it "displays unapproved post if approval is not required" do
+        SiteConfig.campaign_sidebar_enabled = true
+        get "/"
+        expect(response.body).to include(CGI.escapeHTML("Unapproved-post"))
       end
 
       it "displays only approved posts with the campaign tags" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This adds a configuration for whether a "campaign" requires approval on which posts show up in sidebar.