### PR TITLE
Use npm for deploying Storybook

### DIFF
--- a/app/javascript/netlify.toml
+++ b/app/javascript/netlify.toml
@@ -8,4 +8,3 @@
 [build]
   # base set in Netlify settings UI
   command = "npm install && npm run build-storybook"
-  publish = "../../storybook-static"

--- a/app/javascript/netlify.toml
+++ b/app/javascript/netlify.toml
@@ -7,5 +7,5 @@
 
 [build]
   # base set in Netlify settings UI
-  command = "yarn && yarn build-storybook"
+  command = "npm install && npm run build-storybook"
   publish = "storybook-static/"

--- a/app/javascript/netlify.toml
+++ b/app/javascript/netlify.toml
@@ -7,5 +7,5 @@
 
 [build]
   # base set in Netlify settings UI
-  command = "yarn build-storybook"
+  command = "yarn && yarn build-storybook"
   publish = "storybook-static/"

--- a/app/javascript/netlify.toml
+++ b/app/javascript/netlify.toml
@@ -8,4 +8,4 @@
 [build]
   # base set in Netlify settings UI
   command = "npm install && npm run build-storybook"
-  publish = "storybook-static/"
+  publish = "../../storybook-static"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description

Use `npm` instead of `yarn` since using `yarn` will require a `yarn.lock` file in `app/javascript`, which seems unnecessary.