### PR TITLE
Remove trailing slashes from URLs to improve SEO

### DIFF
--- a/app/controllers/page_views_controller.rb
+++ b/app/controllers/page_views_controller.rb
@@ -46,7 +46,7 @@ class PageViewsController < ApplicationMetalController
   def update_organic_page_views
     return if Rails.env.production? && rand(100) != 1 # We need to do this operation only once in a while.
 
-    page_views_from_google_com = @article.page_views.where(referrer: "https://www.google.com/")
+    page_views_from_google_com = @article.page_views.where(referrer: "https://www.google.com")
 
     organic_count = page_views_from_google_com.sum(:counts_for_number_of_views)
     @article.update_column(:organic_page_views_count, organic_count) if organic_count > @article.organic_page_views_count

--- a/app/javascript/crayons/guidelines/__stories__/guidelines.stories.jsx
+++ b/app/javascript/crayons/guidelines/__stories__/guidelines.stories.jsx
@@ -149,7 +149,7 @@ export const Components = () => (
       templates (*.html.erb files). We also build out parts of or sometimes
       complete views using
       {' '}
-      <a href="https://docs.dev.to/frontend/preact/">Preact</a>
+      <a href="https://docs.dev.to/frontend/preact">Preact</a>
       , typically for
       the logged on user experience. For example, the main page feed.
     </p>
@@ -161,7 +161,7 @@ export const Components = () => (
     <p>
       The entire design system uses the
       {' '}
-      <a href="http://getbem.com/naming/">BEM</a>
+      <a href="http://getbem.com/naming">BEM</a>
       {' '}
       methodology for naming CSS
       classes. Even Preact components under the hood use it.
@@ -179,15 +179,14 @@ export const Components = () => (
       and what
       <strong>IS NOT</strong>
       {' '}
-      a
-      Crayons component. It&#x27;s also practical because Crayons was
-      implemented when we already had tons of other frontend classes in the
-      codebase. It prevents overwriting styles by other CSS and it&#x27;s very
-      unlikely someone has ever created a
+      a Crayons component. It&#x27;s also practical
+      because Crayons was implemented when we already had tons of other frontend
+      classes in the codebase. It prevents overwriting styles by other CSS and
+      it&#x27;s very unlikely someone has ever created a
       <code>.crayons-btn</code>
       {' '}
-      style BUT
-      it&#x27;s very likely someone has created
+      style BUT it&#x27;s very likely someone has
+      created
       <code>.btn</code>
       {' '}
       style...

--- a/app/javascript/listings/__tests__/ListingDashboard.test.jsx
+++ b/app/javascript/listings/__tests__/ListingDashboard.test.jsx
@@ -232,7 +232,7 @@ describe('<ListingDashboard />', () => {
     // listing category
     const listing1CfpCategory = getByText('cfp', listing1GetByTextOptions);
 
-    expect(listing1CfpCategory.getAttribute('href')).toEqual('/listings/cfp/');
+    expect(listing1CfpCategory.getAttribute('href')).toEqual('/listings/cfp');
 
     // tags
     const listing1ComputerScienceTag = getByText(
@@ -274,7 +274,7 @@ describe('<ListingDashboard />', () => {
     );
 
     expect(listing2EventsCategory.getAttribute('href')).toEqual(
-      '/listings/events/',
+      '/listings/events',
     );
 
     // tags
@@ -323,7 +323,7 @@ describe('<ListingDashboard />', () => {
     // listing category
     const listing3CfpCategory = getByText('cfp', listing3GetByTextOptions);
 
-    expect(listing3CfpCategory.getAttribute('href')).toEqual('/listings/cfp/');
+    expect(listing3CfpCategory.getAttribute('href')).toEqual('/listings/cfp');
 
     // has no tags
 

--- a/app/javascript/listings/dashboard/listingRow.jsx
+++ b/app/javascript/listings/dashboard/listingRow.jsx
@@ -45,7 +45,7 @@ export const ListingRow = ({ listing }) => {
       {listingExpiry}
       {listing.location && <Location location={listing.location} />}
       <span className="dashboard-listing-category">
-        <a href={`/listings/${listing.category}/`}>{listing.category}</a>
+        <a href={`/listings/${listing.category}`}>{listing.category}</a>
       </span>
       <Tags tagList={listing.tag_list} />
       <ActionButtons

--- a/app/labor/markdown_parser.rb
+++ b/app/labor/markdown_parser.rb
@@ -146,7 +146,7 @@ class MarkdownParser
 
   def allowed_image_host?(src)
     # GitHub camo image won't parse but should be safe to host direct
-    src.start_with?("https://camo.githubusercontent.com/")
+    src.start_with?("https://camo.githubusercontent.com")
   end
 
   def remove_nested_linebreak_in_list(html)

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -45,7 +45,7 @@ class SiteConfig < RailsSettings::Base
   field :periodic_email_digest_min, type: :integer, default: 2
 
   # Jobs
-  field :jobs_url, type: :string, default: "https://jobs.dev.to/"
+  field :jobs_url, type: :string, default: "https://jobs.dev.to"
   field :display_jobs_banner, type: :boolean, default: false
 
   # Google Analytics Reporting API v4

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -47,7 +47,7 @@
         <div class="flex-1 flex items-center justify-between">
           <h2 class="fs-l fw-heavy">Posts</h2>
           <nav class="crayons-tabs hidden s:flex">
-            <a href="<%= list_path %>/" class="crayons-tabs__item <%= "crayons-tabs__item--current" if %w[week month year infinity latest].exclude?(params[:timeframe]) %>">Feed</a>
+            <a href="<%= list_path %>" class="crayons-tabs__item <%= "crayons-tabs__item--current" if %w[week month year infinity latest].exclude?(params[:timeframe]) %>">Feed</a>
 
             <a href="<%= list_path %>/top/week" class="crayons-tabs__item <%= "crayons-tabs__item--current" if timeframe_check("week") %>">Week</a>
             <a href="<%= list_path %>/top/month" class="crayons-tabs__item <%= "crayons-tabs__item--current" if timeframe_check("month") %>">Month</a>
@@ -58,7 +58,7 @@
           </nav>
 
           <select class="crayons-select s:hidden ml-2 s:ml-auto w-auto" id="feed-filter-select" aria-label="feed-filter-select">
-            <option value="<%= list_path %>/" <% if ["week", "month", "year", "infinity", "latest"].exclude?(params[:timeframe]) %> selected<% end %>>Feed</option>
+            <option value="<%= list_path %>" <% if ["week", "month", "year", "infinity", "latest"].exclude?(params[:timeframe]) %> selected<% end %>>Feed</option>
             <option value="<%= list_path %>/top/week" <% if timeframe_check("week") %> selected<% end %>>Week</option>
             <option value="<%= list_path %>/top/month" <% if timeframe_check("month") %> selected<% end %>>Month</option>
             <option value="<%= list_path %>/top/year" <% if timeframe_check("year") %> selected<% end %>>Year</option>

--- a/app/views/articles/manage.html.erb
+++ b/app/views/articles/manage.html.erb
@@ -19,7 +19,7 @@
           Make your own tweet about the post, describing personally why you wrote it or why people might find it useful. <a href="https://twitter.com/<%= SiteConfig.social_media_handles["twitter"] %>">@<%= SiteConfig.social_media_handles["twitter"] %></a> may retweet you.
         </li>
         <li>
-          Share to link aggregators such as <a href="https://www.reddit.com/">Reddit</a>. Try to choose the most topic-specific subreddits, such as <a href="https://www.reddit.com/r/javascript">/r/javascript</a> instead of <a href="https://www.reddit.com/r/programming">/r/programming</a>. <em>Warning: jerks and trolls may be lurking.</em>
+          Share to link aggregators such as <a href="https://www.reddit.com">Reddit</a>. Try to choose the most topic-specific subreddits, such as <a href="https://www.reddit.com/r/javascript">/r/javascript</a> instead of <a href="https://www.reddit.com/r/programming">/r/programming</a>. <em>Warning: jerks and trolls may be lurking.</em>
         </li>
         <li>
           Share with your co-workers or local communities. Ask people to leave questions for you in the comments. It's a great way to spark additional discussion.

--- a/app/views/articles/tag_index.html.erb
+++ b/app/views/articles/tag_index.html.erb
@@ -59,7 +59,7 @@
       <div class="on-page-nav-controls" id="on-page-nav-controls">
         <div class="on-page-nav-label sub-home-nav">
           <div class="wide-nav-links">
-            <a class="nav-chronofiter-link <%= "selected" if %w[week month year infinity latest].exclude?(params[:timeframe]) %>" href="<%= list_path %>/">
+            <a class="nav-chronofiter-link <%= "selected" if %w[week month year infinity latest].exclude?(params[:timeframe]) %>" href="<%= list_path %>">
               FEED
             </a>
             <span class="separator"></span>

--- a/app/views/internal/pages/_form.html.erb
+++ b/app/views/internal/pages/_form.html.erb
@@ -54,7 +54,7 @@
             <%= link_to "Modify flag here", "/internal/feature_flags/features/#{@page.feature_flag_name}" %>
           <% else %>
             Everyone has access. Optionally guard access to this page by creating feature <code><%= @page.feature_flag_name %></code>
-            <%= link_to "here", "/internal/feature_flags/features/" %>
+            <%= link_to "here", "/internal/feature_flags/features" %>
           <% end %>
           </br>
         </p>

--- a/app/views/pages/_coc_text.html.erb
+++ b/app/views/pages/_coc_text.html.erb
@@ -39,5 +39,5 @@
 <ul>
   <li><a href="http://contributor-covenant.org/version/1/4">Contributor Covenant, version 1.4</a></li>
   <li><a href="http://www.writespeakcode.com/code-of-conduct.html">Write/Speak/Code</a></li>
-  <li><a href="https://geekfeminism.org/about/code-of-conduct/">Geek Feminism</a></li>
+  <li><a href="https://geekfeminism.org/about/code-of-conduct">Geek Feminism</a></li>
 </ul>

--- a/app/views/pages/_editor_frontmatter_help.html.erb
+++ b/app/views/pages/_editor_frontmatter_help.html.erb
@@ -6,7 +6,7 @@
       </div>
 
       <ul>
-        <li>This editor is a markdown editor that uses <a href="https://jekyllrb.com/docs/frontmatter/">Jekyll front matter</a>.</li>
+        <li>This editor is a markdown editor that uses <a href="https://jekyllrb.com/docs/frontmatter">Jekyll front matter</a>.</li>
         <li>Most of the time, you can write inline HTML directly into your posts.</li>
         <li>We support native Liquid tags and created some fun custom ones, too! Trying embedding a Tweet or GitHub issue in your post.</li>
         <li>Links to unpublished posts are shareable for feedback/review.</li>

--- a/app/views/pages/_editor_guide_text.html.erb
+++ b/app/views/pages/_editor_guide_text.html.erb
@@ -51,7 +51,7 @@
     <pre>&lt;!-- This won't show up in the content! --&gt;</pre>
     <h2 style="font-size:2.8em" id="liquidtags"><strong>🌊 Liquid Tags</strong></h2>
     <p>We support native
-      <a href="https://shopify.github.io/liquid/" target="_blank" rel="noopener">Liquid tags</a> in our editor, but have created our own custom tags listed below:
+      <a href="https://shopify.github.io/liquid" target="_blank" rel="noopener">Liquid tags</a> in our editor, but have created our own custom tags listed below:
     </p>
     <h3><strong><%= community_name %> Article/Post Embed</strong></h3>
     <p>All you need is the full link of the article:</p>
@@ -90,7 +90,7 @@
     <p>All you need is the Glitch project slug</p>
     <code>{% glitch earthy-course %}</code>
     <p>There are several
-      <a href="https://glitch.com/help/how-can-i-customize-a-glitch-app-embed/">optional attributes</a> you can use in your tag, just add them after the id, separated by spaces.
+      <a href="https://glitch.com/help/how-can-i-customize-a-glitch-app-embed">optional attributes</a> you can use in your tag, just add them after the id, separated by spaces.
     </p>
     <dl>
       <dt><code>app</code></dt>

--- a/app/views/pages/_editor_liquid_help.html.erb
+++ b/app/views/pages/_editor_liquid_help.html.erb
@@ -1,7 +1,7 @@
 <div id="editor-liquid-help">
   <div class="crayons-article">
     <div class="crayons-article__body">
-      <p>We support native <a href="https://shopify.github.io/liquid/" target="_blank" rel="noopener">Liquid tags</a> in our editor, but have created our own custom tags listed below:</p>
+      <p>We support native <a href="https://shopify.github.io/liquid" target="_blank" rel="noopener">Liquid tags</a> in our editor, but have created our own custom tags listed below:</p>
       <h3><%= community_name %> Article/Post Embed</h3>
       <p>All you need is the full link of the article:</p>
       <code>{% link https://dev.to/kazz/boost-your-productivity-using-markdown-1be %}</code>
@@ -39,7 +39,7 @@
       <p>All you need is the Glitch project slug</p>
       <code>{% glitch earthy-course %}</code>
       <p>There are several
-        <a href="https://glitch.com/help/how-can-i-customize-a-glitch-app-embed/">optional attributes</a> you can use in your tag, just add them after the id, separated by spaces.
+        <a href="https://glitch.com/help/how-can-i-customize-a-glitch-app-embed">optional attributes</a> you can use in your tag, just add them after the id, separated by spaces.
       </p>
       <ul>
         <li><code>app</code> – Shows the app preview without the code.<br>

--- a/app/views/pages/_v1_editor_guide_preamble.html.erb
+++ b/app/views/pages/_v1_editor_guide_preamble.html.erb
@@ -1,7 +1,7 @@
 
 <h1><strong>Things to Know</strong></h1>
 <ul>
-  <li>We use a markdown editor that uses <a href="https://jekyllrb.com/docs/frontmatter/">Jekyll front matter</a>.</li>
+  <li>We use a markdown editor that uses <a href="https://jekyllrb.com/docs/frontmatter">Jekyll front matter</a>.</li>
   <li>Most of the time, you can write inline HTML directly into your posts.</li>
   <li>We support native Liquid tags and created some fun custom ones, too! Trying embedding a Tweet or GitHub issue in your post.</li>
   <li>Links to unpublished posts are shareable for feedback/review.</li>

--- a/app/views/pages/generator.html.erb
+++ b/app/views/pages/generator.html.erb
@@ -49,7 +49,7 @@
     </pre>
     <h3>Animal Codes</h3>
     <p><i>The animal images are from the
-      <a href="https://etc.usf.edu/clipart/" target="_blank" rel="noopener">USF ClipArt ETC</a> project. They are used in this O RLY Cover Generator for the purposes of parody.</i>
+      <a href="https://etc.usf.edu/clipart" target="_blank" rel="noopener">USF ClipArt ETC</a> project. They are used in this O RLY Cover Generator for the purposes of parody.</i>
     </p>
     <div class="animal"><%= image_tag("1.png", alt: "grizzly bear") %>1</div>
     <div class="animal"><%= image_tag("2.png", alt: "cat") %>2</div>

--- a/app/views/pages/markdown_basics.html.erb
+++ b/app/views/pages/markdown_basics.html.erb
@@ -41,7 +41,7 @@
 
     <h2><strong><u>Liquid Tags</u></strong></h2>
     <p>We support native
-      <a href="https://shopify.github.io/liquid/" target="_blank" rel="noopener">Liquid tags</a> in our editor, but have created our own custom tags listed below:
+      <a href="https://shopify.github.io/liquid" target="_blank" rel="noopener">Liquid tags</a> in our editor, but have created our own custom tags listed below:
     </p>
 
     <h3><strong>Twitter Embed</strong></h3>

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -125,7 +125,7 @@
       <br>
       <br>
       This allows user behavior to be tracked after they have been redirected to our website by clicking on a Facebook ad. This enables us to measure the effectiveness of Facebook ads. The data collected in this way is anonymous to us, i.e. we do not see the personal data of individual users. However, this data is stored and processed by Facebook, which is why we are informing you, based on our knowledge of the situation. Facebook may link this information to your Facebook account and also use it for its own promotional purposes, in accordance with
-      <a href="https://www.facebook.com/about/privacy/">Facebook’s Data Usage Policy</a>. You can object to the collection of your data by Facebook pixel, or to the use of your data for the purpose of displaying Facebook ads by contacting the following address: https://www.facebook.com/settings?tab=ads.
+      <a href="https://www.facebook.com/about/privacy">Facebook’s Data Usage Policy</a>. You can object to the collection of your data by Facebook pixel, or to the use of your data for the purpose of displaying Facebook ads by contacting the following address: https://www.facebook.com/settings?tab=ads.
     </p>
     <p><strong>Tracking & Cookies</strong>
       <br>

--- a/app/views/pages/rlyweb.html.erb
+++ b/app/views/pages/rlyweb.html.erb
@@ -61,7 +61,7 @@
   <div class="usage">
     <h3>Animal Codes</h3>
     <p><i>The animal images are from the
-      <a href="https://etc.usf.edu/clipart/" target="_blank" rel="noopener">USF ClipArt ETC</a> project. They are used in this O RLY Cover Generator for the purposes of parody.</i>
+      <a href="https://etc.usf.edu/clipart" target="_blank" rel="noopener">USF ClipArt ETC</a> project. They are used in this O RLY Cover Generator for the purposes of parody.</i>
     </p>
     <div class="animal"><%= image_tag("1.png", alt: "grizzly bear") %>1</div>
     <div class="animal"><%= image_tag("2.png", alt: "cat") %>2</div>

--- a/app/views/stories/_narrow_nav_menu.html.erb
+++ b/app/views/stories/_narrow_nav_menu.html.erb
@@ -1,5 +1,5 @@
 <div class="narrow-nav-menu" id="narrow-nav-menu" aria-label="feed-nav-menu">
-  <a href="<%= list_path %>/" class="<%= "selected" if %w[week month year infinity latest].exclude?(params[:timeframe]) %>">&lt;MY <%= community_name %> FEED&gt;</a>
+  <a href="<%= list_path %>" class="<%= "selected" if %w[week month year infinity latest].exclude?(params[:timeframe]) %>">&lt;MY <%= community_name %> FEED&gt;</a>
   <a href="<%= list_path %>/top/week" class="<%= "selected" if timeframe_check("week") %>">&lt;PAST WEEK&gt;</a>
   <a href="<%= list_path %>/top/month" class="<%= "selected" if timeframe_check("month") %>">&lt;PAST MONTH&gt;</a>
   <a href="<%= list_path %>/top/year" class="<%= "selected" if timeframe_check("year") %>">&lt;PAST YEAR&gt;</a>

--- a/app/views/users/_account.html.erb
+++ b/app/views/users/_account.html.erb
@@ -5,7 +5,7 @@
 <div class="crayons-card mb-6 p-6 grid gap-6">
   <header>
     <h2 class="mb-2"><%= community_name %> API Keys</h2>
-    <p>You can generate personal API keys to use for authentication with the <%= community_name %> API. The API is still in early beta though. The <a href="https://docs.dev.to/api/"><%= community_name %> API documentation</a> contains further information.</a></p>
+    <p>You can generate personal API keys to use for authentication with the <%= community_name %> API. The API is still in early beta though. The <a href="https://docs.dev.to/api"><%= community_name %> API documentation</a> contains further information.</a></p>
   </header>
 
   <div>

--- a/app/views/users/_publishing_from_rss.html.erb
+++ b/app/views/users/_publishing_from_rss.html.erb
@@ -31,7 +31,7 @@
   <%= form_for @user, html: { class: "grid gap-6" } do |f| %>
     <div class="crayons-field">
       <%= f.label :feed_url, "RSS Feed URL", class: "crayons-field__label" %>
-      <%= f.url_field :feed_url, placeholder: "https://yoursite.com/feed/", class: "crayons-textfield" %>
+      <%= f.url_field :feed_url, placeholder: "https://yoursite.com/feed", class: "crayons-textfield" %>
     </div>
 
     <div class="crayons-field crayons-field--checkbox">

--- a/config/initializers/s3_direct_upload.rb
+++ b/config/initializers/s3_direct_upload.rb
@@ -3,5 +3,5 @@ S3DirectUpload.config do |c|
   c.secret_access_key = ApplicationConfig["AWS_S3_VIDEO_KEY"] # your secret access key
   c.bucket = ApplicationConfig["AWS_S3_INPUT_BUCKET"] # your bucket name
   c.region = nil # region prefix. _Required_ for non-default AWS region, eg. "eu-west-1"
-  c.url = nil # S3 API endpoint (optional), eg. "https://#{c.bucket}.s3.amazonaws.com/"
+  c.url = nil # S3 API endpoint (optional), eg. "https://#{c.bucket}.s3.amazonaws.com"
 end

--- a/public/404.html
+++ b/public/404.html
@@ -94,7 +94,7 @@
           <img class="tv__inner--special" src="https://i.imgur.com/Vyyjycv.gif" alt="404 not found image as TV static">
           <img class="tv__inner" src="https://i.imgur.com/3v0LCiP.jpg" alt="404 not found DEV logo">
           <br>
-          <p class="tv__inner--text">This page does not exist <br><br> <a href="https://dev.to/">Return to Home Page</a></p>
+          <p class="tv__inner--text">This page does not exist <br><br> <a href="https://dev.to">Return to Home Page</a></p>
         </div>
       </div>
   </div>

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -148,7 +148,7 @@ FactoryBot.define do
       currently_hacking_on { "JSON-LD" }
       mastodon_url { "https://mastodon.social/@test" }
       facebook_url { "www.facebook.com/example" }
-      linkedin_url { "www.linkedin.com/company/example/" }
+      linkedin_url { "www.linkedin.com/company/example" }
       youtube_url { "https://youtube.com/example" }
       behance_url { "www.behance.net/#{username}" }
       stackoverflow_url { "www.stackoverflow.com/example" }

--- a/spec/requests/page_views_spec.rb
+++ b/spec/requests/page_views_spec.rb
@@ -70,12 +70,12 @@ RSpec.describe "PageViews", type: :request do
       end
 
       it "stores aggregate organic page views" do
-        post "/page_views", params: { article_id: article.id, referrer: "https://www.google.com/" }
+        post "/page_views", params: { article_id: article.id, referrer: "https://www.google.com" }
         post "/page_views", params: { article_id: article.id }
         expect(article.reload.organic_page_views_count).to eq(10)
         expect(article.reload.organic_page_views_past_week_count).to eq(10)
         expect(article.reload.organic_page_views_past_month_count).to eq(10)
-        post "/page_views", params: { article_id: article.id, referrer: "https://www.google.com/" }
+        post "/page_views", params: { article_id: article.id, referrer: "https://www.google.com" }
         expect(article.reload.organic_page_views_count).to eq(20)
         post "/page_views", params: { article_id: article.id }
         expect(article.reload.organic_page_views_count).to eq(20)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Across our app, we have a two different variations of how we link to URLs. In the majority of cases, we link to `/foo`, but in some instances, we link to `/foo/`. Google gets pretty confused when we do this; it interprets these as _two different URLs_. When they both resolves successfully (with a status of `200`), Google is forced to pick between the two. The issue with this is that it splits up our "link equity" for those pages, since Google sees them as two links. Instead, we'd much prefer to consolidate all of our "SEO juice" and link equity around _one, standardized link_.

Thus, in an effort to boost SEO, we really need to standardize around _one_ way of representing links, since, at the end of the day, we only want one representation of each URL.

Ideally, we will want to programmatically parse through links going forward (using a linter or something in our `routes.rb` file to handle redirects with trailing slashes), but I wanted to tackle this as a quick, low-hanging fruit that hopefully result in a big win! 🚀 

## Related Tickets & Documents
N/A

## QA Instructions, Screenshots, Recordings

Please make sure I didn't break any links! I did a massive pass through of our app, and while there weren't too many things to change, it's important to check that none of the trailing slashes that I removed will cause broken links! 😉 

## Added tests?

- [x] yes **(updated pre-existing tests)**
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
N/A
