### PR TITLE
Preload InstantClick Linked Pages on Mousedown instead of Hover

### DIFF
--- a/app/assets/javascripts/base.js.erb
+++ b/app/assets/javascripts/base.js.erb
@@ -672,7 +672,7 @@ var instantClick
     InstantClick.on('change', function() {
       initializePage();
     });
-    InstantClick.init();
+    InstantClick.init('mousedown');
   }
 
 // INITIALIZE/ERROR HANDLING

--- a/app/assets/javascripts/base.js.erb
+++ b/app/assets/javascripts/base.js.erb
@@ -672,7 +672,7 @@ var instantClick
     InstantClick.on('change', function() {
       initializePage();
     });
-    InstantClick.init('mousedown');
+    InstantClick.init(50);
   }
 
 // INITIALIZE/ERROR HANDLING

--- a/app/javascript/packs/homePage.jsx
+++ b/app/javascript/packs/homePage.jsx
@@ -138,4 +138,4 @@ InstantClick.on('receive', (address, body, title) => {
     title,
   };
 });
-InstantClick.init('mousedown');
+InstantClick.init(50);

--- a/app/javascript/packs/homePage.jsx
+++ b/app/javascript/packs/homePage.jsx
@@ -138,4 +138,4 @@ InstantClick.on('receive', (address, body, title) => {
     title,
   };
 });
-InstantClick.init();
+InstantClick.init('mousedown');


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
We use [InstantClick](http://instantclick.io/) to help preload certain pages for links so when someone clicks on a link the transition seems instantaneous. Given our heavy use of Fastly many of our pages are already lightning quick. For this reason I think it would be worth it to add a couple of ms to a request in order to save what I think will be thousands of useless server requests.  

## Related Tickets & Documents
Possbily related: https://github.com/thepracticaldev/dev.to/issues/1771

## Added tests?
- [x] no, because they aren't needed

![alt_text](https://media1.tenor.com/images/6b983c8412039fb70422b24ca22ffdb1/tenor.gif?itemid=15626231)
