### PR TITLE
Flaky Spec Fix: Bulk Delete SQL Spec

### DIFF
--- a/spec/services/bulk_sql_delete_spec.rb
+++ b/spec/services/bulk_sql_delete_spec.rb
@@ -7,7 +7,7 @@ describe BulkSqlDelete, type: :service do
       WHERE notifications.id IN (
         SELECT notifications.id
         FROM notifications
-        WHERE created_at < '#{Time.zone.now}'
+        WHERE created_at < '#{Time.current}'
         LIMIT 1
       )
     SQL
@@ -40,7 +40,10 @@ describe BulkSqlDelete, type: :service do
 
     it "deletes all records in batches" do
       create_list :notification, 5, created_at: 1.month.ago
-      expect { described_class.delete_in_batches(sql) }.to change(Notification, :count).from(5).to(0)
+      expect(Notification.count).to eq(5)
+      result = described_class.delete_in_batches(sql)
+      expect(Notification.count).to eq(0)
+      expect(result).to eq(5)
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
In my Knapsack branch this spec would fail about 50% of the time bc the count of Notifications did not change after the delete was wrong. I think it might be something to so with the way the expect block executes and the SQL statement possibly getting rolledback due to database cleaning before the assertion. Changing it to be explicit like this seems to have fixed the problem. I would get this spec to fail almost every run before and with this change it has yet to fail after 4 runs. 

Failed specs are our internal flaky ones, unrelated to this change. 

![alt_text](https://media2.giphy.com/media/3o6nV8TW8AZOqkOHVm/giphy.gif)
