### PR TITLE
Set Redis URL that will not be reused in specs

### DIFF
--- a/spec/requests/api/v0/health_checks_spec.rb
+++ b/spec/requests/api/v0/health_checks_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe "HealthCheck", type: :request do
     end
 
     it "returns json failure if connection check fails" do
-      ENV["REDIS_URL"] = "redis://redis:6379"
+      ENV["REDIS_SESSIONS_URL"] = "redis://redis:6379"
       redis_obj = Redis.new
       allow(Redis).to receive(:new).and_return(redis_obj)
       allow(redis_obj).to receive(:ping).and_return("fail")


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
I seemed to have broken some specs when the REDIS_URL ENV variable gets set. Since we need at least one redis URL I changed it to the session one. 

![alt_text](https://media1.giphy.com/media/5bivKwxhVzshNk2Rjw/giphy.gif)
