### PR TITLE
Allow admins to define onboarding images in config

### DIFF
--- a/app/controllers/internal/configs_controller.rb
+++ b/app/controllers/internal/configs_controller.rb
@@ -135,6 +135,8 @@ class Internal::ConfigsController < Internal::ApplicationController
 
   def onboarding_params
     %i[
+      onboarding_logo_image
+      onboarding_background_image
       onboarding_taskcard_image
       suggested_tags
       suggested_users

--- a/app/javascript/onboarding/Onboarding.jsx
+++ b/app/javascript/onboarding/Onboarding.jsx
@@ -68,13 +68,16 @@ export default class Onboarding extends Component {
 
   render() {
     const { currentSlide } = this.state;
-    return <main className="onboarding-body">{this.slides[currentSlide]}</main>;
+    const { communityConfig } = this.props;
+    return <main className="onboarding-body" style={{backgroundImage: `url(${communityConfig.communityBackground})`}}>{this.slides[currentSlide]}</main>;
   }
 }
 
 Onboarding.propTypes = {
   communityConfig: PropTypes.shape({
     communityName: PropTypes.string.isRequired,
+    communityBackground: PropTypes.string.isRequired,
+    communityLogo: PropTypes.string.isRequired,
     communityDescription: PropTypes.string.isRequired
-  })
+  }).isRequired
 };

