### PR TITLE
Fix node version on GitPod

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -7,7 +7,7 @@ RUN bash -lc "rvm install ruby-$RUBY_VERSION && rvm use ruby-$RUBY_VERSION --def
 
 # Install Node
 ENV NODE_VERSION=12.16.3
-RUN bash -lc ". .nvm/nvm.sh && nvm install $NODE_VERSION"
+RUN bash -lc ". ~/.nvm/nvm.sh && nvm install $NODE_VERSION && nvm alias default $NODE_VERSION && nvm use $NODE_VERSION"
 
 # Install Redis.
 RUN sudo apt-get update \

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -19,8 +19,7 @@ tasks:
   - init: cp config/sample_application.yml config/application.yml
     command: >
       gem install solargraph;
-      bin/setup &&
-      bin/startup
+      nvm use default && bin/setup && bin/startup
 github:
   prebuilds:
     # enable for the master/default branch (defaults to true)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Description

Trying to start the app on GitPod leads to the following:

```
== Restarting application server ==
== STARTING UP ==
04:13:02 web.1       | started with pid 23441
04:13:02 webpacker.1 | started with pid 23442
04:13:02 sidekiq.1   | started with pid 23443
04:13:04 webpacker.1 | yarn run v1.22.4
04:13:04 webpacker.1 | error Command "webpack-dev-server" not found.
04:13:04 webpacker.1 | info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
04:13:05 webpacker.1 | exited with code 1
04:13:05 system      | sending SIGTERM to all processes
04:13:05 web.1       | terminated by SIGTERM
04:13:05 sidekiq.1   | terminated by SIGTERM
```

Trying to manually restart `webpack-dev-server`:

```
gitpod /workspace/dev.to $ webpack-dev-server
bash: webpack-dev-server: command not found
```

Trying to bundle:

```
gitpod /workspace/dev.to $ yarn
yarn install v1.22.4
[1/5] Validating package.json...
error dev.to@1.0.0: The engine "node" is incompatible with this module. Expected version "12.16.x". Got "12.18.0"
```
But it seems we're not using it, as the 12.18 version is still in the path until issuing an `nvm use command`

## Related Tickets & Documents

n/a

## Added tests?

- [X] no, because they aren't needed

## Added to documentation?

- [X] no documentation needed
