### PR TITLE
Hide site-wide messaging for opted-out users

### DIFF
--- a/app/assets/javascripts/initializers/initializeBroadcast.js
+++ b/app/assets/javascripts/initializers/initializeBroadcast.js
@@ -80,14 +80,20 @@ function renderBroadcast(broadcastElement, data) {
 }
 
 /**
- * A function to determine if a broadcast should render
- * Does not render broadcast it has already been inserted,
- * or if the key for the broadcast's title exists in localStorage.
+ * A function to determine if a broadcast should render.
+ * Does not render a broadcast if the current user has opted-out.
+ * Does not render a broadcast it has already been inserted, or
+ * if the key for the broadcast's title exists in localStorage.
  *
  * @function initializeBroadcast
  */
 function initializeBroadcast() {
+  const user = userData();
   const data = broadcastData();
+
+  if (user && !user.display_announcements) {
+    return;
+  }
   if (!data) {
     return;
   }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -19,6 +19,7 @@ FactoryBot.define do
     saw_onboarding               { true }
     checked_code_of_conduct      { true }
     checked_terms_and_conditions { true }
+    display_announcements        { true }
     signup_cta_variant           { "navbar_basic" }
     email_digest_periodic        { false }
     bg_color_hex                 { Faker::Color.hex_color }

--- a/spec/system/homepage/user_visits_homepage_with_announcement_spec.rb
+++ b/spec/system/homepage/user_visits_homepage_with_announcement_spec.rb
@@ -86,5 +86,18 @@ RSpec.describe "User visits a homepage", type: :system do
         expect_no_broadcast_data(page)
       end
     end
+
+    context "when opting-out of announcements" do
+      before do
+        user.update!(display_announcements: false)
+        create(:announcement_broadcast, active: true)
+        get "/async_info/base_data" # Explicitly ensure broadcast data is loaded before doing any checks
+        visit "/"
+      end
+
+      it "does not render the broadcast", js: true do
+        expect_no_broadcast_data(page)
+      end
+    end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Takes the `display_announcements` column on the `user` into account when displaying an announcement. If a logge-in user has opted-out of announcements, the banner will not display. If the user has opted-in to announcements (the default!), then the banner will display.

This should not affect logged-out users, since they are not persisted anywhere (although they can dismiss the announcement still via clicking the `X`, which will persist a key in `localStorage`).

## Related Tickets & Documents
Closes https://github.com/thepracticaldev/dev.to/issues/8262.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
HOW TO QA THIS PR:
**1. Create an active broadcast via `/internal/broadcasts`:**
<img width="1300" alt="Screen Shot 2020-06-11 at 8 54 32 AM" src="https://user-images.githubusercontent.com/6921610/84408844-7ea4f880-abc1-11ea-9c8c-924559f303f9.png">

**2. You should see the broadcast render throughout the site:**
<img width="1300" alt="Screen Shot 2020-06-11 at 8 55 20 AM" src="https://user-images.githubusercontent.com/6921610/84408863-85cc0680-abc1-11ea-8aac-7f1dd76c237b.png">

**3. Go to your `/settings/misc` page, and opt-out of the announcements in your settings:** 
<img width="1300" alt="Screen_Shot_2020-06-11_at_8_54_56_AM" src="https://user-images.githubusercontent.com/6921610/84408969-abf1a680-abc1-11ea-926c-12e5f9cefbce.png">

**4. Navigate throughout the site; you shouldn't see the banner displayed anywhere!**
<img width="1300" alt="Screen Shot 2020-06-11 at 8 55 10 AM" src="https://user-images.githubusercontent.com/6921610/84408990-b0b65a80-abc1-11ea-92fa-10381fc27e8e.png">

**5. If you change your setting back and opt-in again, the banner should render as expected.**

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [x] ~readme~ internal documentation
- [ ] no documentation needed

## Are there any post deployment tasks we need to perform?
N/A
