### PR TITLE
Rails 6: replace deprecated content_type with media_type

### DIFF
--- a/spec/requests/listings_spec.rb
+++ b/spec/requests/listings_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "/listings", type: :request do
 
     it "returns text/html and has status 200" do
       get "/listings"
-      expect(response.content_type).to eq("text/html")
+      expect(response.media_type).to eq("text/html")
       expect(response).to have_http_status(:ok)
     end
 

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Pages", type: :request do
       it "returns json data " do
         get "/page/#{page.slug}"
 
-        expect(response.content_type).to eq("application/json")
+        expect(response.media_type).to eq("application/json")
         expect(response.body).to include(json_text)
       end
 
@@ -37,7 +37,7 @@ RSpec.describe "Pages", type: :request do
         page.save!
         get "/#{page.slug}"
 
-        expect(response.content_type).to eq("application/json")
+        expect(response.media_type).to eq("application/json")
         expect(response.body).to include(json_text)
       end
     end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This fixes messages similar to:

> DEPRECATION WARNING: Rails 6.1 will return Content-Type header without modification. If you want just the MIME type, please use `#media_type` instead. (called from block (3 levels) in <top (required)> at /home/travis/build/thepracticaldev/dev.to/spec/requests/listings_spec.rb:43)


## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
