### PR TITLE
Autoskip Dependabot's travis build

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,12 @@
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "weekly"
+    commit_message:
+      prefix: "[skip travis]"
+  - package_manager: "ruby:bundler"
+    directory: "/"
+    update_schedule: "weekly"
+    commit_message:
+      prefix: "[skip travis]"

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -34,5 +34,5 @@ jobs:
           git config --local user.name ${GITHUB_ACTOR}
           git remote add github "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"
           git add .
-          git commit -m "`git log --oneline --format=%B -n 1 HEAD | head -n 1` (Update vendor/cache)" || true
+          git commit -m "`git log --oneline --format=%B -n 1 HEAD | head -n 1 | sed -e "s/\[skip travis\]\ //"` (Update vendor/cache)" || true
           git push github HEAD:${GITHUB_REF}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] DX

## Description
With the recent addition of our custom GitHub dependabot workflow, each Dependabot PRs needs two Travis builds to apply the changes we need. To mitigate that, this custom dependabot config.yml will add `[skip travis]` prefix on 

It should work in theory but would need to wait until the next time we receive PRs from dependabot.
## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
n/a
## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a