### PR TITLE
Generalize search.xml

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -7,3 +7,4 @@
 // = link administrate/application.css
 // = link administrate/application.js
 // = link katex.css
+// = link search.xml

--- a/app/assets/xml/search.xml.erb
+++ b/app/assets/xml/search.xml.erb
@@ -1,0 +1,9 @@
+<% helper = Module.new { extend ApplicationHelper } %>
+<?xml version="1.0" encoding="UTF-8"?>
+ <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+   <ShortName><%= helper.community_name %> Search</ShortName>
+   <Description>Find posts from the <%= helper.community_qualified_name %>.</Description>
+   <Contact><%= SiteConfig.email_addresses[:default] %></Contact>
+   <Url type="text/html" 
+     template="<%= URL.url("search") %>?q={searchTerms}"/>
+ </OpenSearchDescription>

--- a/app/views/shell/_top.html.erb
+++ b/app/views/shell/_top.html.erb
@@ -44,7 +44,7 @@
       <meta property="fb:pages" content="568966383279687" />
       <meta name="theme-color" content="#000000" />
       <link rel="manifest" href="/manifest.json" />
-      <link rel="search" href="<%= app_url("search.xml") %>" type="application/opensearchdescription+xml" title="<%= community_qualified_name %>" />
+      <link rel="search" href="<%= asset_path("search.xml") %>" type="application/opensearchdescription+xml" title="<%= community_qualified_name %>" />
     <% end %>
   </head>
   <% unless internal_navigation? %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -9,6 +9,8 @@ Rails.application.config.assets.version = "1.1"
 # Add Yarn node_modules folder to the asset load path
 Rails.application.config.assets.paths << Rails.root.join("node_modules")
 
+Rails.application.config.assets.paths << Rails.root.join("app/assets/xml")
+
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.

--- a/public/search.xml
+++ b/public/search.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
- <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
-   <ShortName>DEV Search</ShortName>
-   <Description>Find posts from the DEV community.</Description>
-   <Tags>software development</Tags>
-   <Contact>yo@dev.to</Contact>
-   <Url type="text/html" 
-        template="https://dev.to/search?q={searchTerms}"/>
- </OpenSearchDescription>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Generalization

## Description

This PR generalizes our [OpenSearch specification](https://developer.mozilla.org/en-US/docs/Web/OpenSearch). The file moved from `dev.to/search.xml` to `dev.to/assets/search.xml` but this should matter since I updated the `link` accordingly. Firefox still recognizes the search engine:

<img width="236" alt="Screen Shot 2020-06-03 at 14 52 55" src="https://user-images.githubusercontent.com/47985/83611439-2bbcb700-a5ab-11ea-9eff-bf3136f7b3b0.png">

## Related Tickets & Documents

Closes #8247

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [X] no, because they aren't needed

## Added to documentation?

- [X] no documentation needed
