### PR TITLE
Bug Fix: Add Safety Operator When Handling params[:q]

### DIFF
--- a/app/views/articles/search.html.erb
+++ b/app/views/articles/search.html.erb
@@ -9,7 +9,7 @@
      data-articles-since="<%= Timeframer.new(params[:timeframe]).datetime&.iso8601 %>">
   <%= render "articles/search/sidebar" %>
   <div class="articles-list" id="articles-list">
-    <% if (params[:q].downcase == "job" || params[:q].downcase == "jobs") && SiteConfig.display_jobs_banner %>
+    <% if (params[:q]&.downcase == "job" || params[:q]&.downcase == "jobs") && SiteConfig.display_jobs_banner %>
       <div class="crayons-notice crayons-notice--info mb-3 fs-base">Interested in joining our team? Explore our <a href=<%= SiteConfig.jobs_url %>>open roles</a>.</div>
     <% end %>
     <div class="substories" id="substories">


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Apparently there are ways to get to the search page without running a query. This ensures we dont break when that happens. 

Fixes: https://app.honeybadger.io/fault/66984/7384a8699e342e581a79a069e69148d0
```
NoMethodError: undefined method `downcase' for nil:NilClass
 search.html.erb  12 _app_views_articles_search_html_erb(...)
[PROJECT_ROOT]/app/views/articles/search.html.erb:12:in `_app_views_articles_search_html_erb'
10   <%= render "articles/search/sidebar" %>
11   <div class="articles-list" id="articles-list">
12     <% if (params[:q].downcase == "job" || params[:q].downcase == "jobs") && SiteConfig.display_jobs_banner %>
13       <div class="crayons-notice crayons-notice--info mb-3 fs-base">Interested in joining our team? Explore our <a href=<%= SiteConfig.jobs_url %>>open roles</a>.</div>
14     <% end %>
```
## Added tests?
- [x] no, because they aren't needed

![alt_text](https://media.giphy.com/media/wAkP1CI7ZQty0/200.gif)
