### PR TITLE
Remove Explict Gemfile from travis.yml to Allow vendor/cache to be used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ addons:
       - $(ls tmp/screenshots/*.png | tr "\n" ":")
       - $(ls tmp/csvs/*.csv | tr "\n" ":")
     debug: true
-gemfile:
-- Gemfile
 services:
   - redis-server
 env:


### PR DESCRIPTION
# What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
The addition of this line seems to be preventing bundler from using `vendor/cache` and causing it to install all of the gems for new builds so I removed it. These lines were added in our Rails 6 PR #7658 but based [on the comment](https://github.com/thepracticaldev/dev.to/pull/7658/files#r432139357) and the fact that the specs run green I dont think we need it.

![alt_text](https://media1.tenor.com/images/475f6f0eed82379c810e6f372e4551fa/tenor.gif?itemid=8479349)
