### PR TITLE
Added a search form Storybook story where the search is focused

### DIFF
--- a/app/javascript/Search/__stories__/SearchForm.stories.jsx
+++ b/app/javascript/Search/__stories__/SearchForm.stories.jsx
@@ -1,4 +1,4 @@
-import { h } from 'preact';
+import { h, Component } from 'preact';
 
 import { action } from '@storybook/addon-actions';
 import { SearchForm } from '..';
@@ -11,6 +11,19 @@ const commonProps = {
     action('on submit')(e);
   },
 };
+
+class FocusedForm extends Component {
+  componentDidMount() {
+    document.getElementById('nav-search').focus();
+  }
+
+  render() {
+    // Disabling prop types checks here because this is simply a wrapper
+    // class for a Storybook story.
+    // eslint-disable-next-line react/destructuring-assignment, react/prop-types
+    return this.props.children[0];
+  }
+}
 
 export default {
   component: SearchForm,
@@ -29,4 +42,14 @@ export const WithSearchTerm = () => (
 
 WithSearchTerm.story = {
   name: 'with search term',
+};
+
+export const WithFocus = () => (
+  <FocusedForm>
+    <SearchForm {...commonProps} searchTerm="Hello" />
+  </FocusedForm>
+);
+
+WithFocus.story = {
+  name: 'with focus',
 };


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Added another Storybook story for a component

## Description

A Storybook story for the `<SearchForm />` component showing off our lovely focus styles.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![image](https://user-images.githubusercontent.com/833231/82378986-22045280-99f4-11ea-9965-590d5111c815.png)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![Dwayne "The Rock" Johnson saying focus as he does seated rows](https://media.giphy.com/media/14afmHqKZ3ctsk/giphy.gif)
