### PR TITLE
Remove outdated comment in scaffolds.scss

### DIFF
--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -183,9 +183,6 @@ body.ten-x-hacker-theme {
   text-align: center;
   padding: 0;
   min-height: 45px;
-
-  // TODO: [@thepracticaldev/delightful]: Remove these styles once
-  // https://github.com/thepracticaldev/dev.to/pull/8234 is merged.
   z-index: 101; // Must be higher than the z-index of the sticky-nav.
   position: fixed;
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description
The PR being referenced by this comment (https://github.com/thepracticaldev/dev.to/pull/8234) has been merged, but I think we actually _do_ want these styles to stay here after testing this feature locally both with and without the explicit `position` and `z-index` properties.

## Related Tickets & Documents
#8234

## QA Instructions, Screenshots, Recordings

Here's how these styles look currently after #8234 was merged:

_Fixed header:_
<img width="1464" alt="Screen Shot 2020-06-22 at 9 05 22 AM" src="https://user-images.githubusercontent.com/6921610/85309648-bdf80280-b467-11ea-8bc7-272563cd8304.png">

_Static header:_
<img width="1464" alt="Screen Shot 2020-06-22 at 9 04 55 AM" src="https://user-images.githubusercontent.com/6921610/85309653-c0f2f300-b467-11ea-8503-da05d1126cdd.png">


## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed **(I am updating the inline docs!)**
