### PR TITLE
Change text in failing PUBLISH test

### DIFF
--- a/spec/system/user_uses_the_editor_spec.rb
+++ b/spec/system/user_uses_the_editor_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe "Using the editor", type: :system do
       fill_in "article-form-title", with: "This is a test"
       fill_in "tag-input", with: "What, Yo"
       fill_in "article_body_markdown", with: "Hello"
-      find("button", text: /\APUBLISH\z/).click
+      find("button", text: /\APublish\z/).click
       expect(page).to have_text("Hello")
     end
   end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
I think this test is legit failing and not flaky eh?

Publish text is now only capitalizing first character:
<img width="165" alt="Screen Shot 2020-05-29 at 1 23 38 PM" src="https://user-images.githubusercontent.com/3102842/83287404-9dfa5980-a1af-11ea-9349-cca204e39c4b.png">
