### PR TITLE
Remove some superfluous Percy snapshots

### DIFF
--- a/spec/system/articles/user_visits_articles_by_timeframe_spec.rb
+++ b/spec/system/articles/user_visits_articles_by_timeframe_spec.rb
@@ -12,10 +12,6 @@ RSpec.describe "User visits articles by timeframe", type: :system do
     context "when viewing articles for week" do
       before { visit "/top/week" }
 
-      it "renders the page", js: true, percy: true do
-        Percy.snapshot(page, name: "Articles: /top/week logged out user")
-      end
-
       it "shows correct articles count" do
         expect(page).to have_selector(".crayons-story", visible: :visible, count: 2)
       end
@@ -34,10 +30,6 @@ RSpec.describe "User visits articles by timeframe", type: :system do
 
     context "when viewing articles for month" do
       before { visit "/top/month" }
-
-      it "renders the page", js: true, percy: true do
-        Percy.snapshot(page, name: "Articles: /top/month logged out user")
-      end
 
       it "shows correct articles count" do
         expect(page).to have_selector(".crayons-story", visible: :visible, count: 3)
@@ -59,10 +51,6 @@ RSpec.describe "User visits articles by timeframe", type: :system do
     context "when viewing articles for year" do
       before { visit "/top/year" }
 
-      it "renders the page", js: true, percy: true do
-        Percy.snapshot(page, name: "Articles: /top/year logged out user")
-      end
-
       it "shows correct articles count" do
         expect(page).to have_selector(".crayons-story", visible: :visible, count: 4)
       end
@@ -83,10 +71,6 @@ RSpec.describe "User visits articles by timeframe", type: :system do
 
     context "when viewing articles for infinity" do
       before { visit "/top/infinity" }
-
-      it "renders the page", js: true, percy: true do
-        Percy.snapshot(page, name: "Articles: /top/infinity logged out user")
-      end
 
       it "shows correct articles and cta count" do
         expect(page).to have_selector(".crayons-story", visible: :visible, count: 5)
@@ -110,10 +94,6 @@ RSpec.describe "User visits articles by timeframe", type: :system do
 
     context "when viewing articles for latest" do
       before { visit "/latest" }
-
-      it "renders the page", js: true, percy: true do
-        Percy.snapshot(page, name: "Articles: /latest logged out user")
-      end
 
       it "shows correct articles and cta count" do
         expect(page).to have_selector(".crayons-story", visible: :visible, count: 5)
@@ -144,10 +124,6 @@ RSpec.describe "User visits articles by timeframe", type: :system do
       visit "/top/week"
     end
 
-    it "renders the page", percy: true do
-      Percy.snapshot(page, name: "Articles: /top/week logged in user")
-    end
-
     it "shows correct articles count" do
       expect(page).to have_xpath("//article[contains(@class, 'crayons-story') and contains(@class, 'false')]", count: 1)
     end
@@ -167,7 +143,7 @@ RSpec.describe "User visits articles by timeframe", type: :system do
       before { visit "/top/month" }
 
       it "renders the page", percy: true do
-        Percy.snapshot(page, name: "Articles: /top/month logged in user")
+        Percy.snapshot(page, name: "Articles: /top/month")
       end
 
       it "shows correct articles count" do
@@ -190,10 +166,6 @@ RSpec.describe "User visits articles by timeframe", type: :system do
     context "when viewing articles for year" do
       before { visit "/top/year" }
 
-      it "renders the page", percy: true do
-        Percy.snapshot(page, name: "Articles: /top/year logged in user")
-      end
-
       it "shows correct articles count" do
         expect(page).to have_xpath("//article[contains(@class, 'crayons-story') and contains(@class, 'false')]", count: 3)
       end
@@ -214,10 +186,6 @@ RSpec.describe "User visits articles by timeframe", type: :system do
 
     context "when viewing articles for infinity" do
       before { visit "/top/infinity" }
-
-      it "renders the page", percy: true do
-        Percy.snapshot(page, name: "Articles: /top/infinity logged in user")
-      end
 
       it "shows correct articles count" do
         expect(page).to have_xpath("//article[contains(@class, 'crayons-story') and contains(@class, 'false')]", count: 4)
@@ -242,7 +210,7 @@ RSpec.describe "User visits articles by timeframe", type: :system do
       before { visit "/latest" }
 
       it "renders the page", percy: true do
-        Percy.snapshot(page, name: "Articles: /latest logged in user")
+        Percy.snapshot(page, name: "Articles: /latest")
       end
 
       it "shows correct articles" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
There doesn't seem to be enough of a difference between these snapshots, and, for some reason, the date does not seem to be freezing for some of the data captured within them. Since we already have a snapshot of this page, we don't need so many versions of it.

NOTE: This will also save us some $$$! 🤑 

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [x] yes **(see Percy snapshots)**
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
