### PR TITLE
Keep Pro Membership Relation Until AR Cache's expire

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -92,6 +92,7 @@ class User < ApplicationRecord
   has_many :webhook_endpoints, class_name: "Webhook::Endpoint", foreign_key: :user_id, inverse_of: :user, dependent: :delete_all
 
   has_one :counters, class_name: "UserCounter", dependent: :destroy
+  has_one :pro_membership, dependent: :destroy
 
   mount_uploader :profile_image, ProfileImageUploader
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Here we cache an AR relationship(which we should never do) and that cache has pro membership in the scope so we need to keep it in the user model til the cache expires.
```ruby
        Rails.cache.fetch("classic-article-for-tag-#{tag_name}}", expires_in: 90.minutes) do
          Article.published.cached_tagged_with(tag_name).
            includes(:user).
            limited_column_select.
            where(featured: true).
            where("positive_reactions_count > ?", MIN_REACTION_COUNT).
            where("published_at > ?", 10.months.ago).
            order(Arel.sql("RANDOM()"))
        end
```