### PR TITLE
Flaky Spec Fix: Dont CGI Escape Title Compare

### DIFF
--- a/spec/system/articles/user_visits_articles_by_tag_spec.rb
+++ b/spec/system/articles/user_visits_articles_by_tag_spec.rb
@@ -38,9 +38,9 @@ RSpec.describe "User visits articles by tag", type: :system do
 
       it "shows the correct articles" do
         within("#articles-list") do
-          expect(page).to have_text(CGI.escapeHTML(article.title))
-          expect(page).to have_text(CGI.escapeHTML(article3.title))
-          expect(page).not_to have_text(CGI.escapeHTML(article2.title))
+          expect(page).to have_text(article.title)
+          expect(page).to have_text(article3.title)
+          expect(page).not_to have_text(article2.title)
         end
       end
 
@@ -48,9 +48,9 @@ RSpec.describe "User visits articles by tag", type: :system do
         click_on "WEEK"
 
         within("#articles-list") do
-          expect(page).to have_text(CGI.escapeHTML(article.title))
-          expect(page).not_to have_text(CGI.escapeHTML(article3.title))
-          expect(page).not_to have_text(CGI.escapeHTML(article2.title))
+          expect(page).to have_text(article.title)
+          expect(page).not_to have_text(article3.title)
+          expect(page).not_to have_text(article2.title)
         end
       end
     end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
When a title has a special character in it like an apostrophe, the CGI Escape will break this test so I removed it.
Fixes https://travis-ci.com/github/thepracticaldev/dev.to/jobs/349958000:
```
 1) User visits articles by tag when user hasn't logged in when 2 articles shows the correct articles
     Failure/Error: expect(page).to have_text(CGI.escapeHTML(article3.title))
       expected to find text "It&#39;s a Battlefield499" in "FEED WEEK MONTH YEAR INFINITY LATEST\n<MY DEV(local) FEED>\nToney Kozey\nJun 15\nAbsalom, Absalom!497\n#javascript #iot\nReactions 0  reactions\n1 min read Save Saved\nToney Kozey\nJun 3\nIt's a Battlefield499\n#functional #javascript\nReactions 0  reactions\n1 min read Save Saved\nloading..."
     # ./spec/system/articles/user_visits_articles_by_tag_spec.rb:42:in `block (5 levels) in <top (required)>'
     # ./spec/system/articles/user_visits_articles_by_tag_spec.rb:40:in `block (4 levels) in <top (required)>'
     # ./spec/rails_helper.rb:136:in `block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:136:in `block (2 levels) in <top (required)>'
```

![alt_text](https://media0.giphy.com/media/G7owsnFzVEGje/source.gif)
