### PR TITLE
Leverage announcement broadcasts

### DIFF
--- a/app/controllers/internal/broadcasts_controller.rb
+++ b/app/controllers/internal/broadcasts_controller.rb
@@ -21,7 +21,11 @@ class Internal::BroadcastsController < Internal::ApplicationController
   end
 
   def index
-    @broadcasts = Broadcast.all
+    @broadcasts = if params[:type_of]
+                    Broadcast.where(type_of: params[:type_of].capitalize)
+                  else
+                    Broadcast.all
+                  end
   end
 
   private

--- a/app/controllers/internal/broadcasts_controller.rb
+++ b/app/controllers/internal/broadcasts_controller.rb
@@ -45,8 +45,4 @@ class Internal::BroadcastsController < Internal::ApplicationController
   def authorize_admin
     authorize Broadcast, :access?, policy_class: InternalPolicy
   end
-
-  def active_announcement_params
-    params[:type_of].capitalize == "Announcement" && params[:active] == true
-  end
 end

--- a/app/controllers/internal/broadcasts_controller.rb
+++ b/app/controllers/internal/broadcasts_controller.rb
@@ -3,13 +3,21 @@ class Internal::BroadcastsController < Internal::ApplicationController
 
   def create
     @broadcast = Broadcast.create!(broadcast_params)
+    flash[:success] = "Broadcast has been created!"
+    redirect_to "/internal/broadcasts"
+  rescue ActiveRecord::RecordInvalid => e
+    flash[:danger] = e.message
     redirect_to "/internal/broadcasts"
   end
 
   def update
     @broadcast = Broadcast.find_by!(id: params[:id])
     @broadcast.update!(broadcast_params)
+    flash[:success] = "Broadcast has been updated!"
     redirect_to "/internal/broadcasts"
+  rescue ActiveRecord::RecordInvalid => e
+    flash[:danger] = e.message
+    redirect_to "/internal/broadcasts/#{params[:id]}/edit"
   end
 
   def new
@@ -36,5 +44,9 @@ class Internal::BroadcastsController < Internal::ApplicationController
 
   def authorize_admin
     authorize Broadcast, :access?, policy_class: InternalPolicy
+  end
+
+  def active_announcement_params
+    params[:type_of].capitalize == "Announcement" && params[:active] == true
   end
 end

--- a/app/controllers/internal/broadcasts_controller.rb
+++ b/app/controllers/internal/broadcasts_controller.rb
@@ -33,7 +33,7 @@ class Internal::BroadcastsController < Internal::ApplicationController
                     Broadcast.where(type_of: params[:type_of].capitalize)
                   else
                     Broadcast.all
-                  end
+                  end.order(title: :asc)
   end
 
   private

--- a/app/models/broadcast.rb
+++ b/app/models/broadcast.rb
@@ -5,10 +5,28 @@ class Broadcast < ApplicationRecord
 
   validates :title, :type_of, :processed_html, presence: true
   validates :type_of, inclusion: { in: %w[Announcement Welcome] }
+  validate  :single_active_announcement_broadcast
 
   scope :active, -> { where(active: true) }
+  scope :announcement, -> { where(type_of: "Announcement") }
+  scope :welcome, -> { where(type_of: "Welcome") }
 
   def get_inner_body(content)
     Nokogiri::HTML(content).at("body").inner_html
+  end
+
+  private
+
+  def single_active_announcement_broadcast
+    # Only add errors if we are trying to modify an announcement
+    # broadcast while another announcement broadcast is already
+    # active to ensure that only one can be active at a time.
+    active_broadcasts = Broadcast.announcement.active
+    return unless active_broadcasts.count.positive? &&
+      active &&
+      type_of == "Announcement" &&
+      active_broadcasts.first.id != id
+
+    errors.add(:base, "You can only have one active announcement broadcast")
   end
 end

--- a/app/models/broadcast.rb
+++ b/app/models/broadcast.rb
@@ -22,10 +22,10 @@ class Broadcast < ApplicationRecord
     # broadcast while another announcement broadcast is already
     # active to ensure that only one can be active at a time.
     active_broadcasts = Broadcast.announcement.active
-    return unless active_broadcasts.count.positive? &&
-      active &&
+    first_broadcast = active_broadcasts.order(id: :asc).limit(1)
+    return unless active &&
       type_of == "Announcement" &&
-      active_broadcasts.first.id != id
+      ![nil, id].include?(first_broadcast.pluck(:id).first)
 
     errors.add(:base, "You can only have one active announcement broadcast")
   end

