### PR TITLE
Add API Key to API Write Throttle

### DIFF
--- a/config/initializers/rack/attack.rb
+++ b/config/initializers/rack/attack.rb
@@ -16,7 +16,12 @@ class Rack::Attack
   throttle("api_write_throttle", limit: 1, period: 1) do |request|
     if request.path.starts_with?("/api/") && (request.put? || request.post? || request.delete?)
       Honeycomb.add_field("user_api_key", request.env["HTTP_API_KEY"])
-      track_and_return_ip(request.env["HTTP_FASTLY_CLIENT_IP"])
+      ip_address = track_and_return_ip(request.env["HTTP_FASTLY_CLIENT_IP"])
+      if request.env["HTTP_API_KEY"].present?
+        "#{ip_address}-#{request.env['HTTP_API_KEY']}"
+      elsif ip_address.present?
+        ip_address
+      end
     end
   end
 

--- a/spec/initializers/rack/attack_spec.rb
+++ b/spec/initializers/rack/attack_spec.rb
@@ -49,9 +49,28 @@ describe Rack::Attack, type: :request, throttle: true do
     let(:api_secret) { create(:api_secret) }
     let(:another_api_secret) { create(:api_secret) }
 
-    it "throttles api write endpoints based on IP" do
+    it "throttles api write endpoints based on IP and API key" do
       headers = { "api-key" => api_secret.secret, "content-type" => "application/json", "HTTP_FASTLY_CLIENT_IP" => "5.6.7.8" }
-      dif_headers = { "api-key" => another_api_secret.secret, "content-type" => "application/json", "HTTP_FASTLY_CLIENT_IP" => "1.1.1.1" }
+      dif_headers = { "api-key" => another_api_secret.secret, "content-type" => "application/json", "HTTP_FASTLY_CLIENT_IP" => "5.6.7.8" }
+      params = { article: { body_markdown: "", title: Faker::Book.title } }.to_json
+
+      Timecop.freeze do
+        valid_response = post api_articles_path, params: params, headers: headers
+        throttled_response = post api_articles_path, params: params, headers: headers
+        new_api_response = post api_articles_path, params: params, headers: dif_headers
+
+        expect(valid_response).not_to eq(429)
+        expect(throttled_response).to eq(429)
+        expect(new_api_response).not_to eq(429)
+        expect(Honeycomb).to have_received(:add_field).with("fastly_client_ip", "5.6.7.8").exactly(5).times
+        expect(Honeycomb).to have_received(:add_field).with("user_api_key", api_secret.secret).exactly(2).times
+        expect(Honeycomb).to have_received(:add_field).with("user_api_key", another_api_secret.secret)
+      end
+    end
+
+    it "throttles api write endpoints based on IP if API key not present" do
+      headers = { "content-type" => "application/json", "HTTP_FASTLY_CLIENT_IP" => "5.6.7.8" }
+      dif_headers = { "content-type" => "application/json", "HTTP_FASTLY_CLIENT_IP" => "1.1.1.1" }
       params = { article: { body_markdown: "", title: Faker::Book.title } }.to_json
 
       Timecop.freeze do
@@ -64,8 +83,6 @@ describe Rack::Attack, type: :request, throttle: true do
         expect(new_api_response).not_to eq(429)
         expect(Honeycomb).to have_received(:add_field).with("fastly_client_ip", "5.6.7.8").exactly(3).times
         expect(Honeycomb).to have_received(:add_field).with("fastly_client_ip", "1.1.1.1").exactly(2).times
-        expect(Honeycomb).to have_received(:add_field).with("user_api_key", api_secret.secret).exactly(2).times
-        expect(Honeycomb).to have_received(:add_field).with("user_api_key", another_api_secret.secret)
       end
     end
   end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
We have some applications that make use of our API for their own users. In this case, we might get a lot of requests from their single IP but with different user API keys which can cause them to hit the throttle limit. This will allow those applications to make requests on the behalf of their users without worrying about different API keys causing them to hit the limit. 

## Related Tickets & Documents
https://github.com/toddanglin/PublishToDev/issues/2

## Added tests?
- [x] yes

![alt_text](https://media1.giphy.com/media/12ND6rflVdAL3W/giphy.gif)
