### PR TITLE
Add page view tracking to comment permalinks

### DIFF
--- a/app/assets/javascripts/initializers/initializeBaseTracking.js.erb
+++ b/app/assets/javascripts/initializers/initializeBaseTracking.js.erb
@@ -68,7 +68,7 @@ function eventListening(){
 
 function trackCustomImpressions() {
   setTimeout(function(){
-    var ArticleElement = document.getElementById('article-body');
+    var ArticleElement = document.getElementById('article-body') || document.getElementById('comment-article-indicator');
     var tokenMeta = document.querySelector("meta[name='csrf-token']")
     var isBot = /bot|google|baidu|bing|msn|duckduckbot|teoma|slurp|yandex/i.test(navigator.userAgent) // is crawler
     var windowBigEnough =  window.innerWidth > 1250
@@ -122,7 +122,7 @@ function trackCustomImpressions() {
       var timeOnSiteCounter = 0;
       var timeOnSiteInterval = setInterval(function(){
         timeOnSiteCounter++
-        var ArticleElement = document.getElementById('article-body');
+        var ArticleElement = document.getElementById('article-body') || document.getElementById('comment-article-indicator');
         if (ArticleElement && checkUserLoggedIn()) {
           trackFifteenSecondsOnPage(ArticleElement.dataset.articleId, csrfToken);
         } else {

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -35,7 +35,9 @@
     <% end %>
   <% end %>
 <% end %>
-
+<% if @commentable.class.name == "Article" %>
+  <div id="comment-article-indicator" data-article-id="<%= @commentable.id %>">
+<% end %>
 <% if @root_comment %>
   <div class="single-comment-header"></div>
 <% else %>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] Mechanic adjustment

## Description
This PR makes traffic directly to a comment permalink track as an article page_view because now that we have comments in the feed, folks are more likely to jump right into a comment's view. It's a small adjustment which will help better track post popularity.