### PR TITLE
Attempt to fix rack protection issue with flipper UI

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,7 +42,11 @@ Rails.application.routes.draw do
 
     authenticate :user, ->(user) { user.has_role?(:tech_admin) } do
       mount Blazer::Engine, at: "blazer"
-      mount Flipper::UI.app(Flipper), at: "feature_flags"
+      mount Flipper::UI.app(Flipper) { |builder|
+        builder.use Rack::Session::Cookie,
+                    secret: Rails.application.secrets[:secret_key_base],
+                    key: Rails.application.config.session_options[:key]
+      } => "feature_flags"
     end
 
     resources :articles, only: %i[index show update]


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Attempts to fix issues using the feature flag UI in production. 

What's going on?
Right now in production, attempting to create a feature flag results in a `403 Forbidden`. There's something happening with Rack, our sessions, authenticity tokens, and the way we're mounting the FlipperUI within our Rails application. This feature works just fine in development!

@mstruve solved this similar issue with the Sidekiq UI in PR #5634. I'm trying to do something similar based on the advice in this issue on the Flipper repo: https://github.com/jnunemaker/flipper/issues/99#issuecomment-533216544 (note many of the comment there are talking about modifying Nginx proxies, which I don't think we are using in production, but I'm not sure!)

## Related Tickets & Documents

[](https://github.com/thepracticaldev/dev.to/pull/5634/)
[](https://github.com/mperham/sidekiq/issues/1289)
[](https://github.com/jnunemaker/flipper/issues/99)

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/3o6wr9xUAzjEXcA5BS/giphy.gif)
