### PR TITLE
Bug Fix: Dont Freeze Timeframer Timestamps bc They Will be Inaccurate

### DIFF
--- a/app/labor/timeframer.rb
+++ b/app/labor/timeframer.rb
@@ -2,21 +2,25 @@ class Timeframer
   attr_accessor :timeframe
 
   LATEST_TIMEFRAME = "latest".freeze
-
-  FILTER_TIMEFRAMES = {
-    "infinity" => 5.years.ago,
-    "year" => 1.year.ago,
-    "month" => 1.month.ago,
-    "week" => 1.week.ago
-  }.freeze
-
-  DATETIMES = FILTER_TIMEFRAMES.merge(LATEST_TIMEFRAME: LATEST_TIMEFRAME).freeze
+  FILTER_TIMEFRAMES = %w[infinity year month week].freeze
 
   def initialize(timeframe)
     @timeframe = timeframe
   end
 
   def datetime
-    DATETIMES[timeframe]
+    datetimes[timeframe]
+  end
+
+  private
+
+  def datetimes
+    @datetimes ||= {
+      infinity: 5.years.ago,
+      year: 1.year.ago,
+      month: 1.month.ago,
+      week: 1.week.ago,
+      LATEST_TIMEFRAME: LATEST_TIMEFRAME
+    }.with_indifferent_access
   end
 end

--- a/spec/labor/timeframer_spec.rb
+++ b/spec/labor/timeframer_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe Timeframer, type: :labor do
+  it "sets timeframe for week to 1 week ago" do
+    Timecop.freeze(Time.current) do
+      timeframer = described_class.new("week")
+      expect(timeframer.datetime).to eq(1.week.ago)
+    end
+  end
+
+  it "sets timeframe for month to 1 month ago" do
+    Timecop.freeze(Time.current) do
+      timeframer = described_class.new("month")
+      expect(timeframer.datetime).to eq(1.month.ago)
+    end
+  end
+
+  it "sets timeframe for year to 1 year ago" do
+    Timecop.freeze(Time.current) do
+      timeframer = described_class.new("year")
+      expect(timeframer.datetime).to eq(1.year.ago)
+    end
+  end
+
+  it "sets timeframe for infinity to 5 years ago" do
+    Timecop.freeze(Time.current) do
+      timeframer = described_class.new("infinity")
+      expect(timeframer.datetime).to eq(5.years.ago)
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
We cannot be freezing Timestamps in our Timeframer bc that will cause it to become inaccurate since the timestamps will be frozen to the time the application boots up. The longer the application has been booted, the more inaccurate these will be. This became very apparent when a spec ordering issued caused this class to be instantiated while Timecop had time frozen in March 2019 which caused later specs to fail. 

## Added tests?
- [x] yes

![alt_text](https://media.giphy.com/media/26gs7qldtp7F6v1Ty/giphy.gif)
