### PR TITLE
Add special footer mascot image to config 🦥

### DIFF
--- a/app/controllers/internal/configs_controller.rb
+++ b/app/controllers/internal/configs_controller.rb
@@ -120,6 +120,7 @@ class Internal::ConfigsController < Internal::ApplicationController
     %i[
       mascot_image_description
       mascot_image_url
+      mascot_footer_image_url
       mascot_user_id
     ]
   end

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -63,6 +63,7 @@ class SiteConfig < RailsSettings::Base
   # Mascot
   field :mascot_user_id, type: :integer, default: 1
   field :mascot_image_url, type: :string, default: "https://dev-to-uploads.s3.amazonaws.com/i/y5767q6brm62skiyywvc.png"
+  field :mascot_footer_image_url, type: :string, default: "https://dev-to-uploads.s3.amazonaws.com/i/wmv3mtusjwb3r13d5h2f.png"
   field :mascot_image_description, type: :string, default: "Sloan, the sloth mascot"
 
   # Meta keywords

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -410,6 +410,21 @@
             </div>
 
             <div class="form-group">
+              <%= f.label :mascot_footer_image_url %>
+              <%= f.text_field :mascot_footer_image_url,
+                               class: "form-control",
+                               value: SiteConfig.mascot_footer_image_url,
+                               placeholder: "https://image.url" %>
+
+              <div class="col-12">
+                <img alt="<%= SiteConfig.mascot_image_description %>" class="img-fluid" src="<%= SiteConfig.mascot_footer_image_url %>" />
+              </div>
+
+              <div class="alert alert-info"> Special cute mascot image used in the footer. </div>
+            </div>
+
+
+            <div class="form-group">
               <%= f.label :mascot_image_description %>
               <%= f.text_field :mascot_image_description,
                                class: "form-control",

--- a/spec/requests/internal/configs_spec.rb
+++ b/spec/requests/internal/configs_spec.rb
@@ -201,6 +201,12 @@ RSpec.describe "/internal/config", type: :request do
           expect(SiteConfig.mascot_image_url).to eq(expected_image_url)
         end
 
+        it "updates mascot_footer_image_url" do
+          expected_image_url = "https://dummyimage.com/300x300"
+          post "/internal/config", params: { site_config: { mascot_footer_image_url: expected_image_url }, confirmation: confirmation_message }
+          expect(SiteConfig.mascot_footer_image_url).to eq(expected_image_url)
+        end
+
         it "updates mascot_image_description" do
           description = "Hey hey #{rand(100)}"
           post "/internal/config", params: { site_config: { mascot_image_description: description }, confirmation: confirmation_message }


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This adds a special footer mascot image for use in #8684. 🦥