### PR TITLE
Make Video Permission a Valid Role

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -12,6 +12,7 @@ class Role < ApplicationRecord
     mod_relations_admin
     tech_admin
     trusted
+    video_permission
     warned
     workshop_pass
   ].freeze

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Role, type: :model do
         admin banned chatroom_beta_tester comment_banned
         podcast_admin pro single_resource_admin super_admin
         tag_moderator mod_relations_admin tech_admin
-        trusted warned workshop_pass
+        trusted video_permission warned workshop_pass
       ]
       expect(described_class::ROLES).to eq(expected_roles)
     end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
When we validate a role we check to make sure it is included in our list of `Role::ROLES` which lists the names of all the roles we have. One of the things we are doing to fix our spec suite is ensure roles are correctly added during tests. This uncovered the fact that this was a role we could not successfully add bc it was not valid. This fixes that. 
 
## Added tests?
- [x] yes

![alt_text](https://media2.giphy.com/media/SnWWy34anWNqg/200.gif)
