### PR TITLE
Enqueue feed_customization_notification

### DIFF
--- a/app/services/broadcasts/welcome_notification/generator.rb
+++ b/app/services/broadcasts/welcome_notification/generator.rb
@@ -31,7 +31,7 @@ module Broadcasts
         return if received_notification?(welcome_broadcast) || commented_on_welcome_thread? || user.created_at > 3.hours.ago
 
         Notification.send_welcome_notification(user.id, welcome_broadcast.id)
-        # Please do not remove the @notification_enqueued = true here - it is necessary for the notifications to run in the proper order
+        # Setting @notification_enqueued here prevents us from sending a user two welcome notifications in one day.
         @notification_enqueued = true
       end
 

--- a/app/services/broadcasts/welcome_notification/generator.rb
+++ b/app/services/broadcasts/welcome_notification/generator.rb
@@ -31,6 +31,7 @@ module Broadcasts
         return if received_notification?(welcome_broadcast) || commented_on_welcome_thread? || user.created_at > 3.hours.ago
 
         Notification.send_welcome_notification(user.id, welcome_broadcast.id)
+        # Please do not remove the @notification_enqueued = true here - it is necessary for the notifications to run in the proper order
         @notification_enqueued = true
       end
 

--- a/app/services/broadcasts/welcome_notification/generator.rb
+++ b/app/services/broadcasts/welcome_notification/generator.rb
@@ -45,6 +45,7 @@ module Broadcasts
         return if user_is_following_tags? || received_notification?(customize_feed_broadcast) || user.created_at > 3.days.ago
 
         Notification.send_welcome_notification(user.id, customize_feed_broadcast.id)
+        @notification_enqueued = true
       end
 
       def send_ux_customization_notification

--- a/spec/services/broadcasts/welcome_notification/generator_spec.rb
+++ b/spec/services/broadcasts/welcome_notification/generator_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Broadcasts::WelcomeNotification::Generator, type: :service do
       end.to not_change(user.notifications, :count)
     end
 
-    it "does not send a notification and if no active broadcast exists" do
+    it "does not send a notification if no active broadcast exists" do
       welcome_broadcast.update!(active: false)
       expect do
         sidekiq_perform_enqueued_jobs { described_class.call(user.id) }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR properly enqueues the `customize_feed_notification` within the `WelcomeNotification::Generator` in addition to removing an extra word from the `generator_spec.rb`. 

After a _ton_ of debugging yesterday, it is safe to say that no additional specs are needed for this addition and that the current spec will fail properly if `@notification_enqueued = true` is removed specifically from line 34 of the generator - the only place in the generator where there is a potential enqueuing-related bug. 

The potential bug is caused by the removal of `@notification_enqueued = true` for the _first_ Welcome Notification--if that line is removed, a User could potentially receive the first _and_ second Welcome Notification if the Notification is not properly enqueued, but this would only happen if someone intentionally removed this line from the generator. 

TL;DR: Please refrain from removing `@notification_enqueued = true` from line 34. 😂 

## Related Tickets & Documents
Closes #8069 

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![rubber_duck](https://media.giphy.com/media/L12ZXih8cd6YHZKLYi/giphy.gif)
