### PR TITLE
Spec Cleanup: Stub Elasticsearch for js: true Specs that Dont Need it

### DIFF
--- a/spec/system/homepage/user_visits_homepage_articles_spec.rb
+++ b/spec/system/homepage/user_visits_homepage_articles_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "User visits a homepage", type: :system do
         expect(page).to have_selector(".crayons-story--featured", visible: :visible)
       end
 
-      it "shows the main article readable date", js: true, elasticsearch: "FeedContent" do
+      it "shows the main article readable date", js: true, stub_elasticsearch: true do
         expect(page).to have_selector(".crayons-story--featured time", text: "Mar 4")
       end
 
@@ -40,7 +40,7 @@ RSpec.describe "User visits a homepage", type: :system do
         expect(page).to have_text(article2.title)
       end
 
-      it "shows all articles dates", js: true, elasticsearch: "FeedContent" do
+      it "shows all articles dates", js: true, stub_elasticsearch: true do
         expect(page).to have_selector(".crayons-story time", text: "Mar 4", count: 2)
       end
 

--- a/spec/system/organization/user_views_an_organization_spec.rb
+++ b/spec/system/organization/user_views_an_organization_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Organization index", type: :system do
     context "when 2 articles" do
       before { visit "/#{organization.slug}" }
 
-      it "shows the header", js: true do
+      it "shows the header", js: true, stub_elasticsearch: true do
         within("h1") { expect(page).to have_content(organization.name) }
         within("div.profile-details") do
           expect(page).to have_button("Follow")
@@ -36,7 +36,7 @@ RSpec.describe "Organization index", type: :system do
     end
 
     context "when more articles" do
-      it "visits ok", js: true, percy: true do
+      it "visits ok", js: true, percy: true, stub_elasticsearch: true do
         create_list(:article, 3, organization: organization)
         visit "/#{organization.slug}"
 
@@ -53,7 +53,7 @@ RSpec.describe "Organization index", type: :system do
       user.follows.create(followable: organization)
     end
 
-    it "shows the correct button", js: true do
+    it "shows the correct button", js: true, stub_elasticsearch: true do
       visit "/#{organization.slug}"
 
       within(".profile-details") do

--- a/spec/system/search/display_jobs_banner_spec.rb
+++ b/spec/system/search/display_jobs_banner_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Display Jobs Banner spec", type: :system, js: true do
+RSpec.describe "Display Jobs Banner spec", type: :system, js: true, stub_elasticsearch: true do
   before do
     allow(SiteConfig).to receive(:jobs_url).and_return("www.very_cool_jobs_website.com")
   end

--- a/spec/system/user/view_user_comments_spec.rb
+++ b/spec/system/user/view_user_comments_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "User comments", type: :system do
       end
     end
 
-    it "shows user's comments", js: true, percy: true, elasticsearch: "FeedContent" do
+    it "shows user's comments", js: true, percy: true, stub_elasticsearch: true do
       Percy.snapshot(page, name: "Comments: /:user_id/comments renders")
 
       within("#substories div.index-comments") do

--- a/spec/system/user_uses_the_editor_spec.rb
+++ b/spec/system/user_uses_the_editor_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe "Using the editor", type: :system do
     end
   end
 
-  describe "using v2 editor", js: true do
+  describe "using v2 editor", js: true, stub_elasticsearch: true do
     before { user.update(editor_version: "v2") }
 
     it "fill out form with rich content and click publish" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
In #8453 I stubbed Elasticsearch for `js: true` specs that had recently failed due to Elasticsearch data displaying on the page when not expected. With the flag now an option I put a puts statement in the Search Controller to see what system specs hit Elasticsearch. Once I got that list I went down and found the ones that don't need it and stubbed it for all of those.

![alt_text](https://media1.tenor.com/images/785d981d76c8d8ff1a492c301c372ce0/tenor.gif?itemid=7172460)
