### PR TITLE
Stub Percy.snapshot During Specs

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -82,7 +82,8 @@ RSpec.configure do |config|
   end
 
   config.before do
-    Sidekiq::Worker.clear_all # worker jobs shouldn't linger around between tests
+    # Worker jobs shouldn't linger around between tests
+    Sidekiq::Worker.clear_all
   end
 
   config.around(:each, elasticsearch_reset: true) do |example|
@@ -146,6 +147,9 @@ RSpec.configure do |config|
 
     stub_request(:post, "http://www.google-analytics.com/collect").
       to_return(status: 200, body: "", headers: {})
+
+    # Prevent Percy.snapshot from trying to hit the agent while not in use
+    allow(Percy).to receive(:snapshot)
   end
 
   OmniAuth.config.test_mode = true


### PR DESCRIPTION
# What type of PR is this? (check all applicable)
- [x] Optimization

## Description
I did some digging into Percy and found that even when we are not running the agent, [`Percy.snapshot` will still attempt to make a request to the agent every time it is called.](https://github.com/percy/percy-capybara/blob/ffe355ef3e2c5544c9a1215eb03d463ada5cc450/lib/percy.rb#L109) which can waste time. It's not a ton but its something. This stubs that request and eliminates the HTTP call. 

What do you all think? Honestly, I want to remove it to try and simplify our spec suite as I try and make the leap to parallel builds but I also didn't want to shut this all down completely if we want to use it in the future. 

Requests being made during a build
<img width="1022" alt="Screen Shot 2020-06-04 at 5 11 55 PM" src="https://user-images.githubusercontent.com/1813380/83815925-dfdf4000-a686-11ea-8919-e08891650e8e.png">

## Added tests?
- [x] no, because they aren't needed

![alt_text](https://media.giphy.com/media/3ohzdUaDt5KnvdzuJa/giphy.gif)
