### PR TITLE
Small ActiveRecord optimizations: begone race conditions and hello bulk insert

### DIFF
--- a/app/controllers/poll_skips_controller.rb
+++ b/app/controllers/poll_skips_controller.rb
@@ -2,12 +2,15 @@ class PollSkipsController < ApplicationController
   before_action :authenticate_user!, only: %i[create]
 
   def create
-    @poll_skip = PollSkip.find_or_create_by(poll_id: poll_skips_params[:poll_id], user_id: current_user.id)
-    @poll = Poll.find(poll_skips_params[:poll_id])
-    render json: { voting_data: @poll.voting_data,
-                   poll_id: poll_skips_params[:poll_id].to_i,
-                   user_vote_poll_option_id: nil,
-                   voted: false }
+    poll = Poll.find(poll_skips_params[:poll_id])
+    poll.poll_skips.create_or_find_by(user_id: current_user.id)
+
+    render json: {
+      voting_data: poll.voting_data,
+      poll_id: poll.id,
+      user_vote_poll_option_id: nil,
+      voted: false
+    }
   end
 
   private

--- a/app/models/chat_channel.rb
+++ b/app/models/chat_channel.rb
@@ -103,9 +103,16 @@ class ChatChannel < ApplicationRecord
   end
 
   def add_users(users)
-    Array(users).each do |user|
-      ChatChannelMembership.find_or_create_by!(user_id: user.id, chat_channel_id: id)
+    now = Time.current
+    users_params = Array.wrap(users).map do |user|
+      { user_id: user.id, chat_channel_id: id, created_at: now, updated_at: now }
     end
+
+    # memberships that are not unique are automatically skipped
+    ChatChannelMembership.insert_all(
+      users_params,
+      unique_by: :index_chat_channel_memberships_on_chat_channel_id_and_user_id,
+    )
   end
 
   def invite_users(users:, membership_role: "member", inviter: nil)

--- a/app/models/poll_skip.rb
+++ b/app/models/poll_skip.rb
@@ -1,13 +1,4 @@
 class PollSkip < ApplicationRecord
   belongs_to :poll
   belongs_to :user
-
-  validate :one_vote_per_poll_per_user
-
-  private
-
-  def one_vote_per_poll_per_user
-    already_voted = poll.poll_votes.where(user_id: user_id).any? || poll.poll_skips.where(user_id: user_id).any?
-    errors.add(:base, "cannot vote more than once in one poll") if already_voted
-  end
 end

--- a/app/models/poll_skip.rb
+++ b/app/models/poll_skip.rb
@@ -1,4 +1,13 @@
 class PollSkip < ApplicationRecord
   belongs_to :poll
   belongs_to :user
+
+  validate :one_vote_per_poll_per_user
+
+  private
+
+  def one_vote_per_poll_per_user
+    already_voted = poll.poll_votes.where(user_id: user_id).any? || poll.poll_skips.where(user_id: user_id).any?
+    errors.add(:base, "cannot vote more than once in one poll") if already_voted
+  end
 end

--- a/spec/models/chat_channel_spec.rb
+++ b/spec/models/chat_channel_spec.rb
@@ -72,6 +72,21 @@ RSpec.describe ChatChannel, type: :model do
     end
   end
 
+  describe "#add_users" do
+    it "adds users" do
+      expect do
+        chat_channel.add_users(users)
+      end.to change(chat_channel.users, :count).by(users.size)
+    end
+
+    it "does not add users twice" do
+      expect do
+        chat_channel.add_users(users)
+        chat_channel.add_users(users)
+      end.to change(chat_channel.users, :count).by(users.size)
+    end
+  end
+
   describe "#remove_user" do
     it "removes a user from a channel" do
       chat_channel.add_users(users.first)

--- a/spec/models/data_update_script_spec.rb
+++ b/spec/models/data_update_script_spec.rb
@@ -5,40 +5,10 @@ RSpec.describe DataUpdateScript do
 
   it { is_expected.to validate_uniqueness_of(:file_name) }
 
-  it "can constantize all script names" do
-    described_class.load_script_ids # Create DataUpdateScripts in db
-    described_class.filenames.each do |filename|
-      script = described_class.find_by(file_name: filename)
-      expect { script.file_class }.not_to raise_error
-    end
-  end
-
   it "default orders scripts by name" do
     script1 = create(:data_update_script, file_name: "456_test_script")
     script2 = create(:data_update_script, file_name: "123_test_script")
     expect(described_class.pluck(:id)).to eq([script2.id, script1.id])
