### PR TITLE
Reload on comment error instead of alert

### DIFF
--- a/app/assets/javascripts/initializers/initializeCommentsPage.js.erb
+++ b/app/assets/javascripts/initializers/initializeCommentsPage.js.erb
@@ -252,7 +252,9 @@ function handleCommentSubmit(event) {
       } else {
         response.json().then(function parseError(errorReponse) {
           form.classList.remove('submitting');
-          window.alert(errorReponse.error); // eslint-disable-line no-alert
+          //window.alert(errorReponse.error); // eslint-disable-line no-alert
+          // Reload instead of alert, due to current issue.
+          window.location.href = window.location.href
           return false;
         });
       }


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

There is currently a Datadog SSL issue

https://status.datadoghq.com/incidents/6bqpd511nj4h

Since the only real _user-facing_ problem right now is that they get this message due to our catch-all for errors is to toss up this alert, I feel like we may be better off just refreshing the page on error for now.

Then they will see that their comment was submitted successfully.

<img width="508" alt="Screen Shot 2020-05-30 at 1 49 48 PM" src="https://user-images.githubusercontent.com/3102842/83336737-edaa5500-a283-11ea-9815-2906424bae57.png">
