### PR TITLE
Remove /new from serviceworkers

### DIFF
--- a/app/views/service_worker/index.js.erb
+++ b/app/views/service_worker/index.js.erb
@@ -113,6 +113,7 @@
         !url.href.includes('/robots.txt') && // Skip robots for web crawlers
         !url.href.includes('/shell_') && // Don't fetch for shell.
         !url.href.includes('/sidekiq') && // Skip for Sidekiq dashboard
+        !url.href.includes('/new') && // We have no shell for /new
         !url.href.includes('/ahoy/') && // Skip for ahoy message redirects
         !url.href.includes('/abtests') && // Skip for field_test dashboard
         !url.href.includes('/social_previews') && // Skip for social previews

--- a/app/views/service_worker/index.js.erb
+++ b/app/views/service_worker/index.js.erb
@@ -95,6 +95,8 @@
         event.request.method == "GET" && // Don't fetch on POST, DELETE, etc.
         !event.request.referrer.includes('/signout_confirm') && // If this is the referrer, we instead want to flush.
 
+        url.pathname !== '/new' && // We have no shell for /new
+
         !url.href.includes('i=i') && // Parameter representing "internal" navigation.
         !url.href.includes('.css') && // Don't run on CSS.
         !url.href.includes('.js') && // Don't run on JS.
@@ -113,7 +115,6 @@
         !url.href.includes('/robots.txt') && // Skip robots for web crawlers
         !url.href.includes('/shell_') && // Don't fetch for shell.
         !url.href.includes('/sidekiq') && // Skip for Sidekiq dashboard
-        !url.href.includes('/new') && // We have no shell for /new
         !url.href.includes('/ahoy/') && // Skip for ahoy message redirects
         !url.href.includes('/abtests') && // Skip for field_test dashboard
         !url.href.includes('/social_previews') && // Skip for social previews


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
`/new` foregoes the top bar via #7524. So we don't want to load the shell.

There are maybe other ways we could do this ideally but this is quick and easy enough I think.