--- a/app/views/internal/broadcasts/index.html.erb
+++ b/app/views/internal/broadcasts/index.html.erb
@@ -1,30 +1,46 @@
-<div class="row justify-content-end">
-  <%= link_to "Make A New Broadcast", new_internal_broadcast_path, class: "btn btn-primary" %>
+<div class="row my-3">
+  <div class="col">
+    <ul class="nav nav-pills">
+      <li class="nav-item">
+        <%= link_to "All", internal_broadcasts_path, class: "nav-link #{'active' if params[:type_of].blank?}" %>
+      </li>
+      <li class="nav-item">
+        <%= link_to "Announcement", internal_broadcasts_path(type_of: :announcement), class: "nav-link #{'active' if params[:type_of] == 'announcement'}" %>
+      </li>
+      <li class="nav-item">
+        <%= link_to "Welcome", internal_broadcasts_path(type_of: :welcome), class: "nav-link #{'active' if params[:type_of] == 'welcome'}" %>
+      </li>
+    </ul>
+  </div>
+  <div class="col">
+    <div class="row justify-content-end">
+      <%= link_to "Make A New Broadcast", new_internal_broadcast_path, class: "btn btn-primary" %>
+    </div>
+  </div>
 </div>
 
-<h2>Current Broadcasts</h2>
-<hr>
-
-<div class="row">
-  <div class="alert alert-warning"><strong>Note: You must ensure that your Broadcast is active in order for it to be sent to users!<strong></div>
-  <div class="list-group-flush w-100">
-    <% @broadcasts.each do |broadcast| %>
-      <a class="list-group-item list-group-item-action flex-column align-items-start" href="/internal/broadcasts/<%= broadcast.id %>/edit">
-        <h3 class="mb-2">Title: <%= broadcast.title %></h3>
-        <h3>Broadcast Type: <%= broadcast.type_of %></h3>
-        <h3>Content:</h3>
-        <p>
-          <%= broadcast.processed_html %>
-        </p>
-        <h3>Status:</h3>
-        <h3>
-          <span class="badge badge-<%= broadcast.active? ? "success" : "warning" %>">
-            <%= broadcast.active? ? "Active" : "Inactive" %>
-          </span>
-          <span class="sr-only">Broadcast Status</span>
-        </h3>
-      </a>
-    <% end %>
+<div class="row my-3">
+  <div class="col">
+    <div class="alert alert-warning"><strong>Note: You must ensure that your Broadcast is active in order for it to be sent to users!<strong></div>
+    <div class="list-group-flush w-100">
+      <% @broadcasts.each do |broadcast| %>
+        <a class="list-group-item list-group-item-action flex-column align-items-start" href="/internal/broadcasts/<%= broadcast.id %>/edit">
+          <h3 class="mb-2">Title: <%= broadcast.title %></h3>
+          <h3>Broadcast Type: <%= broadcast.type_of %></h3>
+          <h3>Content:</h3>
+          <p>
+            <%= broadcast.processed_html %>
+          </p>
+          <h3>Status:</h3>
+          <h3>
+            <span class="badge badge-<%= broadcast.active? ? "success" : "warning" %>">
+              <%= broadcast.active? ? "Active" : "Inactive" %>
+            </span>
+            <span class="sr-only">Broadcast Status</span>
+          </h3>
+        </a>
+      <% end %>
+    </div>
   </div>
 </div>
 

--- a/spec/factories/broadcasts.rb
+++ b/spec/factories/broadcasts.rb
@@ -61,5 +61,11 @@ FactoryBot.define do
       type_of        { "Welcome" }
       processed_html { "Sloan here, with one last tip! 👋 Have you downloaded the DEV mobile app yet? Consider <a href='https://dev.to/downloads'>downloading</a> it so you can access all of your favorite DEV content on the go!" }
     end
+
+    factory :announcement_broadcast do
+      title          { "A Very Important Announcement" }
+      type_of        { "Announcement" }
+      processed_html { "Hello, World!" }
+    end
   end
 end

--- a/spec/models/broadcast_spec.rb
+++ b/spec/models/broadcast_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe Broadcast, type: :model do
+  it { is_expected.to validate_presence_of(:title) }
+  it { is_expected.to validate_presence_of(:type_of) }
+  it { is_expected.to validate_presence_of(:processed_html) }
+  it { is_expected.to validate_inclusion_of(:type_of).in_array(%w[Announcement Welcome]) }
+
+  it { is_expected.to have_many(:notifications) }
+
+  it "validates that only one Broadcast with a type_of Announcement can be active" do
+    create(:announcement_broadcast)
+
+    inactive_broadcast = build(:announcement_broadcast)
+
+    expect(inactive_broadcast).not_to be_valid
+    expect(inactive_broadcast.errors.full_messages.join).to include("You can only have one active announcement broadcast")
+  end
+end

--- a/spec/requests/internal/broadcasts_spec.rb
+++ b/spec/requests/internal/broadcasts_spec.rb
@@ -3,7 +3,7 @@ require "requests/shared_examples/internal_policy_dependant_request"
 
 RSpec.describe "/internal/broadcasts", type: :request do
   let(:get_resource) { get "/internal/broadcasts" }
-  let(:params) { { title: "Hello!", processed_html: "<pHello!</p>", type_of: "Welcome", sent: true } }
+  let(:params) { { title: "Hello!", processed_html: "<pHello!</p>", type_of: "Welcome", active: true } }
   let(:post_resource) { post "/internal/broadcasts", params: params }
 
   it_behaves_like "an InternalPolicy dependant request", Broadcast do
