### PR TITLE
Shrink mod button on narrow screens

### DIFF
--- a/app/assets/stylesheets/article-show.scss
+++ b/app/assets/stylesheets/article-show.scss
@@ -61,7 +61,13 @@
   border-radius: 50px;
 
   @media (max-width: $breakpoint-m) {
-    bottom: 90px;
+    bottom: 68px;
+    right: 8px;
+    padding: 0;
+    svg {
+      height: 42px;
+      width: 42px;
+    }
   }
 }
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

At the moment I think the mod button is a little too in-your-face on narrow screens (typically mobile experience) in a way that could distract from reading (remember mods are readers too).

Current:
<img width="197" alt="Screen Shot 2020-06-08 at 6 08 40 PM" src="https://user-images.githubusercontent.com/3102842/84085208-184a8b00-a9b3-11ea-9df6-14def6e93352.png">

Proposed:
<img width="284" alt="Screen Shot 2020-06-08 at 6 08 20 PM" src="https://user-images.githubusercontent.com/3102842/84085188-0b2d9c00-a9b3-11ea-9d06-6ac9c64399c4.png">
