### PR TITLE
Rewrite GithubRepos with async/await for better debugging

### DIFF
--- a/app/javascript/githubRepos/githubRepos.jsx
+++ b/app/javascript/githubRepos/githubRepos.jsx
@@ -1,4 +1,5 @@
 import { h, Component } from 'preact';
+import { request } from '@utilities/http';
 import { SingleRepo } from './singleRepo';
 
 export class GithubRepos extends Component {
@@ -11,34 +12,24 @@ export class GithubRepos extends Component {
     this.getGithubRepos();
   }
 
-  getGithubRepos = () => {
-    fetch(`/github_repos`, {
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-      },
-      credentials: 'same-origin',
-    })
-      .then((response) => response.json())
-      .then((json) => {
-        this.setState({ repos: json });
-      })
-      .catch(() => {
-        this.setState({ erroredOut: true });
-      });
-  };
+  async getGithubRepos() {
+    try {
+      const response = await request('/github_repos');
+      const repositories = await response.json();
+
+      this.setState({ repos: repositories });
+    } catch (error) {
+      this.setState({ erroredOut: true });
+
+      Honeybadger.notify(error);
+
+      // will remove this, need it temporarily to properly debug
+      console.error(error); // eslint-disable-line no-console
+    }
+  }
 
   render() {
     const { repos, erroredOut } = this.state;
-    const allRepos = repos.map((repo) => (
-      <SingleRepo
-        githubIdCode={repo.github_id_code}
-        name={repo.name}
-        fork={repo.fork}
-        featured={repo.featured}
-      />
-    ));
-
     if (erroredOut) {
       return (
         <div className="github-repos github-repos-errored">
@@ -48,6 +39,16 @@ export class GithubRepos extends Component {
         </div>
       );
     }
+
+    const allRepos = repos.map((repo) => (
+      <SingleRepo
+        githubIdCode={repo.github_id_code}
+        name={repo.name}
+        fork={repo.fork}
+        featured={repo.featured}
+      />
+    ));
+
     if (repos.length > 0) {
       return <div className="github-repos">{allRepos}</div>;
     }


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

In an attempt to solve https://github.com/thepracticaldev/dev.to/issues/8076, https://github.com/thepracticaldev/dev.to/issues/8104 and https://github.com/thepracticaldev/dev.to/issues/8172 we need better visibility within the errors.

Currently the JS code only sets an error flag to true, eating up the errors. It also tries to render the repositories, before checking the error state.

I rewrote the fetching code of the component to use `async/await` which is infinitely easier to debug than chained callbacks and also added some error code to both log on the console and send to Honeybadger.

Hopefully we can better understand what's going on. As I can't ever reproduce it locally I'm a bit blind on this.

## Related Tickets & Documents

- https://github.com/thepracticaldev/dev.to/issues/8076
- https://github.com/thepracticaldev/dev.to/issues/8104
- https://github.com/thepracticaldev/dev.to/issues/8172

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
