### PR TITLE
Provide default crayon styles when creating banners

### DIFF
--- a/app/assets/javascripts/initializers/initializeBroadcast.js
+++ b/app/assets/javascripts/initializers/initializeBroadcast.js
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 /**
  * Parses the broadcast object on the document into JSON.
  *
@@ -20,12 +21,16 @@ function initializeBroadcast() {
   if (!data) {
     return;
   }
-  const { html } = data;
-
-  var el = document.getElementById('active-broadcast');
+  const { html, banner_class } = data;
+  const el = document.getElementById('active-broadcast');
 
   if (el.firstElementChild) {
-    return;
-  } // Only append HTML once, on first render.
-  el.insertAdjacentHTML('afterbegin', html);
+    return; // Only append HTML once, on first render.
+  }
+
+  const bannerDiv = `<div class='broadcast-data ${
+    banner_class || ''
+  }'>${html}</div>`;
+  el.insertAdjacentHTML('afterbegin', bannerDiv);
 }
+/* eslint-enable camelcase */

--- a/app/assets/stylesheets/internal/layout.scss
+++ b/app/assets/stylesheets/internal/layout.scss
@@ -1,4 +1,5 @@
 @import '../variables';
+@import '../crayons';
 
 #siteConfigBodyContainer {
   padding: 20px;
