### PR TITLE
Disable InstantClick For Tag Paths in Sidebar

### DIFF
--- a/app/javascript/leftSidebar/TagsFollowed.jsx
+++ b/app/javascript/leftSidebar/TagsFollowed.jsx
@@ -13,6 +13,7 @@ export const TagsFollowed = ({ tags = [] }) => {
           id={`sidebar-element-${tag.name}`}
         >
           <a
+            data-no-instant
             className="sidebar-nav-link sidebar-nav-link-tag"
             href={`/t/${tag.name}`}
           >

--- a/app/javascript/leftSidebar/__tests__/__snapshots__/TagsFollowed.test.jsx.snap
+++ b/app/javascript/leftSidebar/__tests__/__snapshots__/TagsFollowed.test.jsx.snap
@@ -16,6 +16,7 @@ exports[`<TagsFollowed /> should render the tags followed when tags are passed i
   >
     <a
       class="sidebar-nav-link sidebar-nav-link-tag"
+      data-no-instant={true}
       href="/t/javascript"
     >
       <span
@@ -31,6 +32,7 @@ exports[`<TagsFollowed /> should render the tags followed when tags are passed i
   >
     <a
       class="sidebar-nav-link sidebar-nav-link-tag"
+      data-no-instant={true}
       href="/t/webdev"
     >
       <span
@@ -46,6 +48,7 @@ exports[`<TagsFollowed /> should render the tags followed when tags are passed i
   >
     <a
       class="sidebar-nav-link sidebar-nav-link-tag"
+      data-no-instant={true}
       href="/t/react"
     >
       <span
@@ -61,6 +64,7 @@ exports[`<TagsFollowed /> should render the tags followed when tags are passed i
   >
     <a
       class="sidebar-nav-link sidebar-nav-link-tag"
+      data-no-instant={true}
       href="/t/discuss"
     >
       <span
@@ -76,6 +80,7 @@ exports[`<TagsFollowed /> should render the tags followed when tags are passed i
   >
     <a
       class="sidebar-nav-link sidebar-nav-link-tag"
+      data-no-instant={true}
       href="/t/productivity"
     >
       <span
@@ -91,6 +96,7 @@ exports[`<TagsFollowed /> should render the tags followed when tags are passed i
   >
     <a
       class="sidebar-nav-link sidebar-nav-link-tag"
+      data-no-instant={true}
       href="/t/career"
     >
       <span
@@ -106,6 +112,7 @@ exports[`<TagsFollowed /> should render the tags followed when tags are passed i
   >
     <a
       class="sidebar-nav-link sidebar-nav-link-tag"
+      data-no-instant={true}
       href="/t/node"
     >
       <span
@@ -121,6 +128,7 @@ exports[`<TagsFollowed /> should render the tags followed when tags are passed i
   >
     <a
       class="sidebar-nav-link sidebar-nav-link-tag"
+      data-no-instant={true}
       href="/t/css"
     >
       <span
@@ -136,6 +144,7 @@ exports[`<TagsFollowed /> should render the tags followed when tags are passed i
   >
     <a
       class="sidebar-nav-link sidebar-nav-link-tag"
+      data-no-instant={true}
       href="/t/html"
     >
       <span
@@ -151,6 +160,7 @@ exports[`<TagsFollowed /> should render the tags followed when tags are passed i
   >
     <a
       class="sidebar-nav-link sidebar-nav-link-tag"
+      data-no-instant={true}
       href="/t/typescript"
     >
       <span
@@ -166,6 +176,7 @@ exports[`<TagsFollowed /> should render the tags followed when tags are passed i
   >
     <a
       class="sidebar-nav-link sidebar-nav-link-tag"
+      data-no-instant={true}
       href="/t/opensource"
     >
       <span

--- a/app/views/articles/_sidebar_nav.html.erb
+++ b/app/views/articles/_sidebar_nav.html.erb
@@ -104,7 +104,7 @@
         </header>
         <% Tag.where(supported: true).order("hotness_score DESC").limit(30).pluck(:id, :name).each do |tag_array| %>
           <div class="sidebar-nav-element" id="default-sidebar-element-<%= tag_array.second %>">
-            <a class="sidebar-nav-link sidebar-nav-link-tag" href="<%= tag_path(tag_array.second) %>">
+            <a class="sidebar-nav-link sidebar-nav-link-tag" href="<%= tag_path(tag_array.second) %>" data-no-instant>
               <span class="sidebar-nav-tag-text">
                 #<%= tag_array.second %>
               </span>


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
We use [InstantClick](http://instantclick.io/) to help preload certain pages so when someone clicks on a javascript component is seems instantaneous.

## Related Tickets & Documents

![alt_text](gif_link)
