### PR TITLE
Spec Speedup: Comment Out More Percy Only Specs

### DIFF
--- a/spec/system/articles/user_creates_an_article_spec.rb
+++ b/spec/system/articles/user_creates_an_article_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe "Creating an article with the editor", type: :system do
     sign_in user
   end
 
-  it "renders the page", js: true, percy: true do
+  # TODO: Uncomment this spec when we decide to use percy again
+  xit "renders the page", js: true, percy: true do
     visit new_path
     fill_in "article_body_markdown", with: template
     click_button "Save changes"

--- a/spec/system/articles/user_deletes_an_article_spec.rb
+++ b/spec/system/articles/user_deletes_an_article_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe "Deleting Article", type: :system do
     click_on "DELETE"
   end
 
-  it "renders the page", js: true, percy: true do
+  # TODO: Uncomment this spec when we decide to use percy again
+  xit "renders the page", js: true, percy: true do
     # Take snapshot before confirming deletion
     Percy.snapshot(page, name: "Article: confirm deletion")
   end

--- a/spec/system/articles/user_edits_an_article_spec.rb
+++ b/spec/system/articles/user_edits_an_article_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe "Editing with an editor", type: :system, js: true do
     sign_in user
   end
 
-  it "renders the page when user previews their changes", percy: true do
+  # TODO: Uncomment this spec when we decide to use percy again
+  xit "renders the page when user previews their changes", percy: true do
     visit "/#{user.username}/#{article.slug}/edit"
     fill_in "article_body_markdown", with: template.gsub("Suspendisse", "Yooo")
     click_button("Preview")
@@ -37,7 +38,8 @@ RSpec.describe "Editing with an editor", type: :system, js: true do
     expect(page).to have_text("Unpublished Post.")
   end
 
-  it "renders the page when user unpublishes their post", percy: true do
+  # TODO: Uncomment this spec when we decide to use percy again
+  xit "renders the page when user unpublishes their post", percy: true do
     visit "/#{user.username}/#{article.slug}/edit"
     fill_in "article_body_markdown", with: template.gsub("true", "false")
     click_button("Save changes")

--- a/spec/system/articles/user_visits_an_article_spec.rb
+++ b/spec/system/articles/user_visits_an_article_spec.rb
@@ -70,7 +70,8 @@ RSpec.describe "Views an article", type: :system do
       let(:crossposted_article) { create(:article) }
       let(:article2) { create(:article) }
 
-      it "renders the articles in ascending order considering crossposted_at", js: true, percy: true do
+      # TODO: Uncomment this spec when we decide to use percy again
+      xit "renders the articles in ascending order considering crossposted_at", js: true, percy: true do
         visit article1.path
         Percy.snapshot(page, name: "Articles: renders crossposted articles")
       end

--- a/spec/system/articles/user_visits_articles_by_timeframe_spec.rb
+++ b/spec/system/articles/user_visits_articles_by_timeframe_spec.rb
@@ -142,7 +142,8 @@ RSpec.describe "User visits articles by timeframe", type: :system do
     context "when viewing articles for month" do
       before { visit "/top/month" }
 
-      it "renders the page", percy: true do
+      # TODO: Uncomment this spec when we decide to use percy again
+      xit "renders the page", percy: true do
         Percy.snapshot(page, name: "Articles: /top/month")
       end
 
@@ -209,7 +210,8 @@ RSpec.describe "User visits articles by timeframe", type: :system do
     context "when viewing articles for latest" do
       before { visit "/latest" }
 
-      it "renders the page", percy: true do
+      # TODO: Uncomment this spec when we decide to use percy again
+      xit "renders the page", percy: true do
         Percy.snapshot(page, name: "Articles: /latest")
       end
 

--- a/spec/system/comments/user_edits_a_comment_spec.rb
+++ b/spec/system/comments/user_edits_a_comment_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe "Editing A Comment", type: :system, js: true do
   end
 
   context "when user edits comment on the bottom of the article" do
-    it "renders the page", percy: true do
+    # TODO: Uncomment this spec when we decide to use percy again
+    xit "renders the page", percy: true do
       visit article.path.to_s
       Percy.snapshot(page, name: "Edit comment: renders")
     end

--- a/spec/system/internal/admin_awards_badges_spec.rb
+++ b/spec/system/internal/admin_awards_badges_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe "Admin awards badges", type: :system do
     visit "/internal/badges"
   end
 
-  it "renders the page", js: true, percy: true do
+  # TODO: Uncomment this spec when we decide to use percy again
+  xit "renders the page", js: true, percy: true do
     Percy.snapshot(page, name: "Admin: /internal/badges")
   end
 

--- a/spec/system/internal/admin_bans_or_warns_user_spec.rb
+++ b/spec/system/internal/admin_bans_or_warns_user_spec.rb
@@ -38,7 +38,8 @@ RSpec.describe "Admin bans user", type: :system do
     expect(page).to have_content("User has been updated")
   end
 
-  it "renders the page", js: true, percy: true do
+  # TODO: Uncomment this spec when we decide to use percy again
+  xit "renders the page", js: true, percy: true do
     Percy.snapshot(page, name: "Admin: /internal/users/:user_id/edit")
   end
 

--- a/spec/system/internal/admin_creates_new_event_spec.rb
+++ b/spec/system/internal/admin_creates_new_event_spec.rb
@@ -29,7 +29,8 @@ RSpec.describe "Admin creates new event", type: :system do
     expect(page).to have_content("Create New Event")
   end
 
