### PR TITLE
Flaky Spec Fixes: Dont Assume No Elasticsearch Data, Refresh before delete_by_query

### DIFF
--- a/spec/support/elasticsearch_helpers.rb
+++ b/spec/support/elasticsearch_helpers.rb
@@ -10,6 +10,7 @@ module ElasticsearchHelpers
   end
 
   def clear_elasticsearch_data(search_class)
+    search_class.refresh_index
     Search::Client.delete_by_query(
       index: search_class::INDEX_ALIAS, body: { query: { match_all: {} } },
     )

--- a/spec/workers/metrics/record_data_counts_worker_spec.rb
+++ b/spec/workers/metrics/record_data_counts_worker_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Metrics::RecordDataCountsWorker, type: :worker do
 
       expect(
         DatadogStatsClient,
-      ).to have_received(:gauge).with("elasticsearch.document_count", 0, tags: Array).at_least(1)
+      ).to have_received(:gauge).with("elasticsearch.document_count", Integer, tags: Array).at_least(1)
     end
   end
 end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Two Fixes here:
1) Since we are not clearing out Elasticsearch before running our worker spec we can't assume it is empty so I changed the expectation of 0 to any integer
2) If specs start running really fast there is a chance we try to run a delete_by_query before Elasticsearch has "refreshed" ie committed new data to disk. This causes an error so lets refresh the index before we run delete_by_query and after to ensure no data in flight errors occur. 

![alt_text](https://media1.tenor.com/images/d85539662debe8299a7504b3941261e2/tenor.gif?itemid=16741389)
