### PR TITLE
Make Devise.mailer_sender configurable

### DIFF
--- a/Envfile
+++ b/Envfile
@@ -15,6 +15,9 @@ variable :APP_PROTOCOL, :String, default: "http://"
 variable :COMMUNITY_COPYRIGHT_START_YEAR, :String, default: "2016"
 variable :COMMUNITY_NAME, :String, default: "DEV(local)"
 
+# Email related variables
+variable :DEFAULT_EMAIL, :String, default: "yo@dev.to"
+
 # Service timeout length
 variable :RACK_TIMEOUT_WAIT_TIMEOUT, :Integer, default: 100_000
 variable :RACK_TIMEOUT_SERVICE_TIMEOUT, :Integer, default: 100_000

--- a/app/controllers/internal/configs_controller.rb
+++ b/app/controllers/internal/configs_controller.rb
@@ -51,7 +51,7 @@ class Internal::ConfigsController < Internal::ApplicationController
       allowed_params,
       authentication_providers: [],
       social_media_handles: SiteConfig.social_media_handles.keys,
-      email_addresses: SiteConfig.email_addresses.keys,
+      email_addresses: SiteConfig.email_addresses.except(:default).keys,
       meta_keywords: SiteConfig.meta_keywords.keys,
     )
   end

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -34,7 +34,7 @@ class SiteConfig < RailsSettings::Base
 
   # Emails
   field :email_addresses, type: :hash, default: {
-    default: "yo@dev.to",
+    default: ApplicationConfig["DEFAULT_EMAIL"],
     business: "partners@dev.to",
     privacy: "privacy@dev.to",
     members: "members@dev.to"

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -200,6 +200,11 @@
                      } %>
           <div id="emailBodyContainer" class="card-body collapse hide" aria-labelledby="emailBodyContainer">
            <div class="form-group">
+             <div>
+              <label for="site_config_email_addresses_default">Default</label>
+              <input type="text" value="<%= ApplicationConfig['DEFAULT_EMAIL'] %>" class="form-control" readonly>
+              <div class="alert alert-info">Default (set via DEFAULT_EMAIL environment variable)</div>
+             </div>
              <%= f.fields_for :email_addresses do |email_field| %>
                <% SiteConfig.email_addresses.each do |type, address| %>
                  <div>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -11,7 +11,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = "dev.to <yo@dev.to>"
+  config.mailer_sender = "#{ENV['COMMUNITY_NAME']} <#{ENV['DEFAULT_EMAIL']}>"
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/spec/requests/internal/configs_spec.rb
+++ b/spec/requests/internal/configs_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "/internal/config", type: :request do
 
       describe "API tokens" do
         it "updates the health_check_token" do
-          token = "#{rand(20)}"
+          token = rand(20).to_s
           post "/internal/config", params: { site_config: { health_check_token: token }, confirmation: confirmation_message }
           expect(SiteConfig.health_check_token).to eq token
         end
@@ -97,17 +97,15 @@ RSpec.describe "/internal/config", type: :request do
       describe "Emails" do
         it "updates email_addresses" do
           expected_email_addresses = {
-            default: "foo@bar.to",
-            business: "partners@dev.to",
-            privacy: "privacy@bar.to",
-            members: "members@bar.to"
+            business: "partners@example.com",
+            privacy: "privacy@example.com",
+            members: "members@example.com"
           }
           post "/internal/config", params: { site_config: { email_addresses: expected_email_addresses },
                                              confirmation: confirmation_message }
-          expect(SiteConfig.email_addresses[:default]).to eq("foo@bar.to")
-          expect(SiteConfig.email_addresses[:privacy]).to eq("privacy@bar.to")
-          expect(SiteConfig.email_addresses[:business]).to eq("partners@dev.to")
-          expect(SiteConfig.email_addresses[:members]).to eq("members@bar.to")
+          expect(SiteConfig.email_addresses[:privacy]).to eq("privacy@example.com")
+          expect(SiteConfig.email_addresses[:business]).to eq("partners@example.com")
+          expect(SiteConfig.email_addresses[:members]).to eq("members@example.com")
         end
       end
 
@@ -376,7 +374,6 @@ RSpec.describe "/internal/config", type: :request do
           expect(SiteConfig.sidebar_tags).to eq(%w[hey haha hoho bobofofo])
         end
       end
-
     end
   end
   # rubocop:enable RSpec/NestedGroups


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

Our `Devise.mailer_sender` was hardcoded to `dev.to <yo@dev.to>`. This PR changes it to `#{ENV["COMMUNITY_NAME"]} <#{ENV["DEFAULT_EMAIL"]}>` (so `DEV <yo@dev.to>`) as a first attempt at generalizing this. There's more we could do here, but unless we have a comprehensive strategy around `SiteConfig`, default values, etc. this seems sufficient.

## Related Tickets & Documents

Closes #8245 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [X] no, because they aren't needed

## Added to documentation?

- [X] no documentation needed

## Are there any post deployment tasks we need to perform?

* Set the `DEFAULT_EMAIL` env variable to `yo@dev.to`. Other communities need to do this as well.