### PR TITLE
apply word break fix to title as well

### DIFF
--- a/app/assets/stylesheets/components/stories.scss
+++ b/app/assets/stylesheets/components/stories.scss
@@ -115,6 +115,7 @@
     line-height: var(--lh-tight);
     margin-bottom: var(--su-2);
     font-size: var(--title-font-size);
+    overflow-wrap: break-word;
 
     a {
       color: inherit;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

@ludwiczakpawel, oops I guess Mac already merged #8263. I was going to include a commit to address the word-break fix for the title as well. Anyways, here is a separate PR :) 

See #8263 for reference.  

Specifically your comment:
> Would you mind adding the very same fix for post titles too? (Your screenshot has an example like that)

- [ ] yes
- [ ] no, because they aren't needed
- [x] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
