### PR TITLE
Ignore Unfound Elasticsearch Docs and Records

### DIFF
--- a/app/workers/search/index_worker.rb
+++ b/app/workers/search/index_worker.rb
@@ -5,14 +5,8 @@ module Search
     sidekiq_options queue: :high_priority, lock: :until_executing
 
     def perform(object_class, id)
-      object = object_class.constantize.find(id)
-      object.index_to_elasticsearch_inline
-    rescue ActiveRecord::RecordNotFound => e
-      # Reactions can often be destroyed before this indexing job can execute
-      # so we ignore this error
-      return if object_class == "Reaction"
-
-      raise e
+      object = object_class.constantize.find_by(id: id)
+      object&.index_to_elasticsearch_inline
     end
   end
 end

--- a/app/workers/search/remove_from_index_worker.rb
+++ b/app/workers/search/remove_from_index_worker.rb
@@ -6,12 +6,12 @@ module Search
 
     def perform(search_class, id)
       search_class.safe_constantize.delete_document(id)
-    rescue Search::Errors::Transport::NotFound => e
-      # Reactions are often destroyed before the indexing job can execute
-      # so we ignore this error when trying to remove them
-      return if search_class == "Search::Reaction"
-
-      raise e
+    rescue Search::Errors::Transport::NotFound
+      # Often race conditions cause us never to index a document and
+      # we end up with an error when trying to remove it. Because
+      # we have count checks that run every hour to track the counts in
+      # Elasticsearch and db to ensure they match we can ignore this error
+      nil
     end
   end
 end

--- a/spec/workers/search/index_worker_spec.rb
+++ b/spec/workers/search/index_worker_spec.rb
@@ -5,10 +5,6 @@ RSpec.describe Search::IndexWorker, type: :worker, elasticsearch: "Tag" do
 
   include_examples "#enqueues_on_correct_queue", "high_priority", ["Tag", 1]
 
-  it "raises an error if record is not found" do
-    expect { worker.perform("Tag", 1234) }.to raise_error(ActiveRecord::RecordNotFound)
-  end
-
   it "indexes document" do
     tag = FactoryBot.create(:tag)
     expect { tag.elasticsearch_doc }.to raise_error(Search::Errors::Transport::NotFound)
@@ -17,7 +13,7 @@ RSpec.describe Search::IndexWorker, type: :worker, elasticsearch: "Tag" do
     expect(tag.elasticsearch_doc.dig("_source", "id")).to eql(tag.id)
   end
 
-  it "does not raise an error if Reaction record is not found" do
-    expect { worker.perform("Reaction", 1234) }.not_to raise_error(ActiveRecord::RecordNotFound)
+  it "does not raise an error if record is not found" do
+    expect { worker.perform("Tag", 1234) }.not_to raise_error(ActiveRecord::RecordNotFound)
   end
 end

--- a/spec/workers/search/remove_from_index_worker_spec.rb
+++ b/spec/workers/search/remove_from_index_worker_spec.rb
@@ -13,14 +13,8 @@ RSpec.describe Search::RemoveFromIndexWorker, type: :worker do
   end
 
   context "when document is not found" do
-    it "raises error" do
-      expect { described_class.new.perform(search_class.to_s, 1) }.to raise_error(
-        Search::Errors::Transport::NotFound,
-      )
-    end
-
-    it "does not raise error if removing a Reaction" do
-      expect { described_class.new.perform("Search::Reaction", 1) }.not_to raise_error(
+    it "does not raise error" do
+      expect { described_class.new.perform(search_class.to_s, 1) }.not_to raise_error(
         Search::Errors::Transport::NotFound,
       )
     end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
As stated in the comment, we seem to run into a few race conditions where comments are created and destroyed before the Sidekiq workers ever get a chance to index them. Since we have checks every hour to ensure that our db counts match our Elasticsearch counts I think we can safely ignore these missing records and docs and rely on our counts to alert us if there is a problem. 

Failed spec is unrelated, pushing a fix for it: https://github.com/thepracticaldev/dev.to/pull/8227

## Added tests?
- [x] updates


![alt_text](https://media.giphy.com/media/b3aA1UkFdfaM0/giphy.gif)
