### PR TITLE
Add alternate comment-oriented feed algorithms

### DIFF
--- a/app/controllers/stories/feeds_controller.rb
+++ b/app/controllers/stories/feeds_controller.rb
@@ -11,6 +11,8 @@ class Stories::FeedsController < ApplicationController
     "more_tag_weight_randomized_at_end_experiment" => :more_tag_weight_randomized_at_end_experiment,
     "more_experience_level_weight_randomized_at_end_experiment" => :more_experience_level_weight_randomized_at_end_experiment,
     "more_comments_randomized_at_end_experiment" => :more_comments_randomized_at_end_experiment,
+    "more_comments_medium_weight_randomized_at_end_experiment" => :more_comments_medium_weight_randomized_at_end_experiment,
+    "more_comments_minimal_weight_randomized_at_end_experiment" => :more_comments_minimal_weight_randomized_at_end_experiment,
     "mix_of_everything_experiment" => :mix_of_everything_experiment
   }.freeze
 

--- a/app/services/articles/feed.rb
+++ b/app/services/articles/feed.rb
@@ -93,6 +93,20 @@ module Articles
       stories
     end
 
+    # Test variation: the more comments a post has, the higher it's rated!
+    def more_comments_medium_weight_experiment
+      @comment_weight = 0.5
+      _featured_story, stories = default_home_feed_and_featured_story(user_signed_in: true)
+      stories
+    end
+
+    # Test variation: the more comments a post has, the higher it's rated!
+    def more_comments_minimal_weight_experiment
+      @comment_weight = 0.2
+      _featured_story, stories = default_home_feed_and_featured_story(user_signed_in: true)
+      stories
+    end
+
     def more_experience_level_weight_experiment
       @experience_level_weight = 3
       _featured_story, stories = default_home_feed_and_featured_story(user_signed_in: true)
@@ -100,7 +114,7 @@ module Articles
     end
 
     def mix_of_everything_experiment
-      case rand(10)
+      case rand(12)
       when 0
         default_home_feed(user_signed_in: true)
       when 1
@@ -121,6 +135,10 @@ module Articles
         more_experience_level_weight_randomized_at_end_experiment
       when 9
         more_comments_randomized_at_end_experiment
+      when 10
+        more_comments_medium_weight_randomized_at_end_experiment
+      when 11
+        more_comments_minimal_weight_randomized_at_end_experiment
       else
         default_home_feed(user_signed_in: true)
       end
@@ -146,6 +164,18 @@ module Articles
     def more_comments_randomized_at_end_experiment
       @randomness = 0
       results = more_comments_experiment
+      first_half(results).shuffle + last_half(results)
+    end
+
+    def more_comments_medium_weight_randomized_at_end_experiment
+      @randomness = 0
+      results = more_comments_medium_weight_experiment
+      first_half(results).shuffle + last_half(results)
+    end
+
+    def more_comments_minimal_weight_randomized_at_end_experiment
+      @randomness = 0
+      results = more_comments_minimal_weight_experiment
       first_half(results).shuffle + last_half(results)
     end
 

--- a/config/field_test.yml
+++ b/config/field_test.yml
@@ -12,6 +12,8 @@ experiments:
       - more_tag_weight_randomized_at_end_experiment
       - more_experience_level_weight_randomized_at_end_experiment
       - more_comments_randomized_at_end_experiment
+      - more_comments_medium_weight_randomized_at_end_experiment
+      - more_comments_minimal_weight_randomized_at_end_experiment
     weights:
       - 5
       - 5
@@ -23,7 +25,9 @@ experiments:
       - 10
       - 10
       - 5
-      - 35
+      - 25
+      - 5
+      - 5
     goals:
       - user_creates_comment
       - user_creates_reaction

--- a/spec/services/articles/feed_spec.rb
+++ b/spec/services/articles/feed_spec.rb
@@ -10,6 +10,8 @@ NON_DEFAULT_EXPERIMENTS = %i[
   more_tag_weight_randomized_at_end_experiment
   more_experience_level_weight_randomized_at_end_experiment
   more_comments_randomized_at_end_experiment
+  more_comments_medium_weight_randomized_at_end_experiment
+  more_comments_minimal_weight_randomized_at_end_experiment
   mix_of_everything_experiment
 ].freeze
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
The "more comment weight, randomized at end" algorithm is the most appealing according to the data, but I'm concerned that it weighs _just a bit_ too much on raw comment score as the only thing vs individual preferences. This takes comments count as an indicator but dials it back a bit. We'll see how it goes.