### PR TITLE
Fix tag removal case sensitivity for mods

### DIFF
--- a/app/models/tag_adjustment.rb
+++ b/app/models/tag_adjustment.rb
@@ -29,7 +29,7 @@ class TagAdjustment < ApplicationRecord
   end
 
   def article_tag_list
-    errors.add(:tag_id, "selected for removal is not a current live tag.") if adjustment_type == "removal" && article.tag_list.exclude?(tag_name)
+    errors.add(:tag_id, "selected for removal is not a current live tag.") if adjustment_type == "removal" && article.tag_list.none? { |tag| tag.casecmp(tag_name).zero? }
     errors.add(:base, "4 tags max per article.") if adjustment_type == "addition" && article.tag_list.count > 3
   end
 end

--- a/app/services/tag_adjustment_creation_service.rb
+++ b/app/services/tag_adjustment_creation_service.rb
@@ -20,7 +20,7 @@ class TagAdjustmentCreationService
   private
 
   def update_article
-    article.update!(tag_list: article.tag_list.remove(@tag_adjustment.tag_name)) if @tag_adjustment.adjustment_type == "removal"
+    article.update!(tag_list: article.tag_list.remove(article.tag_list.select { |tag| tag.casecmp(tag_name).zero? })) if @tag_adjustment.adjustment_type == "removal"
     article.update!(tag_list: article.tag_list.add(@tag_adjustment.tag_name)) if @tag_adjustment.adjustment_type == "addition"
   end
 

--- a/app/services/tag_adjustment_creation_service.rb
+++ b/app/services/tag_adjustment_creation_service.rb
@@ -20,7 +20,11 @@ class TagAdjustmentCreationService
   private
 
   def update_article
-    article.update!(tag_list: article.tag_list.remove(article.tag_list.select { |tag| tag.casecmp(tag_name).zero? })) if @tag_adjustment.adjustment_type == "removal"
+    if @tag_adjustment.adjustment_type == "removal"
+      removed_tags = article.tag_list.select { |tag| tag.casecmp(@tag_adjustmen.tag_name).zero? }
+      article.update!(tag_list: article.tag_list.remove(removed_tags))
+    end
+
     article.update!(tag_list: article.tag_list.add(@tag_adjustment.tag_name)) if @tag_adjustment.adjustment_type == "addition"
   end
 

--- a/app/services/tag_adjustment_creation_service.rb
+++ b/app/services/tag_adjustment_creation_service.rb
@@ -9,7 +9,7 @@ class TagAdjustmentCreationService
   end
 
   def article
-    @article ||= Article.find(creation_args[:article_id])
+    @article ||= Article.find(@tag_adjustment_params[:article_id])
   end
 
   def update_tags_and_notify
@@ -21,7 +21,7 @@ class TagAdjustmentCreationService
 
   def update_article
     if @tag_adjustment.adjustment_type == "removal"
-      removed_tags = article.tag_list.select { |tag| tag.casecmp(@tag_adjustmen.tag_name).zero? }
+      removed_tags = article.tag_list.select { |tag| tag.casecmp(@tag_adjustment.tag_name).zero? }
       return if removed_tags.empty?
 
       article.update!(tag_list: article.tag_list.remove(removed_tags))
@@ -32,8 +32,18 @@ class TagAdjustmentCreationService
 
   def creation_args
     args = @tag_adjustment_params
+
+    tag =
+      case args[:adjustment_type]
+      when "removal"
+        article.tags.detect { |article_tag| article_tag.name.casecmp(args[:tag_name]).zero? }
+      when "addition"
+        Tag.find_by(name: args[:tag_name])
+      end
+
     args[:user_id] = @user.id
-    args[:tag_id] = Tag.find_by(name: args[:tag_name])&.id
+    args[:tag_id] = tag&.id
+    args[:tag_name] = tag&.name || args[:tag_name]
     args
   end
 end

--- a/app/services/tag_adjustment_creation_service.rb
+++ b/app/services/tag_adjustment_creation_service.rb
@@ -22,6 +22,8 @@ class TagAdjustmentCreationService
   def update_article
     if @tag_adjustment.adjustment_type == "removal"
       removed_tags = article.tag_list.select { |tag| tag.casecmp(@tag_adjustmen.tag_name).zero? }
+      return if removed_tags.empty?
+
       article.update!(tag_list: article.tag_list.remove(removed_tags))
     end
 

--- a/spec/models/tag_adjustment_spec.rb
+++ b/spec/models/tag_adjustment_spec.rb
@@ -84,5 +84,12 @@ RSpec.describe TagAdjustment, type: :model do
       tag_adjustment = build(:tag_adjustment, user_id: admin_user.id, article_id: article.id, adjustment_type: "removal")
       expect(tag_adjustment).to be_invalid
     end
+
+    it "ignores case when checking tag_list" do
+      news_tag = create(:tag, name: "news", pretty_name: "News")
+      article = create(:article, tags: news_tag.name)
+      tag_adjustment = build(:tag_adjustment, user_id: admin_user.id, article_id: article.id, adjustment_type: "removal", tag_id: news_tag.id, tag_name: news_tag.pretty_name)
+      expect(tag_adjustment).to be_valid
+    end
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Our Tags, in general, are messed up. This is a quick band-aid to allow mods to remove tags regardless of case.

_Note: when adding a tag a mod must specify the `name` of the tag and **it is case sensitive**. We can't properly address that issue until we fix the core underlying issue._

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/issues/5325

## Added tests?
- [x] yes

## Added to documentation?
- [x] no documentation needed

![tag_youre_it_gif](https://media.giphy.com/media/65ATdpi3clAdjomZ39/giphy.gif)