--- a/app/javascript/onboarding/__tests__/Onboarding.test.jsx
+++ b/app/javascript/onboarding/__tests__/Onboarding.test.jsx
@@ -29,6 +29,8 @@ function initializeSlides(currentSlide, userData = null, mockData = null) {
     <Onboarding
       communityConfig={{
         communityName: 'Test',
+        communityLogo: '/x.png',
+        communityBackground: '/y.jpg',
         communityDescription: "Wouldn't you like to knoww..",
       }}
     />,

--- a/app/javascript/onboarding/__tests__/__snapshots__/Onboarding.test.jsx.snap
+++ b/app/javascript/onboarding/__tests__/__snapshots__/Onboarding.test.jsx.snap
@@ -3,7 +3,10 @@
 exports[`<Onboarding /> EmailPreferencesForm renders properly 1`] = `
 preact-render-spy (1 nodes)
 -------
-<main class="onboarding-body">
+<main
+  class="onboarding-body"
+  style="background-image: url(/y.jpg);"
+>
   <div class="onboarding-main crayons-modal">
     <div class="crayons-modal__box">
       <nav class="onboarding-navigation">
@@ -89,7 +92,10 @@ preact-render-spy (1 nodes)
 exports[`<Onboarding /> FollowTags renders properly 1`] = `
 preact-render-spy (1 nodes)
 -------
-<main class="onboarding-body">
+<main
+  class="onboarding-body"
+  style="background-image: url(/y.jpg);"
+>
   <div class="onboarding-main crayons-modal">
     <div class="crayons-modal__box overflow-auto">
       <nav class="onboarding-navigation">
@@ -199,7 +205,10 @@ preact-render-spy (1 nodes)
 exports[`<Onboarding /> FollowUsers renders properly 1`] = `
 preact-render-spy (1 nodes)
 -------
-<main class="onboarding-body">
+<main
+  class="onboarding-body"
+  style="background-image: url(/y.jpg);"
+>
   <div class="onboarding-main crayons-modal">
     <div class="crayons-modal__box overflow-auto">
       <nav class="onboarding-navigation">
@@ -337,15 +346,18 @@ preact-render-spy (1 nodes)
 exports[`<Onboarding /> IntroSlide renders properly 1`] = `
 preact-render-spy (1 nodes)
 -------
-<main class="onboarding-body">
+<main
+  class="onboarding-body"
+  style="background-image: url(/y.jpg);"
+>
   <div class="onboarding-main introduction crayons-modal crayons-modal--m">
     <div class="crayons-modal__box overflow-auto">
       <div class="onboarding-content">
         <figure>
           <img
-            src="/assets/purple-dev-logo.png"
+            src="/x.png"
             class="sticker-logo"
-            alt="DEV"
+            alt="Test"
            />
         </figure>
         <h1 class="introduction-title">firstname lastname— welcome to Test!</h1>
@@ -420,7 +432,10 @@ preact-render-spy (1 nodes)
 exports[`<Onboarding /> ProfileForm renders properly 1`] = `
 preact-render-spy (1 nodes)
 -------
-<main class="onboarding-body">
+<main
+  class="onboarding-body"
+  style="background-image: url(/y.jpg);"
+>
   <div class="onboarding-main crayons-modal">
     <div class="crayons-modal__box">
       <nav class="onboarding-navigation">

--- a/app/javascript/onboarding/components/IntroSlide.jsx
+++ b/app/javascript/onboarding/components/IntroSlide.jsx
@@ -107,9 +107,9 @@ class IntroSlide extends Component {
           <div className="onboarding-content">
             <figure>
               <img
-                src="/assets/purple-dev-logo.png"
+                src={communityConfig.communityLogo}
                 className="sticker-logo"
-                alt="DEV"
+                alt={communityConfig.communityName}
               />
             </figure>
             <h1 className="introduction-title">
@@ -196,9 +196,10 @@ IntroSlide.propTypes = {
   slidesCount: PropTypes.number.isRequired,
   currentSlideIndex: PropTypes.func.isRequired,
   communityConfig: PropTypes.shape({
+    communityLogo: PropTypes.string.isRequired,
     communityName: PropTypes.string.isRequired,
     communityDescription: PropTypes.string.isRequired
-  }),
+  }).isRequired,
 };
 
 export default IntroSlide;

--- a/app/javascript/packs/Onboarding.jsx
+++ b/app/javascript/packs/Onboarding.jsx
@@ -14,6 +14,8 @@ function renderPage() {
   const dataElement = document.getElementById('onboarding-container');
   const communityConfig = {
     communityName: dataElement.dataset.communityName,
+    communityLogo: dataElement.dataset.communityLogo,
+    communityBackground: dataElement.dataset.communityBackground,
     communityDescription: dataElement.dataset.communityDescription,
   };
   import('../onboarding/Onboarding')

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -87,6 +87,8 @@ class SiteConfig < RailsSettings::Base
   field :mailchimp_incoming_webhook_secret, type: :string, default: ""
 
   # Onboarding
+  field :onboarding_logo_image, type: :string, default: "https://dev.to/assets/purple-dev-logo.png"
+  field :onboarding_background_image, type: :string, default: "https://dev.to/assets/onboarding-background-white.png"
   field :onboarding_taskcard_image, type: :string, default: "https://practicaldev-herokuapp-com.freetls.fastly.net/assets/staggered-dev.svg"
   field :suggested_tags, type: :array, default: %w[beginners career computerscience javascript security ruby rails swift kotlin]
   field :suggested_users, type: :array, default: %w[ben jess peter maestromac andy liana]

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -528,6 +528,38 @@
                      } %>
           <div id="onboardingBodyContainer" class="card-body collapse hide" aria-labelledby="onboardingBodyContainer">
             <div class="form-group">
+              <%= f.label :onboarding_logo_image %>
+              <%= f.text_field :onboarding_logo_image,
+                               class: "form-control",
+                               value: SiteConfig.onboarding_logo_image,
+                               placeholder: "https://image.url" %>
+              <div class="row mt-2">
+                <div class="col-12">
+                  <img alt="main social image" class="img-fluid" src="<%= SiteConfig.onboarding_logo_image %>" />
+                </div>
+                <div class="col-12">
+                  <div class="alert alert-info"> Main onboarding display logo image </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="form-group">
+              <%= f.label :onboarding_background_image %>
+              <%= f.text_field :onboarding_background_image,
+                               class: "form-control",
+                               value: SiteConfig.onboarding_background_image,
+                               placeholder: "https://image.url" %>
+              <div class="row mt-2">
+                <div class="col-12">
+                  <img alt="main social image" class="img-fluid" src="<%= SiteConfig.onboarding_background_image %>" />
+                </div>
+                <div class="col-12">
+                  <div class="alert alert-info"> Background for onboarding splash page </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="form-group">
               <%= f.label :onboarding_taskcard_image %>
               <%= f.text_field :onboarding_taskcard_image,
                                class: "form-control",

--- a/app/views/onboardings/show.html.erb
+++ b/app/views/onboardings/show.html.erb
@@ -12,7 +12,12 @@
   }
 </style>
 
-<div id="onboarding-container" data-community-name="<%= community_name %>" data-community-description="<%= SiteConfig.community_description %>">
+<div id="onboarding-container"
+  data-community-name="<%= community_name %>"
+  data-community-description="<%= SiteConfig.community_description %>"
+  data-community-logo="<%= cloudinary SiteConfig.onboarding_logo_image %>"
+  data-community-background="<%= cloudinary SiteConfig.onboarding_background_image %>"
+>
   <%= javascript_packs_with_chunks_tag "Onboarding", defer: true %>
 </div>
 

--- a/spec/requests/internal/configs_spec.rb
+++ b/spec/requests/internal/configs_spec.rb
@@ -285,6 +285,18 @@ RSpec.describe "/internal/config", type: :request do
           expect(SiteConfig.onboarding_taskcard_image).to eq(expected_image_url)
         end
 
+        it "updates onboarding_logo_image" do
+          expected_image_url = "https://dummyimage.com/300x300"
+          post "/internal/config", params: { site_config: { onboarding_logo_image: expected_image_url }, confirmation: confirmation_message }
+          expect(SiteConfig.onboarding_logo_image).to eq(expected_image_url)
+        end
+
+        it "updates onboarding_background_image" do
+          expected_image_url = "https://dummyimage.com/300x300"
+          post "/internal/config", params: { site_config: { onboarding_background_image: expected_image_url }, confirmation: confirmation_message }
+          expect(SiteConfig.onboarding_background_image).to eq(expected_image_url)
+        end
+
         it "removes space suggested_tags" do
           post "/internal/config", params: { site_config: { suggested_tags: "hey, haha,hoho, bobo fofo" }, confirmation: confirmation_message }
           expect(SiteConfig.suggested_tags).to eq(%w[hey haha hoho bobofofo])

--- a/spec/requests/onboardings_spec.rb
+++ b/spec/requests/onboardings_spec.rb
@@ -14,5 +14,22 @@ RSpec.describe "Onboardings", type: :request do
       get onboarding_url
       expect(response).to have_http_status(:ok)
     end
+
+    it "contains proper data attribute keys" do
+      sign_in user
+      get onboarding_url
+      expect(response.body).to include("community-description")
+      expect(response.body).to include("community-logo")
+      expect(response.body).to include("community-background")
+      expect(response.body).to include("data-community-name")
+    end
+
+    it "contains proper data attribute values" do
+      sign_in user
+      get onboarding_url
+      expect(response.body).to include(SiteConfig.community_description)
+      expect(response.body).to include(SiteConfig.onboarding_logo_image)
+      expect(response.body).to include(SiteConfig.onboarding_background_image)
+    end
   end
 end

--- a/spec/requests/onboardings_spec.rb
+++ b/spec/requests/onboardings_spec.rb
@@ -18,9 +18,9 @@ RSpec.describe "Onboardings", type: :request do
     it "contains proper data attribute keys" do
       sign_in user
       get onboarding_url
-      expect(response.body).to include("community-description")
-      expect(response.body).to include("community-logo")
-      expect(response.body).to include("community-background")
+      expect(response.body).to include("data-community-description")
+      expect(response.body).to include("data-community-logo")
+      expect(response.body).to include("data-community-background")
       expect(response.body).to include("data-community-name")
     end
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This allows admins to define the values for onboarding....

<img width="1176" alt="Screen Shot 2020-06-11 at 7 18 38 PM" src="https://user-images.githubusercontent.com/3102842/84448352-70ce9200-ac18-11ea-9a06-5cbc567751d6.png">

Addresses a portion of this...

https://github.com/thepracticaldev/dev.to/issues/5507