### PR TITLE
Flaky Spec Fix: Ignore Order For User Suggestion in Sidebar

### DIFF
--- a/spec/services/suggester/users/sidebar_spec.rb
+++ b/spec/services/suggester/users/sidebar_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Suggester::Users::Sidebar, type: :service do
     tags = "html"
     article1 = create(:article, tags: tags)
     article2 = create(:article, tags: tags)
-    expect(described_class.new(user, tags).suggest.to_a).to eq([article1.user, article2.user])
+    expect(described_class.new(user, tags).suggest.to_a).to match_array([article1.user, article2.user])
   end
 
   it "returns no user if there's not enough sample" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This spec failed for me in another branch bc the users were out of order. We don't care about the order here, just that we have the correct users so use match_array instead of eq

![alt_text](https://media3.giphy.com/media/gjTiqVOaOKhrs2j2hF/200.gif)
