### PR TITLE
Update vendor/cache After Dependabot

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -25,6 +25,8 @@ jobs:
       - name: Bundle install
         run: |
           gem install bundler --no-rdoc --no-ri
+          bundle config set cache_all true
+          bundle config cache_all_platforms true
           bundle install
       - name: Commit and push
         run: |

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,36 @@
+#Adopted from https://gist.github.com/filipkis/fab89a09f54ffdd8e70c063755e7ce7f
+
+name: Update vendor/cache After Dependabot
+
+on:
+  push:
+    branches:
+      - 'dependabot/bundler/**'
+    paths:
+      - 'Gemfile.lock'
+
+jobs:
+  update-gems:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby 2.7
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7.1
+      - name: Installing additional dependencies
+        run: |
+          sudo apt-get install postgresql-client libpq-dev
+      - name: Bundle install
+        run: |
+          gem install bundler --no-rdoc --no-ri
+          bundle install
+      - name: Commit and push
+        run: |
+          git config --local user.email `git show -s --format='%ae'`
+          git config --local user.name ${GITHUB_ACTOR}
+          git remote add github "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"
+          git add .
+          git commit -m "`git log --oneline --format=%B -n 1 HEAD | head -n 1` (Update vendor/cache)" || true
+          git push github HEAD:${GITHUB_REF}


### PR DESCRIPTION


## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

We need to update vendor/cache after Dependabot does it's bot duties. This GitHub Action should do the business. 

It was adopted from https://gist.github.com/filipkis/fab89a09f54ffdd8e70c063755e7ce7f which was posted to this Dependabot feedback issue: https://github.com/dependabot/feedback/issues/474#issuecomment-583741305

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![This close](https://i.imgur.com/euRu9De.gif)
