### PR TITLE
Optimization: Remove Comment Count From Aysnc user_data

### DIFF
--- a/app/assets/javascripts/initializers/initializeCommentsPage.js.erb
+++ b/app/assets/javascripts/initializers/initializeCommentsPage.js.erb
@@ -154,9 +154,8 @@ function toggleCodeOfConduct() {
     return;
   }
   var codeOfConduct = user.checked_code_of_conduct
-  var commentCount = user.number_of_comments
   var checkboxWrapper = document.getElementById('toggle-code-of-conduct-checkbox');
-  if (checkboxWrapper && !codeOfConduct && commentCount < 1) {
+  if (checkboxWrapper && !codeOfConduct) {
     checkboxWrapper.innerHTML = '<input type="checkbox" name="checked_code_of_conduct" class="checkbox" required/>\
                                   <label for="checked_code_of_conduct">I\'ve read the <a href="<%= URL.url('code-of-conduct') %>">code of conduct</a></label>'
   }
@@ -298,18 +297,8 @@ function handleSubmit(event) {
     return;
   }
 
-  var commentCount = user.number_of_comments;
-
-  // var codeOfConduct = user.checked_code_of_conduct;
-  // Code of conduct is false the first time even if the user has accepted it
-  // so we are not using it in the check below
-  // It also seems unnecessary if comment count >= 1 indicates that
-  // it was previously accepted
-
-  // Ensure that user has commented at least once
-  // and we have a non-empty comment to post
-  if (commentCount >= 1 &&
-    event.target.value.trim() !== '') {
+  var codeOfConduct = user.checked_code_of_conduct;
+  if (codeOfConduct && event.target.value.trim() !== '') {
     // get a reference to the submit button for the text area (first level comment vs. reply comment)
     var parentFormId = event.target.parentElement.parentElement.id || event.target.parentElement.id;
     var submitButton = document.querySelector('#' + parentFormId + ' input[type="submit"].comment-action-button');

--- a/app/controllers/async_info_controller.rb
+++ b/app/controllers/async_info_controller.rb
@@ -71,7 +71,6 @@ class AsyncInfoController < ApplicationController
     #{current_user&.last_followed_at}__
     #{current_user&.updated_at}__
     #{current_user&.reactions_count}__
-    #{current_user&.comments_count}__
     #{current_user&.saw_onboarding}__
     #{current_user&.checked_code_of_conduct}__
     #{current_user&.articles_count}__

--- a/app/controllers/async_info_controller.rb
+++ b/app/controllers/async_info_controller.rb
@@ -53,7 +53,6 @@ class AsyncInfoController < ApplicationController
         saw_onboarding: @user.saw_onboarding,
         checked_code_of_conduct: @user.checked_code_of_conduct,
         checked_terms_and_conditions: @user.checked_terms_and_conditions,
-        number_of_comments: @user.comments.count,
         display_sponsors: @user.display_sponsors,
         trusted: @user.trusted,
         moderator_for_tags: @user.moderator_for_tags,

--- a/app/javascript/chat/__tests__/util.test.js
+++ b/app/javascript/chat/__tests__/util.test.js
@@ -85,7 +85,6 @@ describe('Chat utilities', () => {
         reading_list_ids: [48, 49, 34, 51, 64, 56],
         saw_onboarding: true,
         checked_code_of_conduct: false,
-        number_of_comments: 0,
         display_sponsors: true,
         trusted: false,
       };


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
We include a user's comment count in our async user_data hash bc we were using it to validate if the code of conduct had been signed. I am assuming there was some sort of bug in the past but its hard to tell bc [some of the code appears to just be slapped in during this PR](https://github.com/thepracticaldev/dev.to/pull/885) with little explanation besides the comment. I did a lot of testing signing in and out, destroying and resigning up with my user and commenting on things and I never once got served the code of conduct twice so I think our user_data hash is updating correctly and therefore this check is no longer needed. 

## Added tests?
- [x] no, because they aren't needed

![alt_text](https://media1.tenor.com/images/6663c3080ab899241bd0a796ac934905/tenor.gif?itemid=8568913)
