### PR TITLE
Makes the dropdown on comments display correctly for small screens

### DIFF
--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -928,8 +928,12 @@ a.header-link {
     .dropdown {
       position: absolute;
       top: 40px;
-      right: 10px;
+      right: 200px;
       display: inline-block;
+
+      @media screen and (min-width: 580px) {
+        right: 10px;
+      }
 
       .dropdown-content {
         display: none;


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Small issue on small screens for comment dropdown is displayed outside the viewport. This may not be the best way to fix this bug sharing this as it seems to fix the issue for me. Not even sure if we need to move it slightly more.

## QA Instructions, Screenshots, Recordings

In production with a mobile device (small screen) try to open the dropdown of an article's comment and you'll see this:

<img width="328" alt="Screen Shot 2020-06-17 at 12 17 48" src="https://user-images.githubusercontent.com/6045239/84934783-0a70c600-b095-11ea-82b6-d2a01f3260de.png">

With the fix it should display like this:

<img width="329" alt="Screen Shot 2020-06-17 at 12 18 05" src="https://user-images.githubusercontent.com/6045239/84934813-15c3f180-b095-11ea-9cc5-b1f5fcdd73fc.png">


## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

Nope
