### PR TITLE
Remove ProMembership Models

### DIFF
--- a/app/models/pro_membership.rb
+++ b/app/models/pro_membership.rb
@@ -1,3 +1,0 @@
-class ProMembership < ApplicationRecord
-  belongs_to :user
-end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -92,7 +92,6 @@ class User < ApplicationRecord
   has_many :webhook_endpoints, class_name: "Webhook::Endpoint", foreign_key: :user_id, inverse_of: :user, dependent: :delete_all
 
   has_one :counters, class_name: "UserCounter", dependent: :destroy
-  has_one :pro_membership, dependent: :destroy
 
   mount_uploader :profile_image, ProfileImageUploader
 

--- a/spec/services/users/delete_spec.rb
+++ b/spec/services/users/delete_spec.rb
@@ -108,8 +108,6 @@ RSpec.describe Users::Delete, type: :service do
       associations = []
 
       names.each do |association|
-        next if association.name == :pro_membership
-
         if user.public_send(association.name).present?
           associations.push(*user.public_send(association.name))
         else


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
Followup to #7894. When I initially deployed the original PR it broke some pages bc we had ActiveRecord relations with the old membership cached. This forced me to add back the relation to ensure that the cache loaded would not break anything. The cache that broke(shown below) expires in 90 minutes so since the Pro model without the code has been out for more than 90 minutes we can merge this.  
```ruby
Rails.cache.fetch("classic-article-for-tag-#{tag_name}}", expires_in: 90.minutes) do
  Article.published.cached_tagged_with(tag_name).
    includes(:user).
    limited_column_select.
    where(featured: true).
    where("positive_reactions_count > ?", MIN_REACTION_COUNT).
    where("published_at > ?", 10.months.ago).
    order(Arel.sql("RANDOM()"))
end
```

## Added tests?
- [x] no, because they aren't needed

![alt_text](https://media.tenor.com/images/68c562ea1f26f6c5bd758d8d538ce85d/tenor.gif)
