### PR TITLE
Generate Random Health Check Tokens on App Setup

### DIFF
--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -118,5 +118,5 @@ class SiteConfig < RailsSettings::Base
   field :shop_url, type: :string, default: "https://shop.dev.to"
 
   # Special API tokens
-  field :health_check_token, type: :string, default: "secret"
+  field :health_check_token, type: :string
 end

--- a/lib/tasks/app_initializer.rake
+++ b/lib/tasks/app_initializer.rake
@@ -14,5 +14,7 @@ namespace :app_initializer do
 
     puts "\n== Updating Data =="
     Rake::Task["data_updates:enqueue_data_update_worker"].execute
+
+    SiteConfig.health_check_token ||= SecureRandom.hex(10)
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
Every new community that is spun up with have a randomly generated health_check_token.

https://github.com/thepracticaldev/dev.to/projects/9#card-39168517

## Tested?
- [x] yes. I destroyed my whole env and ran the setup script which populated the token. On subsequent runs it was not reset.


![alt_text](https://media1.giphy.com/media/LMtxJ3trXmNaMBKNat/200.gif)
