### PR TITLE
Spec Speed Up: Comment Out Percy Only Specs

### DIFF
--- a/spec/system/dashboards/user_scrolls_down_dashboard_follows_spec.rb
+++ b/spec/system/dashboards/user_scrolls_down_dashboard_follows_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe "Infinite scroll on dashboard", type: :system, js: true do
       visit "/dashboard/user_followers?per_page=#{default_per_page}"
     end
 
-    it "renders the page", percy: true do
+    # TODO: Uncomment this spec when we decide to use percy again
+    xit "renders the page", percy: true do
       Percy.snapshot(page, name: "Homepage: /dashboard/user_followers?per_page= infinite scroll")
     end
 
@@ -68,7 +69,8 @@ RSpec.describe "Infinite scroll on dashboard", type: :system, js: true do
       visit dashboard_following_users_path(per_page: default_per_page)
     end
 
-    it "renders the page", percy: true do
+    # TODO: Uncomment this spec when we decide to use percy again
+    xit "renders the page", percy: true do
       Percy.snapshot(page, name: "Homepage: /dashboard/following_users infinite scroll")
     end
 
@@ -87,7 +89,8 @@ RSpec.describe "Infinite scroll on dashboard", type: :system, js: true do
       visit dashboard_following_organizations_path(per_page: default_per_page)
     end
 
-    it "renders the page", percy: true do
+    # TODO: Uncomment this spec when we decide to use percy again
+    xit "renders the page", percy: true do
       Percy.snapshot(page, name: "Homepage: /dashboard/following_organizations infinite scroll")
     end
 

--- a/spec/system/homepage/user_visits_homepage_spec.rb
+++ b/spec/system/homepage/user_visits_homepage_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe "User visits a homepage", type: :system do
   context "when user hasn't logged in" do
     before { visit "/" }
 
-    it "renders the page", js: true, percy: true do
+    # TODO: Uncomment this spec when we decide to use percy again
+    xit "renders the page", js: true, percy: true do
       Percy.snapshot(page, name: "Visits homepage: logged out user")
     end
 
@@ -44,7 +45,8 @@ RSpec.describe "User visits a homepage", type: :system do
       sign_in(user)
     end
 
-    it "renders the page", js: true, percy: true do
+    # TODO: Uncomment this spec when we decide to use percy again
+    xit "renders the page", js: true, percy: true do
       Percy.snapshot(page, name: "Visits homepage: logged in user")
     end
 

--- a/spec/system/user/view_user_index_spec.rb
+++ b/spec/system/user/view_user_index_spec.rb
@@ -68,7 +68,8 @@ RSpec.describe "User index", type: :system do
       visit "/user3000"
     end
 
-    it "renders the page", js: true, percy: true do
+    # TODO: Uncomment this spec when we decide to use percy again
+    xit "renders the page", js: true, percy: true do
       Percy.snapshot(page, name: "User: /:user_id renders with organization membership")
     end
 
@@ -83,7 +84,8 @@ RSpec.describe "User index", type: :system do
       visit "/user3000"
     end
 
-    it "renders the page", js: true, percy: true do
+    # TODO: Uncomment this spec when we decide to use percy again
+    xit "renders the page", js: true, percy: true do
       Percy.snapshot(page, name: "User: /:user_id for logged in user's own profile")
     end
 

--- a/spec/system/user_uses_the_editor_spec.rb
+++ b/spec/system/user_uses_the_editor_spec.rb
@@ -33,7 +33,8 @@ RSpec.describe "Using the editor", type: :system do
       page.evaluate_script("window.onbeforeunload = function(){}")
     end
 
-    it "renders the page", percy: true do
+    # TODO: Uncomment this spec when we decide to use percy again
+    xit "renders the page", percy: true do
       Percy.snapshot(page, name: "Using the editor: preview an article")
     end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Spec Optimization

## Description
We have a few specs that were just being used to take Percy snapshots. When we run these specs we still have to execute all the before actions and possibly setup data. This marks those specs on pending so we dont waste time executing them when they will do nothing. 

Travis Failure due to flaky spec. 

![alt_text](https://media.giphy.com/media/T5wQ1H6gtClt6/giphy.gif)
