### PR TITLE
Fix bug in determining if repo is featured

### DIFF
--- a/app/controllers/github_repos_controller.rb
+++ b/app/controllers/github_repos_controller.rb
@@ -41,7 +41,10 @@ class GithubReposController < ApplicationController
     client = Github::OauthClient.for_user(current_user)
 
     repos = client.repositories(visibility: :public).map do |repo|
-      repo.featured = known_repositories.delete_if { |known| known.github_id_code == repo.id }.present?
+      if (known_index = known_repositories.find_index { |known| known.github_id_code == repo.id })
+        repo.featured = true
+        known_repositories.delete_at(known_index)
+      end
       repo
     end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Description

While #8382 fixed one problem, it introduced another, because I got confused between `Array#delete_if` (returns the modified array) and `Array#delete_at` (return the deleted element). This PR addresses the problem and 

## Related Tickets & Documents

#7751, specifically [this comment](https://github.com/thepracticaldev/dev.to/issues/7751#issuecomment-643412666)

## QA Instructions, Screenshots, Recordings

1. Create a pin for a GH repo.
2. Delete repo.
3. Visit https://dev.to/settings/integrations and make sure the list of pinned/unpinned repositories is what you expect.

## Added tests?

- [X] yes (modified existing ones to cover this case better)

## Added to documentation?

- [X] no documentation needed

