### PR TITLE
Add ApplicationRecord#errors_as_sentence

### DIFF
--- a/app/controllers/api/v0/articles_controller.rb
+++ b/app/controllers/api/v0/articles_controller.rb
@@ -34,7 +34,7 @@ module Api
         if @article.persisted?
           render "show", status: :created, location: @article.url
         else
-          message = @article.errors.full_messages.join(", ")
+          message = @article.errors_as_sentence
           render json: { error: message, status: 422 }, status: :unprocessable_entity
         end
       end

--- a/app/controllers/api_secrets_controller.rb
+++ b/app/controllers/api_secrets_controller.rb
@@ -11,7 +11,7 @@ class ApiSecretsController < ApplicationController
     if @secret.save
       flash[:notice] = "Your API Key has been generated: #{@secret.secret}"
     else
-      flash[:error] = @secret.errors.full_messages.to_sentence
+      flash[:error] = @secret.errors_as_sentence
     end
 
     redirect_back(fallback_location: root_path)

--- a/app/controllers/chat_channels_controller.rb
+++ b/app/controllers/chat_channels_controller.rb
@@ -42,7 +42,7 @@ class ChatChannelsController < ApplicationController
       flash[:settings_notice] = "Channel settings updated."
     else
       default_error_message = "Channel settings updation failed. Try again later."
-      flash[:error] = @chat_channel.errors.full_messages.to_sentence.presence || default_error_message
+      flash[:error] = @chat_channel.errors_as_sentence.presence || default_error_message
     end
     current_user_membership = @chat_channel.mod_memberships.find_by!(user: current_user)
     redirect_to edit_chat_channel_membership_path(current_user_membership)

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -224,7 +224,7 @@ class CommentsController < ApplicationController
     if @comment.save
       render json: { hidden: "true" }, status: :ok
     else
-      render json: { errors: @comment.errors.full_messages.join(", "), status: 422 }, status: :unprocessable_entity
+      render json: { errors: @comment.errors_as_sentence, status: 422 }, status: :unprocessable_entity
     end
   end
 
@@ -237,7 +237,7 @@ class CommentsController < ApplicationController
       @commentable&.update_column(:any_comments_hidden, @commentable.comments.pluck(:hidden_by_commentable_user).include?(true))
       render json: { hidden: "false" }, status: :ok
     else
-      render json: { errors: @comment.errors.full_messages.join(", "), status: 422 }, status: :unprocessable_entity
+      render json: { errors: @comment.errors_as_sentence, status: 422 }, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -104,7 +104,7 @@ class CommentsController < ApplicationController
       comment.destroy
       render json: { error: "comment already exists" }, status: :unprocessable_entity
     else
-      message = @comment.errors.full_messages.to_sentence
+      message = @comment.errors_as_sentence
       render json: { error: message }, status: :unprocessable_entity
     end
   # See https://github.com/thepracticaldev/dev.to/pull/5485#discussion_r366056925

--- a/app/controllers/internal/reactions_controller.rb
+++ b/app/controllers/internal/reactions_controller.rb
@@ -9,7 +9,7 @@ class Internal::ReactionsController < Internal::ApplicationController
       Moderator::SinkArticles.call(@reaction.reactable_id) if confirmed_vomit_reaction?
       render json: { outcome: "Success" }
     else
-      render json: { error: @reaction.errors.full_messages.to_sentence }, status: :unprocessable_entity
+      render json: { error: @reaction.errors_as_sentence }, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/internal/response_templates_controller.rb
+++ b/app/controllers/internal/response_templates_controller.rb
@@ -23,7 +23,7 @@ class Internal::ResponseTemplatesController < Internal::ApplicationController
       flash[:success] = "Response Template: \"#{@response_template.title}\" saved successfully."
       redirect_to internal_response_templates_path
     else
-      flash[:danger] = @response_template.errors.full_messages.to_sentence
+      flash[:danger] = @response_template.errors_as_sentence
       @response_templates = ResponseTemplate.page(params[:page]).per(50)
       render new_internal_response_template_path
     end
@@ -40,7 +40,7 @@ class Internal::ResponseTemplatesController < Internal::ApplicationController
       flash[:success] = "The response template \"#{@response_template.title}\" was updated."
       redirect_to edit_internal_response_template_path(@response_template)
     else
-      flash[:danger] = @response_template.errors.full_messages.to_sentence
+      flash[:danger] = @response_template.errors_as_sentence
       render :edit
     end
   end
@@ -51,7 +51,7 @@ class Internal::ResponseTemplatesController < Internal::ApplicationController
     if @response_template.destroy
       flash[:success] = "The response template \"#{@response_template.title}\" was deleted."
     else
