### PR TITLE
Add subscriber_email to user_subscriptions & more backend updates

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -4,6 +4,7 @@ class Article < ApplicationRecord
   include Storext.model
   include Reactable
   include Searchable
+  include UserSubscriptionSourceable
 
   SEARCH_SERIALIZER = Search::ArticleSerializer
   SEARCH_CLASS = Search::FeedContent
@@ -28,8 +29,6 @@ class Article < ApplicationRecord
   counter_culture :organization
 
   has_many :comments, as: :commentable, inverse_of: :commentable
-  has_many :user_subscriptions, as: :user_subscription_sourceable
-  has_many :sourced_subscribers, class_name: "User", through: :user_subscriptions, source: :subscriber, foreign_key: :user_id
   has_many :top_comments,
            -> { where("comments.score > ? AND ancestry IS NULL and hidden_by_commentable_user is FALSE and deleted is FALSE", 10).order("comments.score DESC") },
            as: :commentable,

--- a/app/models/concerns/user_subscription_sourceable.rb
+++ b/app/models/concerns/user_subscription_sourceable.rb
@@ -12,7 +12,7 @@ module UserSubscriptionSourceable
              foreign_key: :user_id
   end
 
-  def new_user_subscription(subscriber)
+  def build_user_subscription(subscriber)
     UserSubscription.new(user_subscription_attributes(subscriber))
   end
 

--- a/app/models/concerns/user_subscription_sourceable.rb
+++ b/app/models/concerns/user_subscription_sourceable.rb
@@ -25,7 +25,7 @@ module UserSubscriptionSourceable
   def user_subscription_attributes(subscriber)
     {
       user_subscription_sourceable: self,
-      author_id: self&.user_id,
+      author_id: user_id,
       subscriber_id: subscriber&.id,
       subscriber_email: subscriber&.email
     }

--- a/app/models/concerns/user_subscription_sourceable.rb
+++ b/app/models/concerns/user_subscription_sourceable.rb
@@ -1,0 +1,33 @@
+module UserSubscriptionSourceable
+  extend ActiveSupport::Concern
+
+  # This all assumes there's an association with User under the column user_id.
+
+  included do
+    has_many :user_subscriptions, as: :user_subscription_sourceable
+    has_many :sourced_subscribers,
+             class_name: "User",
+             through: :user_subscriptions,
+             source: :subscriber,
+             foreign_key: :user_id
+  end
+
+  def new_user_subscription(subscriber)
+    UserSubscription.new(user_subscription_attributes(subscriber))
+  end
+
+  def create_user_subscription(subscriber)
+    UserSubscription.create(user_subscription_attributes(subscriber))
+  end
+
+  private
+
+  def user_subscription_attributes(subscriber)
+    {
+      user_subscription_sourceable: self,
+      author_id: self&.user_id,
+      subscriber_id: subscriber&.id,
+      subscriber_email: subscriber&.email
+    }
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -45,6 +45,10 @@ class User < ApplicationRecord
   acts_as_followable
   acts_as_follower
 
+  has_many :authored_user_subscriptions, class_name: "UserSubscription", foreign_key: :author_id, inverse_of: :author, dependent: :destroy
+  has_many :subscribers, through: :authored_user_subscriptions, dependent: :destroy
+  has_many :subscribed_to_user_subscriptions, class_name: "UserSubscription", foreign_key: :subscriber_id, inverse_of: :subscriber, dependent: :destroy
+
   has_many :access_grants, class_name: "Doorkeeper::AccessGrant", foreign_key: :resource_owner_id, inverse_of: :resource_owner, dependent: :delete_all
   has_many :access_tokens, class_name: "Doorkeeper::AccessToken", foreign_key: :resource_owner_id, inverse_of: :resource_owner, dependent: :delete_all
   has_many :affected_feedback_messages, class_name: "FeedbackMessage", inverse_of: :affected, foreign_key: :affected_id, dependent: :nullify
