### PR TITLE
--base-50: changed to #fff unreadble text in ten X hacker theme

### DIFF
--- a/app/assets/stylesheets/themes/hacker.scss
+++ b/app/assets/stylesheets/themes/hacker.scss
@@ -27,13 +27,14 @@
   --base-80: #c8c8c8;
   --base-70: #adadad;
   --base-60: #939393;
-  --base-50: #7a7a7a;
+  --base-50: #fff;// unreadable in Ten X hacker theme to light to view and in case of mail 
+  ///and usernames CSS properties are overriding please and that text is getting black out there Ex:-Hidden 
   --base-40: #626262;
   --base-30: #4b4b4b;
   --base-20: #353535;
   --base-10: #1c1c1c;
   --base-0: #0a0a0a;
-  --base-inverted: #000;
+  --base-inverted: #000;///
 
   // Accent colors
   --accent-brand: #2eff7b;


### PR DESCRIPTION
--base-50: changed to #fff unreadable text in ten X hacker theme  light-dark text making eye strain their that's why I changed to white it looks good I tested in firefox and another bug in this theme is in case of mail 
  and usernames CSS properties are overriding  and that text is getting black out there Ex:-Hidden

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
--base-50: changed to #fff unreadable text in ten X hacker theme  light-dark text making eye strain their that's why i changed to white it looks i tested in firefox and another bug in this theme is in case of mail 
  and usernames CSS properties are overriding  and that text is getting black out there Ex:-Hidden

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [ ] yes
- [X] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed

![Annotation 2020-05-21 144920](https://user-images.githubusercontent.com/42638797/82544141-4b4aed00-9b72-11ea-84da-f75e917bed68.png)
![Annotation 2020-05-21 144948](https://user-images.githubusercontent.com/42638797/82544171-5867dc00-9b72-11ea-81d3-11e11233755b.png)
# After changing base 50 value to white text appeared clear🔽
![devto](https://user-images.githubusercontent.com/42638797/82552091-15f8cc00-9b7f-11ea-8f6a-780033ae2e29.png)

 but name and email property is overridden by something I didn't  get I tried but I am not able to find that property there I think that is overridden by some other properties 
Issue assigned from #7998  