### PR TITLE
Add missing unique indexes to notifications

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -82,7 +82,6 @@ Rails/UniqueValidationWithoutIndex:
     - 'app/models/article.rb'
     - 'app/models/comment.rb'
     - 'app/models/follow.rb'
-    - 'app/models/notification.rb'
     - 'app/models/broadcast.rb'
 
 # Offense count: 33

--- a/db/migrate/20200604133925_add_unique_index_to_notifications_user_id_organization_id_notifiable_action.rb
+++ b/db/migrate/20200604133925_add_unique_index_to_notifications_user_id_organization_id_notifiable_action.rb
@@ -1,0 +1,19 @@
+class AddUniqueIndexToNotificationsUserIdOrganizationIdNotifiableAction < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def change
+    return if index_exists?(
+      :notifications,
+      %i[user_id organization_id notifiable_id notifiable_type action],
+      name: :index_notifications_user_id_organization_id_notifiable_action
+    )
+
+    add_index(
+      :notifications,
+      %i[user_id organization_id notifiable_id notifiable_type action],
+      unique: true,
+      algorithm: :concurrently,
+      name: :index_notifications_user_id_organization_id_notifiable_action
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,15 +2,15 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_02_174329) do
+ActiveRecord::Schema.define(version: 2020_06_04_133925) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -683,6 +683,7 @@ ActiveRecord::Schema.define(version: 2020_06_02_174329) do
     t.index ["organization_id"], name: "index_notifications_on_organization_id"
     t.index ["user_id", "notifiable_id", "notifiable_type", "action"], name: "index_notifications_on_user_notifiable_and_action_not_null", unique: true, where: "(action IS NOT NULL)"
     t.index ["user_id", "notifiable_id", "notifiable_type"], name: "index_notifications_on_user_notifiable_action_is_null", unique: true, where: "(action IS NULL)"
+    t.index ["user_id", "organization_id", "notifiable_id", "notifiable_type", "action"], name: "index_notifications_user_id_organization_id_notifiable_action", unique: true
     t.index ["user_id"], name: "index_notifications_on_user_id"
   end
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Follow up to https://github.com/thepracticaldev/dev.to/pull/8215

This adds a unique index to the `notifications` table:

- `user_id organization_id notifiable_id notifiable_type action`

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## [optional] Are there any post deployment tasks we need to perform?

**pre-deployment**

we need to check if we have duplicates

```sql
select user_id, organization_id, notifiable_id, notifiable_type, action, count(*)
from notifications
group by user_id, organization_id, notifiable_id, notifiable_type, action
having count(*) > 1
```
