### PR TITLE
Fix blockquote styling in comments previews and notifications

### DIFF
--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -496,6 +496,12 @@ a.header-link {
       .article-body-image-wrapper img {
         max-width: 100%;
       }
+
+      blockquote {
+        border-left: calc(0.2vw + 2px) solid $dark-gray;
+        padding: 0.1% 6% 0.1% 1%;
+        margin-left: 0.5rem;
+      }
     }
 
     // this css is added to ignore the code under highlight class and use default bg-color and color.

--- a/app/assets/stylesheets/notifications.scss
+++ b/app/assets/stylesheets/notifications.scss
@@ -246,6 +246,11 @@
             max-width: 100%;
             max-height: 400px;
           }
+          blockquote {
+            border-left: calc(0.2vw + 2px) solid $dark-gray;
+            padding: 0.1% 6% 0.1% 2%;
+            margin-left: 0.5rem;
+          }
         }
         .comment-actions {
           position: relative;


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Right now when you add a quote in a comment a hit preview you get this:

![Screenshot_2020-05-25 article with quote](https://user-images.githubusercontent.com/146201/82826451-78b6d400-9ead-11ea-8ea9-54e450d4e3e1.png)

and if you get a comment notification which includes a quote you get this:

![Screenshot_2020-05-25 Notifications - DEV(local) Community 👩‍💻👨‍💻](https://user-images.githubusercontent.com/146201/82826473-82403c00-9ead-11ea-9740-b9da019f6b6f.png)

this fixes it to:

![Screenshot_2020-05-25 article with quote - DEV(local) Community 👩‍💻👨‍💻(1)](https://user-images.githubusercontent.com/146201/82826503-8bc9a400-9ead-11ea-86d2-6981c329ce57.png)

and 

![Screenshot_2020-05-25 Notifications - DEV(local) Community 👩‍💻👨‍💻(1)](https://user-images.githubusercontent.com/146201/82826509-8ff5c180-9ead-11ea-84bc-e083d274d788.png)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
