### PR TITLE
Track How Often We Hit Ambiguous Routes

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -197,8 +197,10 @@ class ArticlesController < ApplicationController
 
   def handle_user_or_organization_feed
     if (@user = User.find_by(username: params[:username]))
+      Honeycomb.add_field("articles_route.user", true)
       @articles = @articles.where(user_id: @user.id)
     elsif (@user = Organization.find_by(slug: params[:username]))
+      Honeycomb.add_field("articles_route.org", true)
       @articles = @articles.where(organization_id: @user.id).includes(:user)
     end
   end

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -105,12 +105,16 @@ class StoriesController < ApplicationController
     @organization = Organization.find_by(slug: params[:username])
     @page = Page.find_by(slug: params[:username], is_top_level_path: true)
     if @podcast
+      Honeycomb.add_field("stories_route.podcast", true)
       handle_podcast_index
     elsif @organization
+      Honeycomb.add_field("stories_route.org", true)
       handle_organization_index
     elsif @page
+      Honeycomb.add_field("stories_route.page", true)
       handle_page_display
     else
+      Honeycomb.add_field("stories_route.user", true)
       handle_user_index
     end
   end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Feature

## Description
We have two controller actions that waste a lot of resources looking up a value on multiple different tables to determine how to handle a route request. I want to know how often we hit these routes so I added some Honeycomb metrics to them to determine how "big" of a problem this actually is. 

If we hit them a ton, we should consider fixing them sooner. If it turns out they are not crazy active then I know to worry about it less. 

## Added tests?
- [x] no, because they aren't needed. This is not mission-critical logging so I dont think we need tests. 


![alt_text](https://media.giphy.com/media/OQvveHgK1ibPW/giphy.gif)
