### PR TITLE
Update dependabot.yml to install libcurl4-openssl-dev

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -21,7 +21,7 @@ jobs:
           ruby-version: 2.7.1
       - name: Installing additional dependencies
         run: |
-          sudo apt-get install postgresql-client libpq-dev
+          sudo apt-get install postgresql-client libpq-dev libcurl4-openssl-dev
       - name: Bundle install
         run: |
           gem install bundler


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

libcurl4-openssl-dev is not installed by default on Ubuntu 18.04.4 LTS. :tada: 

