### PR TITLE
Spec SpeedUp: Refactor and Combine Assertions for Viewing Articles by Timeframe Spec

### DIFF
--- a/spec/system/articles/user_visits_articles_by_timeframe_spec.rb
+++ b/spec/system/articles/user_visits_articles_by_timeframe_spec.rb
@@ -8,19 +8,25 @@ RSpec.describe "User visits articles by timeframe", type: :system do
   let!(:months_old_article) { create(:article, user: author, published_at: 2.months.ago) }
   let!(:years_old_article) { create(:article, user: author, published_at: 2.years.ago) }
 
+  def shows_correct_articles_count(count)
+    expect(page).to have_selector(".crayons-story", visible: :visible, count: count)
+  end
+
+  def shows_correct_articles_count_via_xpath(count)
+    expect(page).to have_xpath("//article[contains(@class, 'crayons-story') and contains(@class, 'false')]", count: count)
+  end
+
+  def shows_main_article
+    expect(page).to have_selector(".crayons-story--featured", visible: :visible, count: 1)
+  end
+
   context "when user hasn't logged in" do
     context "when viewing articles for week" do
       before { visit "/top/week" }
 
-      it "shows correct articles count" do
-        expect(page).to have_selector(".crayons-story", visible: :visible, count: 2)
-      end
-
-      it "shows the main article" do
-        expect(page).to have_selector(".crayons-story--featured", visible: :visible, count: 1)
-      end
-
-      it "shows the correct articles" do
+      it "shows correct articles", :aggregate_failures do
+        shows_correct_articles_count(2)
+        shows_main_article
         within("#articles-list") do
           expect(page).to have_text(article.title)
           expect(page).to have_text(days_old_article.title)
@@ -31,15 +37,10 @@ RSpec.describe "User visits articles by timeframe", type: :system do
     context "when viewing articles for month" do
       before { visit "/top/month" }
 
-      it "shows correct articles count" do
-        expect(page).to have_selector(".crayons-story", visible: :visible, count: 3)
-      end
+      it "shows correct articles", :aggregate_failures do
+        shows_correct_articles_count(3)
+        shows_main_article
 
-      it "shows the main article" do
-        expect(page).to have_selector(".crayons-story--featured", visible: :visible, count: 1)
-      end
-
-      it "shows the correct articles" do
         within("#articles-list") do
           expect(page).to have_text(article.title)
           expect(page).to have_text(days_old_article.title)
@@ -51,15 +52,10 @@ RSpec.describe "User visits articles by timeframe", type: :system do
     context "when viewing articles for year" do
       before { visit "/top/year" }
 
-      it "shows correct articles count" do
-        expect(page).to have_selector(".crayons-story", visible: :visible, count: 4)
-      end
+      it "shows correct articles", :aggregate_failures do
+        shows_correct_articles_count(4)
+        shows_main_article
 
-      it "shows the main article" do
-        expect(page).to have_selector(".crayons-story--featured", visible: :visible, count: 1)
-      end
-
-      it "shows the correct articles" do
         within("#articles-list") do
           expect(page).to have_text(article.title)
           expect(page).to have_text(days_old_article.title)
@@ -72,16 +68,11 @@ RSpec.describe "User visits articles by timeframe", type: :system do
     context "when viewing articles for infinity" do
       before { visit "/top/infinity" }
 
-      it "shows correct articles and cta count" do
-        expect(page).to have_selector(".crayons-story", visible: :visible, count: 5)
+      it "shows correct articles and cta count", :aggregate_failures do
+        shows_correct_articles_count(5)
+        shows_main_article
         expect(page).to have_selector(".feed-cta", count: 1)
-      end
 
-      it "shows the main article" do
-        expect(page).to have_selector(".crayons-story--featured", visible: :visible, count: 1)
-      end
-
-      it "shows the correct articles" do
         within("#articles-list") do
           expect(page).to have_text(article.title)
           expect(page).to have_text(days_old_article.title)
@@ -95,16 +86,11 @@ RSpec.describe "User visits articles by timeframe", type: :system do
     context "when viewing articles for latest" do
       before { visit "/latest" }
 
-      it "shows correct articles and cta count" do
-        expect(page).to have_selector(".crayons-story", visible: :visible, count: 5)
+      it "shows correct articles and cta-count", :aggregate_failures do
+        shows_correct_articles_count(5)
+        shows_main_article
         expect(page).to have_selector(".feed-cta", count: 1)
-      end
 
