### PR TITLE
Bump top-bar's z-index to allow dropdown to render with announcement

### DIFF
--- a/app/assets/stylesheets/top-bar.scss
+++ b/app/assets/stylesheets/top-bar.scss
@@ -10,7 +10,7 @@
   top: 0px;
   left: 0px;
   right: 0px;
-  z-index: 101;
+  z-index: 102; // Must be higher than the z-index of the broadcast-wrapper.
   height: var(--header-height);
   background: var(--header-bg);
   box-shadow: 0 1px 1px var(--header-shadow);


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Currently, the announcement feature [has a `z-index` of `101`](https://github.com/thepracticaldev/dev.to/blob/e532ccbe428809f4bda61e71712fc410cc67622e/app/assets/stylesheets/scaffolds.scss#L177), which is exactly the same as the `top-bar` element. The `top-bar` is the parent element for the user dropdown, so with the exact same z-index, the stacking order of these elements means that the `top-bar` always renders below the announcement, even though they have the same z-index. This PR bumps the `top-bar`'s `z-index` by `1`, such that its children (including the user settings dropdown) will always render above the announcement.

## Related Tickets & Documents
@atsmith813 brought this up in a separate PR's review [here](https://github.com/thepracticaldev/dev.to/pull/8409#pullrequestreview-429072836).

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
Before this change:
<img width="1425" alt="Screen Shot 2020-06-11 at 10 34 50 AM" src="https://user-images.githubusercontent.com/6921610/84421154-fb3ed380-abcf-11ea-9917-19551ad448bd.png">

After this change:
<img width="1425" alt="Screen Shot 2020-06-11 at 10 34 38 AM" src="https://user-images.githubusercontent.com/6921610/84421163-fed25a80-abcf-11ea-802b-bcae204add8d.png">


## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## Are there any post deployment tasks we need to perform?
N/A
