### PR TITLE
Refactor BroadcastsController

### DIFF
--- a/app/controllers/internal/broadcasts_controller.rb
+++ b/app/controllers/internal/broadcasts_controller.rb
@@ -14,7 +14,7 @@ class Internal::BroadcastsController < Internal::ApplicationController
   end
 
   def edit
-    @broadcast = Broadcast.find_by!(id: params[:id])
+    @broadcast = Broadcast.find(params[:id])
   end
 
   def create
@@ -30,7 +30,7 @@ class Internal::BroadcastsController < Internal::ApplicationController
   end
 
   def update
-    @broadcast = Broadcast.find_by!(id: params[:id])
+    @broadcast = Broadcast.find(params[:id])
 
     if @broadcast.update(broadcast_params)
       flash[:success] = "Broadcast has been updated!"
@@ -42,7 +42,7 @@ class Internal::BroadcastsController < Internal::ApplicationController
   end
 
   def destroy
-    @broadcast = Broadcast.find_by!(id: params[:id])
+    @broadcast = Broadcast.find(params[:id])
 
     if @broadcast.destroy
       flash[:success] = "Broadcast has been deleted!"

--- a/app/controllers/internal/broadcasts_controller.rb
+++ b/app/controllers/internal/broadcasts_controller.rb
@@ -1,23 +1,12 @@
 class Internal::BroadcastsController < Internal::ApplicationController
   layout "internal"
 
-  def create
-    @broadcast = Broadcast.create!(broadcast_params)
-    flash[:success] = "Broadcast has been created!"
-    redirect_to "/internal/broadcasts"
-  rescue ActiveRecord::RecordInvalid => e
-    flash[:danger] = e.message
-    redirect_to "/internal/broadcasts"
-  end
-
-  def update
-    @broadcast = Broadcast.find_by!(id: params[:id])
-    @broadcast.update!(broadcast_params)
-    flash[:success] = "Broadcast has been updated!"
-    redirect_to "/internal/broadcasts"
-  rescue ActiveRecord::RecordInvalid => e
-    flash[:danger] = e.message
-    redirect_to "/internal/broadcasts/#{params[:id]}/edit"
+  def index
+    @broadcasts = if params[:type_of]
+                    Broadcast.where(type_of: params[:type_of].capitalize)
+                  else
+                    Broadcast.all
+                  end.order(title: :asc)
   end
 
   def new
@@ -28,22 +17,39 @@ class Internal::BroadcastsController < Internal::ApplicationController
     @broadcast = Broadcast.find_by!(id: params[:id])
   end
 
-  def index
-    @broadcasts = if params[:type_of]
-                    Broadcast.where(type_of: params[:type_of].capitalize)
-                  else
-                    Broadcast.all
-                  end.order(title: :asc)
+  def create
+    @broadcast = Broadcast.new(broadcast_params)
+
+    if @broadcast.save
+      flash[:success] = "Broadcast has been created!"
+      redirect_to internal_broadcasts_path
+    else
+      flash[:danger] = @broadcast.errors.full_messages.to_sentence
+      render new_internal_broadcast_path
+    end
+  end
+
+  def update
+    @broadcast = Broadcast.find_by!(id: params[:id])
+
+    if @broadcast.update(broadcast_params)
+      flash[:success] = "Broadcast has been updated!"
+      redirect_to internal_broadcasts_path
+    else
+      flash[:danger] = @broadcast.errors.full_messages.to_sentence
+      render :edit
+    end
   end
 
   def destroy
-    broadcast = Broadcast.find_by!(id: params[:id])
-    if broadcast.destroy
+    @broadcast = Broadcast.find_by!(id: params[:id])
+
+    if @broadcast.destroy
       flash[:success] = "Broadcast has been deleted!"
-      redirect_to "/internal/broadcasts"
+      redirect_to internal_broadcasts_path
     else
       flash[:danger] = "Something went wrong with deleting the broadcast."
-      redirect_to "/internal/broadcasts/#{params[:id]}/edit"
+      render :edit
     end
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Refactors our currently kind of messy `BroadcastsController`. Uses path helpers instead of hard-coded string paths, and uses `render` rather than `redirect_to` wherever applicable.

## Related Tickets & Documents
@atsmith813 brought up this in a separate PR's review [here](https://github.com/thepracticaldev/dev.to/pull/8409#pullrequestreview-429072836).

## QA Instructions, Screenshots, Recordings

The best way to QA this is to click through creating/updating/destroying a broadcast and make sure everything works! (The tests for this do pass as well 👍)

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