@@ -26,9 +27,9 @@
 }
 
 .buffer-cell {
-    /* Max-width derived from width of a Bootstrap container */
-    max-width: 1140px;
-    word-wrap: break-word;
+  /* Max-width derived from width of a Bootstrap container */
+  max-width: 1140px;
+  word-wrap: break-word;
 }
 
 .bg-featured {

--- a/app/controllers/async_info_controller.rb
+++ b/app/controllers/async_info_controller.rb
@@ -45,7 +45,8 @@ class AsyncInfoController < ApplicationController
 
     {
       title: broadcast&.title,
-      html: broadcast&.processed_html
+      html: broadcast&.processed_html,
+      banner_class: broadcast&.banner_class
     }.to_json
   end
 

--- a/app/controllers/async_info_controller.rb
+++ b/app/controllers/async_info_controller.rb
@@ -46,7 +46,7 @@ class AsyncInfoController < ApplicationController
     {
       title: broadcast&.title,
       html: broadcast&.processed_html,
-      banner_class: broadcast&.banner_class
+      banner_class: helpers.banner_class(broadcast)
     }.to_json
   end
 

--- a/app/controllers/internal/broadcasts_controller.rb
+++ b/app/controllers/internal/broadcasts_controller.rb
@@ -50,7 +50,7 @@ class Internal::BroadcastsController < Internal::ApplicationController
   private
 
   def broadcast_params
-    params.permit(:title, :processed_html, :type_of, :active)
+    params.permit(:title, :processed_html, :type_of, :banner_style, :active)
   end
 
   def authorize_admin

--- a/app/helpers/broadcasts_helper.rb
+++ b/app/helpers/broadcasts_helper.rb
@@ -1,0 +1,11 @@
+module BroadcastsHelper
+  def banner_class(broadcast)
+    return if broadcast.banner_style.blank?
+
+    if broadcast.banner_style == "default"
+      "crayons-banner"
+    else
+      "crayons-banner crayons-banner--#{broadcast.banner_style}"
+    end
+  end
+end

--- a/app/models/broadcast.rb
+++ b/app/models/broadcast.rb
@@ -6,6 +6,7 @@ class Broadcast < ApplicationRecord
   validates :title, uniqueness: { scope: :type_of }, presence: true
   validates :type_of, :processed_html, presence: true
   validates :type_of, inclusion: { in: %w[Announcement Welcome] }
+  validates :banner_style, inclusion: { in: %w[default brand success warning error] }, allow_blank: true
   validate  :single_active_announcement_broadcast
 
   scope :active, -> { where(active: true) }
@@ -14,6 +15,16 @@ class Broadcast < ApplicationRecord
 
   def get_inner_body(content)
     Nokogiri::HTML(content).at("body").inner_html
+  end
+
+  def banner_class
+    return if banner_style.blank?
+
+    if banner_style == "default"
+      "crayons-banner"
+    else
+      "crayons-banner crayons-banner--#{banner_style}"
+    end
   end
 
   private

--- a/app/models/broadcast.rb
+++ b/app/models/broadcast.rb
@@ -1,4 +1,5 @@
 class Broadcast < ApplicationRecord
+  VALID_BANNER_STYLES = %w[default brand success warning error].freeze
   resourcify
 
   has_many :notifications, as: :notifiable, inverse_of: :notifiable
@@ -6,7 +7,7 @@ class Broadcast < ApplicationRecord
   validates :title, uniqueness: { scope: :type_of }, presence: true
   validates :type_of, :processed_html, presence: true
   validates :type_of, inclusion: { in: %w[Announcement Welcome] }
-  validates :banner_style, inclusion: { in: %w[default brand success warning error] }, allow_blank: true
+  validates :banner_style, inclusion: { in: VALID_BANNER_STYLES }, allow_blank: true
   validate  :single_active_announcement_broadcast
 
   scope :active, -> { where(active: true) }
@@ -15,16 +16,6 @@ class Broadcast < ApplicationRecord
 
   def get_inner_body(content)
     Nokogiri::HTML(content).at("body").inner_html
-  end
-
-  def banner_class
-    return if banner_style.blank?
-
-    if banner_style == "default"
-      "crayons-banner"
-    else
-      "crayons-banner crayons-banner--#{banner_style}"
-    end
   end
 
   private

--- a/app/views/internal/broadcasts/_form.html.erb
+++ b/app/views/internal/broadcasts/_form.html.erb
@@ -22,7 +22,7 @@
 <% if @broadcast.processed_html %>
   <div>
     </p><strong>Preview</strong></p>
-    <div class="<%= @broadcast.banner_class %>">
+    <div class="<%= banner_class(@broadcast) %>">
       <%= sanitize @broadcast.processed_html, attributes: %w[href style src] %>
     </div>
     </p><em>Please note: announcement broadcasts will render directly below the nav bar once activated.</em></p>

--- a/app/views/internal/broadcasts/_form.html.erb
+++ b/app/views/internal/broadcasts/_form.html.erb
@@ -10,6 +10,10 @@
   <%= select_tag "type_of", options_for_select(%w[Welcome Announcement], selected: @broadcast.type_of) %>
 </div>
 <div class="form-group">
+  <%= label_tag :banner_style, "Banner Style:" %>
+  <%= select_tag "banner_style", options_for_select(%w[default brand success warning error], selected: @broadcast.banner_style), include_blank: true %>
+</div>
+<div class="form-group">
   <%= label_tag :active, "Active:" %>
   <%= select_tag :active, options_for_select([false, true], selected: @broadcast.active) %>
 </div>
@@ -18,8 +22,10 @@
 <% if @broadcast.processed_html %>
   <div>
     </p><strong>Preview</strong></p>
-    <%= sanitize @broadcast.processed_html, attributes: %w[href style src] %>
-    </p><em>Please note: Announcement Broadcasts will render directly below the nav bar.</em></p>
+    <div class="<%= @broadcast.banner_class %>">
+      <%= sanitize @broadcast.processed_html, attributes: %w[href style src] %>
+    </div>
+    </p><em>Please note: announcement broadcasts will render directly below the nav bar once activated.</em></p>
   <div>
 <% end %>
-<br>
+<hr>

--- a/app/views/internal/broadcasts/edit.html.erb
+++ b/app/views/internal/broadcasts/edit.html.erb
@@ -5,7 +5,6 @@
       <%= render "form" %>
       <%= submit_tag "Update Broadcast", class: "btn btn-primary float-right" %>
     <% end %>
-    <hr class="mt-5">
-      <%= link_to "Destroy Broadcast", url_for(action: :destroy, id: @broadcast.id), method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-danger float-right" %>
+    <%= link_to "Destroy Broadcast", url_for(action: :destroy, id: @broadcast.id), method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-danger" %>
   </div>
 </div>

--- a/db/migrate/20200608175130_add_banner_style_to_broadcasts.rb
+++ b/db/migrate/20200608175130_add_banner_style_to_broadcasts.rb
@@ -1,0 +1,5 @@
+class AddBannerStyleToBroadcasts < ActiveRecord::Migration[6.0]
+  def change
+    add_column :broadcasts, :banner_style, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_04_133925) do
+ActiveRecord::Schema.define(version: 2020_06_08_175130) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -267,6 +267,7 @@ ActiveRecord::Schema.define(version: 2020_06_04_133925) do
 
   create_table "broadcasts", id: :serial, force: :cascade do |t|
     t.boolean "active", default: false
+    t.string "banner_style"
     t.text "body_markdown"
     t.datetime "created_at"
     t.text "processed_html"

--- a/spec/models/broadcast_spec.rb
+++ b/spec/models/broadcast_spec.rb
@@ -18,14 +18,4 @@ RSpec.describe Broadcast, type: :model do
     expect(inactive_broadcast).not_to be_valid
     expect(inactive_broadcast.errors.full_messages.join).to include("You can only have one active announcement broadcast")
   end
