### PR TITLE
Flaky Spec Fix: Stub Requests to Elasticsearch For some js: true Specs

### DIFF
--- a/docs/tests/test-flags.md
+++ b/docs/tests/test-flags.md
@@ -54,10 +54,10 @@ There are two ways to do this:
 ### `js: true` Flag
 
 `js: true` indicates to our specs that we want the javascript on the page to be
-execute when the page is rendered. One side effect of running our javascript is
+executed when the page is rendered. One side effect of running our javascript in our specs is
 that a lot of pages will hit Elasticsearch. Since we don't clean out
-Elasticsearch between every single spec(because it is very costly) this can lead
-to unexpected data being loaded for a spec. To prevent this use the
+Elasticsearch between every single spec (because it is very costly) this can lead
+to unexpected data being loaded for a spec. To prevent this from happening, we can use the
 `:stub_elasticsearch` flag. The `:stub_elasticsearch` flag will stub all index
 and search requests made to Elasticsearch and return an empty response. This
-will ensure that no unwanted data shows up on your page.
+will ensure that no unwanted data shows up on your spec's page.

--- a/docs/tests/test-flags.md
+++ b/docs/tests/test-flags.md
@@ -11,8 +11,9 @@ test example.
 Some flags that we use are:
 
 - `js: true`
-- `elasticsearch: reset`
+- `elasticsearch_reset: true`
 - `elasticsearch: <search class name>`
+- `stub_elasticsearch: true`
 - `throttle: true`
 - `type: <test type>`
 
@@ -25,8 +26,8 @@ don't have a "database cleaner" for Elasticsearch, we have to do it manually.
 There are two ways to do this:
 
 1. `elasticsearch: reset` - This will trigger a complete tear down and rebuild
-   of Elasticsearch via a block. This takes time so it's not something you
-   want to be doing unless you absolutely have to.
+   of Elasticsearch via a block. This takes time so it's not something you want
+   to be doing unless you absolutely have to.
 
 ```ruby
   config.around(:each, elasticsearch_reset: true) do |example|
@@ -50,7 +51,13 @@ There are two ways to do this:
   end
 ```
 
-**NOTE** Any specs that use the `js: true` flag might be hitting Elasticsearch.
-You may want to consider clearing out Elasticsearch data for those specs even if
-you don't intend on working with Elasticsearch directly to ensure that you have
-a clean page load with no unexpected data.
+### `js: true` Flag
+
+`js: true` indicates to our specs that we want the javascript on the page to be
+execute when the page is rendered. One side effect of running our javascript is
+that a lot of pages will hit Elasticsearch. Since we don't clean out
+Elasticsearch between every single spec(because it is very costly) this can lead
+to unexpected data being loaded for a spec. To prevent this use the
+`:stub_elasticsearch` flag. The `:stub_elasticsearch` flag will stub all index
+and search requests made to Elasticsearch and return an empty response. This
+will ensure that no unwanted data shows up on your page.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -98,6 +98,12 @@ RSpec.configure do |config|
     Sidekiq::Worker.clear_all
   end
 
+  config.before(:each, stub_elasticsearch: true) do |_example|
+    stubbed_search_response = { "hits" => { "hits" => [] } }
+    allow(Search::Client).to receive(:search).and_return(stubbed_search_response)
+    allow(Search::Client).to receive(:index).and_return({ "_source" => {} })
+  end
+
   config.around(:each, elasticsearch_reset: true) do |example|
     Search::Cluster.recreate_indexes
     example.run

--- a/spec/system/articles/user_visits_articles_by_tag_spec.rb
+++ b/spec/system/articles/user_visits_articles_by_tag_spec.rb
@@ -14,13 +14,13 @@ RSpec.describe "User visits articles by tag", type: :system do
     context "when 2 articles" do
       before { visit "/t/javascript" }
 
-      it "shows the header", js: true, percy: true, elasticsearch: "FeedContent" do
+      it "shows the header", js: true, percy: true, stub_elasticsearch: true do
         Percy.snapshot(page, name: "Tags: logged out user")
 
         within("h1") { expect(page).to have_text("javascript") }
       end
 
-      it "shows the follow button", js: true, elasticsearch: "FeedContent" do
+      it "shows the follow button", js: true, stub_elasticsearch: true do
         within("h1") { expect(page).to have_button("Follow") }
       end
 
@@ -44,7 +44,7 @@ RSpec.describe "User visits articles by tag", type: :system do
         end
       end
 
-      it "when user clicks 'week'", js: true, elasticsearch: "FeedContent" do
+      it "when user clicks 'week'", js: true, stub_elasticsearch: true do
         click_on "WEEK"
 
         within("#articles-list") do
@@ -72,7 +72,7 @@ RSpec.describe "User visits articles by tag", type: :system do
       visit "/t/functional"
     end
 
-    it "shows the following button", js: true, elasticsearch: "FeedContent" do
+    it "shows the following button", js: true, stub_elasticsearch: true do
       # TODO: Add Percy snapshot?
       wait_for_javascript
 

--- a/spec/system/articles/user_visits_articles_by_timeframe_spec.rb
+++ b/spec/system/articles/user_visits_articles_by_timeframe_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe "User visits articles by timeframe", type: :system do
     end
   end
 
-  context "when user has logged in", js: true, elasticsearch: "FeedContent" do
+  context "when user has logged in", js: true, stub_elasticsearch: true do
     let(:user) { create(:user) }
 
     before do

--- a/spec/system/homepage/user_visits_homepage_with_announcement_spec.rb
+++ b/spec/system/homepage/user_visits_homepage_with_announcement_spec.rb
@@ -13,7 +13,7 @@ def expect_no_broadcast_data(page)
   expect(page).not_to have_text("Hello, World!")
 end
 
-RSpec.describe "User visits a homepage", type: :system do
+RSpec.describe "User visits a homepage", stub_elasticsearch: true, type: :system do
   context "when user hasn't logged in" do
     context "with an active announcement" do
       before do

--- a/spec/system/user/view_user_index_spec.rb
+++ b/spec/system/user/view_user_index_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "User index", type: :system do
+RSpec.describe "User index", type: :system, stub_elasticsearch: true do
   let!(:user) { create(:user, username: "user3000") }
   let!(:article) { create(:article, user: user) }
   let!(:other_article) { create(:article, title: rand(10_000_000).to_s) }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix
- [x] Optimization
- [x] Documentation Update

## Description
Prior to this change, in order to fix a flaky js spec that had unwanted data showing up on the page we would have to clear all the data out of Elasticsearch. Clearing out that data is costly. I think a better way to solve this problem is to stub elasticsearch for these specs. I also think stubbing elasticsearch with the `stub_elasticsearch` flag is more clear about what is happening than having the flag `elasticsearch: <class name>`  on your spec.

Stubbing elasticsearch is also a lot faster than clearing it out and hitting it during the spec so +1 for speed up.

Credit to @vaidehijoshi for making rethink this approach to fixing these specs.

@snackattas 

## Related Tickets & Documents
#8388 

This is me putting Elasticsearch in a timeout
![alt_text](https://4.bp.blogspot.com/-JsAZxu_Oasc/U8hLj3aqOLI/AAAAAAAAGiE/SBzmJHFUscM/s1600/Time-out.gif)
