### PR TITLE
Fixes Cloudinary helper calls that specify custom format

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -396,7 +396,7 @@ class StoriesController < ApplicationController
         "logo": {
           "@context": "http://schema.org",
           "@type": "ImageObject",
-          "url": ApplicationController.helpers.cloudinary(SiteConfig.logo_png, 192, "png"),
+          "url": ApplicationController.helpers.cloudinary(SiteConfig.logo_png, 192, 80, "png"),
           "width": "192",
           "height": "192"
         }

--- a/app/views/service_worker/manifest.json.erb
+++ b/app/views/service_worker/manifest.json.erb
@@ -8,17 +8,17 @@
   "theme_color": "#000000",
   "homepage_url": "<%= app_url %>",
   "icons": [{
-    "src": "<%= ApplicationController.helpers.cloudinary(SiteConfig.logo_png, 192, "png") %>",
+    "src": "<%= ApplicationController.helpers.cloudinary(SiteConfig.logo_png, 192, 80, "png") %>",
     "sizes": "192x192",
     "type": "image/png",
     "purpose": "any maskable"
   }, {
-    "src": "<%= ApplicationController.helpers.cloudinary(SiteConfig.logo_png, 128, "png") %>",
+    "src": "<%= ApplicationController.helpers.cloudinary(SiteConfig.logo_png, 128, 80, "png") %>",
     "sizes": "128x128",
     "type": "image/png",
     "purpose": "any maskable"
   }, {
-    "src": "<%= ApplicationController.helpers.cloudinary(SiteConfig.logo_png, 512, "png") %>",
+    "src": "<%= ApplicationController.helpers.cloudinary(SiteConfig.logo_png, 512, 80, "png") %>",
     "sizes": "512x512",
     "type": "image/png",
     "purpose": "any maskable"

--- a/spec/requests/articles/articles_show_spec.rb
+++ b/spec/requests/articles/articles_show_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "ArticlesShow", type: :request do
           "logo" => {
             "@context" => "http://schema.org",
             "@type" => "ImageObject",
-            "url" => ApplicationController.helpers.cloudinary(SiteConfig.logo_png, 192, "png"),
+            "url" => ApplicationController.helpers.cloudinary(SiteConfig.logo_png, 192, 80, "png"),
             "width" => "192",
             "height" => "192"
           }


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The [cloudinary helper](https://github.com/fdoxyz/dev.to/blob/master/app/helpers/application_helper.rb#L77) method has 1 required parameter (url) and 3 optional parameters (width, quality & format). 

Since these are positional params (not [keyword arguments](https://thoughtbot.com/blog/ruby-2-keyword-arguments)) if we want to specify the **format** (4th param) we must also pass in all 3 other params, otherwise there will be a mismatch in them which was causing this bug.

To see this in action check out the `manifest.json` from production and all 3 images have wrong arguments passed in to Cloudinary, which causes this error:

<img width="1437" alt="Screen Shot 2020-06-03 at 08 18 20" src="https://user-images.githubusercontent.com/6045239/83648234-0b710600-a573-11ea-8834-7ee33bad88ff.png">

With this fix the URLs generated now have the following valid params: `c_limit,f_png,fl_progressive,q_80,w_192`

## Related Tickets & Documents

This error surfaced because of #8158 which mentioned PWA support was failing due to bad image links

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![aha!](https://media.giphy.com/media/XH6MU5zmqIpAA/giphy.gif)