@@ -67,8 +71,6 @@ class User < ApplicationRecord
   has_many :display_ad_events, dependent: :destroy
   has_many :email_authorizations, dependent: :delete_all
   has_many :email_messages, class_name: "Ahoy::Message", dependent: :destroy
-  has_many :user_subscriptions, foreign_key: :author_id, inverse_of: :author, dependent: :destroy
-  has_many :subscribers, through: :user_subscriptions, dependent: :destroy
   has_many :field_test_memberships, class_name: "FieldTest::Membership", as: :participant, dependent: :destroy
   has_many :github_repos, dependent: :destroy
   has_many :html_variants, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -45,8 +45,8 @@ class User < ApplicationRecord
   acts_as_followable
   acts_as_follower
 
-  has_many :authored_user_subscriptions, class_name: "UserSubscription", foreign_key: :author_id, inverse_of: :author, dependent: :destroy
-  has_many :subscribers, through: :authored_user_subscriptions, dependent: :destroy
+  has_many :source_authored_user_subscriptions, class_name: "UserSubscription", foreign_key: :author_id, inverse_of: :author, dependent: :destroy
+  has_many :subscribers, through: :source_authored_user_subscriptions, dependent: :destroy
   has_many :subscribed_to_user_subscriptions, class_name: "UserSubscription", foreign_key: :subscriber_id, inverse_of: :subscriber, dependent: :destroy
 
   has_many :access_grants, class_name: "Doorkeeper::AccessGrant", foreign_key: :resource_owner_id, inverse_of: :resource_owner, dependent: :delete_all

--- a/app/models/user_subscription.rb
+++ b/app/models/user_subscription.rb
@@ -13,4 +13,21 @@ class UserSubscription < ApplicationRecord
   validates :subscriber_id, presence: true, uniqueness: { scope: %i[subscriber_email user_subscription_sourceable_type user_subscription_sourceable_id] }
   validates :user_subscription_sourceable_id, presence: true
   validates :user_subscription_sourceable_type, presence: true, inclusion: { in: ALLOWED_TYPES }
+
+  def self.make_new(source:, subscriber:)
+    new(build_attributes(source, subscriber))
+  end
+
+  def self.make(source:, subscriber:)
+    create(build_attributes(source, subscriber))
+  end
+
+  def self.build_attributes(source, subscriber)
+    {
+      user_subscription_sourceable: source,
+      author_id: source&.user_id,
+      subscriber_id: subscriber&.id,
+      subscriber_email: subscriber&.email
+    }
+  end
 end

--- a/app/models/user_subscription.rb
+++ b/app/models/user_subscription.rb
@@ -14,7 +14,7 @@ class UserSubscription < ApplicationRecord
   validates :user_subscription_sourceable_id, presence: true
   validates :user_subscription_sourceable_type, presence: true, inclusion: { in: ALLOWED_TYPES }
 
-  def self.make_new(source:, subscriber:)
+  def self.build(source:, subscriber:)
     new(build_attributes(source, subscriber))
   end
 

--- a/app/models/user_subscription.rb
+++ b/app/models/user_subscription.rb
@@ -4,12 +4,13 @@
 class UserSubscription < ApplicationRecord
   ALLOWED_TYPES = %w[Article].freeze
 
-  belongs_to :author, class_name: "User", inverse_of: :user_subscriptions
-  belongs_to :subscriber, class_name: "User", inverse_of: :user_subscriptions
+  belongs_to :author, class_name: "User", inverse_of: :authored_user_subscriptions
+  belongs_to :subscriber, class_name: "User", inverse_of: :subscribed_to_user_subscriptions
   belongs_to :user_subscription_sourceable, polymorphic: true
 
   validates :author_id, presence: true
