### PR TITLE
Hide active announcements from logged-in users on the editor

### DIFF
--- a/app/assets/javascripts/initializers/initializeBroadcast.js
+++ b/app/assets/javascripts/initializers/initializeBroadcast.js
@@ -28,6 +28,8 @@ function camelizedBroadcastKey(title) {
 
 /**
  * A function that finds the close button and adds a click handler to it.
+ * The click handler sets a key in local storage and removes the broadcast
+ * element entirely from the DOM.
  *
  * @function addCloseButtonClickHandle
  * @param {string} title The title of the broadcast.
@@ -37,8 +39,8 @@ function addCloseButtonClickHandle(title) {
     'close-announcement-button',
   )[0];
   closeButton.onclick = (e) => {
-    document.getElementById('active-broadcast').style.display = 'none';
     localStorage.setItem(camelizedBroadcastKey(title), true);
+    document.getElementById('active-broadcast').remove();
   };
 }
 
@@ -47,7 +49,7 @@ function addCloseButtonClickHandle(title) {
  * Determines what classes to add to the broadcast element,
  * and inserts a close button and adds a click handler to it.
  *
- * Adds a `.visible` class to the broadcastElement to make it render.
+ * Adds a `.broadcast-visible` class to the broadcastElement to make it display.
  *
  * @function initializeBroadcast
  * @param {string} broadcastElement The HTML element for the broadcast, with a class of `.active-broadcast`.
@@ -76,18 +78,25 @@ function renderBroadcast(broadcastElement, data) {
     `<div class='broadcast-data'>${html}</div>${closeButton}`,
   );
   addCloseButtonClickHandle(title);
-  broadcastElement.classList.add('visible');
+  broadcastElement.classList.add('broadcast-visible');
 }
 
 /**
  * A function to determine if a broadcast should render.
- * Does not render a broadcast if the current user has opted-out.
- * Does not render a broadcast it has already been inserted, or
+ * Does not render a broadcast on the `/new` route, if the current user
+ * has opted-out, if the broadcast has already been inserted, or
  * if the key for the broadcast's title exists in localStorage.
+ *
+ * If the broadcast exists in the DOM but was hidden by the articleForm,
+ * the function will re-display it again by adding a class.
  *
  * @function initializeBroadcast
  */
 function initializeBroadcast() {
+  if (window.location.pathname === '/new') {
+    return;
+  }
+
   const user = userData();
   const data = broadcastData();
 
@@ -105,6 +114,12 @@ function initializeBroadcast() {
 
   const el = document.getElementById('active-broadcast');
   if (el.firstElementChild) {
+    if (!el.classList.contains('broadcast-visible')) {
+      // The articleForm may have hidden the broadcast when
+      // it loaded, so we need to explicitly display it again.
+      el.classList.toggle('broadcast-visible');
+    }
+
     return; // Only append HTML once, on first render.
   }
 

--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -176,10 +176,10 @@ body.ten-x-hacker-theme {
   // https://github.com/thepracticaldev/dev.to/pull/8234 is merged.
   z-index: 101; // Must be higher than the z-index of the sticky-nav.
   position: fixed;
+}
 
-  &.visible {
-    display: flex;
-  }
+.broadcast-visible {
+  display: flex;
 }
 
 .broadcast-data {

--- a/app/javascript/packs/articleForm.jsx
+++ b/app/javascript/packs/articleForm.jsx
@@ -30,7 +30,22 @@ function loadForm() {
   });
 }
 
+/**
+ * A function to hide an active broadcast if it exists
+ * by removing a `broadcast-visible` class from it.
+ *
+ * @function hideActiveBroadcast
+ */
+function hideActiveBroadcast() {
+  const broadcast = document.getElementById('active-broadcast');
+
+  if (broadcast) {
+    broadcast.classList.remove('broadcast-visible');
+  }
+}
+
 document.ready.then(() => {
+  hideActiveBroadcast();
   loadForm();
   window.InstantClick.on('change', () => {
     if (document.getElementById('article-form')) {

--- a/spec/system/articles/user_creates_an_article_spec.rb
+++ b/spec/system/articles/user_creates_an_article_spec.rb
@@ -28,6 +28,20 @@ RSpec.describe "Creating an article with the editor", type: :system do
     expect(page).to have_selector("header h1", text: "Sample Article")
   end
 
+  context "with an active announcement" do
+    before do
+      create(:announcement_broadcast)
+      get "/async_info/base_data" # Explicitly ensure broadcast data is loaded before doing any checks
+      visit new_path
+    end
+
+    it "does not render the announcement broadcast", js: true do
+      expect(page).not_to have_css(".broadcast-wrapper")
+      expect(page).not_to have_selector(".broadcast-data")
+      expect(page).not_to have_text("Hello, World!")
+    end
+  end
+
   context "with Runkit tag", js: true do
     it "creates a new article with a Runkit tag" do
       visit new_path


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Since the editor UI is a bit special, we want to hide any active announcements whenever a (logged-in) user goes to the editor page (`/new`). This PR adds functionality to hide an active announcement on that page, taking care to make sure it reappears on _every other_ page throughout the site.

## Related Tickets & Documents
Closes https://github.com/thepracticaldev/dev.to/issues/8372.

## QA Instructions, Screenshots, Recordings
HOW TO QA THIS PR:
**1. Create an active announcement, and click through the site. The announcement should display on all pages.**
<img width="1416" alt="Screen Shot 2020-06-11 at 2 18 40 PM" src="https://user-images.githubusercontent.com/6921610/84440379-bd04dc80-abee-11ea-8874-c2220cb50e04.png">

**2. Click on "write a post" or go to the `/new` route. The banner should disappear:***
<img width="1416" alt="Screen Shot 2020-06-11 at 2 18 44 PM" src="https://user-images.githubusercontent.com/6921610/84440461-e32a7c80-abee-11ea-859b-f2ae61205866.png">

**3. Go back to the main page by clicking the `X` from the editor or click the `DEV` icon in the top left. The banner should display throughout the site once again.**
<img width="1416" alt="Screen Shot 2020-06-11 at 2 18 33 PM" src="https://user-images.githubusercontent.com/6921610/84440580-1a009280-abef-11ea-8d44-2b8c6b4a6aab.png">

*Note: there is a slight flicker that sometimes happens on the editor page when hiding the announcement banner. It's not ideal, and I _suspect_ the reason that it happens is because there is some occasional slowness when adding/removing from an element's `classList`. I think doing something like `myElement.style.display = "none"` would technically be _faster_, but it's much more extensible to add/remove a class in the long term rather than overtly messing with setting the `display` property, IMO.

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [x] ~readme~ updated the inline documentation!
- [ ] no documentation needed

## Are there any post deployment tasks we need to perform?
N/A

## What gif best describes this PR or how it makes you feel?

![fab llama](https://media0.giphy.com/media/3o7aD43xbIl7shOMx2/giphy.webp?cid=5a38a5a263872a99c673a5090303a7fd46c29fb6cedcd883&rid=giphy.webp)
