### PR TITLE
Add current state to nav bar links properly

### DIFF
--- a/app/assets/javascripts/initializePage.js.erb
+++ b/app/assets/javascripts/initializePage.js.erb
@@ -24,6 +24,7 @@ function callInitalizers(){
       }
     }
   },1)
+  initializeSpecialNavigationFunctionality()
   initializeBaseTracking();
   initializeTouchDevice();
   initializeCommentsPage();

--- a/app/assets/javascripts/initializers/initializeSpecialNavigationFunctionality.js
+++ b/app/assets/javascripts/initializers/initializeSpecialNavigationFunctionality.js
@@ -1,0 +1,23 @@
+function initializeSpecialNavigationFunctionality() {
+  var connectLink = document.getElementById('connect-link');
+  var notificationsLink = document.getElementById('notifications-link');
+  var moderationLink = document.getElementById('moderation-link')
+  if (document.getElementById('notifications-container')) {
+    notificationsLink.blur();
+    notificationsLink.classList.add('top-bar__link--current');
+  } else {
+    notificationsLink.classList.remove('top-bar__link--current');
+  }
+  if (document.getElementById('chat')) {
+    connectLink.blur();
+    connectLink.classList.add('top-bar__link--current');
+  } else {
+    connectLink.classList.remove('top-bar__link--current');
+  }
+  if (document.getElementById('moderation-page')) {
+    moderationLink.blur();
+    moderationLink.classList.add('top-bar__link--current');
+  } else {
+    moderationLink.classList.remove('top-bar__link--current');
+  }
+}

--- a/app/assets/stylesheets/top-bar.scss
+++ b/app/assets/stylesheets/top-bar.scss
@@ -100,7 +100,10 @@
     --indicator-outline: var(--header-bg-current);
 
     color: var(--header-icons-color-hover);
-    background: var(--header-bg-current);
+    background: var(--header-bg-current) !important;
+    .crayons-indicator {
+      display: none;
+    }
   }
 }
 

--- a/app/views/layouts/_top_bar.html.erb
+++ b/app/views/layouts/_top_bar.html.erb
@@ -26,7 +26,7 @@
     <div class="top-bar__links">
       <a href="/new" class="crayons-btn hidden mr-2 s:block">Write a post</a>
 
-      <a class="top-bar__link trusted-visible-block" aria-label="Modeartion" href="<%= mod_path %>">
+      <a id="moderation-link" class="top-bar__link trusted-visible-block" aria-label="Moderation" href="<%= mod_path %>">
         <%= inline_svg_tag("mod.svg", aria: true, class: "crayons-icon", title: "Moderation") %>
       </a>
 

--- a/app/views/moderations/index.html.erb
+++ b/app/views/moderations/index.html.erb
@@ -1,5 +1,6 @@
 <% title "Moderate" %>
 
+<div id="moderation-page"></div>
 <% if current_user&.trusted %>
   <% if @tag %>
   <style>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This ensures the "current" state for nav links is rendered when users are on the right pages.