### PR TITLE
Enforce Uniqueness for Broadcast Titles

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -83,6 +83,7 @@ Rails/UniqueValidationWithoutIndex:
     - 'app/models/comment.rb'
     - 'app/models/follow.rb'
     - 'app/models/notification.rb'
+    - 'app/models/broadcast.rb'
 
 # Offense count: 33
 # Cop supports --auto-correct.

--- a/app/models/broadcast.rb
+++ b/app/models/broadcast.rb
@@ -3,7 +3,8 @@ class Broadcast < ApplicationRecord
 
   has_many :notifications, as: :notifiable, inverse_of: :notifiable
 
-  validates :title, :type_of, :processed_html, presence: true
+  validates :title, uniqueness: { scope: :type_of }, presence: true
+  validates :type_of, :processed_html, presence: true
   validates :type_of, inclusion: { in: %w[Announcement Welcome] }
   validate  :single_active_announcement_broadcast
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
+<<<<<<< HEAD
 ActiveRecord::Schema.define(version: 2020_06_01_121243) do
+=======
+ActiveRecord::Schema.define(version: 2020_06_02_174329) do
+>>>>>>> Add unique index for title and type_of on Broadcasts
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -273,6 +277,7 @@ ActiveRecord::Schema.define(version: 2020_06_01_121243) do
     t.string "title"
     t.string "type_of"
     t.datetime "updated_at"
+    t.index ["title", "type_of"], name: "index_broadcasts_on_title_and_type_of", unique: true
   end
 
   create_table "buffer_updates", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-<<<<<<< HEAD
-ActiveRecord::Schema.define(version: 2020_06_01_121243) do
-=======
 ActiveRecord::Schema.define(version: 2020_06_02_174329) do
->>>>>>> Add unique index for title and type_of on Broadcasts
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/models/broadcast_spec.rb
+++ b/spec/models/broadcast_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Broadcast, type: :model do
   it { is_expected.to validate_presence_of(:type_of) }
   it { is_expected.to validate_presence_of(:processed_html) }
   it { is_expected.to validate_inclusion_of(:type_of).in_array(%w[Announcement Welcome]) }
+  it { is_expected.to validate_uniqueness_of(:title).scoped_to(:type_of) }
 
   it { is_expected.to have_many(:notifications) }
 

--- a/spec/requests/internal/broadcasts_spec.rb
+++ b/spec/requests/internal/broadcasts_spec.rb
@@ -112,4 +112,19 @@ RSpec.describe "/internal/broadcasts", type: :request do
       end
     end
   end
+
+  context "with the same title and the same type_of" do
+    let(:super_admin) { create(:user, :super_admin) }
+    let(:params) { { title: "Hello!", processed_html: "<p>Hello!</p>", type_of: "Announcement", active: true } }
+
+    before { sign_in super_admin }
+
+    it "does not allow for a second broadcast to be created" do
+      expect do
+        2.times do
+          post_resource
+        end
+      end.to change { Broadcast.all.count }.by(1)
+    end
+  end
 end

--- a/spec/requests/internal/broadcasts_spec.rb
+++ b/spec/requests/internal/broadcasts_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe "/internal/broadcasts", type: :request do
 
   context "with the same title and the same type_of" do
     let(:super_admin) { create(:user, :super_admin) }
-    let(:params) { { title: "Hello!", processed_html: "<p>Hello!</p>", type_of: "Announcement", active: true } }
+    let(:params) { { title: "Hello!", processed_html: "<p>Hello!</p>", type_of: "Announcement" } }
 
     before { sign_in super_admin }
 


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR enforces uniqueness on a Broadcast titles, scoped specifically to `type_of` (announcement or welcome), and renders an appropriate error message to an Admin that tries to create a Broadcast with the same title as another Broadcast of the same `type_of`.

## Related Tickets & Documents
Closes #8070 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
When attempting to add a Broadcast of the same `type`, with the same `title`:

<img width="1361" alt="Screen Shot 2020-06-02 at 12 01 35 PM" src="https://user-images.githubusercontent.com/32834804/83553718-db6d2880-a4c8-11ea-9a17-ebd66f7b1fa2.png">
Also note the successful scoping of Broadcasts with the same `title`, but with different `type_of`s.

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?
Heads-Up Team SRE (@mstruve and @maestromac): I have double-checked that there are no duplicate Broadcast titles, so this should be safe to add and should not cause any uniqueness-related errors when running the migration. :crossed_fingers:
