### PR TITLE
Maybe remove index

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -314,7 +314,6 @@ ActiveRecord::Schema.define(version: 2020_05_26_151807) do
     t.string "slug"
     t.string "status", default: "active"
     t.datetime "updated_at", null: false
-    t.index ["slug"], name: "index_chat_channels_on_slug", unique: true
   end
 
   create_table "classified_listing_categories", force: :cascade do |t|


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Clean up

## Description

Welcome to another episode of "Walking Dead: `index_chat_channels_on_slug` Edition". 

History (`git grep index_chat_channels_on_slug $(git rev-list --all -- db/schema.rb)`:

1. Originally added in #7105
2. Removed, but I can't find where
3. Re-added in #7495 
4. Removed again in #7528
5. Added again in #7777, 514516b18b67b77a5c614f6ab181cf04becc212e and #8059

So, should this index be present or not? If yes, and I'm starting to suspect that might actually be the case, we should leave it in and close this PR. If not, we should remove it and make sure it stays removed, so everyone should drop it manually from their system just in case:

```
$ rails dbconsole
psql (12.3)
Type "help" for help.

PracticalDeveloper_development=# DROP INDEX IF EXISTS index_chat_channels_on_slug;
DROP INDEX
```

## Related Tickets & Documents

n/a

## Added tests?

- [X] no, because they aren't needed

## Added to documentation?

- [x] no documentation needed
