### PR TITLE
Swap sponsorships link

### DIFF
--- a/app/views/articles/_sidebar.html.erb
+++ b/app/views/articles/_sidebar.html.erb
@@ -15,7 +15,7 @@
             <% @sponsorships.each do |sponsorship| %>
               <%= render "articles/single_sponsor", sponsorship: sponsorship %>
             <% end %>
-            <a href="/partnerships" class="crayons-btn crayons-btn--secondary fs-s">Become a sponsor</a>
+            <a href="/sponsorships" class="crayons-btn crayons-btn--secondary fs-s">Become a sponsor</a>
           </div>
         <% end %>
       </div>

--- a/app/views/pages/sponsors.html.erb
+++ b/app/views/pages/sponsors.html.erb
@@ -71,6 +71,6 @@
       <% end %>
     </div>
 
-    <h5>Interested in sponsoring <%= community_name %>? Check out our <a href="<%= app_url("/partnerships") %>">partnerships</a> page.</h5>
+    <h5>Interested in sponsoring <%= community_name %>? Check out our <a href="<%= app_url("/sponsorships") %>">sponsorships</a> page.</h5>
   </div>
 </div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [x] link update

## Description
Pointing potential sponsors to `/sponsorships` instead of `/partnerships` in two locations.

- Location 1, bottom of `/sponsors` page
- Location 2, "Become a sponsor" box on the homepage sidebar

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
