### PR TITLE
Fix comment/reaction count hiding issue on narrow screens

### DIFF
--- a/app/javascript/articles/__tests__/Article.test.jsx
+++ b/app/javascript/articles/__tests__/Article.test.jsx
@@ -159,7 +159,7 @@ describe('<Article /> component', () => {
 
     const reactions = getByTitle('Number of reactions');
 
-    expect(reactions.textContent).toEqual('232 reactions');
+    expect(reactions.textContent).toEqual('232 reactions');
   });
 
   it('should render with comments', () => {
@@ -173,7 +173,7 @@ describe('<Article /> component', () => {
 
     const comments = getByTitle('Number of comments');
 
-    expect(comments.textContent).toEqual('213 comments');
+    expect(comments.textContent).toEqual('213 comments');
   });
 
   it('should render with an add comment button when there are no comments', () => {

--- a/app/javascript/articles/components/CommentsCount.jsx
+++ b/app/javascript/articles/components/CommentsCount.jsx
@@ -24,8 +24,12 @@ export const CommentsCount = ({ count, articlePath }) => {
         icon={commentsSVG}
         tagName="a"
       >
-        <span title="Number of comments" className="hidden s:inline">
-          {`${count} ${count > 1 ? 'comments' : 'comment'}`}
+        <span title="Number of comments">
+          {count} 
+          <span className="hidden s:inline">
+            &nbsp;
+            {`${count > 1 ? 'comments' : 'comment'}`}
+          </span>
         </span>
       </Button>
     );

--- a/app/javascript/articles/components/ReactionsCount.jsx
+++ b/app/javascript/articles/components/ReactionsCount.jsx
@@ -24,8 +24,12 @@ export const ReactionsCount = ({ article }) => {
       icon={reactionsSVG}
       tagName="a"
     >
-      <span title="Number of reactions" className="hidden s:inline">
-        {`${totalReactions} ${totalReactions > 1 ? 'reactions' : 'reaction'}`}
+      <span title="Number of reactions">
+        {totalReactions}
+        <span className="hidden s:inline">
+          &nbsp;
+          {`${totalReactions > 1 ? 'reactions' : 'reaction'}`}
+        </span>
       </span>
     </Button>
   );


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Comment/reaction counts were accidentally moved to _within_ the span that hides for small screens. It is only supposed to be the _word_ that is hidden.

This PR fixes that.

Currently:

<img width="477" alt="Screen Shot 2020-06-18 at 9 23 33 PM" src="https://user-images.githubusercontent.com/3102842/85086914-02ef1100-b1aa-11ea-8513-c610c75b0ed2.png">

Should look like:

<img width="479" alt="Screen Shot 2020-06-18 at 9 24 32 PM" src="https://user-images.githubusercontent.com/3102842/85086961-2023df80-b1aa-11ea-8d9f-2405a90bbc71.png">
