### PR TITLE
Remove unnecessary "action-space" for non-signed-in users

### DIFF
--- a/app/assets/stylesheets/article-show.scss
+++ b/app/assets/stylesheets/article-show.scss
@@ -244,6 +244,9 @@ article {
       .published-at {
         margin-right: 0;
         display: inline-block;
+        @media screen and (max-width: 450px) {
+          display: none;
+        }
       }
 
       .posted-date-inline {

--- a/app/assets/stylesheets/article-show.scss
+++ b/app/assets/stylesheets/article-show.scss
@@ -244,9 +244,6 @@ article {
       .published-at {
         margin-right: 0;
         display: inline-block;
-        @media screen and (max-width: 450px) {
-          display: none;
-        }
       }
 
       .posted-date-inline {

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -152,7 +152,9 @@
             </span>
           <% end %>
           <span class="published-at">・<%= @article.reading_time < 1 ? 1 : @article.reading_time %> min read</span>
-          <span class="action-space" id="action-space">&nbsp;</span>
+          <% if user_signed_in? %>
+            <span class="action-space" id="action-space">&nbsp;</span>
+          <% end %>
         </h3>
         <% cache("main-article-tags-#{@article.cached_tag_list}", expires_in: 30.hours) do %>
           <div class="tags">


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related docu
mentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR removes the "action-space" for non-logged-in users when it would never be present. We leave space here so if it renders for the appropriate user it doesn't cause a "jump" but it causes this weird gap for non-trusted/non-author posts...

<img width="361" alt="Screen Shot 2020-05-29 at 9 58 59 AM" src="https://user-images.githubusercontent.com/3102842/83268036-0edf4880-a193-11ea-8ae3-682cdaa3a87e.png">

The weird gap will still be present for logged-in non-trusted/author users, but this quick fix will help it for many users and then we can make a further adjustment to fix this in future.