### PR TITLE
Display site-wide announcements

### DIFF
--- a/app/assets/javascripts/initializePage.js
+++ b/app/assets/javascripts/initializePage.js
@@ -10,7 +10,7 @@
   initializeUserProfilePage, initializePodcastPlayback, initializeDrawerSliders,
   initializeHeroBannerClose, initializeOnboardingTaskCard, initScrolling,
   nextPage:writable, fetching:writable, done:writable, adClicked:writable,
-  initializeSpecialNavigationFunctionality
+  initializeSpecialNavigationFunctionality, initializeBroadcast
 */
 
 function callInitializers() {
@@ -25,6 +25,7 @@ function callInitializers() {
         initializeAllChatButtons();
         initializeAllTagEditButtons();
       }
+      initializeBroadcast();
       initializeAllFollowButts();
       initializeUserFollowButts();
       initializeReadingListIcons();

--- a/app/assets/javascripts/initializers/initializeBodyData.js
+++ b/app/assets/javascripts/initializers/initializeBodyData.js
@@ -20,6 +20,7 @@ function fetchBaseData() {
   }
   xmlhttp.onreadystatechange = () => {
     if (xmlhttp.readyState === XMLHttpRequest.DONE) {
+      // Assigning CSRF
       var json = JSON.parse(xmlhttp.responseText);
       if (json.token) {
         removeExistingCSRF();
@@ -33,6 +34,14 @@ function fetchBaseData() {
       newCsrfTokenMeta.content = json.token;
       document.getElementsByTagName('head')[0].appendChild(newCsrfTokenMeta);
       document.getElementsByTagName('body')[0].dataset.loaded = 'true';
+
+      // Assigning Broadcast
+      if (json.broadcast) {
+        document.getElementsByTagName('body')[0].dataset.broadcast =
+          json.broadcast;
+      }
+
+      // Assigning User
       if (checkUserLoggedIn()) {
         document.getElementsByTagName('body')[0].dataset.user = json.user;
         browserStoreCache('set', json.user);

--- a/app/assets/javascripts/initializers/initializeBodyData.js
+++ b/app/assets/javascripts/initializers/initializeBodyData.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 /* global checkUserLoggedIn */
 
@@ -37,8 +37,7 @@ function fetchBaseData() {
 
       // Assigning Broadcast
       if (json.broadcast) {
-        document.getElementsByTagName('body')[0].dataset.broadcast =
-          json.broadcast;
+        document.body.dataset.broadcast = json.broadcast;
       }
 
       // Assigning User

--- a/app/assets/javascripts/initializers/initializeBroadcast.js
+++ b/app/assets/javascripts/initializers/initializeBroadcast.js
@@ -1,0 +1,25 @@
+/**
+ * Parses the broadcast object on the document into JSON.
+ *
+ * @function broadcastData
+ */
+function broadcastData() {
+  const { broadcast = null } = document.body.dataset;
+  return JSON.parse(broadcast);
+}
+
+/**
+ * Inserts the broadcast's HTML into `active-broadcast` element
+ * as the first child within the document's body, and only inserts the HTML once.
+ *
+ * @function initializeBroadcast
+ */
+function initializeBroadcast() {
+  const { html } = broadcastData();
+  var el = document.getElementById('active-broadcast');
+
+  if (el.firstElementChild) {
+    return;
+  } // Only append HTML once, on first render.
+  el.insertAdjacentHTML('afterbegin', html);
+}

--- a/app/assets/javascripts/initializers/initializeBroadcast.js
+++ b/app/assets/javascripts/initializers/initializeBroadcast.js
@@ -5,6 +5,7 @@
  */
 function broadcastData() {
   const { broadcast = null } = document.body.dataset;
+
   return JSON.parse(broadcast);
 }
 
@@ -15,7 +16,11 @@ function broadcastData() {
  * @function initializeBroadcast
  */
 function initializeBroadcast() {
-  const { html } = broadcastData();
+  if (!broadcastData()) {
+    return;
+  }
+  const { html = null } = broadcastData();
+
   var el = document.getElementById('active-broadcast');
 
   if (el.firstElementChild) {

--- a/app/assets/javascripts/initializers/initializeBroadcast.js
+++ b/app/assets/javascripts/initializers/initializeBroadcast.js
@@ -16,10 +16,11 @@ function broadcastData() {
  * @function initializeBroadcast
  */
 function initializeBroadcast() {
-  if (!broadcastData()) {
+  const data = broadcastData();
+  if (!data) {
     return;
   }
-  const { html = null } = broadcastData();
+  const { html } = data;
 
   var el = document.getElementById('active-broadcast');
 

--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -242,6 +242,14 @@ body.hidden-shell {
   z-index: -1;
 }
 
+.broadcast-wrapper {
+  // TODO: [@thepracticaldev/delightful]: Remove these styles once
+  // https://github.com/thepracticaldev/dev.to/pull/8234 is merged.
+  z-index: 101; // Must be higher than the z-index of the sticky-nav.
+  position: fixed;
+  width: 100%;
+}
+
 @keyframes loading-fadein {
   from {
     opacity: 0;

--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -164,10 +164,24 @@ body.ten-x-hacker-theme {
   }
 }
 
+.broadcast-wrapper {
+  // TODO: [@thepracticaldev/delightful]: Remove these styles once
+  // https://github.com/thepracticaldev/dev.to/pull/8234 is merged.
+  z-index: 101; // Must be higher than the z-index of the sticky-nav.
+  position: fixed;
+  width: 100%;
+  font-size: 20px;
+  text-align: center;
+}
+
 body.static-navbar-config {
   padding-top: 0;
   .top-bar {
     position: relative !important;
+  }
+
+  .broadcast-wrapper {
+    position: relative; // Unset fixed position for static navbar config.
   }
 }
 
@@ -193,7 +207,7 @@ body.hidden-shell {
   }
 }
 
-// Remove post confirmaiton
+// Remove post confirmation
 .delete-confirm.container {
   padding: 150px 10px;
   min-height: 300px;
@@ -240,14 +254,6 @@ body.hidden-shell {
   animation-delay: 0.6s;
   font-size: 1.2em;
   z-index: -1;
-}
-
-.broadcast-wrapper {
-  // TODO: [@thepracticaldev/delightful]: Remove these styles once
-  // https://github.com/thepracticaldev/dev.to/pull/8234 is merged.
-  z-index: 101; // Must be higher than the z-index of the sticky-nav.
-  position: fixed;
-  width: 100%;
 }
 
 @keyframes loading-fadein {

--- a/app/views/internal/broadcasts/_form.html.erb
+++ b/app/views/internal/broadcasts/_form.html.erb
@@ -14,3 +14,12 @@
   <%= select_tag :active, options_for_select([false, true]) %>
 </div>
 <br>
+
+<% if @broadcast.processed_html %>
+  <div>
+    </p><strong>Preview</strong></p>
+    <%= @broadcast.processed_html.html_safe %>
+    </p><em>Please note: Announcement Broadcasts will render directly below the nav bar.</em></p>
+  <div>
+<% end %>
+<br>

--- a/app/views/internal/broadcasts/_form.html.erb
+++ b/app/views/internal/broadcasts/_form.html.erb
@@ -18,7 +18,7 @@
 <% if @broadcast.processed_html %>
   <div>
     </p><strong>Preview</strong></p>
-    <%= @broadcast.processed_html.html_safe %>
+    <%= sanitize @broadcast.processed_html, attributes: %w[href style src] %>
     </p><em>Please note: Announcement Broadcasts will render directly below the nav bar.</em></p>
   <div>
 <% end %>

--- a/app/views/internal/broadcasts/_form.html.erb
+++ b/app/views/internal/broadcasts/_form.html.erb
@@ -7,11 +7,11 @@
 </div>
 <div class="form-group">
   <%= label_tag :type, "Type:" %>
-  <%= select_tag "type_of", options_for_select(%w[Welcome Announcement]) %>
+  <%= select_tag "type_of", options_for_select(%w[Welcome Announcement], selected: @broadcast.type_of) %>
 </div>
 <div class="form-group">
   <%= label_tag :active, "Active:" %>
-  <%= select_tag :active, options_for_select([false, true]) %>
+  <%= select_tag :active, options_for_select([false, true], selected: @broadcast.active) %>
 </div>
 <br>
 

--- a/app/views/shell/_top.html.erb
+++ b/app/views/shell/_top.html.erb
@@ -58,6 +58,7 @@
           <%= yield(:audio) %>
         </div>
         <%= render "layouts/top_bar" %>
+        <div id="active-broadcast"></div>
         <div id="message-notice"></div>
         <div class="app-shell-loader">
           loading...

--- a/app/views/shell/_top.html.erb
+++ b/app/views/shell/_top.html.erb
@@ -58,7 +58,7 @@
           <%= yield(:audio) %>
         </div>
         <%= render "layouts/top_bar" %>
-        <div id="active-broadcast"></div>
+        <div id="active-broadcast" class="broadcast-wrapper"></div>
         <div id="message-notice"></div>
         <div class="app-shell-loader">
           loading...

--- a/spec/factories/broadcasts.rb
+++ b/spec/factories/broadcasts.rb
@@ -65,7 +65,7 @@ FactoryBot.define do
     factory :announcement_broadcast do
       title          { "A Very Important Announcement" }
       type_of        { "Announcement" }
-      processed_html { "Hello, World!" }
+      processed_html { "<div style='background-color: salmon;'><p style='width: 100%;'>Hello, World!</p></div>" }
     end
   end
 end

--- a/spec/requests/async_info_spec.rb
+++ b/spec/requests/async_info_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe "AsyncInfo", type: :request do
     context "when not logged-in" do
       before { get "/async_info/base_data" }
 
+      it "returns broadcast" do
+        expect(response.body).to include("broadcast")
+      end
+
       it "returns token" do
         expect(response.body).to include("token")
       end
@@ -25,7 +29,7 @@ RSpec.describe "AsyncInfo", type: :request do
         allow(controller_instance).to receive(:remember_user_token).and_return(nil)
         sign_in create(:user)
         get "/async_info/base_data"
-        expect(response.body).to include("token", "user")
+        expect(response.body).to include("broadcast", "token", "user")
       end
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This feature allows active announcement broadcasts to be displayed, site-wide.

Specifically, this PR does the following: 
- [x] Adds a `broadcast:` key to our `AsyncInfoController`'s `base_data`, regardless of whether a user is logged in or not. If a broadcast is not present, passes along a `nil` value.
- [x] Initializes the active broadcast (if present) when rendering _any_ page.
- [x] Allows admins to preview a broadcast's `processed_html` when editing the broadcast on `/internal/broadcasts/:id`.
- [x] Adds specs around serializing and rendering an active broadcast (request + system-level specs).
- [x] Add some temporary styling to the broadcast banner such that it is `fixed` to the top of the page, below the nav. I actually don't really like how this looks, but it ensures that the broadcast renders with the highest `z-index` on an article page. **HOWEVER, once https://github.com/thepracticaldev/dev.to/pull/8234 is merged, the default style on a broadcast will Just Work™️, and we can remove this styling (you'll notice I added a TODO for this).**

The next step in this feature will be https://github.com/thepracticaldev/dev.to/issues/8091, which will allow the user to dismiss this active announcement. But, since this feature isn't being used yet in production and it doesn't affect any users just yet, I'll be handling that in a subsequent PR.

## Related Tickets & Documents
Closes https://github.com/thepracticaldev/dev.to/issues/8090.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
**TO QA THIS PR:**
1. Go to `/internal/broadcasts`, and create/update a broadcast with some html/inline css. Once you save it, you can preview the broadcast and update it to be active:
<img width="1077" alt="Screen_Shot_2020-06-04_at_4_39_31_PM" src="https://user-images.githubusercontent.com/6921610/83911342-f33ee980-a720-11ea-97df-cae17b608954.png">
2. Go to any page on the site. You should see the broadcast displayed:
<img width="1520" alt="Screen Shot 2020-06-04 at 4 39 48 PM" src="https://user-images.githubusercontent.com/6921610/83911119-980cf700-a720-11ea-9ab7-c6650b7dc3bc.png">
3. Try setting that same broadcast to "inactive" from the internal page. You should no longer see the broadcast displayed anywhere on the site!

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## Are there any post deployment tasks we need to perform?
Nope!

## What gif best describes this PR or how it makes you feel?

![Seth Meyers has an announcement gif](https://media2.giphy.com/media/3o6ZteOz7Uz6bE4l6U/giphy.webp?cid=5a38a5a2ff17f22b5534bfecd9c831f8e3bd581d9903a464&rid=giphy.webp)
