### PR TITLE
Flaky Spec Fix: Ensure Article Titles are Unique

### DIFF
--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
 
   factory :article do
     transient do
-      title { Faker::Food.dish }
+      title { generate :title }
       published { true }
       date { "01/01/2015" }
       tags { "javascript, html, css" }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Fixes the following flaky specs(and likely others) by ensuring that ALL article titles are unique: 
```
1) User comments when user is unauthorized does not show user's articles
     Failure/Error: expect(page).not_to have_content(article.title)
       expected not to find text "Caesar Salad" in "View All Activity\nAll 2 Comments\nre: Souvlaki Jun 15\nDrinking stumptown etsy small batch banh mi tofu flannel medi...\nre: Caesar Salad Jun 15\nTaxidermy quinoa post-ironic shoreditch. Vinegar vice swag."
     # ./spec/system/user/view_user_comments_spec.rb:14:in `block (4 levels) in <top (required)>'
     # ./spec/system/user/view_user_comments_spec.rb:13:in `block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:136:in `block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:136:in `block (2 levels) in <top (required)>'

1) Articles GET /feed when :username param is not given returns only featured articles
     Failure/Error: expect(response.body).not_to include(not_featured_article.title)
       expected "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<rss version=\"2.0\">\n  <channel>\n    <title>DEV(local...     <category>html</category>\n      <category>css</category>\n    </item>\n  </channel>\n</rss>\n" not to include "French Fries with Sausages"
     # ./spec/requests/articles/articles_spec.rb:64:in `block (4 levels) in <top (required)>'
     # ./spec/rails_helper.rb:130:in `block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:130:in `block (2 levels) in <top (required)>'
```

In the above spec we create an article and then we create two comments that are attached to 2 different articles. 
```ruby
  let!(:article) { create(:article, user: user) }
  let!(:comment) { create(:comment, user: user, commentable: create(:article)) }
  let!(:comment2) { create(:comment, user: user, commentable: create(:article)) }
```
In our assertion, we assert that the title for the standalone article not connected to any comment is not present on the page. 
```ruby
it "does not show user's articles" do
  within("#substories") do
    expect(page).not_to have_content(article.title)
  end
end
```
However sometimes this assertion would fail, and it failed because we were using `Faker::Food.dish` to set the title and that Faker list only has 37 items in it which means there is a decent chance that our standalone article will have the same title as one of our comment articles. I [verified this was the case by logging](https://travis-ci.com/github/thepracticaldev/dev.to/jobs/349346738) the article title, id, and then the comment attributes. As you can see the comments are connected to unique articles but those articles just happen to have the same title as our standalone article. 
```ruby
Barbecue Ribs
521
{"id"=>326, ..., "commentable_id"=>522, "commentable_type"=>"Article",....}
{"id"=>327, ... "commentable_id"=>523, "commentable_type"=>"Article"...}
``` 

@snackattas 

![alt_text](https://media0.giphy.com/media/l0HlFZ3c4NENSLQRi/giphy.gif)
