### PR TITLE
Revert "Update safe params for Array params (#7914)"

### DIFF
--- a/config/fastly/snippets/safe_params_list.vcl
+++ b/config/fastly/snippets/safe_params_list.vcl
@@ -1,9 +1,7 @@
 import querystring;
 sub vcl_recv {
-  # return this URL with only the parameters that match this regular expression
-  if (req.url !~ "/internal/" && req.url !~ "/search/") {
-    set req.http.decodeurl = urldecode(req.url);
-    set req.http.decodeurl = querystring.regfilter_except(req.http.decodeurl, "^(a_id|args|article_id|article_ids|articles|asc|callback_url|category|chat_channel_id|client_id|code|collection_id|commentable_id|commentable_type|confirmation_token|created_at|end|filter|followable_id|followable_type|fork_id|i|ids\[\]|key|message_offset|name|oauth_token|oauth_verifier|offset|org_id|organization_id|p|page|per_page|prefill|preview|purchaser|reactable_ids|redirect_uri|reported_url|reporter_username|response_type|scope|search|signature|sort|start|state|status|tag|tag_list|top|type_of|url|username|ut|verb)$");
-    set req.url = req.http.decodeurl;
-  }
+    # return this URL with only the parameters that match this regular expression
+    if (req.url !~ "/internal/" && req.url !~ "/search/" && req.url !~ "/bulk_show") {
+      set req.url = querystring.regfilter_except(req.url, "^(a_id|args|article_id|article_ids|articles|asc|callback_url|category|chat_channel_id|client_id|code|collection_id|commentable_id|commentable_type|confirmation_token|created_at|end|filter|followable_id|followable_type|fork_id|i|key|message_offset|name|oauth_token|oauth_verifier|offset|org_id|organization_id|p|page|per_page|prefill|preview|purchaser|reactable_ids|redirect_uri|reported_url|reporter_username|response_type|scope|search|signature|sort|start|state|status|tag|tag_list|top|type_of|url|username|ut|verb)$");
+    }
 }


### PR DESCRIPTION
This reverts commit 4eba14f15008564d53470ca7dd7ca2b2c8ad0b11.

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)
- [x ] Bug Fix

## Description
Ahoy encodes URL params and our new Fastly way of decoding messes up the URL - therefore breaking Ahoy links.

## Related Tickets & Documents
#7914
https://github.com/thepracticaldev/dev.to/issues/7982

## Added tests?
- [x] no, because they aren't needed
Already tested live in Fastly

## Added to documentation?
- [x] no documentation needed