### PR TITLE
made all frontend unit tests uniform by preffering it(...) over test(...)

### DIFF
--- a/app/javascript/onboarding/__tests__/Onboarding.test.jsx
+++ b/app/javascript/onboarding/__tests__/Onboarding.test.jsx
@@ -139,15 +139,15 @@ describe('<Onboarding />', () => {
       onboardingSlides = initializeSlides(slideIndex, getUserData());
     });
 
-    test('renders properly', () => {
+    it('renders properly', () => {
       expect(onboardingSlides).toMatchSnapshot();
     });
 
-    test('it does not render a stepper', () => {
+    it('it does not render a stepper', () => {
       expect(onboardingSlides.find('.stepper').length).toBe(0);
     });
 
-    test('should advance if required boxes are checked', async () => {
+    it('should advance if required boxes are checked', async () => {
       fetch.once({});
       expect(onboardingSlides.state().currentSlide).toBe(slideIndex);
 
@@ -162,7 +162,7 @@ describe('<Onboarding />', () => {
       expect(onboardingSlides.state().currentSlide).toBe(slideIndex + 1);
     });
 
-    test('should not have basic a11y violations', async () => {
+    it('should not have basic a11y violations', async () => {
       const results = await axe(onboardingSlides.toString());
 
       expect(results).toHaveNoViolations();
@@ -182,19 +182,19 @@ describe('<Onboarding />', () => {
       await flushPromises();
     });
 
-    test('renders properly', () => {
+    it('renders properly', () => {
       expect(onboardingSlides).toMatchSnapshot();
     });
 
-    test('renders a stepper', () => {
+    it('renders a stepper', () => {
       expectStepperToRender(onboardingSlides, slideIndex);
     });
 
-    test('should render three tags', async () => {
+    it('should render three tags', async () => {
       expect(onboardingSlides.find('.onboarding-tags__item').length).toBe(3);
     });
 
-    test('should allow a user to add a tag and advance', async () => {
+    it('should allow a user to add a tag and advance', async () => {
       fetch.once({});
       expect(onboardingSlides.find('.next-button').text()).toContain(
         'Skip for now',
@@ -236,15 +236,15 @@ describe('<Onboarding />', () => {
       onboardingSlides = initializeSlides(slideIndex, getUserData());
     });
 
-    test('renders properly', () => {
+    it('renders properly', () => {
       expect(onboardingSlides).toMatchSnapshot();
     });
 
-    test('renders a stepper', () => {
+    it('renders a stepper', () => {
       expectStepperToRender(onboardingSlides, slideIndex);
     });
 
-    test('should allow user to fill forms and advance', async () => {
+    it('should allow user to fill forms and advance', async () => {
       fetch.once({});
       const summaryEvent = { target: { value: 'my bio', name: 'summary' } };
       const locationEvent = {
@@ -310,19 +310,19 @@ describe('<Onboarding />', () => {
       await flushPromises();
     });
 
-    test('renders properly', () => {
+    it('renders properly', () => {
       expect(onboardingSlides).toMatchSnapshot();
     });
 
-    test('renders a stepper', () => {
+    it('renders a stepper', () => {
       expectStepperToRender(onboardingSlides, slideIndex);
     });
 
-    test('should render three users', async () => {
+    it('should render three users', async () => {
       expect(onboardingSlides.find('.user').length).toBe(3);
     });
 
-    test('should allow a user to select and advance', async () => {
+    it('should allow a user to select and advance', async () => {
       fetch.once({});
 
       expect(onboardingSlides.find('.next-button').text()).toContain(
@@ -349,7 +349,7 @@ describe('<Onboarding />', () => {
       expect(onboardingSlides.state().currentSlide).toBe(slideIndex + 1);
     });
 
-    test('should have a functioning select-all toggle', async () => {
+    it('should have a functioning select-all toggle', async () => {
       fetch.once({});
 
       expect(onboardingSlides.find('button').last().text()).toBe(
@@ -383,15 +383,15 @@ describe('<Onboarding />', () => {
       window.location = location;
     });
 
-    test('renders properly', () => {
+    it('renders properly', () => {
       expect(onboardingSlides).toMatchSnapshot();
     });
 
-    test('renders a stepper', () => {
+    it('renders a stepper', () => {
       expectStepperToRender(onboardingSlides, slideIndex);
     });
 
-    test('should redirect user when finished', async () => {
+    it('should redirect user when finished', async () => {
       fetch.once({});
 
       // Setup: Enable window.location to be writable.

--- a/app/javascript/shared/components/__tests__/tags.test.jsx
+++ b/app/javascript/shared/components/__tests__/tags.test.jsx
@@ -17,7 +17,7 @@ describe('<Tags />', () => {
 
   describe('handleKeyDown', () => {
     const preventDefaultMock = jest.fn();
-    const createKeyDown = key => ({
+    const createKeyDown = (key) => ({
       key,
       preventDefault: preventDefaultMock,
     });
@@ -26,13 +26,13 @@ describe('<Tags />', () => {
       preventDefaultMock.mockClear();
     });
 
-    test('calls preventDefault on unused keyCode', () => {
+    it('calls preventDefault on unused keyCode', () => {
       tags.find('#tag-input').simulate('keydown', createKeyDown('§'));
       tags.find('#tag-input').simulate('keydown', createKeyDown('\\'));
       expect(preventDefaultMock).toHaveBeenCalledTimes(2);
     });
 
-    test('does not call preventDefault on used keyCode', () => {
+    it('does not call preventDefault on used keyCode', () => {
       tags.find('#tag-input').simulate('keypress', createKeyDown('a'));
       tags.find('#tag-input').simulate('keydown', createKeyDown('1'));
       tags.find('#tag-input').simulate('keypress', createKeyDown(','));


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This makes all our frontend unit tests uniform. There were two test files that were using `test(...)` instead of `it(...)`.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![Spongebob Squarepants saying "Much better"](https://media.giphy.com/media/xUPJPtVxT4bA9Rht9S/giphy.gif)