-  it "renders the page", js: true, percy: true do
+  # TODO: Uncomment this spec when we decide to use percy again
+  xit "renders the page", js: true, percy: true do
     Percy.snapshot(page, name: "Admin: /internal/events shows published events")
   end
 

--- a/spec/system/internal/admin_manages_reports_spec.rb
+++ b/spec/system/internal/admin_manages_reports_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe "Admin manages reports", type: :system do
     visit internal_feedback_messages_path
   end
 
-  it "renders the page", js: true, percy: true do
+  # TODO: Uncomment this spec when we decide to use percy again
+  xit "renders the page", js: true, percy: true do
     Percy.snapshot(page, name: "Admin: /internal/feedback_messages")
   end
 
@@ -34,7 +35,8 @@ RSpec.describe "Admin manages reports", type: :system do
       clear_search_boxes
     end
 
-    it "renders the page when searching reports", js: true, percy: true do
+    # TODO: Uncomment this spec when we decide to use percy again
+    xit "renders the page when searching reports", js: true, percy: true do
       fill_in "q_reporter_username_cont", with: user.username.to_s
       click_on "Search"
 
@@ -55,7 +57,8 @@ RSpec.describe "Admin manages reports", type: :system do
       expect(page).to have_css("#edit_feedback_message_#{feedback_message3.id}")
     end
 
-    it "renders the page when filtering", js: true, percy: true do
+    # TODO: Uncomment this spec when we decide to use percy again
+    xit "renders the page when filtering", js: true, percy: true do
       select "Invalid", from: "q[status_eq]"
       click_on "Search"
 

--- a/spec/system/organization/user_updates_org_settings_spec.rb
+++ b/spec/system/organization/user_updates_org_settings_spec.rb
@@ -32,7 +32,8 @@ RSpec.describe "Organization setting page(/settings/organization)", type: :syste
     )
   end
 
-  it "renders the page", js: true, percy: true do
+  # TODO: Uncomment this spec when we decide to use percy again
+  xit "renders the page", js: true, percy: true do
     visit "/settings/organization"
     fill_in_org_form
     click_button "Create Organization"

--- a/spec/system/user/user_edits_integrations_spec.rb
+++ b/spec/system/user/user_edits_integrations_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe "User edits their integrations", type: :system, js: true do
       visit "/settings"
     end
 
-    it "renders the page", percy: true do
+    # TODO: Uncomment this spec when we decide to use percy again
+    xit "renders the page", percy: true do
       click_link "Integrations"
 
       Percy.snapshot(page, name: "Settings: /settings renders integrations")

--- a/spec/system/user/user_settings_response_templates_spec.rb
+++ b/spec/system/user/user_settings_response_templates_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe "User uses response templates settings", type: :system do
     end
 
     context "when user has a response template already" do
-      it "renders the page", js: true, percy: true do
+      # TODO: Uncomment this spec when we decide to use percy again
+      xit "renders the page", js: true, percy: true do
         visit "/settings/response-templates"
 
         Percy.snapshot(page, name: "Settings: /response-templates renders")
@@ -28,7 +29,8 @@ RSpec.describe "User uses response templates settings", type: :system do
         expect(page).to have_current_path "/settings/response-templates/#{response_template.id}", ignore_query: true
       end
 
-      it "renders the page when deleting a response template", js: true, percy: true do
+      # TODO: Uncomment this spec when we decide to use percy again
+      xit "renders the page when deleting a response template", js: true, percy: true do
         visit "/settings/response-templates"
         accept_confirm { click_button "Remove" }
 

--- a/spec/system/user_selects_looking_for_work_spec.rb
+++ b/spec/system/user_selects_looking_for_work_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe "Looking For Work", type: :system do
     visit "/settings"
   end
 
-  it "renders the page", js: true, percy: true do
+  # TODO: Uncomment this spec when we decide to use percy again
+  xit "renders the page", js: true, percy: true do
     Percy.snapshot(page, name: "Logged in user: settings page")
   end
 

--- a/spec/system/user_uses_the_editor_spec.rb
+++ b/spec/system/user_uses_the_editor_spec.rb
@@ -47,7 +47,8 @@ RSpec.describe "Using the editor", type: :system do
   end
 
   describe "Submitting an article", js: true do
-    it "renders the page", percy: true do
+    # TODO: Uncomment this spec when we decide to use percy again
+    xit "renders the page", percy: true do
       fill_markdown_with(read_from_file(raw_text))
       find("button", text: /\ASave changes\z/).click
       Percy.snapshot(page, name: "Using the editor: submit an article")
@@ -76,7 +77,8 @@ RSpec.describe "Using the editor", type: :system do
         find("button", text: /\ASave changes\z/).click
       end
 
-      it "renders the page", percy: true do
+      # TODO: Uncomment this spec when we decide to use percy again
+      xit "renders the page", percy: true do
         Percy.snapshot(page, name: "Using the editor: publishing an article without a title")
       end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
Find all fail! [When I did the first round of these](https://github.com/thepracticaldev/dev.to/pull/8347) I searched with tab indentation in my search string which led to me missing the vast majority of these Percy only specs. Here are the rest of them commented out.  I was also only looking for specs with a single Percy.snapshot line, however, as you can see in this PR, some specs have lines before the Percy snapshot to setup the environment. The key is that NONE of them have any additional expectations. 

Thats ok, its another excuse to put a gif of a hedgehog in a PR 😄 
![alt_text](https://media.giphy.com/media/55BYgtzNx2SkM/giphy.gif)
