### PR TITLE
Display Jobs Banner if User searches jobs or job

### DIFF
--- a/app/controllers/internal/configs_controller.rb
+++ b/app/controllers/internal/configs_controller.rb
@@ -45,7 +45,8 @@ class Internal::ConfigsController < Internal::ApplicationController
       rate_limit_params |
       mascot_params |
       image_params |
-      onboarding_params
+      onboarding_params |
+      job_params
 
     params.require(:site_config).permit(
       allowed_params,
@@ -137,6 +138,13 @@ class Internal::ConfigsController < Internal::ApplicationController
       onboarding_taskcard_image
       suggested_tags
       suggested_users
+    ]
+  end
+
+  def job_params
+    %i[
+      jobs_url
+      display_jobs_before_search
     ]
   end
 end

--- a/app/controllers/internal/configs_controller.rb
+++ b/app/controllers/internal/configs_controller.rb
@@ -144,7 +144,7 @@ class Internal::ConfigsController < Internal::ApplicationController
   def job_params
     %i[
       jobs_url
-      display_jobs_before_search
+      display_jobs_banner
     ]
   end
 end

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -46,7 +46,7 @@ class SiteConfig < RailsSettings::Base
 
   # Jobs
   field :jobs_url, type: :string, default: "https://jobs.dev.to/"
-  field :display_jobs_before_search, type: :boolean, default: false
+  field :display_jobs_banner, type: :boolean, default: false
 
   # Google Analytics Reporting API v4
   # <https://developers.google.com/analytics/devguides/reporting/core/v4>

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -44,6 +44,10 @@ class SiteConfig < RailsSettings::Base
   field :periodic_email_digest_max, type: :integer, default: 0
   field :periodic_email_digest_min, type: :integer, default: 2
 
+  # Jobs
+  field :jobs_url, type: :string, default: "https://jobs.dev.to/"
+  field :display_jobs_before_search, type: :boolean, default: false
+
   # Google Analytics Reporting API v4
   # <https://developers.google.com/analytics/devguides/reporting/core/v4>
   field :ga_view_id, type: :string, default: ""

--- a/app/views/articles/search.html.erb
+++ b/app/views/articles/search.html.erb
@@ -9,7 +9,7 @@
      data-articles-since="<%= Timeframer.new(params[:timeframe]).datetime&.iso8601 %>">
   <%= render "articles/search/sidebar" %>
   <div class="articles-list" id="articles-list">
-    <% if (params[:q].downcase == "job" || params[:q].downcase == "jobs") && SiteConfig.display_jobs_before_search %>
+    <% if (params[:q].downcase == "job" || params[:q].downcase == "jobs") && SiteConfig.display_jobs_banner %>
       <div class="crayons-notice crayons-notice--info mb-3 fs-base">Interested in joining our team? Explore our <a href=<%= SiteConfig.jobs_url %>>open roles</a>.</div>
     <% end %>
     <div class="substories" id="substories">

--- a/app/views/articles/search.html.erb
+++ b/app/views/articles/search.html.erb
@@ -10,7 +10,7 @@
   <%= render "articles/search/sidebar" %>
   <div class="articles-list" id="articles-list">
     <% if (params[:q].downcase == "job" || params[:q].downcase == "jobs") && SiteConfig.display_jobs_before_search %>
-      <div class="crayons-notice crayons-notice--info mb-3 fs-base">Interested in joining our team? Explore our <a href=<%= SiteConfig.jobs_url %>>open roles</a></div>
+      <div class="crayons-notice crayons-notice--info mb-3 fs-base">Interested in joining our team? Explore our <a href=<%= SiteConfig.jobs_url %>>open roles</a>.</div>
     <% end %>
     <div class="substories" id="substories">
       <div class="query-results-nothing">

--- a/app/views/articles/search.html.erb
+++ b/app/views/articles/search.html.erb
@@ -9,6 +9,9 @@
      data-articles-since="<%= Timeframer.new(params[:timeframe]).datetime&.iso8601 %>">
   <%= render "articles/search/sidebar" %>
   <div class="articles-list" id="articles-list">
+    <% if (params[:q].downcase == "job" || params[:q].downcase == "jobs") && SiteConfig.display_jobs_before_search %>
+      <div class="crayons-notice crayons-notice--info mb-3 fs-base">Interested in joining our team? Explore our <a href=<%= SiteConfig.jobs_url %>>open roles</a></div>
+    <% end %>
     <div class="substories" id="substories">
       <div class="query-results-nothing">
         <div class="query-results-loader"></div>

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -263,8 +263,8 @@
               <div class="alert alert-info">URL of the website where open positions are posted.</div>
 
             <div class="form-group">
