### PR TITLE
Fix loading bug with mod center articles

### DIFF
--- a/app/javascript/packs/modCenter.jsx
+++ b/app/javascript/packs/modCenter.jsx
@@ -2,6 +2,8 @@ import { h, render } from 'preact';
 import { ModerationArticles } from '../modCenter/moderationArticles';
 import { initializeModCenterFunctions } from '../modCenter/modCenter';
 
+let elementLoaded = false;
+
 function loadElement() {
   const root = document.getElementById('mod-index-list');
   if (root) {
@@ -10,8 +12,14 @@ function loadElement() {
 }
 
 window.InstantClick.on('change', () => {
-  loadElement();
+  if (!elementLoaded) {
+    loadElement();
+    elementLoaded = true;
+  }
 });
 
-loadElement();
-initializeModCenterFunctions();
+if (!elementLoaded) {
+  loadElement();
+  initializeModCenterFunctions();
+  elementLoaded = true;
+}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This fixes the loading bug where the same articles are loaded multiple times.

## QA Instructions, Screenshots, Recordings
1. Visit /mod
2. click on a tag view
3. visit "All topics" again
4. see that it shouldn't have duplicate articles

## Added tests?
- [x] no, because they aren't needed and this should be redone in Preact (probably)

## Added to documentation?
- [x] no documentation needed