### PR TITLE
Comment out Percy Code Failing Specs to Unblock Master

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -156,14 +156,14 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
 
   # Explicitly set a seed and time to ensure deterministic Percy snapshots.
-  config.around(:each, percy: true) do |example|
-    Timecop.freeze("2020-05-13T10:00:00Z")
-    prev_random_seed = Faker::Config.random
-    Faker::Config.random = Random.new(42)
+  # config.around(:each, percy: true) do |example|
+  #   Timecop.freeze("2020-05-13T10:00:00Z")
+  #   prev_random_seed = Faker::Config.random
+  #   Faker::Config.random = Random.new(42)
 
-    example.run
+  #   example.run
 
-    Faker::Config.random = prev_random_seed
-    Timecop.return
-  end
+  #   Faker::Config.random = prev_random_seed
+  #   Timecop.return
+  # end
 end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Specs are currently failing due to having to freeze time for Percy but that timestamp is too far in the past so users are constantly logged out after a single action. This comments out that Percy code until we can come up with a fix for it. 


![alt_text](https://media1.tenor.com/images/0aef0d3d87de4dfc305e9794cb7aec33/tenor.gif?itemid=12930246)