-  validates :subscriber_id, presence: true, uniqueness: { scope: %i[user_subscription_sourceable_type user_subscription_sourceable_id] }
+  validates :subscriber_email, presence: true
+  validates :subscriber_id, presence: true, uniqueness: { scope: %i[subscriber_email user_subscription_sourceable_type user_subscription_sourceable_id] }
   validates :user_subscription_sourceable_id, presence: true
   validates :user_subscription_sourceable_type, presence: true, inclusion: { in: ALLOWED_TYPES }
 end

--- a/app/models/user_subscription.rb
+++ b/app/models/user_subscription.rb
@@ -4,7 +4,7 @@
 class UserSubscription < ApplicationRecord
   ALLOWED_TYPES = %w[Article].freeze
 
-  belongs_to :author, class_name: "User", inverse_of: :authored_user_subscriptions
+  belongs_to :author, class_name: "User", inverse_of: :source_authored_user_subscriptions
   belongs_to :subscriber, class_name: "User", inverse_of: :subscribed_to_user_subscriptions
   belongs_to :user_subscription_sourceable, polymorphic: true
 

--- a/db/migrate/20200617014320_add_subscriber_email_to_user_subscriptions.rb
+++ b/db/migrate/20200617014320_add_subscriber_email_to_user_subscriptions.rb
@@ -1,0 +1,5 @@
+class AddSubscriberEmailToUserSubscriptions < ActiveRecord::Migration[6.0]
+  def change
+    add_column :user_subscriptions, :subscriber_email, :string, null: false
+  end
+end

--- a/db/migrate/20200617014509_add_subscriber_email_index_to_user_subscriptions.rb
+++ b/db/migrate/20200617014509_add_subscriber_email_index_to_user_subscriptions.rb
@@ -1,0 +1,45 @@
+class AddSubscriberEmailIndexToUserSubscriptions < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def up
+    if index_exists?(:user_subscriptions, %i[subscriber_id user_subscription_sourceable_id user_subscription_sourceable_type])
+      remove_index :user_subscriptions,
+                   column: %i[subscriber_id user_subscription_sourceable_id user_subscription_sourceable_type],
+                   algorithm: :concurrently
+    end
+
+    if !index_exists?(:user_subscriptions, :subscriber_email)
+      add_index :user_subscriptions,
+                :subscriber_email,
+                algorithm: :concurrently
+    end
+
+    if !index_exists?(:user_subscriptions, %i[subscriber_id subscriber_email user_subscription_sourceable_type user_subscription_sourceable_id])
+      add_index :user_subscriptions,
+                %i[subscriber_id subscriber_email user_subscription_sourceable_type user_subscription_sourceable_id],
+                name: "index_subscriber_id_and_email_with_user_subscription_source",
+                unique: true,
+                algorithm: :concurrently
+    end
+  end
+
+  def down
+    if !index_exists?(:user_subscriptions, %i[subscriber_id user_subscription_sourceable_id user_subscription_sourceable_type])
+      add_index :user_subscriptions,
+                %i[subscriber_id user_subscription_sourceable_id user_subscription_sourceable_type],
+                unique: true,
+                name: :index_on_subscriber_id_user_subscription_sourceable_type_and_id,
+                algorithm: :concurrently
+    end
+
+    if index_exists?(:user_subscriptions, :subscriber_email)
+      remove_index :user_subscriptions, column: :subscriber_email, algorithm: :concurrently
+    end
+
+    if index_exists?(:user_subscriptions, %i[subscriber_id subscriber_email user_subscription_sourceable_type user_subscription_sourceable_id])
+      remove_index :user_subscriptions,
+                   column: %i[subscriber_id subscriber_email user_subscription_sourceable_type user_subscription_sourceable_id],
+                   algorithm: :concurrently
+    end
+  end
+end

--- a/db/migrate/20200617014509_add_subscriber_email_index_to_user_subscriptions.rb
+++ b/db/migrate/20200617014509_add_subscriber_email_index_to_user_subscriptions.rb
@@ -8,13 +8,13 @@ class AddSubscriberEmailIndexToUserSubscriptions < ActiveRecord::Migration[6.0]
                    algorithm: :concurrently
     end
 
