### PR TITLE
Fix db:reset by adding search:setup after search:destroy

### DIFF
--- a/lib/tasks/search.rake
+++ b/lib/tasks/search.rake
@@ -18,8 +18,8 @@ namespace :search do
 
     Search::Cluster.delete_indexes
   end
+end
 
-  if %(development).include?(Rails.env)
-    Rake::Task["db:drop"].enhance(["search:destroy"])
-  end
+if %(development).include?(Rails.env)
+  Rake::Task["db:drop"].enhance(["search:destroy", "search:setup"])
 end

--- a/lib/tasks/search.rake
+++ b/lib/tasks/search.rake
@@ -20,6 +20,6 @@ namespace :search do
   end
 end
 
-if %(development).include?(Rails.env)
+if Rails.env.development?
   Rake::Task["db:drop"].enhance(["search:destroy", "search:setup"])
 end

--- a/lib/tasks/search.rake
+++ b/lib/tasks/search.rake
@@ -21,5 +21,6 @@ namespace :search do
 end
 
 if Rails.env.development?
-  Rake::Task["db:drop"].enhance(["search:destroy", "search:setup"])
+  Rake::Task["db:create"].enhance(["search:setup"])
+  Rake::Task["db:drop"].enhance(["search:destroy"])
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Ran `rails db:reset` locally, ran into "ES index not found", figured the problem was that we drop the indexes but not re-create them after the drop. 

This works.

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
