### PR TITLE
Add missing unique indexes - part 1

### DIFF
--- a/db/migrate/20200520091835_add_unique_index_to_webhook_endpoints_target_url.rb
+++ b/db/migrate/20200520091835_add_unique_index_to_webhook_endpoints_target_url.rb
@@ -1,0 +1,7 @@
+class AddUniqueIndexToWebhookEndpointsTargetUrl < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :webhook_endpoints, :target_url, unique: true, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20200520092247_add_unique_index_to_tag_adjustments_tag_name.rb
+++ b/db/migrate/20200520092247_add_unique_index_to_tag_adjustments_tag_name.rb
@@ -1,0 +1,7 @@
+class AddUniqueIndexToTagAdjustmentsTagName < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :tag_adjustments, %i[tag_name article_id], unique: true, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20200520092613_add_unique_index_to_response_templates_content.rb
+++ b/db/migrate/20200520092613_add_unique_index_to_response_templates_content.rb
@@ -1,0 +1,14 @@
+class AddUniqueIndexToResponseTemplatesContent < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index(
+      :response_templates,
+      %i[content user_id type_of content_type],
+      unique: true,
+      algorithm: :concurrently,
+      # needs a custom name as the generated one is too long
+      name: :idx_response_templates_on_content_user_id_type_of_content_type
+    )
+  end
+end

--- a/db/migrate/20200520092938_add_unique_index_to_profile_pins_pinnable_id.rb
+++ b/db/migrate/20200520092938_add_unique_index_to_profile_pins_pinnable_id.rb
@@ -1,0 +1,14 @@
+class AddUniqueIndexToProfilePinsPinnableId < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index(
+      :profile_pins,
+      %i[pinnable_id profile_id profile_type pinnable_type],
+      unique: true,
+      algorithm: :concurrently,
+      # needs a custom name as the generated one is too long
+      name: :idx_pins_on_pinnable_id_profile_id_profile_type_pinnable_type
+    )
+  end
+end

--- a/db/migrate/20200520092951_add_unique_index_to_poll_votes_poll_id.rb
+++ b/db/migrate/20200520092951_add_unique_index_to_poll_votes_poll_id.rb
@@ -1,0 +1,7 @@
+class AddUniqueIndexToPollVotesPollId < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :poll_votes, %i[poll_id user_id], unique: true, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_15_085746) do
+ActiveRecord::Schema.define(version: 2020_05_20_092951) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -857,6 +857,7 @@ ActiveRecord::Schema.define(version: 2020_05_15_085746) do
     t.bigint "poll_option_id", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
+    t.index ["poll_id", "user_id"], name: "index_poll_votes_on_poll_id_and_user_id", unique: true
     t.index ["poll_option_id", "user_id"], name: "index_poll_votes_on_poll_option_and_user", unique: true
   end
 
@@ -893,6 +894,7 @@ ActiveRecord::Schema.define(version: 2020_05_15_085746) do
     t.bigint "profile_id"
     t.string "profile_type"
     t.datetime "updated_at", null: false
+    t.index ["pinnable_id", "profile_id", "profile_type", "pinnable_type"], name: "idx_pins_on_pinnable_id_profile_id_profile_type_pinnable_type", unique: true
     t.index ["pinnable_id"], name: "index_profile_pins_on_pinnable_id"
     t.index ["profile_id"], name: "index_profile_pins_on_profile_id"
   end
@@ -936,6 +938,7 @@ ActiveRecord::Schema.define(version: 2020_05_15_085746) do
     t.string "type_of", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id"
+    t.index ["content", "user_id", "type_of", "content_type"], name: "idx_response_templates_on_content_user_id_type_of_content_type", unique: true
     t.index ["type_of"], name: "index_response_templates_on_type_of"
     t.index ["user_id", "type_of"], name: "index_response_templates_on_user_id_and_type_of"
     t.index ["user_id"], name: "index_response_templates_on_user_id"
@@ -992,6 +995,7 @@ ActiveRecord::Schema.define(version: 2020_05_15_085746) do
     t.string "tag_name"
     t.datetime "updated_at", null: false
     t.integer "user_id"
+    t.index ["tag_name", "article_id"], name: "index_tag_adjustments_on_tag_name_and_article_id", unique: true
   end
 
   create_table "taggings", id: :serial, force: :cascade do |t|
@@ -1253,6 +1257,7 @@ ActiveRecord::Schema.define(version: 2020_05_15_085746) do
     t.bigint "user_id", null: false
     t.index ["events"], name: "index_webhook_endpoints_on_events"
     t.index ["oauth_application_id"], name: "index_webhook_endpoints_on_oauth_application_id"
+    t.index ["target_url"], name: "index_webhook_endpoints_on_target_url", unique: true
     t.index ["user_id"], name: "index_webhook_endpoints_on_user_id"
   end
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Our PostgreSQL is missing quite a few unique indexes that are only checked via Rails, with the side-effect of potentially generating slow SQL queries and leaving it open to duplicate rows if the data comes in via other sources.

I tried to group some tables that have relatively little rows. There are still quite a few, I'll send them in "parts"

> This helper validates that the attribute's value is unique right before the object gets saved. It does not create a uniqueness constraint in the database, so it may happen that two different database connections create two records with the same value for a column that you intend to be unique. To avoid that, you must create a unique index on that column in your database.

https://guides.rubyonrails.org/active_record_validations.html#uniqueness

## Related Tickets & Documents

https://github.com/rubocop-hq/rubocop-rails/pull/197

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
