### PR TITLE
Optimization: Remove Unused Fields From Async user_data

### DIFF
--- a/app/controllers/async_info_controller.rb
+++ b/app/controllers/async_info_controller.rb
@@ -57,8 +57,6 @@ class AsyncInfoController < ApplicationController
         display_sponsors: @user.display_sponsors,
         trusted: @user.trusted,
         moderator_for_tags: @user.moderator_for_tags,
-        experience_level: @user.experience_level,
-        preferred_languages_array: @user.preferred_languages_array,
         config_body_class: @user.config_body_class,
         pro: @user.pro?,
         created_at: @user.created_at

--- a/app/labor/email_logic.rb
+++ b/app/labor/email_logic.rb
@@ -97,8 +97,6 @@ class EmailLogic
   end
 
   def user_has_followings?
-    following_users = @user.cached_following_users_ids
-    following_tags = @user.cached_followed_tag_names
-    following_users.any? || following_tags.any?
+    @user.cached_following_users_ids.any? || @user.cached_followed_tag_names.any?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -301,7 +301,7 @@ class User < ApplicationRecord
   end
 
   def trusted
-    Rails.cache.fetch("user-#{id}/has_trusted_role", expires_in: 200.hours) do
+    @trusted ||= Rails.cache.fetch("user-#{id}/has_trusted_role", expires_in: 200.hours) do
       has_role? :trusted
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
There are a couple of optimizations being made in this PR.
1) I removed fields that do not appear to be used in the view anywhere from the user_data hash
2) `user.config_body_class` calls `user.trusted` so I updated the trusted method to memoize the trusted value so we dont have to hit the cache twice.
3) While searching around the codebase I found in our email logic file we were looking up 2 sets of cached IDs when technically if the first returns values there is no reason to lookup the second. 

## Added tests?
- [x] no, because they aren't needed

![alt_text](https://media.giphy.com/media/FzuiifgDBL3Lq/giphy.gif)