-    if !index_exists?(:user_subscriptions, :subscriber_email)
+    unless index_exists?:user_subscriptions, :subscriber_email)
       add_index :user_subscriptions,
                 :subscriber_email,
                 algorithm: :concurrently
     end
 
-    if !index_exists?(:user_subscriptions, %i[subscriber_id subscriber_email user_subscription_sourceable_type user_subscription_sourceable_id])
+    unless index_exists?:user_subscriptions, %i[subscriber_id subscriber_email user_subscription_sourceable_type user_subscription_sourceable_id])
       add_index :user_subscriptions,
                 %i[subscriber_id subscriber_email user_subscription_sourceable_type user_subscription_sourceable_id],
                 name: "index_subscriber_id_and_email_with_user_subscription_source",
@@ -24,7 +24,7 @@ class AddSubscriberEmailIndexToUserSubscriptions < ActiveRecord::Migration[6.0]
   end
 
   def down
-    if !index_exists?(:user_subscriptions, %i[subscriber_id user_subscription_sourceable_id user_subscription_sourceable_type])
+    unless index_exists?:user_subscriptions, %i[subscriber_id user_subscription_sourceable_id user_subscription_sourceable_type])
       add_index :user_subscriptions,
                 %i[subscriber_id user_subscription_sourceable_id user_subscription_sourceable_type],
                 unique: true,

--- a/db/migrate/20200617014509_add_subscriber_email_index_to_user_subscriptions.rb
+++ b/db/migrate/20200617014509_add_subscriber_email_index_to_user_subscriptions.rb
@@ -8,13 +8,13 @@ class AddSubscriberEmailIndexToUserSubscriptions < ActiveRecord::Migration[6.0]
                    algorithm: :concurrently
     end
 
-    unless index_exists?:user_subscriptions, :subscriber_email)
+    unless index_exists?(:user_subscriptions, :subscriber_email)
       add_index :user_subscriptions,
                 :subscriber_email,
                 algorithm: :concurrently
     end
 
-    unless index_exists?:user_subscriptions, %i[subscriber_id subscriber_email user_subscription_sourceable_type user_subscription_sourceable_id])
+    unless index_exists?(:user_subscriptions, %i[subscriber_id subscriber_email user_subscription_sourceable_type user_subscription_sourceable_id])
       add_index :user_subscriptions,
                 %i[subscriber_id subscriber_email user_subscription_sourceable_type user_subscription_sourceable_id],
                 name: "index_subscriber_id_and_email_with_user_subscription_source",
@@ -24,7 +24,7 @@ class AddSubscriberEmailIndexToUserSubscriptions < ActiveRecord::Migration[6.0]
   end
 
   def down
-    unless index_exists?:user_subscriptions, %i[subscriber_id user_subscription_sourceable_id user_subscription_sourceable_type])
+    unless index_exists?(:user_subscriptions, %i[subscriber_id user_subscription_sourceable_id user_subscription_sourceable_type])
       add_index :user_subscriptions,
                 %i[subscriber_id user_subscription_sourceable_id user_subscription_sourceable_type],
                 unique: true,

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_16_200005) do
+ActiveRecord::Schema.define(version: 2020_06_17_014509) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1134,12 +1134,14 @@ ActiveRecord::Schema.define(version: 2020_06_16_200005) do
   create_table "user_subscriptions", force: :cascade do |t|
     t.bigint "author_id", null: false
     t.datetime "created_at", precision: 6, null: false
+    t.string "subscriber_email", null: false
     t.bigint "subscriber_id", null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "user_subscription_sourceable_id", null: false
     t.string "user_subscription_sourceable_type", null: false
     t.index ["author_id"], name: "index_user_subscriptions_on_author_id"
