### PR TITLE
Optimization: Remove cached_followed_tag_names From Async User Data

### DIFF
--- a/app/controllers/async_info_controller.rb
+++ b/app/controllers/async_info_controller.rb
@@ -44,7 +44,6 @@ class AsyncInfoController < ApplicationController
         name: @user.name,
         username: @user.username,
         profile_image_90: ProfileImage.new(@user).get(width: 90),
-        followed_tag_names: @user.cached_followed_tag_names,
         followed_tags: @user.cached_followed_tags.to_json(only: %i[id name bg_color_hex text_color_hex hotness_score], methods: [:points]),
         followed_user_ids: @user.cached_following_users_ids,
         followed_organization_ids: @user.cached_following_organizations_ids,

--- a/app/javascript/packs/readingList.jsx
+++ b/app/javascript/packs/readingList.jsx
@@ -4,11 +4,12 @@ import { ReadingList } from '../readingList/readingList';
 
 function loadElement() {
   getUserDataAndCsrfToken().then(({ currentUser }) => {
+    const followedTagNames = JSON.parse(currentUser.followed_tags).map(t => t.name);
     const root = document.getElementById('reading-list');
     if (root) {
       render(
         <ReadingList
-          availableTags={currentUser.followed_tag_names}
+          availableTags={followedTagNames}
           statusView={root.dataset.view}
         />,
         root,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
base_data in our AsyncInfo Controller is above and beyond our most hit route(see purple line on the graph below) so it should be as lean and mean as possible. I noticed that we were using two calls and different methods to return tags and their names when one would suffice. I removed the tag names and added a little snippet so our javascript can parse them out itself.

<img width="1031" alt="Screen Shot 2020-05-28 at 7 05 54 PM" src="https://user-images.githubusercontent.com/1813380/83206387-69868f00-a116-11ea-8b60-bb759bb3c6d2.png">

CodeClimate is not a fan of removing code. It can be ignored in this case. 

## Added tests?
- [x] no, because they aren't needed, no behavior change so as long as current tests pass we should be good and I checked we do have tests for this javascript. 

![alt_text](https://media1.tenor.com/images/a87362e218e0b4960d1c7f95c97f1a76/tenor.gif?itemid=4556385)
