### PR TITLE
Flaky Spec Fix: Replace let_it_be_changeable with let for stripe spec

### DIFF
--- a/spec/requests/stripe_active_cards_spec.rb
+++ b/spec/requests/stripe_active_cards_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "StripeActiveCards", type: :request do
-  let_it_be_changeable(:user) { create(:user) }
+  let(:user) { create(:user) }
   let(:stripe_helper) { StripeMock.create_test_helper }
   let(:card_token) { stripe_helper.generate_card_token }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
While updating rack to fix our bundle audit failure #8696 I had a bunch of specs in `spec/requests/stripe_active_cards_spec.rb` fail with the following error
```
1) StripeActiveCards POST /stripe_active_cards increments sidekiq.errors.new_subscription in Datadog on failure
     Failure/Error: sign_in user
     ActiveRecord::RecordNotFound:
       Couldn't find User with 'id'=1097
     # ./spec/requests/stripe_active_cards_spec.rb:11:in `block (2 levels) in <top (required)>'
     # ./spec/rails_helper.rb:136:in `block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:136:in `block (2 levels) in <top (required)>'
```

Upon looking in the file I noticed we were persisting the user through the spec so if anything removed it the rest of the specs would fail. I updated the spec so the user is created for each spec rather than persisted. 

@snackattas 

![alt_text](https://images.gr-assets.com/hostedimages/1421673238ra/13402221.gif)
