### PR TITLE
feat(styling): add focus state for crayons-btn class

### DIFF
--- a/app/assets/stylesheets/components/buttons.scss
+++ b/app/assets/stylesheets/components/buttons.scss
@@ -47,6 +47,7 @@
   color: var(--color);
 
   &[href]:hover,
+  &[href]:focus,
   &:hover:enabled,
   &:active:enabled,
   &:focus:enabled {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description
Specify `[href]` for the `focus` pseudoselector of `.crayons-btn` as I don't believe `:enabled` would work on an anchor tag.

## Related Tickets & Documents
closes #7949 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
**Currently**

<img width="550" alt="Screen Shot 2020-05-25 at 9 55 17 AM" src="https://user-images.githubusercontent.com/9807835/82823836-dfb49880-9e6d-11ea-9718-931c42109e8e.png">

**PR**

<img width="550" alt="Screen Shot 2020-05-25 at 9 54 19 AM" src="https://user-images.githubusercontent.com/9807835/82823737-be53ac80-9e6d-11ea-8c2e-39189fe8703c.png">


## Added tests?

- [x] no, because they aren't needed

## Added to documentation?

- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![giphy](https://user-images.githubusercontent.com/9807835/82824255-9e70b880-9e6e-11ea-86d0-d443372c1b06.gif)

