### PR TITLE
Replace whitelisted_ips with permissions in Docker init

### DIFF
--- a/config/initializers/docker.rb
+++ b/config/initializers/docker.rb
@@ -9,5 +9,5 @@ if Rails.env.development? && File.file?("/.dockerenv")
     BetterErrors::Middleware.allow_ip!(host_ip)
   end
 
-  Rails.application.config.web_console.whitelisted_ips << host_ip
+  Rails.application.config.web_console.permissions = host_ip
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Rails [web-console](https://github.com/rails/web-console) officially uses the `.permissions` settings instead of the deprecated `.whitelisted_ips`. I've updated the code to follow suit.

## Related Tickets & Documents

See https://github.com/rails/web-console#configweb_consolepermissions

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
