### PR TITLE
Style hide link with Crayons

### DIFF
--- a/app/javascript/contentDisplayPolicy/initHiddenComments.js
+++ b/app/javascript/contentDisplayPolicy/initHiddenComments.js
@@ -8,16 +8,16 @@ All child comments in this thread will also be hidden.
 
 For further actions, you may consider blocking this person and/or reporting abuse.
     `;
-    const confirmHide = window.confirm(confirmMsg)
-    if(confirmHide) {
+    const confirmHide = window.confirm(confirmMsg);
+    if (confirmHide) {
       fetch(`/comments/${commentId}/hide`, {
         method: 'PATCH',
         headers: {
           'X-CSRF-Token': window.csrfToken,
         },
       })
-        .then(response => response.json())
-        .then(response => {
+        .then((response) => response.json())
+        .then((response) => {
           if (response.hidden === 'true') {
             /* eslint-disable-next-line no-restricted-globals */
             location.reload();
@@ -33,8 +33,8 @@ For further actions, you may consider blocking this person and/or reporting abus
         'X-CSRF-Token': window.csrfToken,
       },
     })
-      .then(response => response.json())
-      .then(response => {
+      .then((response) => response.json())
+      .then((response) => {
         if (response.hidden === 'false') {
           /* eslint-disable-next-line no-restricted-globals */
           location.reload();
@@ -42,21 +42,20 @@ For further actions, you may consider blocking this person and/or reporting abus
       });
   }
 
-  const hideButtons = Array.from(
-    document.getElementsByClassName('hide-comment')
-  )
-  
-  hideButtons.forEach(butt => {
-    const { hideType, commentId } = butt.dataset
+  const hideLinks = Array.from(document.getElementsByClassName('hide-comment'));
+
+  hideLinks.forEach((link) => {
+    const { hideType, commentId } = link.dataset;
+
     if (hideType === 'hide') {
-      butt.addEventListener('click', () => {
-        hide(commentId)
-      })
+      link.addEventListener('click', () => {
+        hide(commentId);
+      });
     } else if (hideType === 'unhide') {
-      butt.addEventListener('click', () => {
+      link.addEventListener('click', () => {
         unhide(commentId);
       });
     }
-  })
+  });
 }
 /* eslint-enable no-alert */

--- a/app/views/comments/_comment_proper.html.erb
+++ b/app/views/comments/_comment_proper.html.erb
@@ -63,7 +63,7 @@
             </span>
             <% action = comment.hidden_by_commentable_user ? "Unhide" : "Hide" %>
             <span class="comment-actions hidden" data-action="hide-button" data-commentable-user-id="<%= commentable.user_id %>" data-user-id="<%= comment.user_id %>" style="display: none; width: 100%;">
-              <button class="hide-comment" type="button" data-hide-type="<%= action.downcase %>" data-comment-id="<%= comment.id %>">
+              <a class="crayons-link crayons-link--block hide-comment" data-hide-type="<%= action.downcase %>" data-comment-id="<%= comment.id %>">
                 <%= action %>
               </button>
             </span>


### PR DESCRIPTION
#7747  What type of PR is this? (check all applicable)

- [X] Refactor

## Description

While triaging an issue I randomly noticed that the "Hide" buttons on comments look quite out of place in the new design:

<img width="194" alt="Screen Shot 2020-06-22 at 14 11 43" src="https://user-images.githubusercontent.com/47985/85262659-4a221e00-b498-11ea-9319-637929a7afae.png">

This PR changes the link from a `button` to an `a` tag and applies Crayon styles.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

![2020-06-22 14 40 44](https://user-images.githubusercontent.com/47985/85263086-dd5b5380-b498-11ea-811f-4487856794de.gif)


## Added tests?

- [X] no, because they aren't needed

## Added to documentation?

- [X] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![image](https://user-images.githubusercontent.com/47985/85263156-f49a4100-b498-11ea-9fdb-2c9d22263d42.png)

