### PR TITLE
Add timestamps to broadcasts

### DIFF
--- a/db/migrate/20200530084533_add_timestamps_to_broadcasts.rb
+++ b/db/migrate/20200530084533_add_timestamps_to_broadcasts.rb
@@ -1,0 +1,7 @@
+class AddTimestampsToBroadcasts < ActiveRecord::Migration[5.2]
+  def change
+    # NOTE: we need to have nullable timestamps as the table is already
+    # populated. Will remove the NULL clause when data is safely backfilled
+    add_timestamps(:broadcasts, null: true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -268,9 +268,11 @@ ActiveRecord::Schema.define(version: 2020_05_26_151807) do
   create_table "broadcasts", id: :serial, force: :cascade do |t|
     t.boolean "active", default: false
     t.text "body_markdown"
+    t.datetime "created_at"
     t.text "processed_html"
     t.string "title"
     t.string "type_of"
+    t.datetime "updated_at"
   end
 
   create_table "buffer_updates", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_26_151807) do
+ActiveRecord::Schema.define(version: 2020_05_30_084533) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/lib/data_update_scripts/20200530085153_backfill_broadcasts_timestamps.rb
+++ b/lib/data_update_scripts/20200530085153_backfill_broadcasts_timestamps.rb
@@ -1,0 +1,13 @@
+module DataUpdateScripts
+  class BackfillBroadcastsTimestamps
+    def run
+      # Broadcasts didn't have timestamps columns until
+      # 20200530084533_add_timestamps_to_broadcasts was created, thus we can
+      # safely assume that only those with `created_at IS NULL` need their
+      # timestamps overridden
+      Broadcast.where(created_at: nil).order(title: :asc).each do |cast|
+        cast.update(created_at: Time.current, updated_at: Time.current)
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

@vaidehijoshi found out that the `broadcasts` table doesn't have the two timestamps (`created_at` and `updated_at`).

As the table is already populated, I need to do this in two steps.

- [x] add nullable columns and backfill data (this PR)
- [ ] remove the `NULL` default from columns

## Related Tickets & Documents

https://github.com/thepracticaldev/dev.to/pull/8150#discussion_r432565867

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