-  end
-
-  describe ".load_script_ids" do
-    before { stub_const "#{described_class}::DIRECTORY", test_directory }
-
-    it "creates new DataUpdateScripts from files" do
-      expect do
-        described_class.load_script_ids
-      end.to change(described_class, :count).by(1)
-    end
-
-    it "returns script ids that need to be run" do
-      script = create(:data_update_script)
-      need_running_ids = described_class.load_script_ids
-      expect(need_running_ids).to include(script.id)
-    end
-
-    it "does not return script ids that are running" do
-      script = create(:data_update_script, run_at: Time.current, status: :working)
-      need_running_ids = described_class.load_script_ids
-      expect(need_running_ids).not_to include(script.id)
-    end
   end
 
   describe ".scripts_to_run" do
@@ -124,10 +94,8 @@ RSpec.describe DataUpdateScript do
 
   describe "#file_path" do
     it "returns correct loadable file_path" do
-      described_class.load_script_ids
-      described_class.filenames.each do |filename|
+      described_class.scripts_to_run.each do |script|
         expect do
-          script = described_class.find_by(file_name: filename)
           require script.file_path
         end.not_to raise_error
       end

--- a/spec/requests/chat_channel_memberships_spec.rb
+++ b/spec/requests/chat_channel_memberships_spec.rb
@@ -20,9 +20,8 @@ RSpec.describe "ChatChannelMemberships", type: :request do
       end
 
       it "return all details of chat channel" do
-        expect(response.status).to eq(200)
-        puts response.body.inspect
-        expect(JSON.parse(response.body)["result"].keys).to eq(%w[chat_channel memberships current_membership])
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body["result"].keys).to eq(%w[chat_channel memberships current_membership])
       end
     end
 

--- a/spec/requests/poll_skips_spec.rb
+++ b/spec/requests/poll_skips_spec.rb
@@ -7,27 +7,32 @@ RSpec.describe "PollSkips", type: :request do
 
   before { sign_in user }
 
-  describe "POST /poll_votes" do
+  describe "POST /poll_skips" do
     it "votes on behalf of current user" do
-      post "/poll_skips", params: {
-        poll_skip: { poll_id: poll.id }
-      }
-      expect(JSON.parse(response.body)["voting_data"]["votes_count"]).to eq(0)
-      expect(JSON.parse(response.body)["voting_data"]["votes_distribution"]).to include([poll.poll_options.first.id, 0])
-      expect(JSON.parse(response.body)["poll_id"]).to eq(poll.id)
-      expect(JSON.parse(response.body)["voted"]).to eq(false)
+      post "/poll_skips", params: { poll_skip: { poll_id: poll.id } }
+
+      json = response.parsed_body
+
+      expect(json["voting_data"]["votes_count"]).to eq(0)
+      expect(json["voting_data"]["votes_distribution"]).to include([poll.poll_options.first.id, 0])
+      expect(json["poll_id"]).to eq(poll.id)
+      expect(json["voted"]).to be(false)
       expect(user.poll_skips.size).to eq(1)
     end
 
     it "only allows one of vote or skip" do
-      post "/poll_skips", params: {
-        poll_skip: { poll_id: poll.id }
-      }
-      post "/poll_votes", params: {
-        poll_vote: { poll_option_id: poll.poll_options.first.id }
-      }
+      post "/poll_skips", params: { poll_skip: { poll_id: poll.id } }
+      post "/poll_votes", params: { poll_vote: { poll_option_id: poll.poll_options.first.id } }
+
       expect(user.poll_skips.size).to eq(1)
       expect(user.poll_votes.size).to eq(0)
+    end
+
+    it "does not allow two skips" do
+      expect do
+        post "/poll_skips", params: { poll_skip: { poll_id: poll.id } }
+        post "/poll_skips", params: { poll_skip: { poll_id: poll.id } }
+      end.to change(user.poll_skips, :count).by(1)
     end
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

This PR contains three things:

- usage of [create_or_find_by](https://api.rubyonrails.org/classes/ActiveRecord/Relation.html#method-i-create_or_find_by) in `PollSkip`: which is a new Rails 6 methods with works only in certain cases, the goal here is to avoid the possible race condition of "find or create" where something can be created by a different thread between the find and the create (given the model this is used and the fact polls are not used much, it's not strictly necessary but it's a good addition to our tools ;)) *[this only works with a corresponding unique index]*

- bulk inserts for both memberships in a chat channel (going from N queries, one per each user, to 1)
- bulk inserts for data update scripts (I also moved stuff that was only used in tests as `private`, no point keeping it public if we never use it)

Yay Rails 6 :D

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
