### PR TITLE
Fix gists sometimes rendered in wrong order (attempt)

### DIFF
--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -14,7 +14,7 @@
           clearInterval(waitingOnPostscribe);
           var els = document.getElementsByClassName("ltag_gist-liquid-tag");
           for (var i = 0; i < els.length; i++) {
-            var current = els[i];
+            let current = els[i];
             postscribe(current, current.firstElementChild.outerHTML, {
               beforeWrite: function (context) {
                 return function (text) {


### PR DESCRIPTION
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Debugging finds

When debugging, I found that the `beforeWrite` function is sometimes called with the wrong text, causing the bug. The `context` variable seems to be correct, which I think rules out my solution and seems to point to a bug in postscribe itself. Or maybe it should only be called once at a time?

## Description

Sending this as an attempt to fix the gist ordering bug (think of it as a place for discussion). I haven't confirmed the fix works (probably not!), since I don't have time to set up the dev environment this weekend, but, looking at the code, this seems like a mistake that could cause it.

I made a small script to reproduce something similar:

```javascript
function randomInt(min, max) {
	return min + Math.floor((max - min) * Math.random());
}

function makeRequest() {
    return new Promise((resolve) => {
       setTimeout(resolve, randomInt(0, 5000);
    });
}

async function process() {
    var els = ["one", "two", "three", "four", "five"];
    for(var i = 0; i < els.length; i++) {
      let a = i + 1;
      let current = els[i]; // change to `var` to reproduce bug
      makeRequest().then(e => console.log(`${a}: ${current}`));
    }
}

process();
```

I normally wouldn't send a PR without fully testing it in practice, but I really wanted to kick start this, since it's affecting my tutorials and leaving readers confused. I'll try and make time next weekend to set everything up if no one can confirm/debunk this fix.

## Reproducing the bug

Link to my tutorial: https://dev.to/cardoso/how-to-build-a-twitch-clone-game-live-streaming-app-for-ios-5f0p
Image of bug happening:
![IMG_E20C3831DE80-1](https://user-images.githubusercontent.com/5606812/83356757-87363d00-a33e-11ea-9816-4de214b9c24a.jpeg)
Correct snippet is: https://gist.github.com/cardoso/889bb3933d0f135d8889b028f4153708#file-podfile

I reproduced in Safari and Chrome. macOS and iOS. Normally the first snippet is affected, but also throughout the tutorial other snippets may be wrong.

**IMPORTANT:** It seems to happen very frequently when navigating from another page (such as dashboard) to the tutorial. On reload, it's always correct for me.

## Related Tickets & Documents

Attempts to fix #1679 

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

Might be needed, if so, point me in the right direction :)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
