### PR TITLE
Display 'Originally published' for canonical URLs

### DIFF
--- a/app/helpers/articles_helper.rb
+++ b/app/helpers/articles_helper.rb
@@ -41,11 +41,12 @@ module ArticlesHelper
   end
 
   def should_show_crossposted_on?(article)
-    article.crossposted_at &&
+    article.canonical_url ||
+      (article.crossposted_at &&
       article.published_from_feed &&
       article.published &&
       article.published_at &&
-      article.feed_source_url.present?
+      article.feed_source_url.present?)
   end
 
   def get_host_without_www(url)

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -166,8 +166,8 @@
                 <em>
                   Originally published at
                   <a href="<%= @article.canonical_url || @article.feed_source_url %>" style="color:#1395b8"><%= get_host_without_www(@article.canonical_url || @article.feed_source_url) %></a>
-                  on
                   <% if @article.crossposted_at %>
+                    on
                     <time datetime="<%= (@article.originally_published_at || @article.published_at)&.utc&.iso8601 %>"><%= (@article.originally_published_at || @article.published_at)&.strftime("%b %d, %Y") %></time>
                   <% end %>
                 </em>

--- a/spec/views/articles_spec.rb
+++ b/spec/views/articles_spec.rb
@@ -47,4 +47,11 @@ RSpec.describe "articles/show", type: :view do
     expect(rendered).to have_css("form#new_comment")
     expect(rendered).to have_css("input#submit-button")
   end
+
+  it "shows a note about the canonical URL" do
+    allow(article1).to receive(:canonical_url).and_return("https://example.com/lamas")
+    render
+    expect(rendered).to have_text("Originally published at")
+    expect(rendered).to have_text("example.com")
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

So far we only added "Originally published at" for articles imported from feeds, but not for posts that had a canonical URL set. This has confused several users in the past, including your truly.

## Related Tickets & Documents

Closes #8726

## QA Instructions, Screenshots, Recordings

<img width="711" alt="Screen Shot 2020-06-18 at 13 42 26" src="https://user-images.githubusercontent.com/47985/84987908-41191000-b16b-11ea-9ec1-989f4b1f5b6d.png">

Note the missing "on <timestamp>" if we only have a canonical URL.

## Added tests?

- [X] yes

## Added to documentation?

- [X] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![image](https://user-images.githubusercontent.com/47985/84988406-25623980-b16c-11ea-9390-45f11d1e44a0.png)

