### PR TITLE
Add If Statements to Skip Migrations If Index Exists

### DIFF
--- a/db/migrate/20200601121243_add_unique_indexes_to_comments_body_markdown_user_id_ancestry_commentable.rb
+++ b/db/migrate/20200601121243_add_unique_indexes_to_comments_body_markdown_user_id_ancestry_commentable.rb
@@ -1,13 +1,33 @@
 class AddUniqueIndexesToCommentsBodyMarkdownUserIdAncestryCommentable < ActiveRecord::Migration[5.2]
   disable_ddl_transaction!
 
-  def change
+  def up
+    return if index_exists?(
+      :comments,
+      %i[body_markdown user_id ancestry commentable_id commentable_type],
+      name: :index_comments_on_body_markdown_user_id_ancestry_commentable
+    )
+
     add_index(
       :comments,
       %i[body_markdown user_id ancestry commentable_id commentable_type],
       unique: true,
       algorithm: :concurrently,
       name: :index_comments_on_body_markdown_user_id_ancestry_commentable
+    )
+  end
+
+  def down
+    return unless index_exists?(
+      :comments,
+      %i[body_markdown user_id ancestry commentable_id commentable_type],
+      name: :index_comments_on_body_markdown_user_id_ancestry_commentable
+    )
+
+    remove_index(
+      :comments,
+      name: :index_comments_on_body_markdown_user_id_ancestry_commentable,
+      algorithm: :concurrently
     )
   end
 end


### PR DESCRIPTION
Migration failed but actually created the index so the retry failed bc the index already exists. This adds a check for the index before adding or removing it. 

![alt_text](https://media.tenor.com/images/d91720023779c2c862286760d3610fc7/tenor.gif)
