### PR TITLE
Fixed issue with jest picking up the built storybook folder causing tests to run out of memory

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,6 +10,7 @@ module.exports = {
     '!app/javascript/packs/**/*.js', // avoids running coverage on webpacker pack files
     '!**/__tests__/**',
     '!**/__stories__/**',
+    '!app/javascript/storybook-static/**/*.js',
   ],
   coverageThreshold: {
     global: {
@@ -32,5 +33,6 @@ module.exports = {
     './config/webpack',
     // Allows developers to add utility modules that jest won't run as test suites.
     '/__tests__/utilities/',
+    './app/javascript/storybook-static',
   ],
 };


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This issue came about due to changes made in #8088. It will only ever happen on a local dev machine if a dev builds storybook (not run it) and then run jest. jest will hang during code coverage because node runs out of memory.

## Related Tickets & Documents

#8088

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![MIB using their erase memory pen](https://media.giphy.com/media/5zh1j8sUfLUJGI5T5d/giphy.gif)