-      it "shows the main article" do
-        expect(page).to have_selector(".crayons-story--featured", visible: :visible, count: 1)
-      end
-
-      it "shows the correct articles" do
         within("#articles-list") do
           expect(page).to have_text(article.title)
           expect(page).to have_text(days_old_article.title)
@@ -124,15 +110,10 @@ RSpec.describe "User visits articles by timeframe", type: :system do
       visit "/top/week"
     end
 
-    it "shows correct articles count" do
-      expect(page).to have_xpath("//article[contains(@class, 'crayons-story') and contains(@class, 'false')]", count: 1)
-    end
+    it "shows correct articles", :aggregate_failures do
+      shows_correct_articles_count_via_xpath(1)
+      shows_main_article
 
-    it "shows the main article" do
-      expect(page).to have_selector(".crayons-story--featured", visible: :visible, count: 1)
-    end
-
-    it "shows the correct articles" do
       within("#articles-list") do
         expect(page).to have_text(article.title)
         expect(page).to have_text(days_old_article.title)
@@ -147,15 +128,10 @@ RSpec.describe "User visits articles by timeframe", type: :system do
         Percy.snapshot(page, name: "Articles: /top/month")
       end
 
-      it "shows correct articles count" do
-        expect(page).to have_xpath("//article[contains(@class, 'crayons-story') and contains(@class, 'false')]", count: 2)
-      end
+      it "shows correct articles", :aggregate_failures do
+        shows_correct_articles_count_via_xpath(2)
+        shows_main_article
 
-      it "shows the main article" do
-        expect(page).to have_selector(".crayons-story--featured", visible: :visible, count: 1)
-      end
-
-      it "shows the correct articles" do
         within("#articles-list") do
           expect(page).to have_text(article.title)
           expect(page).to have_text(days_old_article.title)
@@ -167,15 +143,10 @@ RSpec.describe "User visits articles by timeframe", type: :system do
     context "when viewing articles for year" do
       before { visit "/top/year" }
 
-      it "shows correct articles count" do
-        expect(page).to have_xpath("//article[contains(@class, 'crayons-story') and contains(@class, 'false')]", count: 3)
-      end
+      it "shows correct articles", :aggregate_failures do
+        shows_correct_articles_count_via_xpath(3)
+        shows_main_article
 
-      it "shows the main article" do
-        expect(page).to have_selector(".crayons-story--featured", visible: :visible, count: 1)
-      end
-
-      it "shows the correct articles" do
         within("#articles-list") do
           expect(page).to have_text(article.title)
           expect(page).to have_text(days_old_article.title)
@@ -188,15 +159,10 @@ RSpec.describe "User visits articles by timeframe", type: :system do
     context "when viewing articles for infinity" do
       before { visit "/top/infinity" }
 
-      it "shows correct articles count" do
-        expect(page).to have_xpath("//article[contains(@class, 'crayons-story') and contains(@class, 'false')]", count: 4)
-      end
+      it "shows correct articles", :aggregate_failures do
+        shows_correct_articles_count_via_xpath(4)
+        shows_main_article
 
-      it "shows the main article" do
-        expect(page).to have_selector(".crayons-story--featured", visible: :visible, count: 1)
-      end
-
-      it "shows the correct articles" do
         within("#articles-list") do
           expect(page).to have_text(article.title)
           expect(page).to have_text(days_old_article.title)
@@ -215,15 +181,10 @@ RSpec.describe "User visits articles by timeframe", type: :system do
         Percy.snapshot(page, name: "Articles: /latest")
       end
 
-      it "shows correct articles" do
-        expect(page).to have_xpath("//article[contains(@class, 'crayons-story') and contains(@class, 'false')]", count: 4)
-      end
+      it "shows correct articles", :aggregate_failures do
+        shows_correct_articles_count_via_xpath(4)
+        shows_main_article
 
-      it "shows the main article" do
-        expect(page).to have_selector(".crayons-story--featured", visible: :visible, count: 1)
-      end
-
-      it "shows the correct articles" do
         within("#articles-list") do
           expect(page).to have_text(article.title)
           expect(page).to have_text(days_old_article.title)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Optimization

## Description
The following changes **cut the runtime for this spec in half.** It took it from running around 40 seconds to running around 20 seconds on my computer. Loading the feed page is a big ask and makes a lot of requests so rather than loading it 3 times for each assertion I moved the assertions into a common method since they are all the came and combined them for each scenario. I added the flag `aggregate_failures` so every assertion that fails will be reported, not just the first one. 

@snackattas 

![alt_text](https://media.giphy.com/media/10AANF4gx80DRK/giphy.gif)
