### PR TITLE
fix footnote anchor tag misposition

### DIFF
--- a/app/assets/stylesheets/article-show.scss
+++ b/app/assets/stylesheets/article-show.scss
@@ -50,6 +50,12 @@
   }
 }
 
+body.default-navbar-config {
+  .article .body [id] {
+    scroll-margin-top: var(--header-height);
+  }
+}
+
 article {
   padding: 0 0;
   position: relative;

--- a/app/assets/stylesheets/top-bar.scss
+++ b/app/assets/stylesheets/top-bar.scss
@@ -2,9 +2,10 @@
 @import 'variables';
 @import 'mixins';
 
-:target {
-  padding-top: var(--header-height);
-  margin-top: calc(-1 * var(--header-height));
+body.default-navbar-config {
+  .article .body [id] {
+    scroll-margin-top: var(--header-height);
+  }
 }
 
 .top-bar {

--- a/app/assets/stylesheets/top-bar.scss
+++ b/app/assets/stylesheets/top-bar.scss
@@ -2,6 +2,11 @@
 @import 'variables';
 @import 'mixins';
 
+:target {
+  padding-top: var(--header-height) !important;
+  margin-top: calc(-1 * var(--header-height)) !important;
+}
+
 .top-bar {
   --indicator-outline: var(--header-bg);
   --dropdown-display: none;

--- a/app/assets/stylesheets/top-bar.scss
+++ b/app/assets/stylesheets/top-bar.scss
@@ -3,8 +3,8 @@
 @import 'mixins';
 
 :target {
-  padding-top: var(--header-height) !important;
-  margin-top: calc(-1 * var(--header-height)) !important;
+  padding-top: var(--header-height);
+  margin-top: calc(-1 * var(--header-height));
 }
 
 .top-bar {

--- a/app/assets/stylesheets/top-bar.scss
+++ b/app/assets/stylesheets/top-bar.scss
@@ -2,12 +2,6 @@
 @import 'variables';
 @import 'mixins';
 
-body.default-navbar-config {
-  .article .body [id] {
-    scroll-margin-top: var(--header-height);
-  }
-}
-
 .top-bar {
   --indicator-outline: var(--header-bg);
   --dropdown-display: none;


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When following links to footnotes and back from footnotes the line with the anchor gets hidden behind the top bar. This is due to the fact that we have to offset an html anchor to adjust for fixed header.

The solution is to add something like this to the CSS:

```css
:target {
  padding-top: var(--header-height);
  margin-top: calc(-1 * var(--header-height));
}
```

Once we make that change, we no longer have the problem referenced at issue #7760. The header no longer covers the footnote.

![Screenshot from 2020-06-05 11-14-45](https://user-images.githubusercontent.com/60417145/83893365-da810480-a71d-11ea-8565-693b10d87a09.png)

The JavaScript solution was originally considered, where we listen to the `onhashchange` event. On change we want to select the dom element and use `window.scrollTo()` to scroll to the correct Y position using position data from `getboundingclientrect()`. Ultimately, the CSS solution was preferred for its simplicity.

## To Reproduce

Author an article and view/preview it. The article should have anchor tags that refer to in-document ids (in-page anchors).

```html
<p>This is a test <sup id="fnref1"><a href="#fn1">1</a></sup>.</p>

<p>This is just some random content to fill the space.</p>

<ol>
  <li id="fn1">
    <p>A test.&nbsp;<a href="#fnref1">↩</a></p>
  </li>
</ol>
```

Then click on one of any in-page anchor and you should navigated to the correct position in the document.
 
## Related Tickets & Documents

This PR attempts to resolve issue #7760.

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
