### PR TITLE
Update FlareTag not to cache AR object

### DIFF
--- a/spec/requests/async_info_spec.rb
+++ b/spec/requests/async_info_spec.rb
@@ -9,18 +9,9 @@ RSpec.describe "AsyncInfo", type: :request do
 
   describe "GET /async_info/base_data" do
     context "when not logged-in" do
-      before { get "/async_info/base_data" }
-
-      it "returns broadcast" do
-        expect(response.body).to include("broadcast")
-      end
-
-      it "returns token" do
-        expect(response.body).to include("token")
-      end
-
-      it "does not return user" do
-        expect(response.body).not_to include("user")
+      it "returns json without user" do
+        get "/async_info/base_data"
+        expect(response.parsed_body.keys).to match_array(%w[broadcast param token])
       end
     end
 
@@ -28,8 +19,9 @@ RSpec.describe "AsyncInfo", type: :request do
       it "returns token and user" do
         allow(controller_instance).to receive(:remember_user_token).and_return(nil)
         sign_in create(:user)
+
         get "/async_info/base_data"
-        expect(response.body).to include("broadcast", "token", "user")
+        expect(response.parsed_body.keys).to match_array(%w[broadcast param token user])
       end
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
Prefer caching ActiveRecord ids instead of ActiveRecord objects. Also updated cache name for clarity and invalidation.

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/9#card-39519016
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?
- [x] no, existing spec will support this

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a