-    t.index ["subscriber_id", "user_subscription_sourceable_id", "user_subscription_sourceable_type"], name: "index_on_subscriber_id_user_subscription_sourceable_type_and_id", unique: true
+    t.index ["subscriber_email"], name: "index_user_subscriptions_on_subscriber_email"
+    t.index ["subscriber_id", "subscriber_email", "user_subscription_sourceable_type", "user_subscription_sourceable_id"], name: "index_subscriber_id_and_email_with_user_subscription_source", unique: true
     t.index ["subscriber_id"], name: "index_user_subscriptions_on_subscriber_id"
     t.index ["user_subscription_sourceable_type", "user_subscription_sourceable_id"], name: "index_on_user_subscription_sourcebable_type_and_id"
   end

--- a/spec/factories/user_subscription.rb
+++ b/spec/factories/user_subscription.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     association :subscriber, factory: :user, strategy: :create
     association :user_subscription_sourceable, factory: :article
 
-    author { user_subscription_sourceable.user }
+    author           { user_subscription_sourceable.user }
+    subscriber_email { subscriber.email }
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Article, type: :model do
   let!(:article) { create(:article, user: user) }
 
   include_examples "#sync_reactions_count", :article
+  it_behaves_like "UserSubscriptionSourceable"
 
   describe "validations" do
     it { is_expected.to validate_uniqueness_of(:canonical_url).allow_blank }

--- a/spec/models/shared_examples/user_subscription_sourceable_spec.rb
+++ b/spec/models/shared_examples/user_subscription_sourceable_spec.rb
@@ -3,7 +3,7 @@ RSpec.shared_examples "UserSubscriptionSourceable" do
   let(:source) { create(model.to_s.underscore.to_sym) }
   let(:subscriber) { create(:user) }
 
-  describe "#new_user_subscription" do
+  describe "#build_user_subscription" do
     it "returns a new UserSubcription with the correct attributes" do
       new_user_subscription = UserSubscription.new(
         user_subscription_sourceable: source,
@@ -12,7 +12,7 @@ RSpec.shared_examples "UserSubscriptionSourceable" do
         subscriber_email: subscriber.email,
       )
 
-      factory_user_subscription = source.new_user_subscription(subscriber)
+      factory_user_subscription = source.build_user_subscription(subscriber)
 
       factory_user_subscription.attributes.each do |name, val|
         expect(new_user_subscription[name]).to eq val

--- a/spec/models/shared_examples/user_subscription_sourceable_spec.rb
+++ b/spec/models/shared_examples/user_subscription_sourceable_spec.rb
@@ -1,0 +1,42 @@
+RSpec.shared_examples "UserSubscriptionSourceable" do
+  let(:model) { described_class }
+  let(:source) { create(model.to_s.underscore.to_sym) }
+  let(:subscriber) { create(:user) }
+
+  describe "#new_user_subscription" do
+    it "returns a new UserSubcription with the correct attributes" do
+      new_user_subscription = UserSubscription.new(
+        user_subscription_sourceable: source,
+        author_id: source.user_id,
+        subscriber_id: subscriber.id,
+        subscriber_email: subscriber.email,
+      )
+
+      factory_user_subscription = source.new_user_subscription(subscriber)
+
+      factory_user_subscription.attributes.each do |name, val|
+        expect(new_user_subscription[name]).to eq val
+      end
+    end
+  end
+
+  describe "#create_user_subscription" do
+    it "returns a created UserSubcription with the correct attributes" do
+      user_subscription_fields = %w[author_id subsciber_id subscriber_email user_subscription_sourceable_id user_susbcription_sourceable_type]
+
+      user_subscription = create(
+        :user_subscription,
+        user_subscription_sourceable: source,
+        author_id: source.user_id,
+        subscriber_id: subscriber.id,
+        subscriber_email: subscriber.email,
+      )
+
+      factory_user_subscription = source.create_user_subscription(subscriber)
+
+      user_subscription_fields.each do |field|
+        expect(factory_user_subscription[field]).to eq user_subscription[field]
+      end
+    end
+  end
+end

