### PR TITLE
Fix broken tag filters in listings

### DIFF
--- a/app/assets/stylesheets/classified_listings.scss
+++ b/app/assets/stylesheets/classified_listings.scss
@@ -49,6 +49,7 @@
       }
     }
     .classified-filters-tags {
+      display: flex;
       padding: 20px 0px;
       position: relative;
       input {

--- a/app/javascript/common-prop-types/selected-tags-prop-types.js
+++ b/app/javascript/common-prop-types/selected-tags-prop-types.js
@@ -1,8 +1,7 @@
 import PropTypes from 'prop-types';
-import { tagPropTypes } from './tag-prop-types';
 
 export const selectedTagsPropTypes = PropTypes.shape({
-  tags: PropTypes.arrayOf(tagPropTypes).isRequired,
+  tags: PropTypes.arrayOf(PropTypes.string).isRequired,
   onClick: PropTypes.func.isRequired,
   onKeyPress: PropTypes.func.isRequired,
 });

--- a/app/javascript/listings/__tests__/ClassifiedFilterTags.test.jsx
+++ b/app/javascript/listings/__tests__/ClassifiedFilterTags.test.jsx
@@ -3,20 +3,7 @@ import { deep } from 'preact-render-spy';
 import ClassifiedFiltersTags from '../components/ClassifiedFiltersTags';
 
 describe('<ClassifiedFilterTags />', () => {
-  const firstTag = {
-    id: 1,
-    tag: 'clojure',
-  };
-  const secondTag = {
-    id: 2,
-    tag: 'java',
-  };
-  const thirdTag = {
-    id: 3,
-    tag: 'dotnet',
-  };
-
-  const getTags = () => [firstTag, secondTag, thirdTag];
+  const getTags = () => ['clojure', 'java', 'dotnet'];
 
   const getProps = () => ({
     message: 'Some message',
@@ -78,9 +65,10 @@ describe('<ClassifiedFilterTags />', () => {
   it('Should render the selected Tags', () => {
     const context = renderClassifiedFilterTags();
     getTags().forEach((tag) => {
-      const selectedTag = context.find(`#selected-tag-${tag.id}`);
+      const selectedTag = context.find(`#selected-tag-${tag}`);
 
-      expect(selectedTag.text()).toBe('×');
+      expect(selectedTag.text()).toEqual(expect.stringContaining(tag));
+      expect(selectedTag.text()).toEqual(expect.stringContaining('×'));
     });
   });
 });

--- a/app/javascript/listings/__tests__/ClassifiedFilters.test.jsx
+++ b/app/javascript/listings/__tests__/ClassifiedFilters.test.jsx
@@ -4,19 +4,16 @@ import ClassifiedFilters from '../components/ClassifiedFilters';
 
 describe('<ClassifiedFilters />', () => {
   const firstCategory = {
-    id: 20,
     slug: 'clojure',
     name: 'Clojure',
   };
 
   const secondCategory = {
-    id: 21,
     slug: 'illa-iara-ques-htyashsayas-6kj8',
     name: 'Go',
   };
 
   const thirdCategory = {
-    id: 22,
     slug: 'alle-bece-tzehj-htyashsayas-7jh9',
     name: 'csharp',
   };

--- a/app/javascript/listings/__tests__/ClassifiedFilters.test.jsx
+++ b/app/javascript/listings/__tests__/ClassifiedFilters.test.jsx
@@ -3,19 +3,6 @@ import render from 'preact-render-to-json';
 import ClassifiedFilters from '../components/ClassifiedFilters';
 
 describe('<ClassifiedFilters />', () => {
-  const firstTag = {
-    id: 1,
-    tag: 'clojure',
-  };
-  const secondTag = {
-    id: 2,
-    tag: 'java',
-  };
-  const thirdTag = {
-    id: 3,
-    tag: 'dotnet',
-  };
-
   const firstCategory = {
     id: 20,
     slug: 'clojure',
@@ -35,7 +22,7 @@ describe('<ClassifiedFilters />', () => {
   };
 
   const getCategories = () => [firstCategory, secondCategory, thirdCategory];
-  const getTags = () => [firstTag, secondTag, thirdTag];
+  const getTags = () => ['clojure', 'java', 'dotnet'];
 
   const getProps = () => ({
     category: 'clojure',

--- a/app/javascript/listings/__tests__/ClassifiedFiltersCategories.test.jsx
+++ b/app/javascript/listings/__tests__/ClassifiedFiltersCategories.test.jsx
@@ -4,19 +4,16 @@ import ClassifiedFiltersCategories from '../components/ClassifiedFiltersCategori
 
 describe('<ClassifiedFiltersCategories />', () => {
   const firstCategory = {
-    id: 20,
     slug: 'clojure',
     name: 'Clojure',
   };
 
   const secondCategory = {
-    id: 21,
     slug: 'illa-iara-ques-htyashsayas-6kj8',
     name: 'Go',
   };
 
   const thirdCategory = {
-    id: 22,
     slug: 'alle-bece-tzehj-htyashsayas-7jh9',
     name: 'csharp',
   };
@@ -76,7 +73,7 @@ describe('<ClassifiedFiltersCategories />', () => {
     const context = renderClassifiedFilterCategories();
     it('Should render the categories name and their respective links', () => {
       categories.forEach((category) => {
-        const categoryLink = context.find(`#category-link-${category.id}`);
+        const categoryLink = context.find(`#category-link-${category.slug}`);
         expect(categoryLink.attr('href')).toBe(`/listings/${category.slug}`);
         expect(categoryLink.text()).toBe(category.name);
       });
@@ -85,7 +82,7 @@ describe('<ClassifiedFiltersCategories />', () => {
     it('Should set the class of the category link as "selected" when category slug matches the selected category name', () => {
       const selectedCategoryLink = context.find(`.selected`);
       expect(selectedCategoryLink.attr('id')).toBe(
-        `category-link-${firstCategory.id}`,
+        `category-link-${firstCategory.slug}`,
       );
     });
 
@@ -95,7 +92,7 @@ describe('<ClassifiedFiltersCategories />', () => {
       );
       unselectedCategories.forEach((unselectedCategory) => {
         const unselectedCategoryLink = context.find(
-          `#category-link-${unselectedCategory.id}`,
+          `#category-link-${unselectedCategory.slug}`,
         );
         expect(unselectedCategoryLink.attr('className')).toBe('');
       });

--- a/app/javascript/listings/__tests__/SelectedTags.test.jsx
+++ b/app/javascript/listings/__tests__/SelectedTags.test.jsx
@@ -2,20 +2,7 @@ import { h } from 'preact';
 import render from 'preact-render-to-json';
 import SelectedTags from '../components/SelectedTags';
 
-const firstTag = {
-  id: 1,
-  tag: 'clojure',
-};
-const secondTag = {
-  id: 2,
-  tag: 'java',
-};
-const thirdTag = {
-  id: 3,
-  tag: 'dotnet',
-};
-
-const tags = [firstTag, secondTag, thirdTag];
+const tags = ['clojure', 'java', 'dotnet'];
 const getProps = () => ({
   tags,
   onClick: () => {

--- a/app/javascript/listings/__tests__/__snapshots__/ClassifiedFilters.test.jsx.snap
+++ b/app/javascript/listings/__tests__/__snapshots__/ClassifiedFilters.test.jsx.snap
@@ -18,29 +18,26 @@ exports[`<ClassifiedFilters /> Should match the snapshot 1`] = `
     </a>
     <section>
       <a
-        Key={20}
         class="selected"
         data-no-instant={true}
         href="/listings/clojure"
-        id="category-link-20"
+        id="category-link-clojure"
         onClick={[Function]}
       >
         Clojure
       </a>
       <a
-        Key={21}
         data-no-instant={true}
         href="/listings/illa-iara-ques-htyashsayas-6kj8"
-        id="category-link-21"
+        id="category-link-illa-iara-ques-htyashsayas-6kj8"
         onClick={[Function]}
       >
         Go
       </a>
       <a
-        Key={22}
         data-no-instant={true}
         href="/listings/alle-bece-tzehj-htyashsayas-7jh9"
-        id="category-link-22"
+        id="category-link-alle-bece-tzehj-htyashsayas-7jh9"
         onClick={[Function]}
       >
         csharp

--- a/app/javascript/listings/__tests__/__snapshots__/ClassifiedFilters.test.jsx.snap
+++ b/app/javascript/listings/__tests__/__snapshots__/ClassifiedFilters.test.jsx.snap
@@ -84,83 +84,77 @@ exports[`<ClassifiedFilters /> Should match the snapshot 1`] = `
     <section>
       <span
         class="classified-tag"
-        id="selected-tag-1"
+        id="selected-tag-clojure"
       >
         <a
           class="tag-name"
           data-no-instant={true}
-          href="/listings?tags="
-          onClick={[Function]}
+          href="/listings?t=clojure"
         >
-          <span>
-            Object {
-              "id": 1,
-              "tag": "clojure",
-            }
+          <span
+            role="button"
+            tabIndex="0"
+          >
+            clojure
           </span>
-          <button
-            class="tag-close"
-            data-no-instant={true}
+          <span
+            onClick={[Function]}
             onKeyPress={[Function]}
-            t={true}
-            type="button"
+            role="button"
+            tabIndex="0"
           >
             ×
-          </button>
+          </span>
         </a>
       </span>
       <span
         class="classified-tag"
-        id="selected-tag-2"
+        id="selected-tag-java"
       >
         <a
           class="tag-name"
           data-no-instant={true}
-          href="/listings?tags="
-          onClick={[Function]}
+          href="/listings?t=java"
         >
-          <span>
-            Object {
-              "id": 2,
-              "tag": "java",
-            }
+          <span
+            role="button"
+            tabIndex="0"
+          >
+            java
           </span>
-          <button
-            class="tag-close"
-            data-no-instant={true}
+          <span
+            onClick={[Function]}
             onKeyPress={[Function]}
-            t={true}
-            type="button"
+            role="button"
+            tabIndex="0"
           >
             ×
-          </button>
+          </span>
         </a>
       </span>
       <span
         class="classified-tag"
-        id="selected-tag-3"
+        id="selected-tag-dotnet"
       >
         <a
           class="tag-name"
           data-no-instant={true}
-          href="/listings?tags="
-          onClick={[Function]}
+          href="/listings?t=dotnet"
         >
-          <span>
-            Object {
-              "id": 3,
-              "tag": "dotnet",
-            }
+          <span
+            role="button"
+            tabIndex="0"
+          >
+            dotnet
           </span>
-          <button
-            class="tag-close"
-            data-no-instant={true}
+          <span
+            onClick={[Function]}
             onKeyPress={[Function]}
-            t={true}
-            type="button"
+            role="button"
+            tabIndex="0"
           >
             ×
-          </button>
+          </span>
         </a>
       </span>
     </section>

--- a/app/javascript/listings/__tests__/__snapshots__/SelectedTags.test.jsx.snap
+++ b/app/javascript/listings/__tests__/__snapshots__/SelectedTags.test.jsx.snap
@@ -4,83 +4,77 @@ exports[`<SelectedTags /> Should render all the tags 1`] = `
 <section>
   <span
     class="classified-tag"
-    id="selected-tag-1"
+    id="selected-tag-clojure"
   >
     <a
       class="tag-name"
       data-no-instant={true}
-      href="/listings?tags="
-      onClick={[Function]}
+      href="/listings?t=clojure"
     >
-      <span>
-        Object {
-          "id": 1,
-          "tag": "clojure",
-        }
+      <span
+        role="button"
+        tabIndex="0"
+      >
+        clojure
       </span>
-      <button
-        class="tag-close"
-        data-no-instant={true}
+      <span
+        onClick={[Function]}
         onKeyPress={[Function]}
-        t={true}
-        type="button"
+        role="button"
+        tabIndex="0"
       >
         ×
-      </button>
+      </span>
     </a>
   </span>
   <span
     class="classified-tag"
-    id="selected-tag-2"
+    id="selected-tag-java"
   >
     <a
       class="tag-name"
       data-no-instant={true}
-      href="/listings?tags="
-      onClick={[Function]}
+      href="/listings?t=java"
     >
-      <span>
-        Object {
-          "id": 2,
-          "tag": "java",
-        }
+      <span
+        role="button"
+        tabIndex="0"
+      >
+        java
       </span>
-      <button
-        class="tag-close"
-        data-no-instant={true}
+      <span
+        onClick={[Function]}
         onKeyPress={[Function]}
-        t={true}
-        type="button"
+        role="button"
+        tabIndex="0"
       >
         ×
-      </button>
+      </span>
     </a>
   </span>
   <span
     class="classified-tag"
-    id="selected-tag-3"
+    id="selected-tag-dotnet"
   >
     <a
       class="tag-name"
       data-no-instant={true}
-      href="/listings?tags="
-      onClick={[Function]}
+      href="/listings?t=dotnet"
     >
-      <span>
-        Object {
-          "id": 3,
-          "tag": "dotnet",
-        }
+      <span
+        role="button"
+        tabIndex="0"
+      >
+        dotnet
       </span>
-      <button
-        class="tag-close"
-        data-no-instant={true}
+      <span
+        onClick={[Function]}
         onKeyPress={[Function]}
-        t={true}
-        type="button"
+        role="button"
+        tabIndex="0"
       >
         ×
-      </button>
+      </span>
     </a>
   </span>
 </section>

--- a/app/javascript/listings/components/CategoryLinks.jsx
+++ b/app/javascript/listings/components/CategoryLinks.jsx
@@ -7,13 +7,10 @@ const CategoryLinks = ({ categories, onClick, selectedCategory }) => {
       {categories.map((category) => (
         <a
           href={`/listings/${category.slug}`}
-          id={`category-link-${category.id}`}
+          id={`category-link-${category.slug}`}
           className={category.slug === selectedCategory ? 'selected' : ''}
-          onClick={(e) => {
-            onClick(e, category.slug);
-          }}
+          onClick={(e) => onClick(e, category.slug)}
           data-no-instant
-          Key={category.id}
         >
           {category.name}
         </a>
@@ -23,7 +20,12 @@ const CategoryLinks = ({ categories, onClick, selectedCategory }) => {
 };
 
 CategoryLinks.propTypes = {
-  categories: PropTypes.isRequired,
+  categories: PropTypes.arrayOf(
+    PropTypes.shape({
+      slug: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
+    }),
+  ).isRequired,
   onClick: PropTypes.func.isRequired,
   selectedCategory: PropTypes.string.isRequired,
 };

--- a/app/javascript/listings/components/ClassifiedFilters.jsx
+++ b/app/javascript/listings/components/ClassifiedFilters.jsx
@@ -36,8 +36,11 @@ const ClassifiedFilters = ({
 };
 
 ClassifiedFilters.propTypes = {
-  categories: PropTypes.isRequired,
-  category: PropTypes.isRequired,
+  categories: PropTypes.shape({
+    slug: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+  }).isRequired,
+  category: PropTypes.string.isRequired,
   onSelectCategory: PropTypes.func.isRequired,
   message: PropTypes.isRequired,
   onKeyUp: PropTypes.func.isRequired,

--- a/app/javascript/listings/components/ClassifiedFilters.jsx
+++ b/app/javascript/listings/components/ClassifiedFilters.jsx
@@ -2,7 +2,6 @@ import { h } from 'preact';
 import PropTypes from 'prop-types';
 import ClassifiedFiltersCategories from './ClassifiedFiltersCategories';
 import ClassifiedFiltersTags from './ClassifiedFiltersTags';
-import { tagPropTypes } from '../../common-prop-types';
 
 const ClassifiedFilters = ({
   categories,
@@ -44,7 +43,7 @@ ClassifiedFilters.propTypes = {
   onKeyUp: PropTypes.func.isRequired,
   onClearQuery: PropTypes.func.isRequired,
   onRemoveTag: PropTypes.func.isRequired,
-  tags: PropTypes.arrayOf(tagPropTypes).isRequired,
+  tags: PropTypes.arrayOf(PropTypes.string).isRequired,
   onKeyPress: PropTypes.func.isRequired,
   query: PropTypes.string.isRequired,
 };

--- a/app/javascript/listings/components/ClassifiedFiltersCategories.jsx
+++ b/app/javascript/listings/components/ClassifiedFiltersCategories.jsx
@@ -36,9 +36,14 @@ const ClassifiedFiltersCategories = ({ categories, category, onClick }) => (
 );
 
 ClassifiedFiltersCategories.propTypes = {
-  categories: PropTypes.isRequired,
+  categories: PropTypes.arrayOf(
+    PropTypes.shape({
+      slug: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
+    }),
+  ).isRequired,
+  category: PropTypes.string.isRequired,
   onClick: PropTypes.func.isRequired,
-  category: PropTypes.isRequired,
 };
 
 export default ClassifiedFiltersCategories;

--- a/app/javascript/listings/components/ClassifiedFiltersTags.jsx
+++ b/app/javascript/listings/components/ClassifiedFiltersTags.jsx
@@ -1,6 +1,5 @@
 import { h } from 'preact';
 import PropTypes from 'prop-types';
-import { tagPropTypes } from '../../common-prop-types';
 import ClearQueryButton from './ClearQueryButton';
 import SelectedTags from './SelectedTags';
 
@@ -28,7 +27,11 @@ const ClassifiedFiltersTags = ({
       {shouldRenderClearQueryButton && (
         <ClearQueryButton onClick={onClearQuery} />
       )}
-      <SelectedTags tags={tags} onClick={onRemoveTag} onKeyPress={onKeyPress} />
+      <SelectedTags
+        tags={tags}
+        onRemoveTag={onRemoveTag}
+        onKeyPress={onKeyPress}
+      />
     </div>
   );
 };
@@ -39,7 +42,7 @@ ClassifiedFiltersTags.propTypes = {
   onClearQuery: PropTypes.func.isRequired,
   onRemoveTag: PropTypes.func.isRequired,
   onKeyPress: PropTypes.func.isRequired,
-  tags: PropTypes.arrayOf(tagPropTypes).isRequired,
+  tags: PropTypes.arrayOf(PropTypes.string).isRequired,
   query: PropTypes.string.isRequired,
 };
 

--- a/app/javascript/listings/components/SelectedTags.jsx
+++ b/app/javascript/listings/components/SelectedTags.jsx
@@ -1,31 +1,23 @@
 import { h } from 'preact';
 import { selectedTagsPropTypes } from '../../common-prop-types';
 
-const SelectedTags = ({ tags, onClick, onKeyPress }) => {
+const SelectedTags = ({ tags, onRemoveTag, onKeyPress }) => {
   return (
     <section>
       {tags.map((tag) => (
-        <span
-          className="classified-tag"
-          key={tag.id}
-          id={`selected-tag-${tag.id}`}
-        >
-          <a
-            href="/listings?tags="
-            className="tag-name"
-            onClick={onClick}
-            data-no-instant
-          >
-            <span>{tag}</span>
-            <button
-              className="tag-close"
-              t
-              type="button"
-              data-no-instant
-              onKeyPress={onKeyPress}
+        <span className="classified-tag" key={tag} id={`selected-tag-${tag}`}>
+          <a href={`/listings?t=${tag}`} className="tag-name" data-no-instant>
+            <span role="button" tabIndex="0">
+              {tag}
+            </span>
+            <span
+              role="button"
+              tabIndex="0"
+              onClick={(e) => onRemoveTag(e, tag)}
+              onKeyPress={(e) => onKeyPress(e, tag)}
             >
               ×
-            </button>
+            </span>
           </a>
         </span>
       ))}


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Currently in production tag filters can't be removed:

![before](https://user-images.githubusercontent.com/146201/82884119-99316d80-9f43-11ea-8474-b045a58890db.gif)

This PR fixes it and adds tabbing index to the tags so they can be selected with the keyboard.

While checking for a11y issues I also noticed how `categories` were mis-rendered by using a non existent ID. I fixed that as well.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![after](https://user-images.githubusercontent.com/146201/82885837-f3333280-9f45-11ea-8e54-5906e72f65de.gif)


## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
