### PR TITLE
Fix load more listings button colors

### DIFF
--- a/app/assets/stylesheets/classified_listings.scss
+++ b/app/assets/stylesheets/classified_listings.scss
@@ -271,7 +271,9 @@
   }
   .classifieds-load-more-button {
     text-align: center;
+
     button {
+      background: var(--theme-container-background);
       color: var(--body-color);
       border: 1px solid var(--card-color-tertiary);
       font-size: 17px;


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The "Load more listings" button text is not clearly visible in dark themes.

## Related Tickets & Documents

Closes https://github.com/thepracticaldev/dev.to/issues/8047

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![Screenshot_2020-05-25 Listings - DEV(local) Community 👩‍💻👨‍💻](https://user-images.githubusercontent.com/146201/82808602-945cb300-9e8a-11ea-9b70-545f96a049b3.png)
![Screenshot_2020-05-25 Listings - DEV(local) Community 👩‍💻👨‍💻(1)](https://user-images.githubusercontent.com/146201/82808604-958de000-9e8a-11ea-8efe-510dbb800cc6.png)
![Screenshot_2020-05-25 Listings - DEV(local) Community 👩‍💻👨‍💻(2)](https://user-images.githubusercontent.com/146201/82808605-958de000-9e8a-11ea-9273-4474f9f06e17.png)
![Screenshot_2020-05-25 Listings - DEV(local) Community 👩‍💻👨‍💻(3)](https://user-images.githubusercontent.com/146201/82808607-958de000-9e8a-11ea-914c-b16219a64c1e.png)


## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
