### PR TITLE
Optimization: Add Index to Article Public Reaction Counts for Sorting

### DIFF
--- a/db/migrate/20200616200005_add_index_to_articles_public_reactions_counts.rb
+++ b/db/migrate/20200616200005_add_index_to_articles_public_reactions_counts.rb
@@ -1,0 +1,15 @@
+class AddIndexToArticlesPublicReactionsCounts < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def up
+    if !index_exists?(:articles, :public_reactions_count)
+      add_index :articles, :public_reactions_count, order: { public_reactions_count: :desc }, algorithm: :concurrently
+    end
+  end
+
+  def down
+    if index_exists?(:articles, :public_reactions_count)
+      remove_index :articles, column: :public_reactions_count, algorithm: :concurrently
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_15_213003) do
+ActiveRecord::Schema.define(version: 2020_06_16_200005) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -128,6 +128,7 @@ ActiveRecord::Schema.define(version: 2020_06_15_213003) do
     t.index ["feed_source_url"], name: "index_articles_on_feed_source_url"
     t.index ["hotness_score"], name: "index_articles_on_hotness_score"
     t.index ["path"], name: "index_articles_on_path"
+    t.index ["public_reactions_count"], name: "index_articles_on_public_reactions_count", order: :desc
     t.index ["published"], name: "index_articles_on_published"
     t.index ["published_at"], name: "index_articles_on_published_at"
     t.index ["slug"], name: "index_articles_on_slug"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
Another one of our most time consuming queries is fetching articles by timeframe and sorting them by public_reactions_count. The PR adds a sorted index for public_reactions_count which Postgres can use to optimize this query. 
![Screen Shot 2020-06-16 at 3 09 45 PM](https://user-images.githubusercontent.com/1813380/84823135-7b57a580-afe3-11ea-93b4-86fb9d80dd99.png)
 

![alt_text](https://uploads-ssl.webflow.com/5d2b950d9ea87fc61f0c1f3e/5daa2f818bfff61e250fd7da_ezgif.com-resize.gif)
