### PR TITLE
Flaky Spec Fix: Assert Result of Delete Statement Rather Than DB State

### DIFF
--- a/spec/services/bulk_sql_delete_spec.rb
+++ b/spec/services/bulk_sql_delete_spec.rb
@@ -38,12 +38,9 @@ describe BulkSqlDelete, type: :service do
       )
     end
 
-    # TODO: @mstruve will be addressing this
-    xit "deletes all records in batches" do
+    it "deletes all records in batches" do
       create_list :notification, 5, created_at: 1.month.ago
-      expect(Notification.count).to eq(5)
       result = described_class.delete_in_batches(sql)
-      expect(Notification.count).to eq(0)
       expect(result).to eq(5)
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This spec tends to be very flaky when run with the entire sweet. The reason for this is because we use transactional fixtures for our tests which means for a test like this we open a transaction but never commit it bc we want to roll it back at the end of the test example. This means our end count is not going to be what we expect. However, the result returned from the delete statement is correct so I choose to assert that it equals the number of records we would expect to delete.

@snackattas 

![alt_text](https://media2.giphy.com/media/l1AsQ4OLzVVMqMQ9y/giphy.gif)
