### PR TITLE
Fix badge count update after merge

### DIFF
--- a/app/controllers/internal/users_controller.rb
+++ b/app/controllers/internal/users_controller.rb
@@ -65,7 +65,7 @@ class Internal::UsersController < Internal::ApplicationController
   def merge
     @user = User.find(params[:id])
     begin
-      Moderator::MergeUser.call_merge(admin: current_user, keep_user: @user, delete_user_id: user_params["merge_user_id"])
+      Moderator::MergeUser.call(admin: current_user, keep_user: @user, delete_user_id: user_params["merge_user_id"])
     rescue StandardError => e
       flash[:danger] = e.message
     end

--- a/app/services/moderator/merge_user.rb
+++ b/app/services/moderator/merge_user.rb
@@ -1,15 +1,15 @@
 module Moderator
   class MergeUser < ManageActivityAndRoles
+    def self.call(admin:, keep_user:, delete_user_id:)
+      new(keep_user: keep_user, admin: admin, delete_user_id: delete_user_id).merge
+    end
+
     attr_reader :keep_user, :admin, :delete_user_id
 
     def initialize(admin:, keep_user:, delete_user_id:)
       @keep_user = keep_user
       @admin = admin
       @delete_user = User.find(delete_user_id.to_i)
-    end
-
-    def self.call_merge(admin:, keep_user:, delete_user_id:)
-      new(keep_user: keep_user, admin: admin, delete_user_id: delete_user_id).merge
     end
 
     def merge
@@ -56,7 +56,7 @@ module Moderator
       end
       if @delete_user.badge_achievements.any?
         @delete_user.badge_achievements.update_all(user_id: @keep_user.id)
-        @keep_user.badge_achievements_count = @keep_user.badge_achievements.size
+        BadgeAchievement.counter_culture_fix_counts(where: { users: { id: @keep_user.id } })
       end
 
       @keep_user.update_columns(created_at: @delete_user.created_at) if @delete_user.created_at < @keep_user.created_at


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Description

We recently merged two accounts on a user's request, but badges did not show up on the new account. Trying to reassign them also did not work. I did some digging and found the following:

1. The badges had been moved over and assigned to the new user correctly. This is why they couldn't be reassigned. 
2. In `app/views/articles/_badges_area.html.erb` we perform the following conditional check:
    ```ruby
    if @user.badge_achievements_count > 0 
    ````
3. I checked, and the `badge_achievements_count` for the new user was indeed 0. 

I then had a look at `Moderator::MergeUser` and fixed the count update logic during merges. The newly added spec fails with the old code and succeeds with this change.

## Related Tickets & Documents

https://github.com/thepracticaldev/tech-private/issues/445#issuecomment-636615311

## Added tests?

- [X] yes

## Added to documentation?

- [X] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![image](https://user-images.githubusercontent.com/47985/83386255-eb2b3500-a414-11ea-8569-615897a272d2.png)

