### PR TITLE
Add Health Check Endpoint for Cache

### DIFF
--- a/app/controllers/api/v0/health_checks_controller.rb
+++ b/app/controllers/api/v0/health_checks_controller.rb
@@ -23,6 +23,14 @@ module Api
         end
       end
 
+      def cache
+        if all_cache_instances_connected?
+          render json: { message: "Redis connected" }, status: :ok
+        else
+          render json: { message: "Redis NOT connected!" }, status: :internal_server_error
+        end
+      end
+
       private
 
       def authenticate_with_token
@@ -31,6 +39,12 @@ module Api
         return if key == SiteConfig.health_check_token
 
         error_unauthorized
+      end
+
+      def all_cache_instances_connected?
+        [ENV["REDIS_URL"], ENV["REDIS_SESSIONS_URL"], ENV["REDIS_SIDEKIQ_URL"]].compact.all? do |url|
+          Redis.new(url: url).ping == "PONG"
+        end
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -149,6 +149,7 @@ Rails.application.routes.draw do
           get :app
           get :search
           get :database
+          get :cache
         end
       end
     end

--- a/spec/requests/api/v0/health_checks_spec.rb
+++ b/spec/requests/api/v0/health_checks_spec.rb
@@ -50,4 +50,22 @@ RSpec.describe "HealthCheck", type: :request do
       expect(response.parsed_body["message"]).to eq("Database NOT connected!")
     end
   end
+
+  describe "GET /api/health_checks/cache" do
+    it "returns json success if connection check succeeds" do
+      get cache_api_health_checks_path, headers: headers
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["message"]).to eq("Redis connected")
+    end
+
+    it "returns json failure if connection check fails" do
+      ENV["REDIS_URL"] = "redis://redis:6379"
+      redis_obj = Redis.new
+      allow(Redis).to receive(:new).and_return(redis_obj)
+      allow(redis_obj).to receive(:ping).and_return("fail")
+      get cache_api_health_checks_path, headers: headers
+      expect(response.status).to eq(500)
+      expect(response.parsed_body["message"]).to eq("Redis NOT connected!")
+    end
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
This adds a health check endpoint for all of our Redis instances. In this case, I labeled the endpoint "cache" since who knows if we will always use Redis or not. 
 
## Added tests?
- [x] yes

![alt_text](https://media.giphy.com/media/3oKIP9tk4g8syW2TV6/giphy.gif)