--- a/spec/models/user_subscription_spec.rb
+++ b/spec/models/user_subscription_spec.rb
@@ -7,8 +7,9 @@ RSpec.describe UserSubscription, type: :model do
     it { is_expected.to validate_presence_of(:user_subscription_sourceable_id) }
     it { is_expected.to validate_presence_of(:user_subscription_sourceable_type) }
     it { is_expected.to validate_presence_of(:subscriber_id) }
+    it { is_expected.to validate_presence_of(:subscriber_email) }
     it { is_expected.to validate_presence_of(:author_id) }
     it { is_expected.to validate_inclusion_of(:user_subscription_sourceable_type).in_array(%w[Article]) }
-    it { is_expected.to validate_uniqueness_of(:subscriber_id).scoped_to(:user_subscription_sourceable_type, :user_subscription_sourceable_id) }
+    it { is_expected.to validate_uniqueness_of(:subscriber_id).scoped_to(%i[subscriber_email user_subscription_sourceable_type user_subscription_sourceable_id]) }
   end
 end

--- a/spec/models/user_subscription_spec.rb
+++ b/spec/models/user_subscription_spec.rb
@@ -3,6 +3,9 @@ require "rails_helper"
 RSpec.describe UserSubscription, type: :model do
   subject { build(:user_subscription) }
 
+  let(:source) { create(:article) }
+  let(:subscriber) { create(:user) }
+
   describe "validations" do
     it { is_expected.to validate_presence_of(:user_subscription_sourceable_id) }
     it { is_expected.to validate_presence_of(:user_subscription_sourceable_type) }
@@ -11,5 +14,40 @@ RSpec.describe UserSubscription, type: :model do
     it { is_expected.to validate_presence_of(:author_id) }
     it { is_expected.to validate_inclusion_of(:user_subscription_sourceable_type).in_array(%w[Article]) }
     it { is_expected.to validate_uniqueness_of(:subscriber_id).scoped_to(%i[subscriber_email user_subscription_sourceable_type user_subscription_sourceable_id]) }
+  end
+
+  describe "#make_new" do
+    it "returns a new UserSubcription with the correct attributes" do
+      new_user_subscription = described_class.new(
+        user_subscription_sourceable: source,
+        author_id: source.user_id,
+        subscriber_id: subscriber.id,
+        subscriber_email: subscriber.email,
+      )
+
+      factory_user_subscription = described_class.make_new(source: source, subscriber: subscriber)
+
+      factory_user_subscription.attributes.each do |name, val|
+        expect(new_user_subscription[name]).to eq val
+      end
+    end
+  end
+
+  describe "#make" do
+    it "returns a created UserSubcription with the correct attributes" do
+      user_subscription_fields = %w[author_id subsciber_id subscriber_email user_subscription_sourceable_id user_susbcription_sourceable_type]
+
+      user_subscription = create(:user_subscription,
+                                 user_subscription_sourceable: source,
+                                 author_id: source.user_id,
+                                 subscriber_id: subscriber.id,
+                                 subscriber_email: subscriber.email)
+
+      factory_user_subscription = described_class.make(source: source, subscriber: subscriber)
+
+      user_subscription_fields.each do |field|
+        expect(factory_user_subscription[field]).to eq user_subscription[field]
+      end
+    end
   end
 end

--- a/spec/models/user_subscription_spec.rb
+++ b/spec/models/user_subscription_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe UserSubscription, type: :model do
     it { is_expected.to validate_uniqueness_of(:subscriber_id).scoped_to(%i[subscriber_email user_subscription_sourceable_type user_subscription_sourceable_id]) }
   end
 
-  describe "#make_new" do
+  describe "#build" do
     it "returns a new UserSubcription with the correct attributes" do
       new_user_subscription = described_class.new(
         user_subscription_sourceable: source,
@@ -25,7 +25,7 @@ RSpec.describe UserSubscription, type: :model do
         subscriber_email: subscriber.email,
       )
 
