### PR TITLE
Enable ActsAsTaggableOn.strict_case_match

### DIFF
--- a/config/initializers/acts_as_taggable_on.rb
+++ b/config/initializers/acts_as_taggable_on.rb
@@ -1,1 +1,2 @@
 ActsAsTaggableOn.force_lowercase = true
+ActsAsTaggableOn.strict_case_match = true


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This is a nice default to have. Instead of relying on sql's `LIKE` during tag find_or_create to pick up a bad tag, it will be case strict.
## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/pull/8175
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
n/a
## Added tests?
- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a