-      flash[:danger] = @response_template.errors.full_messages.to_sentence # this will probably never fail
+      flash[:danger] = @response_template.errors_as_sentence # this will probably never fail
     end
 
     redirect_back(fallback_location: internal_response_templates_path)

--- a/app/controllers/internal/sponsorships_controller.rb
+++ b/app/controllers/internal/sponsorships_controller.rb
@@ -15,7 +15,7 @@ class Internal::SponsorshipsController < Internal::ApplicationController
       flash[:notice] = "Sponsorship was successfully updated"
       redirect_to internal_sponsorships_path
     else
-      flash[:danger] = @sponsorship.errors.full_messages.join(", ")
+      flash[:danger] = @sponsorship.errors_as_sentence
       render action: :edit
     end
   end

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -94,6 +94,6 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   def user_persisted_but_username_taken?
-    @user.persisted? && @user.errors.full_messages.join(", ").include?("username has already been taken")
+    @user.persisted? && @user.errors_as_sentence.include?("username has already been taken")
   end
 end

--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -88,7 +88,7 @@ class ReactionsController < ApplicationController
           Audit::Logger.log(:moderator, current_user, params.dup)
         end
       else
-        render json: { error: reaction.errors.full_messages.join(", "), status: 422 }, status: :unprocessable_entity
+        render json: { error: reaction.errors_as_sentence, status: 422 }, status: :unprocessable_entity
         return
       end
     end

--- a/app/controllers/response_templates_controller.rb
+++ b/app/controllers/response_templates_controller.rb
@@ -35,7 +35,7 @@ class ResponseTemplatesController < ApplicationController
       flash[:settings_notice] = "Your response template \"#{response_template.title}\" was created."
       redirect_to user_settings_path(tab: "response-templates", id: response_template.id)
     else
-      flash[:error] = "Response template error: #{response_template.errors.full_messages.to_sentence}"
+      flash[:error] = "Response template error: #{response_template.errors_as_sentence}"
       attributes = permitted_attributes(ResponseTemplate)
       redirect_to user_settings_path(
         tab: "response-templates",
@@ -52,7 +52,7 @@ class ResponseTemplatesController < ApplicationController
     if response_template.destroy
       flash[:settings_notice] = "Your response template \"#{response_template.title}\" was deleted."
     else
-      flash[:error] = response_template.errors.full_messages.to_sentence # this will probably never fail
+      flash[:error] = response_template.errors_as_sentence # this will probably never fail
     end
 
     redirect_to user_settings_path(tab: "response-templates")
@@ -66,7 +66,7 @@ class ResponseTemplatesController < ApplicationController
       flash[:settings_notice] = "Your response template \"#{response_template.title}\" was updated."
       redirect_to user_settings_path(tab: "response-templates", id: response_template.id)
     else
-      flash[:error] = "Response template error: #{response_template.errors.full_messages.to_sentence}"
+      flash[:error] = "Response template error: #{response_template.errors_as_sentence}"
       redirect_to user_settings_path(
         tab: "response-templates",
         id: response_template.id,

--- a/app/controllers/user_blocks_controller.rb
+++ b/app/controllers/user_blocks_controller.rb
@@ -24,7 +24,7 @@ class UserBlocksController < ApplicationController
       @user_block.blocked.stop_following(current_user)
       render json: { result: "blocked" }
     else
-      render json: { error: @user_block.errors.full_messages.join(", "), status: 422 }, status: :unprocessable_entity
+      render json: { error: @user_block.errors_as_sentence, status: 422 }, status: :unprocessable_entity
     end
   end
 
@@ -42,7 +42,7 @@ class UserBlocksController < ApplicationController
       UserBlocks::ChannelHandler.new(@user_block).unblock_chat_channel
       render json: { result: "unblocked" }
     else
-      render json: { error: @user_block.errors.full_messages.join(", "), status: 422 }, status: :unprocessable_entity
+      render json: { error: @user_block.errors_as_sentence, status: 422 }, status: :unprocessable_entity
     end
   end
 

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -49,4 +49,8 @@ class ApplicationRecord < ActiveRecord::Base
 
     raise UninferrableDecoratorError, "Could not infer a decorator for #{called_on.class.name}."
   end
+
+  def errors_as_sentence
+    errors.full_messages.to_sentence
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

I've been advocating the use of `errors.full_messages.to_sentence` over `errors.full_messages.join(' ')` for a while now. We're now using it in more places, so I added `ApplicationRecord#errors_as_sentence` to cut down on typing. I updated all existing usages that made sense and also replaced a few more manual `.join(' ')` calls.

## Related Tickets & Documents

n/a

## Added tests?

- [x] no, because they aren't needed

## Added to documentation?

- [X] no documentation needed