-      factory_user_subscription = described_class.make_new(source: source, subscriber: subscriber)
+      factory_user_subscription = described_class.build(source: source, subscriber: subscriber)
 
       factory_user_subscription.attributes.each do |name, val|
         expect(new_user_subscription[name]).to eq val


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
I had another PR ready to go, but it became quite large so this is me breaking it out into smaller chunks. This PR adds a `subscriber_email` field to `user_subscriptions` so we can record the subscriber's email address at the time of subscription to display to an author.

For the scope of this feature and CodeLand, a user can subscribe to an author via an article one time. If they change their email address, they cannot re-subscribe to the same article with the new email address. That functionality will be in a future iteration post-CodeLand.

We are also intentionally allowing an author to subscribe to themself. That way they can test and experiment on their own.

I've included some name changes for some relationships and updated some DB indexes.

```ruby
subscriber = User.last
article = Article.first

UserSubscription.make(source: article, subscriber: subscriber)
UserSubscription.build(source: article, subscriber: subscriber)

article.create_user_subscription(subscriber)
article.build_user_subscription(subscriber)
```

I added the latter two to a model concern and moved the associations in there as well. Adding this to comments in the future will just be:
```ruby
include UserSubscriptionSourceable
```

**I'll copy and paste this description on each PR.**
We are building a liquid tag where permitted authors can embed a button that users/readers can click to share the email address associated with their DEV account with the author.

_We are restricting this liquid tag only for use in `Articles` (not `Comments`, or `Pages`) and for use only by approved organizations for CodeLand (using a new role)._
- [x] [Create a new database table to hold subscriptions](https://github.com/thepracticaldev/dev.to/issues/8170)
- [x] [Capture the subscriber's email address](https://github.com/thepracticaldev/dev.to/issues/8722)
- [ ] [Create a new endpoint to handle email signups from the new liquid tag](https://github.com/thepracticaldev/dev.to/issues/8171)
- [ ] [Create an email signup button liquid tag](https://github.com/thepracticaldev/dev.to/issues/8168)
- [ ] [Add new tab to User dashboard to display email addresses from the email signup button liquid tag](https://github.com/thepracticaldev/dev.to/issues/8169)

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/issues/8722

## QA Instructions, Screenshots, Recordings
You can create some objects locally if you'd like to test the associations.

```ruby
# If you're copying and pasting, make sure you execute this setup in order.
subscriber = User.last
article = Article.first
author = article.user

user_subscription = UserSubscription.create(user_subscription_sourceable: article, subscriber_id: subscriber.id, subscriber_email: subscriber.email, author_id: author.id)

##########################

# Test source_authored_user_subscriptions

# Should return an ActiveRecordCollection with 1 UserSubscription from above
author.source_authored_user_subscriptions
=> [UserSubscription]

##########################

# Test subscribed_to_user_subscriptions

# Should return an ActiveRecordCollection with 1 UserSubscription from above
subscriber.subscribed_to_user_subscriptions
=> [UserSubscription]

##########################

# Test subscriber

# Should return 1 User object - the subscriber from above
user_subscription.subscriber
=> User

##########################

# Test author

# Should return 1 User object - the author from above
user_subscription.author
=> User

##########################

# Test user_subscription_sourceable

# Should return 1 Article object - the article from above
user_subscription.user_subscription_sourceable
=> Article

##########################

# Test subscriber_email
user_subscription.subscriber_email == subscriber.email
=> true

##########################

# Bonus points, try to create invalid user_subscriptions (i.e. missing attributes,
# duplicate records, etc.) and you should see it fail.
```

## Added tests?
- [x] yes

## Added to documentation?
- [x] no documentation needed

![will_smith_getting_ready_gif](https://media.giphy.com/media/gjBmWQRZaWVNH0abPP/giphy.gif)