### PR TITLE
Improve RssReader::Assembler's image path correction

### DIFF
--- a/app/services/rss_reader/assembler.rb
+++ b/app/services/rss_reader/assembler.rb
@@ -127,7 +127,11 @@ class RssReader
         path = (img_tag.attributes["src"] || img_tag.attributes["data-src"])&.value
         next unless path
 
-        img_tag.attributes["src"].value = URI.join(url, path).to_s if path.start_with? "/"
+        # Only update source if the path is not already an URL
+        unless path.match?(/\A#{URI::DEFAULT_PARSER.make_regexp}\z/)
+          resource = path.start_with?("/") ? url : @feed_source_url
+          img_tag.attributes["src"].value = URI.join(resource, path).to_s
+        end
       end
     end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
`RssReader::Assembler` will only correct image src that starts with `/`. This updates it to account for src without `/`.
## Related Tickets & Documents
Resolves https://github.com/thepracticaldev/dev.to/issues/7918

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
n/a
## Added tests?
- [x] no, because they aren't needed. RssReader spec covers it.

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a