### PR TITLE
Cofigure config.hosts on GitPod

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -17,3 +17,4 @@ RUN wget "${ES_REPO}/${ES_ARCHIVE}" \
   && wget "${ES_REPO}/${ES_ARCHIVE}.sha512" \
   && shasum -a 512 -c ${ES_ARCHIVE}.sha512 \
   && tar -xzf ${ES_ARCHIVE}
+

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -74,7 +74,9 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-  config.hosts << ENV["APP_DOMAIN"] unless ENV["APP_DOMAIN"].nil?
+  if (host = ENV["GITPOD_WORKSPACE_URL"].presence || ENV["APP_DOMAIN"].presence)
+    config.hosts << host
+  end
   config.app_domain = "localhost:3000"
 
   config.action_mailer.default_url_options = { host: "localhost:3000" }


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Description

Rails 6 only allows requests from localhost, for accepting requests from other hosts `config.hosts` needs to be set. #8295 addresses this for our local development workflow and this PR fixes the issue on GitPod as well.

## Related Tickets & Documents

Closes #8458

## Added tests?

- [X] no, because they aren't needed

## Added to documentation?

- [X] no documentation needed
