### PR TITLE
Tweak How We Track Ambiguous Routes to Make them Easier to Track

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -197,10 +197,10 @@ class ArticlesController < ApplicationController
 
   def handle_user_or_organization_feed
     if (@user = User.find_by(username: params[:username]))
-      Honeycomb.add_field("articles_route.user", true)
+      Honeycomb.add_field("articles_route", "user")
       @articles = @articles.where(user_id: @user.id)
     elsif (@user = Organization.find_by(slug: params[:username]))
-      Honeycomb.add_field("articles_route.org", true)
+      Honeycomb.add_field("articles_route", "org")
       @articles = @articles.where(organization_id: @user.id).includes(:user)
     end
   end

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -105,16 +105,16 @@ class StoriesController < ApplicationController
     @organization = Organization.find_by(slug: params[:username])
     @page = Page.find_by(slug: params[:username], is_top_level_path: true)
     if @podcast
-      Honeycomb.add_field("stories_route.podcast", true)
+      Honeycomb.add_field("stories_route", "podcast")
       handle_podcast_index
     elsif @organization
-      Honeycomb.add_field("stories_route.org", true)
+      Honeycomb.add_field("stories_route", "org")
       handle_organization_index
     elsif @page
-      Honeycomb.add_field("stories_route.page", true)
+      Honeycomb.add_field("stories_route", "page")
       handle_page_display
     else
-      Honeycomb.add_field("stories_route.user", true)
+      Honeycomb.add_field("stories_route", "user")
       handle_user_index
     end
   end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
Having different fields makes grouping these in Honeycomb difficult. Having a single field with different values makes running a simple field exists query A LOT easier. 

## Added tests?
- [x] no, because they aren't needed

![alt_text](https://media1.giphy.com/media/1qjvWFkKfyd3K4YGU2/giphy.gif)
