### PR TITLE
Fix accessiblity warnings on Listings page

### DIFF
--- a/app/views/listings/index.html.erb
+++ b/app/views/listings/index.html.erb
@@ -26,26 +26,15 @@
   <meta name="twitter:card" content="summary_large_image">
 <% end %>
 
-<div class="home">
-  <div class="listings-container" id="listings-index-container"
-    data-category="<%= params[:category] %>" data-listings="<%= @listings_json %>"
-    data-allcategories="<%= categories_for_display.to_json %>"
-    <% if @displayed_listing %>
-      data-displayedlisting="<%= @displayed_listing_json %> "
-    <% end %>>
-
-    <div class="listing-filters">
-    <div class="listing-filters-categories">
-      <a href="<%= listings_path %>" class="<%= "selected" if params[:category].blank? %> data-no-instant=" true ">all</a>
-      <% categories_for_display.each do |cat| %>
-        <a href="<%= listing_category_path(category: cat[:slug]) %> " class="<%= "selected" if params[:category] == cat[:slug] %> data-no-instant="true"><%= cat[:name] %></a>
-      <% end %>
-      <a href="<%= new_listing_path %>" class='listing-create-link'>Create a Listing</a>
-      <% if @displayed_listing %>
-        <div class="listing-listings-modal-background" role='presentation'></div>
-      <% end %>
-    </div>
-  </div>
-</div>
+<main class="home">
+  <h1 class="visually-hidden-header">Listings</h1>
+  <section class="listings-container" id="listings-index-container"
+           data-category="<%= params[:category] %>" data-listings="<%= @listings_json %>"
+           data-allcategories="<%= categories_for_display.to_json %>"
+           <% if @displayed_listing %>
+           data-displayedlisting="<%= @displayed_listing_json %> "
+           <% end %>>
+  </section>
+</main>
 
 <%= javascript_packs_with_chunks_tag "listings", defer: true %>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This should fix ~60 axe warnings on this page. This commit also removes
some markup that is being overwritten by Preact.

There are no UI changes.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, as well
as any relevant images for UI changes._

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
