### PR TITLE
Temporarily raise read_timeout of Github::OauthClient

### DIFF
--- a/app/services/github/oauth_client.rb
+++ b/app/services/github/oauth_client.rb
@@ -126,7 +126,9 @@ module Github
       Octokit.connection_options.merge(
         request: {
           open_timeout: 5,
-          timeout: 5
+          timeout: 5,
+          # NOTE: [rhymes] temporarily raise the read timeout to see if we can intercept the actual error
+          read_timeout: 30
         },
       )
     end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We're experiencing some timeout issues with getting repos from GitHub API v3.

AFAIK nothing changed in the code recently but as the timeout is 5 seconds, I'm finding it hard to figure out exactl what's going on. 

Temporarily raising the timeout to the Heroku limit, to see if we can get the actual error in the request.

See https://github.com/lostisland/faraday/blob/90b4564cecde7fd35b7d752fc84a785b89efd9e2/lib/faraday/adapter.rb#L91-L114

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