-
-  it "determines the correct banner_class for the Broadcast" do
-    no_style_broadcast = create(:announcement_broadcast, active: false)
-    default_style_broadcast = create(:announcement_broadcast, title: "Default", banner_style: "default", active: false)
-    warning_style_broadcast = create(:announcement_broadcast, title: "Warning", banner_style: "warning", active: false)
-
-    expect(no_style_broadcast.banner_class).to eq(nil)
-    expect(default_style_broadcast.banner_class).to eq("crayons-banner")
-    expect(warning_style_broadcast.banner_class).to eq("crayons-banner crayons-banner--warning")
-  end
 end

--- a/spec/models/broadcast_spec.rb
+++ b/spec/models/broadcast_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Broadcast, type: :model do
   it { is_expected.to validate_presence_of(:type_of) }
   it { is_expected.to validate_presence_of(:processed_html) }
   it { is_expected.to validate_inclusion_of(:type_of).in_array(%w[Announcement Welcome]) }
+  it { is_expected.to validate_inclusion_of(:banner_style).in_array(%w[default brand success warning error]) }
   it { is_expected.to validate_uniqueness_of(:title).scoped_to(:type_of) }
 
   it { is_expected.to have_many(:notifications) }
@@ -16,5 +17,15 @@ RSpec.describe Broadcast, type: :model do
 
     expect(inactive_broadcast).not_to be_valid
     expect(inactive_broadcast.errors.full_messages.join).to include("You can only have one active announcement broadcast")
+  end
+
+  it "determines the correct banner_class for the Broadcast" do
+    no_style_broadcast = create(:announcement_broadcast, active: false)
+    default_style_broadcast = create(:announcement_broadcast, title: "Default", banner_style: "default", active: false)
+    warning_style_broadcast = create(:announcement_broadcast, title: "Warning", banner_style: "warning", active: false)
+
+    expect(no_style_broadcast.banner_class).to eq(nil)
+    expect(default_style_broadcast.banner_class).to eq("crayons-banner")
+    expect(warning_style_broadcast.banner_class).to eq("crayons-banner crayons-banner--warning")
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

- [x] Imports crayons styles into `/internal` pages.
- [x] Allows admins to use crayons banner styles when creating broadcasts.
- [x] Previews banner styles with crayons.
- [x] Fixes a UI bug with buttons on the `/internal/broadcast/:id/edit` page.

## Related Tickets & Documents
Closes https://github.com/thepracticaldev/dev.to/issues/8355.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

### HOW TO QA THIS PR:

**1. Go to the `/internal/broadcasts` page locally, and pick a `type_of: Announcement` broadcast that you want to activate, or is already active.**

**2. Choose a crayons banner style, or leave it blank. If blank, you should see plain old HTML represented:**
<img width="1073" alt="Screen Shot 2020-06-08 at 3 18 22 PM" src="https://user-images.githubusercontent.com/6921610/84088205-dfa1b600-a9a0-11ea-9d8d-8f3f51ba763f.png">

**3. If you select a banner style, you should be able to save the broadcast, and see the banner style reflected. For example, with the style of `warning`:**
<img width="1073" alt="Screen Shot 2020-06-08 at 3 18 02 PM" src="https://user-images.githubusercontent.com/6921610/84088213-e16b7980-a9a0-11ea-84f7-26d6917e85e2.png">

**And this is with the style of `brand`:**
<img width="1058" alt="Screen Shot 2020-06-08 at 3 17 22 PM" src="https://user-images.githubusercontent.com/6921610/84088217-e29ca680-a9a0-11ea-841d-9b21c86d7d4e.png">

**4. Finally, you should see that same banner style from the crayons design system reflected when you view the active announcement throughout the site:**
<img width="1221" alt="Screen Shot 2020-06-08 at 4 00 55 PM" src="https://user-images.githubusercontent.com/6921610/84088406-46bf6a80-a9a1-11ea-888c-de9899695c46.png">

This PR also fixes a UI regression on the `/internal/broadcasts/:id/edit` page:
_Before:_
<img width="1047" alt="Screen Shot 2020-06-08 at 3 15 50 PM" src="https://user-images.githubusercontent.com/6921610/84088181-d3b5f400-a9a0-11ea-962a-19a502ea8b80.png">

_After:_
<img width="1046" alt="Screen Shot 2020-06-08 at 3 16 09 PM" src="https://user-images.githubusercontent.com/6921610/84088187-d7497b00-a9a0-11ea-928b-1b981e746d2a.png">

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
N/A

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/BV88cCpyeHogU/giphy.gif)
