### PR TITLE
Remove type onboarding from broadcast form options

### DIFF
--- a/app/views/internal/broadcasts/_form.html.erb
+++ b/app/views/internal/broadcasts/_form.html.erb
@@ -7,7 +7,7 @@
 </div>
 <div class="form-group">
   <%= label_tag :type, "Type:" %>
-  <%= select_tag "type_of", options_for_select(%w[Welcome Onboarding Announcement]) %>
+  <%= select_tag "type_of", options_for_select(%w[Welcome Announcement]) %>
 </div>
 <div class="form-group">
   <%= label_tag :active, "Active:" %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
We removed the `Onboarding` type on the `Broadcast` model [some time ago](https://github.com/thepracticaldev/dev.to/pull/7067/files), but we still show admins this type of Broadcast as an option for select when creating a broadcast. Since selecting this option will fail on the server-side, we shouldn't even show it as an option in the form :)

## Related Tickets & Documents
Related to work in https://github.com/thepracticaldev/dev.to/pull/7067.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
Before this change:
<img width="525" alt="Screen Shot 2020-05-27 at 9 06 47 AM" src="https://user-images.githubusercontent.com/6921610/83044751-795c8100-9ff9-11ea-93af-05ad8b4e51f6.png">

After this change:
<img width="510" alt="Screen Shot 2020-05-27 at 9 06 31 AM" src="https://user-images.githubusercontent.com/6921610/83044763-7c577180-9ff9-11ea-9419-6c1080c8c870.png">


## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

