### PR TITLE
Sync public reactions count with positive reactions count

### DIFF
--- a/lib/data_update_scripts/20200518173504_update_public_reactions_count_from_positive_reactions_count.rb
+++ b/lib/data_update_scripts/20200518173504_update_public_reactions_count_from_positive_reactions_count.rb
@@ -1,8 +1,8 @@
 module DataUpdateScripts
   class UpdatePublicReactionsCountFromPositiveReactionsCount
     def run
-      ActiveRecord::Base.connection.execute("UPDATE articles SET public_reactions_count = positive_reactions_count, previous_public_reactions_count = previous_positive_reactions_count")
-      ActiveRecord::Base.connection.execute("UPDATE comments SET public_reactions_count = positive_reactions_count")
+      # ActiveRecord::Base.connection.execute("UPDATE articles SET public_reactions_count = positive_reactions_count, previous_public_reactions_count = previous_positive_reactions_count")
+      # ActiveRecord::Base.connection.execute("UPDATE comments SET public_reactions_count = positive_reactions_count")
     end
   end
 end

--- a/lib/data_update_scripts/20200526181850_update_public_reaction_counts_again.rb
+++ b/lib/data_update_scripts/20200526181850_update_public_reaction_counts_again.rb
@@ -1,0 +1,10 @@
+module DataUpdateScripts
+  class UpdatePublicReactionCountsAgain
+    def run
+      ActiveRecord::Base.connection.execute("UPDATE articles SET public_reactions_count = positive_reactions_count, previous_public_reactions_count = previous_positive_reactions_count WHERE id < #{Article.count / 2}")
+      ActiveRecord::Base.connection.execute("UPDATE articles SET public_reactions_count = positive_reactions_count, previous_public_reactions_count = previous_positive_reactions_count WHERE id > #{Article.count / 2}")
+      ActiveRecord::Base.connection.execute("UPDATE comments SET public_reactions_count = positive_reactions_count WHERE id < #{Comment.count / 2}")
+      ActiveRecord::Base.connection.execute("UPDATE comments SET public_reactions_count = positive_reactions_count WHERE id > #{Comment.count / 2}")
+    end
+  end
+end

--- a/lib/data_update_scripts/20200526181850_update_public_reaction_counts_again.rb
+++ b/lib/data_update_scripts/20200526181850_update_public_reaction_counts_again.rb
@@ -1,10 +1,12 @@
 module DataUpdateScripts
   class UpdatePublicReactionCountsAgain
     def run
-      ActiveRecord::Base.connection.execute("UPDATE articles SET public_reactions_count = positive_reactions_count, previous_public_reactions_count = previous_positive_reactions_count WHERE id <= #{Article.count / 2}")
-      ActiveRecord::Base.connection.execute("UPDATE articles SET public_reactions_count = positive_reactions_count, previous_public_reactions_count = previous_positive_reactions_count WHERE id > #{Article.count / 2}")
-      ActiveRecord::Base.connection.execute("UPDATE comments SET public_reactions_count = positive_reactions_count WHERE id <= #{Comment.count / 2}")
-      ActiveRecord::Base.connection.execute("UPDATE comments SET public_reactions_count = positive_reactions_count WHERE id > #{Comment.count / 2}")
+      article_count = Article.count
+      comment_count = Comment.count
+      ActiveRecord::Base.connection.execute("UPDATE articles SET public_reactions_count = positive_reactions_count, previous_public_reactions_count = previous_positive_reactions_count WHERE id <= #{article_count / 2}")
+      ActiveRecord::Base.connection.execute("UPDATE articles SET public_reactions_count = positive_reactions_count, previous_public_reactions_count = previous_positive_reactions_count WHERE id > #{article_count / 2}")
+      ActiveRecord::Base.connection.execute("UPDATE comments SET public_reactions_count = positive_reactions_count WHERE id <= #{comment_count / 2}")
+      ActiveRecord::Base.connection.execute("UPDATE comments SET public_reactions_count = positive_reactions_count WHERE id > #{comment_count / 2}")
     end
   end
 end

--- a/lib/data_update_scripts/20200526181850_update_public_reaction_counts_again.rb
+++ b/lib/data_update_scripts/20200526181850_update_public_reaction_counts_again.rb
@@ -1,9 +1,9 @@
 module DataUpdateScripts
   class UpdatePublicReactionCountsAgain
     def run
-      ActiveRecord::Base.connection.execute("UPDATE articles SET public_reactions_count = positive_reactions_count, previous_public_reactions_count = previous_positive_reactions_count WHERE id < #{Article.count / 2}")
+      ActiveRecord::Base.connection.execute("UPDATE articles SET public_reactions_count = positive_reactions_count, previous_public_reactions_count = previous_positive_reactions_count WHERE id <= #{Article.count / 2}")
       ActiveRecord::Base.connection.execute("UPDATE articles SET public_reactions_count = positive_reactions_count, previous_public_reactions_count = previous_positive_reactions_count WHERE id > #{Article.count / 2}")
-      ActiveRecord::Base.connection.execute("UPDATE comments SET public_reactions_count = positive_reactions_count WHERE id < #{Comment.count / 2}")
+      ActiveRecord::Base.connection.execute("UPDATE comments SET public_reactions_count = positive_reactions_count WHERE id <= #{Comment.count / 2}")
       ActiveRecord::Base.connection.execute("UPDATE comments SET public_reactions_count = positive_reactions_count WHERE id > #{Comment.count / 2}")
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This adds a data update script to sync `article.public_reactions_count`, `article.previous_public_reactions_count`, and `comment.public_reactions_count` with positive reactions count again. This is necessary since #7926 was merged today.

## [optional] What gif best describes this PR or how it makes you feel?

!["Fantastic! One more time!"](https://media.giphy.com/media/3o6MbaNXf2VFMqAX7y/giphy.gif)