### PR TITLE
Use Faker to generate user + article factory data

### DIFF
--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
 
   factory :article do
     transient do
-      title { generate :title }
+      title { Faker::Food.dish }
       published { true }
       date { "01/01/2015" }
       tags { Faker::Hipster.words(number: 4).join(", ") }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -21,6 +21,8 @@ FactoryBot.define do
     checked_terms_and_conditions { true }
     signup_cta_variant           { "navbar_basic" }
     email_digest_periodic        { false }
+    bg_color_hex                 { Faker::Color.hex_color }
+    text_color_hex               { Faker::Color.hex_color }
 
     trait :with_identity do
       transient { identities { Authentication::Providers.available } }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
We need to deterministically generate data for tests tagged with `percy: true` so that our snapshots are reliably the same, each time we try to build Percy. Currently, however, we have a couple factories that do _not_ use `Faker` to do this, which means we can't deterministically generate data.

This PR ensures that we use `Faker` instead of `generate` to make sure that we don't get intermittent Percy diffs where the colors, ~usernames, or emails~ and article titles change on each build. 😢 

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [x] yes **(check snapshots)**
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed