### PR TITLE
Remove redundant include of CloudinaryHelper

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,4 @@
 module ApplicationHelper
-  include CloudinaryHelper
-
   # rubocop:disable Performance/OpenStruct
   DELETED_USER = OpenStruct.new(
     id: nil,

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,5 @@
 module ApplicationHelper
-  include CloudinaryHelper
+  extend CloudinaryHelper
 
   # rubocop:disable Performance/OpenStruct
   DELETED_USER = OpenStruct.new(

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,5 @@
 module ApplicationHelper
-  extend CloudinaryHelper
+  include CloudinaryHelper
 
   # rubocop:disable Performance/OpenStruct
   DELETED_USER = OpenStruct.new(

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -159,9 +159,15 @@ RSpec.describe ApplicationHelper, type: :helper do
   end
 
   describe "#sanitize_and_decode" do
-    it "Sanitize and decode string" do
+    it "sanitize and decode string" do
       expect(helper.sanitize_and_decode("<script>alert('alert')</script>")).to eq("alert('alert')")
       expect(helper.sanitize_and_decode("&lt; hello")).to eq("< hello")
+    end
+  end
+
+  describe "#cloudinary" do
+    it "returns cloudinary-manipulated link" do
+      expect(helper.cloudinary(Faker::Placeholdit.image)).to start_with("https://res.cloudinary.com")
     end
   end
 end

--- a/spec/system/user_uses_the_editor_spec.rb
+++ b/spec/system/user_uses_the_editor_spec.rb
@@ -84,4 +84,17 @@ RSpec.describe "Using the editor", type: :system do
       end
     end
   end
+
+  describe "using v2 editor", js: true do
+    before { user.update(editor_version: "v2") }
+
+    it "fill out form with rich content and click publish" do
+      visit "/new"
+      fill_in "article-form-title", with: "This is a test"
+      fill_in "tag-input", with: "What, Yo"
+      fill_in "article_body_markdown", with: "Hello"
+      find("button", text: /\APUBLISH\z/).click
+      expect(page).to have_text("Hello")
+    end
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix ?

## Description
As I was creating new spec to prep for tag changes. I was getting the following error (after commenting out some VCR codes) and it was leading me down the wrong path.
```ruby
Failures:

  1) Using the editor using v2 editor fill out form with rich content and click publish
     Got 1 failure and 1 other error:

     1.1) Failure/Error: expect(page).to have_text("hello")
            expected to find text "hello" in "[manually ommited]". (However, it was found 1 time using a case insensitive search.)
          # ./spec/system/user_uses_the_editor_spec.rb:97:in `block (3 levels) in <main>'
          # -e:1:in `<main>'

     1.2) Failure/Error: // <---- this one
            def image_path(source, options = {})
              path_to_asset(source, { type: :image }.merge!(options))
            end

          ArgumentError:
            wrong number of arguments (given 0, expected 1..2)
          # -e:1:in `<main>'

Finished in 17.45 seconds (files took 0.58905 seconds to load)
1 example, 1 failure
```
The error 1.1 is expected but 1.2 is not. The weirdest part is this error only happens on fail, never on success. Ultimately I have no idea what is the cause of this but I come to realize `CloudinaryHelper` is [automatically included anyway](https://github.com/cloudinary/cloudinary_gem/blob/master/lib/cloudinary/railtie.rb#L10). Removing the manual include also fixed my weird problem 🤷‍♂️ 🤷 . 

Please let me know if anyone knows what's causing this or I made a mistake somewhere.
## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?
- [x] yes

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a