### PR TITLE
Fix article preamble style

### DIFF
--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -129,7 +129,7 @@
           <% end %>
           <h1 class="fs-3xl s:fs-4xl l:fs-5xl fw-bold s:fw-heavy lh-tight mb-4 <%= @article.title_length_classification %>">
             <% if @article.search_optimized_title_preamble.present? && !user_signed_in? %>
-              <span class="article-title-preamble"><%= @article.search_optimized_title_preamble %></span>
+              <span class="fs-xl color-base-70 block"><%= @article.search_optimized_title_preamble %></span>
             <% end %>
             <%= sanitize_and_decode @article.title %>
           </h1>

--- a/spec/requests/stories_show_spec.rb
+++ b/spec/requests/stories_show_spec.rb
@@ -54,19 +54,19 @@ RSpec.describe "StoriesShow", type: :request do
     it "renders title preamble with search_optimized_title_preamble if set and not signed in" do
       article.update_column(:search_optimized_title_preamble, "Hey this is a test")
       get article.reload.path
-      expect(response.body).to include "<span class=\"article-title-preamble\">Hey this is a test</span>"
+      expect(response.body).to include "<span class=\"fs-xl color-base-70 block\">Hey this is a test</span>"
     end
 
     it "does not render preamble with search_optimized_title_preamble if set and signed in" do
       sign_in user
       article.update_column(:search_optimized_title_preamble, "Hey this is a test")
       get article.path
-      expect(response.body).not_to include "<span class=\"article-title-preamble\">Hey this is a test</span>"
+      expect(response.body).not_to include "<span class=\"fs-xl color-base-70 block\">Hey this is a test</span>"
     end
 
     it "does not render title tag with search_optimized_title_preamble not signed in but search_optimized_title_preamble not set" do
       get article.path
-      expect(response.body).not_to include "<span class=\"article-title-preamble\">Hey this is a test</span>"
+      expect(response.body).not_to include "<span class=\"fs-xl color-base-70 block\">Hey this is a test</span>"
     end
 
     it "renders user payment pointer if set" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
The article _preamble_ is not actually part of the title but the latest change made it lose its styling.

This helps place it distinctively separate from the title, like such:

<img width="701" alt="Screen Shot 2020-06-17 at 6 19 48 PM" src="https://user-images.githubusercontent.com/3102842/84956639-a4e9fd00-b0c7-11ea-997f-4c02f1c91ad2.png">

Done with utility classes rather than a hack. Definitely a win 😄