### PR TITLE
Dont Use Colons In Timestamps For CI CSVs

### DIFF
--- a/spec/support/initializers/ci_csv_formatter.rb
+++ b/spec/support/initializers/ci_csv_formatter.rb
@@ -21,7 +21,7 @@ class CSVFormatter
     status = :pending
     started_at = notification.example.metadata[:execution_result].started_at
     start_date = started_at.strftime("%m-%d-%Y")
-    start_time = started_at.strftime("%H:%M:%S.%3N")
+    start_time = started_at.strftime("%H-%M-%S.%3N")
     run_time = notification.example.metadata[:execution_result].run_time.round(3)
     @rows << [description, file, status, start_date, start_time, run_time, nil, nil, nil]
   end
@@ -32,7 +32,7 @@ class CSVFormatter
     status = :passed
     started_at = notification.example.metadata[:execution_result].started_at
     start_date = started_at.strftime("%m-%d-%Y")
-    start_time = started_at.strftime("%H:%M:%S.%3N")
+    start_time = started_at.strftime("%H-%M-%S.%3N")
     run_time = notification.example.metadata[:execution_result].run_time.round(3)
     retry_attempt = notification.example.metadata[:retry_attempts]
     @rows << [description, file, status, start_date, start_time, run_time, nil, nil, retry_attempt]
@@ -45,7 +45,7 @@ class CSVFormatter
     status = :failed
     started_at = notification.example.metadata[:execution_result].started_at
     start_date = started_at.strftime("%m-%d-%Y")
-    start_time = started_at.strftime("%H:%M:%S.%3N")
+    start_time = started_at.strftime("%H-%M-%S.%3N")
     run_time = notification.example.metadata[:execution_result].run_time.round(3)
     exception = notification.example.metadata[:execution_result].exception.inspect
     backtrace = notification.example.metadata[:execution_result].exception.backtrace
@@ -100,7 +100,7 @@ RSpec.configure do |config|
     status = :failed
     started_at = ex.metadata[:execution_result].started_at
     start_date = started_at.strftime("%m-%d-%Y")
-    start_time = started_at.strftime("%H:%M:%S.%3N")
+    start_time = started_at.strftime("%H-%M-%S.%3N")
     run_time = (Time.zone.now - started_at).round(3)
     exception = ex.metadata[:retry_exceptions].last.inspect
     backtrace = ex.metadata[:retry_exceptions].last.backtrace


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Based on the CSV upload failures in travis is looks like we are incorrectly parsing the timestamp names of files bc of the colons. Even though it looks weird, I replaced the colons with dashes to try and fix this. The reason for the timestamps is to avoid duplicates so I think its fine if its format is not "pretty"
```
artifact: /home/travis/build/thepracticaldev/dev.to/06Z.csv
  err: open /home/travis/build/thepracticaldev/dev.to/06Z.csv: no such file or directory
  retry: 1
DEBUG: retrying
  artifact: /home/travis/build/thepracticaldev/dev.to/tmp/csvs/2020-05-22T16
  err: open /home/travis/build/thepracticaldev/dev.to/tmp/csvs/2020-05-22T16: no such file or directory
  retry: 2
DEBUG: retrying
  artifact: /home/travis/build/thepracticaldev/dev.to/53
  err: open /home/travis/build/thepracticaldev/dev.to/53: no such file or directory
  retry: 2
DEBUG: retrying
  artifact: /home/travis/build/thepracticaldev/dev.to/06Z.csv
  err: open /home/travis/build/thepracticaldev/dev.to/06Z.csv: no such file or directory
  retry: 2
ERROR: failed to upload: /home/travis/build/thepracticaldev/dev.to/tmp/csvs/2020-05-22T16
  err: open /home/travis/build/thepracticaldev/dev.to/tmp/csvs/2020-05-22T16: no such file or directory
```

## Added tests?
- [x] no, because they aren't needed

![alt_text](https://media.giphy.com/media/xT1R9C0vNMPoHa5XDa/giphy.gif)
