### PR TITLE
Travis Speed Up/Fixes: Dont Run Deploy Stages for PRs, Fix Notification and Service Warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ addons:
       - $(ls tmp/csvs/*.csv | tr "\n" ":")
     debug: true
 services:
-  - redis-server
+  - redis
 env:
   global:
     - RAILS_ENV=test
@@ -76,9 +76,19 @@ script:
 after_script:
   - ./cc-test-reporter format-coverage -t simplecov -o ./coverage/codeclimate.$KNAPSACK_PRO_CI_NODE_INDEX.json ./coverage/spec/.resultset.json
   - ./cc-test-reporter sum-coverage --output - --parts $COVERAGE_REPORTS_TOTAL coverage/codeclimate.*.json | ./cc-test-reporter upload-coverage --input -
+notifications:
+  slack:
+    if: branch = master
+    on_pull_requests: false
+    on_success: change
+    on_failure: always
+    rooms:
+      secure: vzIee4jDgPSRY4szZPdD/jW7YW4GzGqo5NoLV9Exz9TBoWH9UqJnc0TOb2YN84Ys5baRK7LOqxpfp8kFveZkrKGi7/ypeEJlpc9E5UqVh/bwQhvOGrKEg1fvNXbARRnO/sJ49o1CMvroMWvt3GurzuuY9Qu2r+3NBjn9aVwLnLzXsBuF+m2lLoeSkHnW13OC73EeJMsse6JBoCe3gp/srDwISp9+MU+sEAPaY333WK9Vk1kdG7D5oUIuT7743airLRiyWiNUCD1450g864628CEOEZKJAAtqk6kTmvwB91DJMnhD/XhMm4H21kd54YHy0fhqzcG8hYd1lDZuUfrOBfpdEtfnpcRwMyMpY+FPPHXkHhck3OiLJnzkV4L+Lr5W/RvDJ63Ye2nxT4hOItLWaoZWax/LhoIrhZjgYBc4JhiGRQJ8m2HzoRyceeG9Y80vayGVN7y46sjYHP5NHRI36qmJipneDRAJklBTXLdYATvVM/6Mh9B7+H/nBGR6UVJLBC/txi2C8rZRjKBZ/i9e+q/MZs0UEvOuvbz9BXKU08rI+rarJqH3h5Ji9G/k3M0mQ8EfvadabA9lu+gNUAAnq+vwLETweKvfbRpDQjVBKnWsOJoUl9aarfkBn3lhQE8fxZJT/GchLGZPx/CWUE4o1OhliBA9avJ7WINyYStM4Mc=
+
 jobs:
   include:
     - stage: Deploy
+      if: type != pull_request
       script: skip
       after_script: skip
       deploy:
@@ -88,11 +98,3 @@ jobs:
           master: practicaldev
         on:
           condition: $TRAVIS_COMMIT_MESSAGE =~ \[deploy\]
-      notifications:
-        slack:
-          if: branch = master
-          on_pull_requests: false
-          on_success: change
-          on_failure: always
-          rooms:
-            secure: vzIee4jDgPSRY4szZPdD/jW7YW4GzGqo5NoLV9Exz9TBoWH9UqJnc0TOb2YN84Ys5baRK7LOqxpfp8kFveZkrKGi7/ypeEJlpc9E5UqVh/bwQhvOGrKEg1fvNXbARRnO/sJ49o1CMvroMWvt3GurzuuY9Qu2r+3NBjn9aVwLnLzXsBuF+m2lLoeSkHnW13OC73EeJMsse6JBoCe3gp/srDwISp9+MU+sEAPaY333WK9Vk1kdG7D5oUIuT7743airLRiyWiNUCD1450g864628CEOEZKJAAtqk6kTmvwB91DJMnhD/XhMm4H21kd54YHy0fhqzcG8hYd1lDZuUfrOBfpdEtfnpcRwMyMpY+FPPHXkHhck3OiLJnzkV4L+Lr5W/RvDJ63Ye2nxT4hOItLWaoZWax/LhoIrhZjgYBc4JhiGRQJ8m2HzoRyceeG9Y80vayGVN7y46sjYHP5NHRI36qmJipneDRAJklBTXLdYATvVM/6Mh9B7+H/nBGR6UVJLBC/txi2C8rZRjKBZ/i9e+q/MZs0UEvOuvbz9BXKU08rI+rarJqH3h5Ji9G/k3M0mQ8EfvadabA9lu+gNUAAnq+vwLETweKvfbRpDQjVBKnWsOJoUl9aarfkBn3lhQE8fxZJT/GchLGZPx/CWUE4o1OhliBA9avJ7WINyYStM4Mc=


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
Currently, the Deploy stage will always run but only actually deploy if the branch is master and the deploy flag is present. This wastes a couple of mins to get a passing build on pull requests [so I figured out how to skip that stage altogether for PRs](https://docs.travis-ci.com/user/build-stages/#specifying-stage-order-and-conditions). 

![Screen Shot 2020-06-12 at 2 51 54 PM](https://user-images.githubusercontent.com/1813380/84541094-48986f00-acbc-11ea-8745-f668bae83708.png)

We want notifications when any job fails so I moved the notification block out into the shared resources area which got rid of this warning and I think should fix that problem. Will have to wait til a merge to find out. 
![Screen Shot 2020-06-12 at 2 46 31 PM](https://user-images.githubusercontent.com/1813380/84540980-1981fd80-acbc-11ea-84af-50bd2afe5752.png)

`redis-server` was also giving us a warning so I changed that to redis per the warning suggestion
![Screen Shot 2020-06-12 at 2 46 35 PM](https://user-images.githubusercontent.com/1813380/84541043-2ef72780-acbc-11ea-92fc-eff7d5807e23.png)


![alt_text](https://media2.giphy.com/media/3o7aTIGlhSo1bL8QUg/200.gif)