-              <%= f.label :display_jobs_before_search %>
-              <%= f.check_box :display_jobs_before_search, checked: SiteConfig.display_jobs_before_search %>
+              <%= f.label :display_jobs_banner %>
+              <%= f.check_box :display_jobs_banner, checked: SiteConfig.display_jobs_banner %>
               <div class="alert alert-info">Display a jobs banner that points users to the <%= community_name %> jobs page when they type "job" or "jobs" in the search box</div>
             </div>
           </div>

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -248,6 +248,31 @@
         <div class="card mt-3">
           <%= render partial: "card_header",
                      locals: {
+                       header: "Jobs",
+                       state: "collapse",
+                       target: "jobsBodyContainer",
+                       expanded: "false"
+                     } %>
+          <div id="jobsBodyContainer" class="card-body collapse hide" aria-labelledby="jobsBodyContainer">
+            <div class="form-group">
+              <%= f.label :jobs_url %>
+              <%= f.text_field :jobs_url,
+                               class: "form-control",
+                               value: SiteConfig.jobs_url,
+                               placeholder: "Jobs URL" %>
+              <div class="alert alert-info">URL of the website where open positions are posted.</div>
+
+            <div class="form-group">
+              <%= f.label :display_jobs_before_search %>
+              <%= f.check_box :display_jobs_before_search, checked: SiteConfig.display_jobs_before_search %>
+              <div class="alert alert-info">Display a small jobs banner that points users to the jobs url when they search job or jobs in the search box</div>
+            </div>
+          </div>
+        </div>
+
+        <div class="card mt-3">
+          <%= render partial: "card_header",
+                     locals: {
                        header: "Google Analytics Reporting API v4",
                        state: "collapse",
                        target: "gaBodyContainer",

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -265,7 +265,7 @@
             <div class="form-group">
               <%= f.label :display_jobs_before_search %>
               <%= f.check_box :display_jobs_before_search, checked: SiteConfig.display_jobs_before_search %>
-              <div class="alert alert-info">Display a small jobs banner that points users to the jobs url when they search job or jobs in the search box</div>
+              <div class="alert alert-info">Display a jobs banner that points users to the <%= community_name %> jobs page when they type "job" or "jobs" in the search box</div>
             </div>
           </div>
         </div>

--- a/spec/requests/internal/configs_spec.rb
+++ b/spec/requests/internal/configs_spec.rb
@@ -134,9 +134,9 @@ RSpec.describe "/internal/config", type: :request do
           expect(SiteConfig.jobs_url).to eq("www.jobs.com")
         end
 
-        it "updates display_jobs_before_search" do
-          post "/internal/config", params: { site_config: { display_jobs_before_search: true }, confirmation: confirmation_message }
-          expect(SiteConfig.display_jobs_before_search).to eq(true)
+        it "updates display_jobs_banner" do
+          post "/internal/config", params: { site_config: { display_jobs_banner: true }, confirmation: confirmation_message }
+          expect(SiteConfig.display_jobs_banner).to eq(true)
         end
       end
 

--- a/spec/requests/internal/configs_spec.rb
+++ b/spec/requests/internal/configs_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "/internal/config", type: :request do
 
       describe "API tokens" do
         it "updates the health_check_token" do
-          token = "#{rand(20)}"
+          token = rand(20).to_s
           post "/internal/config", params: { site_config: { health_check_token: token }, confirmation: confirmation_message }
           expect(SiteConfig.health_check_token).to eq token
         end
@@ -125,6 +125,18 @@ RSpec.describe "/internal/config", type: :request do
         it "rejects update without proper confirmation" do
           expect { post "/internal/config", params: { site_config: { periodic_email_digest_min: 6 }, confirmation: "Incorrect yo!" } }.to raise_error Pundit::NotAuthorizedError
           expect(SiteConfig.periodic_email_digest_min).not_to eq(6)
+        end
+      end
+
+      describe "Jobs" do
+        it "updates jobs_url" do
+          post "/internal/config", params: { site_config: { jobs_url: "www.jobs.com" }, confirmation: confirmation_message }
+          expect(SiteConfig.jobs_url).to eq("www.jobs.com")
+        end
+
+        it "updates display_jobs_before_search" do
+          post "/internal/config", params: { site_config: { display_jobs_before_search: true }, confirmation: confirmation_message }
+          expect(SiteConfig.display_jobs_before_search).to eq(true)
         end
       end
 
@@ -376,7 +388,6 @@ RSpec.describe "/internal/config", type: :request do
           expect(SiteConfig.sidebar_tags).to eq(%w[hey haha hoho bobofofo])
         end
       end
-
     end
   end
   # rubocop:enable RSpec/NestedGroups


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
Earlier, I went to go look up one of our posted jobs at DEV. I typed "dev.to jobs" into Chrome and it landed me on dev.to's search page with the search query "jobs" which wasn't quite what I was going for. I wondered how many others might be looking for jobs AT DEV and end up where I did so I brought it up in #hiring and we can up with this little fix. Thanks @ludwiczakpawel for the design and Gracie for the copy. 

We have the ability to turn this on or off using SiteConfig. 

![Screen Shot 2020-06-03 at 1 57 53 PM](https://user-images.githubusercontent.com/1813380/83677776-42aadb80-a5a2-11ea-9875-73e0e4428e2c.png)


## Added tests?
- [x] yes

![alt_text](https://media0.giphy.com/media/kGKoSE3BhSCALEdDOT/giphy.gif)
