### PR TITLE
CI Speed Up: Use Gems in Vendor Cache for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,8 @@ before_install:
   - sudo chown -R elasticsearch:elasticsearch /etc/default/elasticsearch
   - sudo systemctl start elasticsearch
 install:
-  - bundle install --path vendor/bundle
+  - bundle config set path 'vendor/bundle'
+  - bundle install --local --jobs 2
   - yarn install --frozen-lockfile
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64
     > ./cc-test-reporter


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
Rather than wasting up to 3+ minutes installing gems during a Travis run, lets use the ones we have cached in our vendor/cache file by setting the `--local` flag. I also added [`--jobs 2`](https://bundler.io/bundle_install.html) which allows us to use 2 workers in parallel to load the gems.

## Added tests?
- [x] no, because they aren't needed

![alt_text](https://media1.tenor.com/images/eaa251d97f44f51c0c3cf77460829b88/tenor.gif?itemid=14207634)
