### PR TITLE
Add download_app Welcome Notification

### DIFF
--- a/app/services/broadcasts/welcome_notification/generator.rb
+++ b/app/services/broadcasts/welcome_notification/generator.rb
@@ -18,6 +18,7 @@ module Broadcasts
         send_feed_customization_notification unless notification_enqueued
         send_ux_customization_notification unless notification_enqueued
         send_discuss_and_ask_notification unless notification_enqueued
+        send_download_app_notification unless notification_enqueued
       rescue ActiveRecord::RecordNotFound => e
         Honeybadger.notify(e)
       end
@@ -60,6 +61,13 @@ module Broadcasts
         @notification_enqueued = true
       end
 
+      def send_download_app_notification
+        return if received_notification?(download_app_broadcast) || user.created_at > 7.days.ago
+
+        Notification.send_welcome_notification(user.id, download_app_broadcast.id)
+        @notification_enqueued = true
+      end
+
       def received_notification?(broadcast)
         Notification.exists?(notifiable: broadcast, user: user)
       end
@@ -95,6 +103,10 @@ module Broadcasts
 
       def discuss_and_ask_broadcast
         @discuss_and_ask_broadcast ||= find_discuss_ask_broadcast
+      end
+
+      def download_app_broadcast
+        @download_app_broadcast ||= Broadcast.active.find_by!(title: "Welcome Notification: download_app")
       end
 
       def identities

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -245,7 +245,7 @@ broadcast_messages = {
   start_discussion: "Sloan here! 👋 I noticed that you haven't <a href='https://dev.to/t/discuss'>started a discussion</a> yet. Starting a discussion is easy to do; just click on 'Write a Post' in the sidebar of the tag page to get started!",
   ask_question: "Sloan here! 👋 I noticed that you haven't <a href='https://dev.to/t/explainlikeimfive'>asked a question</a> yet. Asking a question is easy to do; just click on 'Write a Post' in the sidebar of the tag page to get started!",
   discuss_and_ask: "Sloan here! 👋 I noticed that you haven't <a href='https://dev.to/t/explainlikeimfive'>asked a question</a> or <a href='https://dev.to/t/discuss'>started a discussion</a> yet. It's easy to do both of these; just click on 'Write a Post' in the sidebar of the tag page to get started!",
-  download_app: "Sloan here, with one last tip! 👋  Have you downloaded the DEV mobile app yet? Consider <a href='https://dev.to/downloads'>downloading</a> it so you can access all of your favorite DEV content on the go!"
+  download_app: "Sloan here, with one last tip! 👋 Have you downloaded the DEV mobile app yet? Consider <a href='https://dev.to/downloads'>downloading</a> it so you can access all of your favorite DEV content on the go!"
 }
 
 broadcast_messages.each do |type, message|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -244,7 +244,8 @@ broadcast_messages = {
   customize_experience: "Sloan here! 👋 Did you know that that you can customize your DEV experience? Try changing <a href='settings/ux'>your font and theme</a> and find the best style for you!",
   start_discussion: "Sloan here! 👋 I noticed that you haven't <a href='https://dev.to/t/discuss'>started a discussion</a> yet. Starting a discussion is easy to do; just click on 'Write a Post' in the sidebar of the tag page to get started!",
   ask_question: "Sloan here! 👋 I noticed that you haven't <a href='https://dev.to/t/explainlikeimfive'>asked a question</a> yet. Asking a question is easy to do; just click on 'Write a Post' in the sidebar of the tag page to get started!",
-  discuss_and_ask: "Sloan here! 👋 I noticed that you haven't <a href='https://dev.to/t/explainlikeimfive'>asked a question</a> or <a href='https://dev.to/t/discuss'>started a discussion</a> yet. It's easy to do both of these; just click on 'Write a Post' in the sidebar of the tag page to get started!"
+  discuss_and_ask: "Sloan here! 👋 I noticed that you haven't <a href='https://dev.to/t/explainlikeimfive'>asked a question</a> or <a href='https://dev.to/t/discuss'>started a discussion</a> yet. It's easy to do both of these; just click on 'Write a Post' in the sidebar of the tag page to get started!",
+  download_app: "Sloan here, with one last tip! 👋  Have you downloaded the DEV mobile app yet? Consider <a href=’https://dev.to/downloads>downloading</a> it so you can access all of your favorite DEV content on the go!"
 }
 
 broadcast_messages.each do |type, message|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -245,7 +245,7 @@ broadcast_messages = {
   start_discussion: "Sloan here! 👋 I noticed that you haven't <a href='https://dev.to/t/discuss'>started a discussion</a> yet. Starting a discussion is easy to do; just click on 'Write a Post' in the sidebar of the tag page to get started!",
   ask_question: "Sloan here! 👋 I noticed that you haven't <a href='https://dev.to/t/explainlikeimfive'>asked a question</a> yet. Asking a question is easy to do; just click on 'Write a Post' in the sidebar of the tag page to get started!",
   discuss_and_ask: "Sloan here! 👋 I noticed that you haven't <a href='https://dev.to/t/explainlikeimfive'>asked a question</a> or <a href='https://dev.to/t/discuss'>started a discussion</a> yet. It's easy to do both of these; just click on 'Write a Post' in the sidebar of the tag page to get started!",
-  download_app: "Sloan here, with one last tip! 👋  Have you downloaded the DEV mobile app yet? Consider <a href=’https://dev.to/downloads>downloading</a> it so you can access all of your favorite DEV content on the go!"
+  download_app: "Sloan here, with one last tip! 👋  Have you downloaded the DEV mobile app yet? Consider <a href='https://dev.to/downloads'>downloading</a> it so you can access all of your favorite DEV content on the go!"
 }
 
 broadcast_messages.each do |type, message|

