### PR TITLE
Use official Asciinema player embed

### DIFF
--- a/app/javascript/article-form/articleForm.jsx
+++ b/app/javascript/article-form/articleForm.jsx
@@ -32,6 +32,17 @@ export default class ArticleForm extends Component {
     activateRunkitTags();
   }
 
+  // Scripts inserted via innerHTML won't execute, so we use this handler to
+  // make the Asciinema player work in previews.
+  static handleAsciinemaPreview() {
+    const els = document.getElementsByClassName('ltag_asciinema');
+    for (let i = 0; i < els.length; i += 1) {
+      const el = els[i];
+      const script = el.removeChild(el.firstElementChild);
+      postscribe(el, script.outerHTML);
+    }
+  }
+
   static propTypes = {
     version: PropTypes.string.isRequired,
     article: PropTypes.string.isRequired,
@@ -103,6 +114,7 @@ export default class ArticleForm extends Component {
     if (previewResponse) {
       this.constructor.handleGistPreview();
       this.constructor.handleRunkitPreview();
+      this.constructor.handleAsciinemaPreview();
     }
   }
 

--- a/app/views/liquids/_asciinema.html.erb
+++ b/app/views/liquids/_asciinema.html.erb
@@ -1,9 +1,3 @@
 <div class="ltag_asciinema">
-  <iframe frameborder="0"
-    scrolling="no"
-    id="asciinema_<%= id %>"
-    src="https://asciinema.org/a/<%= id %>/iframe"
-    loading="lazy"
-    style="width:100%;height:50vh;">
-  </iframe>
+  <script id="asciicast-<%= id %>" src="https://asciinema.org/a/<%= id %>.js" async></script>
 </div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Description

1. While doing the [original PR](4152) we noticed that the Asciinema IFrames are quite small, so added a `vh50` attribute to them (`style="width:100%;height:50vh;"`).
2. The problem with hardcoding this value: every Asciinema recording has a different width and height, and the site doesn't scale them in any way to avoid legibility issues. Instead, they emit an event containing the proper size after the video is loaded.
3. The event is then handled by [this JS function](https://github.com/asciinema/asciinema-server/blob/7250aaca1cc739bf53de9c3e804dbe6a431b4ef2/app/assets/javascripts/widget.js#L71-L82) for resizing the IFrame based on an event. 

All of this is handled by their official player embed and this PR replaces the direct IFrame embed with a script tag. 

## Related Tickets & Documents

#8185

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Screenshot of a properly resized player with one of the examples linked in the issue:

<img width="783" alt="Screen Shot 2020-06-08 at 15 16 19" src="https://user-images.githubusercontent.com/47985/84007712-052bc100-a99b-11ea-9491-247ec938bd64.png">

The other video linked in the issue:

<img width="748" alt="Screen Shot 2020-06-08 at 15 17 30" src="https://user-images.githubusercontent.com/47985/84007852-30161500-a99b-11ea-8b18-a1711b77e31b.png">

## Added tests?

- [X] Existing tests were recently amended in the refactor PR (#8288).

## Added to documentation?

- [X] no documentation needed
