### PR TITLE
Fix bug in db/seeds that may blow up while assigning fake user roles

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -71,8 +71,11 @@ users_in_random_order = seeder.create_if_none(User, num_users) do
 
     if i.zero?
       user.add_role(:trusted) # guarantee at least one moderator
+    elsif i == num_users - 1
+      next # guarantee at least one user with no role
     else
-      user.add_role(roles[rand(0..roles.length)]) # includes chance of having no role
+      role_index = rand(0..roles.length)
+      user.add_role(roles[role_index]) if role_index != roles.length # increases chance of more no-role users
     end
 
     Identity.create!(


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
In the current `db/seeds.rb` file, while assigning roles to fake users, if the script references a non-existent role, the process blows up. Specifically, this code block:
```ruby
if i.zero?
   user.add_role(:trusted)
else
   user.add_role(roles[rand(0..roles.length)])
end
```
`roles.length` equals `3`; if `rand(0..roles.length)` returns `3`, the loop blows up.
I decided against just modifying to `rand(0..roles.length - 1)` because that solution won't yield any additional no-role users.

***Note: the `db/schema/rb` change is one that has been popping up on all my commits. Until now, I've been reversing it, but @rhymes says it's alright to commit the change.*** 😄 

## Added tests?

- [ ] yes
- [X] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![Black woman saying you're welcome](https://media.giphy.com/media/3ofT5zixhJOx82Zkly/giphy.gif)
