### PR TITLE
Flaky Spec Fix: Stub pro? on user instead of using real role

### DIFF
--- a/spec/system/articles/user_visits_article_stats_spec.rb
+++ b/spec/system/articles/user_visits_article_stats_spec.rb
@@ -1,12 +1,12 @@
 require "rails_helper"
 
 RSpec.describe "Viewing an article stats", type: :system, js: true do
-  let_it_be(:user) { create(:user) }
-  let_it_be(:article, reload: true) { create(:article, user: user) }
+  let(:user) { create(:user) }
+  let(:article) { create(:article, user: user) }
 
   it "shows stats for pro users by clicking on the stats button", percy: true do
     path = "/#{user.username}/#{article.slug}/stats"
-    user.add_role(:pro)
+    allow(user).to receive(:pro?).and_return(true)
     sign_in user
     visit path
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Fixes this flaky spec:
```
1) Viewing an article stats shows stats for pro users by clicking on the stats button
     Failure/Error: user.add_role(:pro)
     
     ActiveRecord::RecordNotFound:
       Couldn't find all Roles with 'id': (512, 514) (found 1 results, but was looking for 2). Couldn't find Role with id 512.
     
     [Screenshot]: tmp/screenshots/r_spec_example_groups_viewing_an_article_stats_shows_stats_for_pro_users_by_clicking_on_the_stats_button_602_2020-06-02T15:-02-53-436Z.png
     
     # ./spec/system/articles/user_visits_article_stats_spec.rb:9:in `block (2 levels) in <top (required)>'
     # ./spec/rails_helper.rb:117:in `block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:117:in `block (2 levels) in <top (required)>'
     # ./spec/support/initializers/ci_csv_formatter.rb:92:in `block (2 levels) in <top (required)>'
```


![alt_text](https://media1.tenor.com/images/150dc71f5c40b95d8ca122c68db405f6/tenor.gif?itemid=4649173)
