### PR TITLE
Add q Back to Whitelist Params for Fastly

### DIFF
--- a/config/fastly/snippets/safe_params_list.vcl
+++ b/config/fastly/snippets/safe_params_list.vcl
@@ -1,7 +1,7 @@
 import querystring;
 sub vcl_recv {
     # return this URL with only the parameters that match this regular expression
-    if (req.url !~ "/internal/" && req.url !~ "/search/" && req.url !~ "/bulk_show") {
+    if (req.url !~ "/internal/" && req.url !~ "/search" && req.url !~ "/bulk_show") {
       set req.url = querystring.regfilter_except(req.url, "^(a_id|args|article_id|article_ids|articles|asc|callback_url|category|chat_channel_id|client_id|code|collection_id|commentable_id|commentable_type|confirmation_token|created_at|end|filter|followable_id|followable_type|fork_id|i|key|message_offset|name|oauth_token|oauth_verifier|offset|org_id|organization_id|p|page|per_page|prefill|preview|purchaser|reactable_ids|redirect_uri|reported_url|reporter_username|response_type|scope|search|signature|sort|start|state|status|tag|tag_list|top|type_of|url|username|ut|verb)$");
     }
 }

--- a/config/fastly/snippets/safe_params_list.vcl
+++ b/config/fastly/snippets/safe_params_list.vcl
@@ -1,7 +1,7 @@
 import querystring;
 sub vcl_recv {
     # return this URL with only the parameters that match this regular expression
-    if (req.url !~ "/internal/" && req.url !~ "/search" && req.url !~ "/bulk_show") {
-      set req.url = querystring.regfilter_except(req.url, "^(a_id|args|article_id|article_ids|articles|asc|callback_url|category|chat_channel_id|client_id|code|collection_id|commentable_id|commentable_type|confirmation_token|created_at|end|filter|followable_id|followable_type|fork_id|i|key|message_offset|name|oauth_token|oauth_verifier|offset|org_id|organization_id|p|page|per_page|prefill|preview|purchaser|reactable_ids|redirect_uri|reported_url|reporter_username|response_type|scope|search|signature|sort|start|state|status|tag|tag_list|top|type_of|url|username|ut|verb)$");
+    if (req.url !~ "/internal/" && req.url !~ "/search/" && req.url !~ "/bulk_show") {
+      set req.url = querystring.regfilter_except(req.url, "^(a_id|args|article_id|article_ids|articles|asc|callback_url|category|chat_channel_id|client_id|code|collection_id|commentable_id|commentable_type|confirmation_token|created_at|end|filter|followable_id|followable_type|fork_id|i|key|message_offset|name|oauth_token|oauth_verifier|offset|org_id|organization_id|p|page|per_page|prefill|preview|purchaser|q|reactable_ids|redirect_uri|reported_url|reporter_username|response_type|scope|search|signature|sort|start|state|status|tag|tag_list|top|type_of|url|username|ut|verb)$");
     }
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Earlier I merged [a PR](#8259) that tried to make use of `params[:q]` from the query. This however is not present bc this `/search` is not exempt from params whitelisting and q is not on the params list. This changes that so we can use that `params[:q]` to decide whether or not to show the jobs banner. 
 
## Added tests?
- [x] no, because they aren't needed


![alt_text](https://static.wixstatic.com/media/12b46c_57722790f76e4eca8d57f078e93b60aa~mv2.gif)
