### PR TITLE
[Mod Center] Add New-Author Indicator; other small improvements

### DIFF
--- a/app/assets/stylesheets/moderators.scss
+++ b/app/assets/stylesheets/moderators.scss
@@ -164,7 +164,6 @@
 }
 
 .mod-index-container {
-  width: 800px; // TODO: check with Lisa about this width
   .mod-index-header-new {
     background-color: var(--base-inverted);
     border-radius: var(--radius) var(--radius) 0 0;

--- a/app/controllers/moderations_controller.rb
+++ b/app/controllers/moderations_controller.rb
@@ -4,7 +4,7 @@ class ModerationsController < ApplicationController
   JSON_OPTIONS = {
     only: %i[title published_at cached_tag_list path],
     include: {
-      user: { only: %i[username name path] }
+      user: { only: %i[username name path articles_count] }
     }
   }.freeze
 

--- a/app/javascript/modCenter/singleArticle/index.jsx
+++ b/app/javascript/modCenter/singleArticle/index.jsx
@@ -53,6 +53,13 @@ const SingleArticle = ({
     } ${origDatePublished.getDate()}`;
   };
 
+  const newAuthorNotification = () => {
+    if (user.articles_count <= 3) {
+      return '👋 ';
+    }
+    return '';
+  };
+
   return (
     <div className="moderation-single-article">
       <span className="article-title">
@@ -61,7 +68,10 @@ const SingleArticle = ({
         </header>
         {tags}
       </span>
-      <span className="article-author">{user.name}</span>
+      <span className="article-author">
+        {newAuthorNotification()}
+        {user.name}
+      </span>
       <span className="article-published-at">{formatDate(publishedAt)}</span>
     </div>
   );

--- a/app/views/moderations/_mod_sidebar_left.html.erb
+++ b/app/views/moderations/_mod_sidebar_left.html.erb
@@ -1,6 +1,8 @@
 <div class="crayons-layout__sidebar-left">
   <p class="fw-heavy fs-3xl mod-center-heading">Mod Center</p>
-  <div class="fw-bold fs-s mod-center-section-title">INBOX</div>
+  <div class="fw-bold fs-s mod-center-section-title">
+    INBOX
+  </div>
   <div id="mod-center-inbox" class="mod-center-inbox">
     <% if @current_user_tags.any? %>
       <% @current_user_tags.each do |tag| %>
@@ -20,10 +22,10 @@
   <div class="fw-bold fs-s mod-center-section-title resources">RESOURCES</div>
   <div id="mod-center-other-options">
     <a href="#" class="crayons-link crayons-link--block">
-      Connect Chat
-    </a>
-    <a href="#" class="crayons-link crayons-link--block">
-      Settings
+      Feedback?
+      <span class="crayons-icon">
+        <%= inline_svg_tag("external-link-logo.svg", aria: true, title: "External link") %>
+      </span>
     </a>
     <a href="<%= URL.url %>/community-moderation" class="crayons-link crayons-link--block">
       Moderator Guide

--- a/app/views/moderations/index.html.erb
+++ b/app/views/moderations/index.html.erb
@@ -4,7 +4,7 @@
 
 <div id="moderation-page"></div>
 <% if current_user&.trusted %>
-  <div class="crayons-layout crayons-layout--3-cols crayons-layout--3-cols--drop-right-left" id="mod-center">
+  <div class="crayons-layout crayons-layout--2-cols" id="mod-center">
     <%= render "moderations/mod_sidebar_left" %>
     <div class="mod-index-container articles-list crayons-layout__content">
       <header class="mod-index-header-new">
@@ -25,7 +25,6 @@
         </header>
       </main>
     </div>
-    <%= render "moderations/mod_sidebar_right" %>
   </div>
 <% else %>
 <div class="container" style="margin-top: 90px;">


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR:
- extends the width of the Inbox, removing the right column
- adds a 👋 indicator next to the names of authors with 3 or less posts
- renames "Connect Chat" link to "Feedback?" (more descriptive of the link's purpose)

## QA Instructions, Screenshots, Recordings

After firing up localhost, ensure that users with 3 or less total articles (`user.articles_count`) have a wave emoji next to their name in the Mod Center.

<img width="1428" alt="Screen Shot 2020-06-15 at 4 24 06 PM" src="https://user-images.githubusercontent.com/32520970/84702863-4ab13680-af25-11ea-9aa9-f608c403beec.png">


## Added tests?

- [ ] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
- [X] no, not yet

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![Donald Duck picking fruit](https://media.giphy.com/media/wJRhcjWc7fKIE/giphy.gif)
