### PR TITLE
Notify Honeybadger when no id can be found for a welcome notification

### DIFF
--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -26,8 +26,7 @@
    * @param {Event} The click event on the notification.
    */
   function trackNotification(event) {
-    let title = event.target.parentElement.id;
-    let text = event.target.text;
+    const { parentElement: { id: title }, text } = event.target;
     if (!title) {
       Honeybadger.notify(`Could not find parentElement.id when clicking on event target text: ${text}`);
     }

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -25,9 +25,14 @@
    *
    * @param {Event} The click event on the notification.
    */
-  function trackNotification(e) {
-    let title = e.target.parentElement.id
-    ahoy.track("Clicked Welcome Notification", { title });
+  function trackNotification(event) {
+    let title = event.target.parentElement.id;
+    let text = event.target.text;
+    if (!title) {
+      Honeybadger.notify(`Could not find parentElement.id when clicking on event target text: ${text}`);
+    }
+
+    ahoy.track("Clicked Welcome Notification", { title, text });
   }
 </script>
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

After recently [adding tracking to welcome notifications](https://github.com/thepracticaldev/dev.to/pull/8758), I checked up on the `Ahoy::Event`s associated with welcome notifications. As it turns out, some of the click events for our welcome notifications aren't being tracked with a "title". Here's a screenshot from the [relevant blazer query](https://dev.to/internal/blazer/queries/96-welcome-notification-events):

<img width="1169" alt="Screen_Shot_2020-06-22_at_10_12_57_AM" src="https://user-images.githubusercontent.com/6921610/85316215-3fa05e00-b471-11ea-9b91-6a8a41499176.png">

The "empty" title is due to an empty `target.parentElement.id` on the click `event` object. 

**When I tried to investigate this locally, I could not ever get an empty `id` to appear in tracked events; in other words, I could not reproduce this locally and everything seems to work correctly on dev. This leads me to believe that something is different about the notifications on production versus local dev, or there is something else at play here.**

I'm notifying Honeybadger here so that we can be alerted when this happens, and so that I can debug _why_ this is happening! However, I am continuing to track the event after notifying Honeybadger so that we still continue to capture the click data.

I also added the event's `target.text` to the tracked data for a welcome notification's click event. I figured it would be helpful to have while doing this investigation as well.

I'm hoping that these changes will help in investigating this issue, which I really want to fix ASAP, since tracking "empty title events" isn't helpful to us at all 😬 

## Related Tickets & Documents

[Relevant Blazer query!](https://dev.to/internal/blazer/queries/96-welcome-notification-events)

## QA Instructions, Screenshots, Recordings

This isn't really "QA-able" perse, unless you want to try to see if `Honeybadger.notify` can be triggered locally from this function.

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## Are there any post deployment tasks we need to perform?
I'm going to keep an eye on our [Honeybadger dashboard](https://app.honeybadger.io/projects/66984/faults?q=-is%3Aresolved+-is%3Aignored) after this is deployed to see if I can trigger a new error and get some more data to help investigate this.

## What gif best describes this PR or how it makes you feel?

![confused kermit](https://media2.giphy.com/media/Ysce790SgjJK0/giphy.webp?cid=5a38a5a22384fcd5c2cfd1f00899c19bdce2a0aaa50a5218&rid=giphy.webp)
