### PR TITLE
Remove video_permissions Role Reference From Specs and Code

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -12,7 +12,6 @@ class Role < ApplicationRecord
     mod_relations_admin
     tech_admin
     trusted
-    video_permission
     warned
     workshop_pass
   ].freeze

--- a/app/services/moderator/manage_activity_and_roles.rb
+++ b/app/services/moderator/manage_activity_and_roles.rb
@@ -25,7 +25,6 @@ module Moderator
     end
 
     def remove_privileges
-      @user.remove_role :video_permission
       @user.remove_role :workshop_pass
       @user.remove_role :pro
       remove_mod_roles

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -73,10 +73,6 @@ FactoryBot.define do
       after(:build) { |user| user.add_role(:banned) }
     end
 
-    trait :video_permission do
-      after(:build) { |user| user.created_at = 3.weeks.ago }
-    end
-
     trait :ignore_mailchimp_subscribe_callback do
       after(:build) do |user|
         user.define_singleton_method(:subscribe_to_mailchimp_newsletter) {}

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Role, type: :model do
         admin banned chatroom_beta_tester comment_banned
         podcast_admin pro single_resource_admin super_admin
         tag_moderator mod_relations_admin tech_admin
-        trusted video_permission warned workshop_pass
+        trusted warned workshop_pass
       ]
       expect(described_class::ROLES).to eq(expected_roles)
     end

--- a/spec/requests/api/v0/videos_spec.rb
+++ b/spec/requests/api/v0/videos_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Api::V0::Videos", type: :request do
-  let_it_be_readonly(:user) { create(:user, :video_permission) }
+  let(:user) { create(:user, created_at: 1.month.ago) }
 
   def create_article(article_params = {})
     default_params = {

--- a/spec/requests/videos_spec.rb
+++ b/spec/requests/videos_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Videos", type: :request do
   let(:unauthorized_user) { create(:user) }
-  let(:authorized_user)   { create(:user, :video_permission) }
+  let(:authorized_user)   { create(:user, created_at: 1.month.ago) }
 
   describe "GET /videos" do
     it "shows video page" do

--- a/spec/system/internal/admin_bans_or_warns_user_spec.rb
+++ b/spec/system/internal/admin_bans_or_warns_user_spec.rb
@@ -61,14 +61,12 @@ RSpec.describe "Admin bans user", type: :system do
 
   it "removes other roles if user is banned" do
     user.add_role :trusted
-    user.add_role :video_permission
     add_tag_moderator_role
     ban_user
 
     expect(user.banned).to eq(true)
     expect(user.trusted).to eq(false)
     expect(user.warned).to eq(false)
-    expect(user.has_role?(:video_permission)).to eq(false)
     expect(user.has_role?(:tag_modertor)).to eq(false)
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
We are not using the video_permissions role that is referenced in our codebase so this removes it and replaces it with the actual video authorization method which is ensuring the user was created more than 2 weeks ago. 

Spec Failure is a flaky one 

@snackattas 

![alt_text](https://media.giphy.com/media/2yyJ9hUwolK1oin2q1/giphy.gif)