--- a/spec/factories/broadcasts.rb
+++ b/spec/factories/broadcasts.rb
@@ -59,7 +59,7 @@ FactoryBot.define do
     factory :download_app_broadcast do
       title          { "Welcome Notification: download_app" }
       type_of        { "Welcome" }
-      processed_html { "Sloan here, with one last tip! 👋  Have you downloaded the DEV mobile app yet? Consider <a href='https://dev.to/downloads'>downloading</a> it so you can access all of your favorite DEV content on the go!" }
+      processed_html { "Sloan here, with one last tip! 👋 Have you downloaded the DEV mobile app yet? Consider <a href='https://dev.to/downloads'>downloading</a> it so you can access all of your favorite DEV content on the go!" }
     end
   end
 end

--- a/spec/factories/broadcasts.rb
+++ b/spec/factories/broadcasts.rb
@@ -55,5 +55,11 @@ FactoryBot.define do
       type_of        { "Welcome" }
       processed_html { "Sloan here! 👋 I noticed that you haven't <a href='https://dev.to/t/explainlikeimfive'>asked a question</a> or <a href='https://dev.to/t/discuss'>started a discussion</a> yet. It's easy to do both of these; just click on 'Write a Post' in the sidebar of the tag page to get started!" }
     end
+
+    factory :download_app_broadcast do
+      title          { "Welcome Notification: download_app" }
+      type_of        { "Welcome" }
+      processed_html { "Sloan here, with one last tip! 👋  Have you downloaded the DEV mobile app yet? Consider <a href=’https://dev.to/downloads>downloading</a> it so you can access all of your favorite DEV content on the go!" }
+    end
   end
 end

--- a/spec/factories/broadcasts.rb
+++ b/spec/factories/broadcasts.rb
@@ -59,7 +59,7 @@ FactoryBot.define do
     factory :download_app_broadcast do
       title          { "Welcome Notification: download_app" }
       type_of        { "Welcome" }
-      processed_html { "Sloan here, with one last tip! 👋  Have you downloaded the DEV mobile app yet? Consider <a href=’https://dev.to/downloads>downloading</a> it so you can access all of your favorite DEV content on the go!" }
+      processed_html { "Sloan here, with one last tip! 👋  Have you downloaded the DEV mobile app yet? Consider <a href='https://dev.to/downloads'>downloading</a> it so you can access all of your favorite DEV content on the go!" }
     end
   end
 end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR adds a "download app" welcome notification, which will be sent out 7 days after a user has signed up. This particular notification prompts new users to download the DEV mobile app.

## Related Tickets & Documents
Closes #8021 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![Screen Shot 2020-05-26 at 3 09 29 PM](https://user-images.githubusercontent.com/32834804/82950701-fe488b80-9f62-11ea-86cb-cac6990760ae.png)

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?
**YES: After this PR is approved, I will have to add this specific Broadcast to `/internal/broadcasts`.**

## [optional] What gif best describes this PR or how it makes you feel?

![Spongebob](https://media.giphy.com/media/CTX0ivSQbI78A/giphy.gif)
