### PR TITLE
Only track server-side events when needed

### DIFF
--- a/config/initializers/ahoy.rb
+++ b/config/initializers/ahoy.rb
@@ -6,3 +6,6 @@ Ahoy.api = true
 
 # set to false to disable geocode tracking
 Ahoy.geocode = false
+
+# only create visits server-side when needed for events and `visitable`
+Ahoy.server_side_visits = :when_needed


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

I recently made a change to turn off ahoy from [tracking visits by default](https://github.com/thepracticaldev/dev.to/pull/8782). However, it still seems like we are tracking a small amount of them, and it's unclear where exactly those visits are being "tracked" from. I am honestly still not entirely sure what is causing these to be "tracked".

However, as it turns out, this library defaults to `Ahoy.server_side_visits` being set to `true`. I suspect that this default is what is causing some of this "unexplained tracking" to occur. This PR sets that configuration to `:when_needed`, which should only create an `Ahoy::Visit` when it is needed by an `Ahoy::Event`.

According to the `ahoy` docs:
> You can also defer visit tracking to JavaScript. This is useful for preventing bots (that aren’t detected by their user agent) and users with cookies disabled from creating a new visit on each request. :when_needed will create visits server-side only when needed by events, and false will disable server-side creation completely, discarding events without a visit.

I _suspect_ that the default configuration is the culprit of our unexplained tracked events, and that this is the setting we want.

## Related Tickets & Documents
N/A

## QA Instructions, Screenshots, Recordings

The `spec/system/notifications/notifications_page_spec.rb` spec should continue to pass. And hopefully, after this is deployed, the count of `Ahoy::Visits` should stop slowly incrementing. 🤞 

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [x] inline documentation
- [ ] docs.dev.to
- [ ] readme
- [ ] no documentation needed

## Are there any post deployment tasks we need to perform?
I'll keep an eye on the [recent ahoy visits](https://dev.to/internal/blazer/queries/97-recent-ahoy-visits) and make sure that they're not increasing.

## What gif best describes this PR or how it makes you feel?

![ugh flower](https://media3.giphy.com/media/3oz8xMpLWoX2uUEKw8/giphy.webp?cid=5a38a5a20c86ddbeb31688a0b7ffa262912d36fbe0a7bd2e&rid=giphy.webp)
