### PR TITLE
Flaky Spec Fix:Sitemap: Don't assume Database Ordering, Explicitly Set Articles for Assertions

### DIFF
--- a/spec/requests/sitemaps_spec.rb
+++ b/spec/requests/sitemaps_spec.rb
@@ -26,13 +26,14 @@ RSpec.describe "Sitemaps", type: :request do
     end
 
     it "sends a surrogate key (for Fastly's user)" do
-      create_list(:article, 4)
-      Article.limit(3).update_all(published_at: "2020-03-07T00:27:30Z", score: 10)
+      articles = create_list(:article, 4)
+      included_articles = articles.first(3)
+      included_articles.each { |a| a.update(published_at: "2020-03-07T00:27:30Z", score: 10) }
       get "/sitemap-Mar-2020.xml"
-      article = Article.first
+      article = included_articles.first
       expect(response.body).to include("<loc>#{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}#{article.path}</loc>")
       expect(response.body).to include("<lastmod>#{article.last_comment_at.strftime('%F')}</lastmod>")
-      expect(response.body).not_to include(Article.last.path)
+      expect(response.body).not_to include(articles.last.path)
       expect(response.media_type).to eq("application/xml")
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
In this spec we are calling `Article.limit(3)` to update 3 articles and then we are calling `Article.first` and `Article.last` for our assertions with the assumption that `limit(3)` grabbed the first 3 articles. However, `limit()` does not order the articles 
```
[5] pry(main)> Article.limit(2)
  Article Load (3.5ms)  SELECT "articles".* FROM "articles" LIMIT $1  [["LIMIT", 2]]
```
so there is no guarantee `Article.first` was in our original limit(3) list. This explicitly splits up the articles and ensures the article we assert is present in the sitemap is one we actually updated.

@snackattas 


![alt_text](https://media2.giphy.com/media/YHJeQZFyBjb2w/200.gif)
