### PR TITLE
Bug Fix: Change Cache Key to Bust Cache

### DIFF
--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -96,7 +96,7 @@ class ReactionsController < ApplicationController
   end
 
   def cached_user_public_reactions(user)
-    Rails.cache.fetch("cached_user_reactions-#{user.id}-#{user.public_reactions_count}", expires_in: 24.hours) do
+    Rails.cache.fetch("cached-user-reactions-#{user.id}-#{user.public_reactions_count}", expires_in: 24.hours) do
       user.reactions.public_category
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

Fixes: https://app.honeybadger.io/projects/66984/faults/64426845 which was caused by caching ActiveRecord objects that are not compatible with Rails 6. This changes the cache key so we start fresh. YES it is on my todo list to remove all of the AR object caching, I just haven't gotten to it yet. https://github.com/thepracticaldev/dev.to/projects/9#card-39519016

![alt_text](https://media.giphy.com/media/dM8fBhhhAmbaU/giphy.gif)
