### PR TITLE
Add json template to Pages

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -7,6 +7,7 @@ class PagesController < ApplicationController
     not_found unless FeatureFlag.accessible?(@page.feature_flag_name, current_user)
 
     set_surrogate_key_header "show-page-#{params[:slug]}"
+    render json: @page.processed_html if @page.template == "json"
   end
 
   def about

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -157,7 +157,12 @@ class StoriesController < ApplicationController
   def handle_page_display
     @story_show = true
     set_surrogate_key_header "show-page-#{params[:username]}"
-    render template: "pages/show"
+
+    if @page.template == "json"
+      render json: @page.processed_html
+    else
+      render template: "pages/show"
+    end
   end
 
   def handle_base_index

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,5 +1,5 @@
 class Page < ApplicationRecord
-  TEMPLATE_OPTIONS = %w[contained full_within_layout].freeze
+  TEMPLATE_OPTIONS = %w[contained full_within_layout json].freeze
 
   validates :title, presence: true
   validates :description, presence: true

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -16,6 +16,31 @@ RSpec.describe "Pages", type: :request do
       expect(response.body).not_to include("/page/#{page.slug}")
       expect(response.body).to include("stories-show")
     end
+
+    context "when json template" do
+      let_it_be(:json_text) { "{\"foo\": \"bar\"}" }
+      let_it_be(:page) { create(:page, title: "sample_data", template: "json", body_html: json_text, body_markdown: nil) }
+
+      before do
+        page.save! # Trigger processing of page.body_html
+      end
+
+      it "returns json data " do
+        get "/page/#{page.slug}"
+
+        expect(response.content_type).to eq("application/json")
+        expect(response.body).to include(json_text)
+      end
+
+      it "returns json data for top level template" do
+        page.is_top_level_path = true
+        page.save!
+        get "/#{page.slug}"
+
+        expect(response.content_type).to eq("application/json")
+        expect(response.body).to include(json_text)
+      end
+    end
   end
 
   describe "GET /about" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds a `json` template type to `/internal/pages`. The concept is Pages could be used to host lightweight data structures that change infrequently and serve as an alternative to a heavier weight data store like a database or API.

The use case we have for this is dynamic data on the CodeLand page: as videos are aired, we want to update information about the talk's speaker, title, and summary. Instead of adding this information to our database or redis and serving it over an API (all of which would require additions to the codebase), we can serve up this information AND change it easily by exporting it via a `Pages` page. We'll change this data as different videos air in order to update clients that are currently watching the content without requiring them to refresh their pages.

The only problem is that currently `pages` have one of two layouts (`contained` or `full_within_layout`) both of are HTML layouts with a full header, styles, etc. The `json` template options serves up the contents of a page as content-type `application/json`.

Originally I added this feature as a template option to `html_variants`, but I think it makes more sense as a `pages` addition:
- `html_variants` are designed around testing different pieces of content in the same spot. For example: you could have 3 different banners that are rotated. It's unlikely data would be treated in this manner
- `pages` already contains code for setting cache headers
- `pages` allow admins to change content in place, whereas `html_variants` requires deactivation and reactivation
- `html_variants` are only exposed by id right now, `pages` have friendly slug names  

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

Let's make some data...

<img width="1462" alt="Pages" src="https://user-images.githubusercontent.com/37842/84073204-f7c00800-a995-11ea-8f32-778c024c51d1.png">

..and then let's view it!

<img width="1462" alt="localhost_3000_page_codeland_data" src="https://user-images.githubusercontent.com/37842/84073229-04446080-a996-11ea-8098-9ec931a2c7ec.png">



## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![Jason?](https://media.giphy.com/media/xT9KVn8tApfgnNLpL2/giphy.gif)
