### PR TITLE
Allow Admins to Delete Broadcasts

### DIFF
--- a/app/controllers/internal/broadcasts_controller.rb
+++ b/app/controllers/internal/broadcasts_controller.rb
@@ -37,13 +37,14 @@ class Internal::BroadcastsController < Internal::ApplicationController
   end
 
   def destroy
-    @broadcast = Broadcast.find_by!(id: params[:id])
-    @broadcast.destroy
-    flash[:success] = "Broadcast has been deleted!"
-    redirect_to "/internal/broadcasts"
-  rescue ActiveRecord::RecordInvalid => e
-    flash[:danger] = e.message
-    redirect_to "/internal/broadcasts/#{params[:id]}/delete"
+    broadcast = Broadcast.find_by(id: params[:id])
+    if broadcast.destroy
+      flash[:success] = "Broadcast has been deleted!"
+      redirect_to "/internal/broadcasts"
+    else
+      flash[:danger] = "Something went wrong with deleting the broadcast."
+      redirect_to "/internal/broadcasts/#{params[:id]}/edit"
+    end
   end
 
   private

--- a/app/controllers/internal/broadcasts_controller.rb
+++ b/app/controllers/internal/broadcasts_controller.rb
@@ -36,6 +36,16 @@ class Internal::BroadcastsController < Internal::ApplicationController
                   end.order(title: :asc)
   end
 
+  def destroy
+    @broadcast = Broadcast.find_by!(id: params[:id])
+    @broadcast.destroy
+    flash[:success] = "Broadcast has been deleted!"
+    redirect_to "/internal/broadcasts"
+  rescue ActiveRecord::RecordInvalid => e
+    flash[:danger] = e.message
+    redirect_to "/internal/broadcasts/#{params[:id]}/delete"
+  end
+
   private
 
   def broadcast_params

--- a/app/controllers/internal/broadcasts_controller.rb
+++ b/app/controllers/internal/broadcasts_controller.rb
@@ -37,7 +37,7 @@ class Internal::BroadcastsController < Internal::ApplicationController
   end
 
   def destroy
-    broadcast = Broadcast.find_by(id: params[:id])
+    broadcast = Broadcast.find_by!(id: params[:id])
     if broadcast.destroy
       flash[:success] = "Broadcast has been deleted!"
       redirect_to "/internal/broadcasts"

--- a/app/views/internal/broadcasts/edit.html.erb
+++ b/app/views/internal/broadcasts/edit.html.erb
@@ -5,5 +5,7 @@
       <%= render "form" %>
       <%= submit_tag "Update Broadcast", class: "btn btn-primary float-right" %>
     <% end %>
+    <hr class="mt-5">
+      <%= link_to "Destroy Broadcast", url_for(action: :destroy, id: @broadcast.id), method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-danger float-right" %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,7 +50,7 @@ Rails.application.routes.draw do
     end
 
     resources :articles, only: %i[index show update]
-    resources :broadcasts, only: %i[index new create edit update]
+    resources :broadcasts, only: %i[index new create edit update destroy]
     resources :buffer_updates, only: %i[create update]
     resources :listings, only: %i[index edit update destroy]
     resources :comments, only: [:index]

--- a/spec/requests/internal/broadcasts_spec.rb
+++ b/spec/requests/internal/broadcasts_spec.rb
@@ -47,6 +47,17 @@ RSpec.describe "/internal/broadcasts", type: :request do
         end.to change { Broadcast.all.count }.by(1)
       end
     end
+
+    describe "DELETE /internal/broadcasts/:id" do
+      let!(:broadcast) { create(:welcome_broadcast) }
+
+      it "deletes the broadcast" do
+        expect do
+          delete "/internal/broadcasts/#{broadcast.id}"
+        end.to change { Broadcast.all.count }.by(-1)
+        expect(response.body).to redirect_to "/internal/broadcasts"
+      end
+    end
   end
 
   context "when the user is a single resource admin" do
@@ -66,6 +77,17 @@ RSpec.describe "/internal/broadcasts", type: :request do
         expect do
           post_resource
         end.to change { Broadcast.all.count }.by(1)
+      end
+    end
+
+    describe "DELETE /internal/broadcasts/:id" do
+      let!(:broadcast) { create(:welcome_broadcast) }
+
+      it "deletes the broadcast" do
+        expect do
+          delete "/internal/broadcasts/#{broadcast.id}"
+        end.to change { Broadcast.all.count }.by(-1)
+        expect(response.body).to redirect_to "/internal/broadcasts"
       end
     end
   end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR allows Admins to delete Broadcasts from `/internal/broadcasts`. In addition to this, this PR adds appropriate flash messages when deleting a broadcast and adds a "Destroy Broadcast" button to the `/internal/broadcasts/edit` UI.

## Related Tickets & Documents
Closes #8068 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
**Destroy Button:**
<img width="1358" alt="Screen Shot 2020-06-03 at 12 19 17 PM" src="https://user-images.githubusercontent.com/32834804/83673147-a201ef00-a594-11ea-9fcf-5c042bb765ea.png">
**Confirmation Message Shown After Clicking "Destroy Broadcast":**
<img width="1358" alt="Screen Shot 2020-06-03 at 12 19 28 PM" src="https://user-images.githubusercontent.com/32834804/83673172-ab8b5700-a594-11ea-8b5d-7e89f2ab20f8.png">
**Deletion Confirmation:**
<img width="1358" alt="Screen Shot 2020-06-03 at 12 19 55 PM" src="https://user-images.githubusercontent.com/32834804/83673245-c8278f00-a594-11ea-99e4-c4f001502e7e.png">

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![Delete](https://media.giphy.com/media/5xaOcLwEvFOizxHVyVy/giphy.gif)
