### PR TITLE
Turn off ahoy visit tracking

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  skip_before_action :track_ahoy_visit
   protect_from_forgery with: :exception, prepend: true
 
   include SessionCurrentUser


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

We recently deployed ahoy for tracking events, but it also tracks _all visits_ by default; this is going to end up being a lot of visits, and we probably want to incrementally add visit tracking in (rather than turning them all on).

This `skip_before_action` will stop us from collecting a ton of visit data.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

Pull down this PR, and click around the site. You should not see any new `Ahoy::Visit`s being created in the database. Without this line, you _should_ see them, and that's what is currently live in production.

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
