### PR TITLE
Always set the default email address to ENV variable

### DIFF
--- a/app/controllers/internal/configs_controller.rb
+++ b/app/controllers/internal/configs_controller.rb
@@ -48,11 +48,12 @@ class Internal::ConfigsController < Internal::ApplicationController
       onboarding_params |
       job_params
 
+    params[:site_config][:email_addresses][:default] = ApplicationConfig["DEFAULT_EMAIL"]
     params.require(:site_config).permit(
       allowed_params,
       authentication_providers: [],
       social_media_handles: SiteConfig.social_media_handles.keys,
-      email_addresses: SiteConfig.email_addresses.except(:default).keys,
+      email_addresses: SiteConfig.email_addresses.keys,
       meta_keywords: SiteConfig.meta_keywords.keys,
     )
   end

--- a/app/controllers/internal/configs_controller.rb
+++ b/app/controllers/internal/configs_controller.rb
@@ -48,7 +48,7 @@ class Internal::ConfigsController < Internal::ApplicationController
       onboarding_params |
       job_params
 
-    params[:site_config][:email_addresses][:default] = ApplicationConfig["DEFAULT_EMAIL"]
+    params[:site_config][:email_addresses][:default] = ApplicationConfig["DEFAULT_EMAIL"] if params[:site_config][:email_addresses].present?
     params.require(:site_config).permit(
       allowed_params,
       authentication_providers: [],

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -206,7 +206,7 @@
               <div class="alert alert-info">Default (set via DEFAULT_EMAIL environment variable)</div>
              </div>
              <%= f.fields_for :email_addresses do |email_field| %>
-               <% SiteConfig.email_addresses.each do |type, address| %>
+               <% SiteConfig.email_addresses.except(:default).each do |type, address| %>
                  <div>
                    <%= email_field.label type %>
                    <%= email_field.text_field type,

--- a/spec/requests/internal/configs_spec.rb
+++ b/spec/requests/internal/configs_spec.rb
@@ -106,6 +106,7 @@ RSpec.describe "/internal/config", type: :request do
           expect(SiteConfig.email_addresses[:privacy]).to eq("privacy@example.com")
           expect(SiteConfig.email_addresses[:business]).to eq("partners@example.com")
           expect(SiteConfig.email_addresses[:members]).to eq("members@example.com")
+          expect(SiteConfig.email_addresses[:default]).to eq(ApplicationConfig["DEFAULT_EMAIL"])
         end
       end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Before, whenever a site config was updated via the controller (`/internal/config`), it would remove the `default` email address, but still show it in the UI. This fixes it so the default email address is always set to the ENV variable. It also prevents it from being edited via a duplicate form in the view.

## Related Tickets & Documents
#8246 

## QA Instructions, Screenshots, Recordings
1. Go to `/internal/config`
2. Add yourself as site config admin with:
```
me = User.find(your_id) # replace your_id with your actual ID
me.add_role :single_resource_admin, Config
```
2. Submit the form via the update button in the view
3. Check in console that the email address is still present:
```
SiteConfig.email_addresses
#=> :default should point to your ENV variable
```

### Before:

![Screen Shot 2020-06-15 at 11 55 21 AM](https://user-images.githubusercontent.com/17884966/84679537-673a7800-aeff-11ea-8519-7daf71142d8d.png)

### After:

![Screen Shot 2020-06-15 at 11 54 47 AM](https://user-images.githubusercontent.com/17884966/84679541-69043b80-aeff-11ea-8c4f-52ab3dee578c.png)

## Added tests?
- [x] yes

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
Don't update any site config variables until this is merged!

## [optional] What gif best describes this PR or how it makes you feel?

![A suspicious cat looks around, with text that says, "Pretty sure... I smell a Monday here!"](https://media.giphy.com/media/13sz48R33vovLi/giphy.gif)