@@ -84,6 +84,31 @@ RSpec.describe "/internal/broadcasts", type: :request do
     describe "POST /internal/broadcasts" do
       it "blocks the request" do
         expect { post_resource }.to raise_error(Pundit::NotAuthorizedError)
+      end
+    end
+  end
+
+  context "with type_of Announcement" do
+    let(:super_admin) { create(:user, :super_admin) }
+    let(:params) { { title: "Hello!", processed_html: "<pHello!</p>", type_of: "Announcement", active: true } }
+
+    before { sign_in super_admin }
+
+    context "when an announcement broadcast is already active" do
+      before { create(:announcement_broadcast) }
+
+      it "does not allow a second broadcast to be set to active" do
+        expect do
+          post_resource
+        end.to change { Broadcast.all.count }.by(0)
+      end
+    end
+
+    context "when no announcement broadcast is active" do
+      it "allows a broadcast to be set to active" do
+        expect do
+          post_resource
+        end.to change { Broadcast.all.count }.by(1)
       end
     end
   end

--- a/spec/requests/internal/broadcasts_spec.rb
+++ b/spec/requests/internal/broadcasts_spec.rb
@@ -3,7 +3,7 @@ require "requests/shared_examples/internal_policy_dependant_request"
 
 RSpec.describe "/internal/broadcasts", type: :request do
   let(:get_resource) { get "/internal/broadcasts" }
-  let(:params) { { title: "Hello!", processed_html: "<pHello!</p>", type_of: "Welcome", active: true } }
+  let(:params) { { title: "Hello!", processed_html: "<p>Hello!</p>", type_of: "Welcome", active: true } }
   let(:post_resource) { post "/internal/broadcasts", params: params }
 
   it_behaves_like "an InternalPolicy dependant request", Broadcast do
@@ -90,7 +90,7 @@ RSpec.describe "/internal/broadcasts", type: :request do
 
   context "with type_of Announcement" do
     let(:super_admin) { create(:user, :super_admin) }
-    let(:params) { { title: "Hello!", processed_html: "<pHello!</p>", type_of: "Announcement", active: true } }
+    let(:params) { { title: "Hello!", processed_html: "<p>Hello!</p>", type_of: "Announcement", active: true } }
 
     before { sign_in super_admin }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
In preparation for a new "site-wide messaging" feature (see https://github.com/thepracticaldev/dev.to/issues/8090), I've started cleaning up some of our admin UI around the `Broadcast` model, and adding some constraints around the Broadcasts with a `type_of: "Announcement"`, which is what we'll use for our site-wide messaging service.

This PR does the following:

- [x] Differentiates between welcome + announcement broadcasts in the admin UI.
- [x] Allow admins to filter between these two types in the `/internal/broadcasts` UI by passing a `type_of` param into the route.
- [x] Only allows one `Announcement` broadcast to be active at a time (AND adds a bunch of tests related to this validation).
- [x] Adds some useful `announcement` and `welcome` scopes on the `Broadcast` class.
- [x] Adds some `flash[:success]` messages in the `BroadcastsController`.

## Related Tickets & Documents
Closes #8089! 🚀 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
**To QA this, you will want to do the following:**

1. Check out the `/internal/broadcasts` page! You'll see an improved UI that lets you filter based on the `type_of` on the broadcast:
<img width="1600" alt="Screen Shot 2020-05-28 at 6 00 21 PM" src="https://user-images.githubusercontent.com/6921610/83209613-9f734580-a10d-11ea-9e4d-9b9c70f73afb.png">

2. Check that you can create some inactive announcement broadcasts:
<img width="1640" alt="Screen Shot 2020-05-28 at 3 52 19 PM" src="https://user-images.githubusercontent.com/6921610/83209671-b74ac980-a10d-11ea-8470-fa605e15a6d1.png">

3. Check that you can set one of those announcement broadcasts to `active`, and that you see a super cute flash message:
<img width="1640" alt="Screen Shot 2020-05-28 at 3 28 16 PM" src="https://user-images.githubusercontent.com/6921610/83209748-e3fee100-a10d-11ea-861a-11174f855d75.png">
<img width="1640" alt="Screen Shot 2020-05-28 at 3 53 06 PM" src="https://user-images.githubusercontent.com/6921610/83209843-288a7c80-a10e-11ea-82fb-838372acf576.png">
<img width="1640" alt="Screen Shot 2020-05-28 at 3 28 22 PM" src="https://user-images.githubusercontent.com/6921610/83209742-df3a2d00-a10d-11ea-9ebb-09dc0ab1863c.png">

4. Check that you CANNOT set another announcement broadcast to `active`, thus ensuring that only _one_ of these types of broadcasts can ever be active at once!
<img width="1640" alt="Screen Shot 2020-05-28 at 3 52 42 PM" src="https://user-images.githubusercontent.com/6921610/83209835-21636e80-a10e-11ea-892a-68ea64600918.png">






## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
