### PR TITLE
Fix text out of bounds in Search results feed

### DIFF
--- a/app/assets/stylesheets/components/stories.scss
+++ b/app/assets/stylesheets/components/stories.scss
@@ -187,6 +187,7 @@
       color: var(--card-color);
       background: var(--accent-warning-lighter);
     }
+    overflow-wrap: break-word;
   }
 
   &__headline {

--- a/app/services/search/feed_content.rb
+++ b/app/services/search/feed_content.rb
@@ -26,7 +26,6 @@ module Search
         source["tag_list"] = source["tags"]&.map { |t| t["name"] } || []
         source["flare_tag"] = source["flare_tag_hash"]
         source["user_id"] = source.dig("user", "id")
-        hit.dig("highlight", "body_text").map! { |p| p.gsub(/\&nbsp;/, " ") }
         source["highlight"] = hit["highlight"]
         source["readable_publish_date"] = source["readable_publish_date_string"]
         source["podcast"] = {

--- a/app/services/search/feed_content.rb
+++ b/app/services/search/feed_content.rb
@@ -26,6 +26,7 @@ module Search
         source["tag_list"] = source["tags"]&.map { |t| t["name"] } || []
         source["flare_tag"] = source["flare_tag_hash"]
         source["user_id"] = source.dig("user", "id")
+        hit.dig("highlight", "body_text").map! { |p| p.gsub(/\&nbsp;/, " ") }
         source["highlight"] = hit["highlight"]
         source["readable_publish_date"] = source["readable_publish_date_string"]
         source["podcast"] = {


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Issue #8238 is caused by the non-breaking space (`&nbsp`). See below.

![nbsp](https://user-images.githubusercontent.com/60417145/83894689-a27ac100-a71f-11ea-9546-4c8a74d3719e.png)

To reproduce the issue on production server, follow the directions:
- Search: https://dev.to/search?q=project%20ideas
- Scroll down till article below shows up (should be around 20th-25th result).

![Screenshot from 2020-06-03 21-50-24](https://user-images.githubusercontent.com/60417145/83705971-4f502380-a5e4-11ea-90e1-53ff1a08bb15.png)

I originally thought about 3 ways to solve this issue.

### Client side option

If we want to change it client side, we need to do something on line 221 [here](https://github.com/thepracticaldev/dev.to/blob/master/app/assets/javascripts/utilities/buildArticleHTML.js#L221) where we just replace `&nbsp` with `" "`. 

```js
// something like this
bodyTextSnippet =
        startingEllipsis + article.highlight.body_text.map(x=>x.replace(/&nbsp;/g, " ")).join('...') + '…';
```

### Server side option

If we want to change it server side, it really depends on how downstream or upstream we want to 
gsub out the `&nbsp`. Upon cursory inspection, a good candidate seemed to be the `prepare_doc` method in [feed_content.rb](https://github.com/thepracticaldev/dev.to/blob/master/app/services/search/feed_content.rb#L22).

```rb
def prepare_doc(hit)
        source = hit.dig("_source")
        hit.dig("highlight", "body_text").map! { |p| p.gsub(/\&nbsp;/, " ") }
        source["highlight"] = hit["highlight"]
```

But really the most simple solution is to change the CSS.

### CSS option

```css
  &__snippet {
    overflow-wrap: break-word;
  }
```

This solution is what this PR implements. Note that this solution is consistent with how we treat `.container.body` which holds the `body_text`.

![container-body](https://user-images.githubusercontent.com/60417145/83707224-8116b980-a5e7-11ea-935e-3d145c87a88b.png)

After break-word is applied:

![break-word](https://user-images.githubusercontent.com/60417145/83707673-83c5de80-a5e8-11ea-9da2-c32320eae020.png)

### What caused this?

I wrote a test article entitled 

```md
"THIS IS A TEST &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; TEST &nbsp;&nbsp;&nbsp;"
```

and I got back this:

![test](https://user-images.githubusercontent.com/60417145/83707929-2c743e00-a5e9-11ea-9f0b-187d892b71ec.png)

The root issue, then, is that some people will choose to write their titles and articles with `&nbsp` instead of `" "`. I don't have the production DB in front of me to procure the statistic, but I would say that it's an extremely low sample size - those people that choose to encode their white space explicitly. 

## Added tests?

- [ ] yes
- [ ] no, because they aren't needed
- [x] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed