### PR TITLE
Skip pro memberships for spec

### DIFF
--- a/spec/services/users/delete_spec.rb
+++ b/spec/services/users/delete_spec.rb
@@ -108,6 +108,8 @@ RSpec.describe Users::Delete, type: :service do
       associations = []
 
       names.each do |association|
+        next if association.name == :pro_membership
+
         if user.public_send(association.name).present?
           associations.push(*user.public_send(association.name))
         else


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Spec Fix

## Description
pro memberships cannot be accurately created in this spec without a bunch of the old validations and constraints which leads to invalid records and the spec fails. This skips that association and I validated the spec passes