### PR TITLE
Remove private reactions from notifictaions

### DIFF
--- a/app/services/notifications/reactions/send.rb
+++ b/app/services/notifications/reactions/send.rb
@@ -22,7 +22,7 @@ module Notifications
       def call
         return unless receiver.is_a?(User) || receiver.is_a?(Organization)
 
-        reaction_siblings = Reaction.where(reactable_id: reaction.reactable_id, reactable_type: reaction.reactable_type).
+        reaction_siblings = Reaction.public_category.where(reactable_id: reaction.reactable_id, reactable_type: reaction.reactable_type).
           where.not(reactions: { user_id: reaction.reactable_user_id }).
           preload(:reactable).includes(:user).where.not(users: { id: nil }).
           order("reactions.created_at DESC")

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -187,12 +187,6 @@ RSpec.describe "NotificationsIndex", type: :request do
         expect(has_both_names(response.body)).to be true
       end
 
-      it "does not include private reactions" do
-        mock_heart_reaction_notifications(50, %w[like unicorn thumbsdown])
-        get "/notifications"
-        expect(response.body).not_to include("Thumbsdown")
-      end
-
       it "renders the proper message for multiple reactions" do
         random_amount = rand(3..10)
         mock_heart_reaction_notifications(random_amount, %w[unicorn like])
@@ -588,6 +582,7 @@ RSpec.describe "NotificationsIndex", type: :request do
     context "when user is trusted" do
       let(:user) { create(:user, :trusted) }
       let(:reaction) { create(:thumbsdown_reaction, user: user) }
+      let(:like_reaction) { create(:reaction, user: user) }
 
       it "allow sees thumbsdown category" do
         sign_in user
@@ -595,6 +590,17 @@ RSpec.describe "NotificationsIndex", type: :request do
         get "/notifications"
         expect(response.body).to include("Notifications")
       end
+
+      it "does not show notification" do
+        other_user = create(:user)
+        sign_in other_user
+        Notification.send_reaction_notification_without_delay(reaction, other_user)
+        Notification.send_reaction_notification_without_delay(like_reaction, other_user)
+        get "/notifications"
+        expect(response.body).to include("Like")
+        expect(response.body).not_to include("Thumbsdown")
+      end
+
     end
 
     context "when a user has a new welcome notification" do

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -187,6 +187,12 @@ RSpec.describe "NotificationsIndex", type: :request do
         expect(has_both_names(response.body)).to be true
       end
 
+      it "does not include private reactions" do
+        mock_heart_reaction_notifications(50, %w[like unicorn thumbsdown])
+        get "/notifications"
+        expect(response.body).not_to include("Thumbsdown")
+      end
+
       it "renders the proper message for multiple reactions" do
         random_amount = rand(3..10)
         mock_heart_reaction_notifications(random_amount, %w[unicorn like])


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

It appears that in some cases the existence of negative reaction is leaking into notifications.