### PR TITLE
Optimization:Remove followed_organization_ids from Async user_data

### DIFF
--- a/app/controllers/async_info_controller.rb
+++ b/app/controllers/async_info_controller.rb
@@ -46,7 +46,6 @@ class AsyncInfoController < ApplicationController
         profile_image_90: ProfileImage.new(@user).get(width: 90),
         followed_tags: @user.cached_followed_tags.to_json(only: %i[id name bg_color_hex text_color_hex hotness_score], methods: [:points]),
         followed_user_ids: @user.cached_following_users_ids,
-        followed_organization_ids: @user.cached_following_organizations_ids,
         followed_podcast_ids: @user.cached_following_podcasts_ids,
         reading_list_ids: ReadingList.new(@user).cached_ids_of_articles,
         blocked_user_ids: @user.all_blocking.pluck(:blocked_id),


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
These ids are 100% not used anywhere in the codebase so no need for them here. 

## Added tests?
- [x] no, because they aren't needed


![alt_text](https://media0.giphy.com/media/VeIEJObxMCayUWdTKk/200.gif)
