### PR TITLE
Spec Fix: Update Button to Match New Editor Changes

### DIFF
--- a/spec/system/user_uses_the_editor_spec.rb
+++ b/spec/system/user_uses_the_editor_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe "Using the editor", type: :system do
       fill_in "article-form-title", with: "This is a test"
       fill_in "tag-input", with: "What, Yo"
       fill_in "article_body_markdown", with: "Hello"
-      find("button", text: /\APUBLISH\z/).click
+      find("button", text: /\APublish\z/).click
       expect(page).to have_text("Hello")
     end
   end


### PR DESCRIPTION
Spec Fix: We changed the buttons for publishing articles with our recent editor changes so the word is no longer all caps. This updates the button in the spec to match