### PR TITLE
Modify default size for onboarding graphic

### DIFF
--- a/app/views/onboardings/show.html.erb
+++ b/app/views/onboardings/show.html.erb
@@ -16,7 +16,7 @@
   data-community-name="<%= community_name %>"
   data-community-description="<%= SiteConfig.community_description %>"
   data-community-logo="<%= cloudinary SiteConfig.onboarding_logo_image %>"
-  data-community-background="<%= cloudinary SiteConfig.onboarding_background_image %>"
+  data-community-background="<%= cloudinary(SiteConfig.onboarding_background_image, "1680", 75) %>"
 >
   <%= javascript_packs_with_chunks_tag "Onboarding", defer: true %>
 </div>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Default `cloudinary` method size is 500 which is too small for splash images like this.