### PR TITLE
Use regex for gitpod allowed host

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -76,7 +76,7 @@ Rails.application.configure do
 
   config.hosts << ENV["APP_DOMAIN"] unless ENV["APP_DOMAIN"].nil?
   if (gitpod_workspace_url = ENV["GITPOD_WORKSPACE_URL"])
-    config.hosts << URI.parse(gitpod_workspace_url).host
+    config.hosts << /.*#{URI.parse(gitpod_workspace_url).host}/
   end
   config.app_domain = "localhost:3000"
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

PR https://github.com/thepracticaldev/dev.to/pull/8732 had issues passing Travis due to ordering errors. Trying this again on a new branch/pr....

This PR tweaks the allowed host on Gitpod. Gitpod preview URLS are in the format <port>-<workspace_url>. Our currently configuration is only allowing <workspace url>, leading to a 'blocked host' error. I've added a wildcard in front of that url to allow for serving on any port.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, as well
as any relevant images for UI changes._

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/AeUcmWquAI8tW/giphy.gif)
