### PR TITLE
Track Article IDs for Controller Requests

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -201,6 +201,7 @@ class ArticlesController < ApplicationController
                       Article.includes(:user).find(params[:id])
                     end
     @article = found_article || not_found
+    Honeycomb.add_field("article_id", @article.id)
   end
 
   def article_params


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Feature

## Description
While trying to debug some failing Sidekiq workers that were handling articles I ran into a little issue. The workers that I was looking at all had the article ID. However, controller request paths that kick off those workers use the article slug. In my case the articles were deleted so the only information I had was the ID and I was unable to match up the workers with any controller requests. This will add the article_id to the request spans so we can easily use that to help us trace the life of a request and its fallout. 

## Added tests?
- [x] no, because they aren't needed

![alt_text](https://media1.tenor.com/images/37c617aee37229b25ae9d7571c491e4c/tenor.gif?itemid=13929287)
