### PR TITLE
Use Action Mailer parameterized syntax

### DIFF
--- a/app/controllers/internal/feedback_messages_controller.rb
+++ b/app/controllers/internal/feedback_messages_controller.rb
@@ -44,7 +44,7 @@ class Internal::FeedbackMessagesController < Internal::ApplicationController
   end
 
   def send_email
-    if NotifyMailer.feedback_message_resolution_email(params).deliver
+    if NotifyMailer.with(params).feedback_message_resolution_email.deliver_now
       render json: { outcome: "Success" }
     else
       render json: { outcome: "Failure" }

--- a/app/controllers/internal/users_controller.rb
+++ b/app/controllers/internal/users_controller.rb
@@ -100,15 +100,15 @@ class Internal::UsersController < Internal::ApplicationController
   end
 
   def send_email
-    if NotifyMailer.user_contact_email(params).deliver
-      redirect_back(fallback_location: "/users")
+    if NotifyMailer.with(params).user_contact_email.deliver_now
+      redirect_back(fallback_location: users_path)
     else
       flash[:danger] = "Email failed to send!"
     end
   end
 
   def verify_email_ownership
-    if VerificationMailer.account_ownership_verification_email(params).deliver
+    if VerificationMailer.with(user_id: params[:user_id]).account_ownership_verification_email.deliver_now
       flash[:success] = "Email Verification Mailer sent!"
       redirect_back(fallback_location: internal_users_path)
     else

--- a/app/controllers/video_states_controller.rb
+++ b/app/controllers/video_states_controller.rb
@@ -21,7 +21,9 @@ class VideoStatesController < ApplicationController
 
     if @article
       @article.update(video_state: "COMPLETED") # Only is called on completion
-      NotifyMailer.video_upload_complete_email(@article).deliver
+
+      NotifyMailer.with(article: @article).video_upload_complete_email.deliver_now
+
       render json: { message: "Video state updated" }
     else
       render json: { message: "Related article not found" }, status: :not_found

--- a/app/labor/assign_tag_moderator.rb
+++ b/app/labor/assign_tag_moderator.rb
@@ -7,7 +7,7 @@ module AssignTagModerator
     user.update(email_community_mod_newsletter: true)
     MailchimpBot.new(user).manage_community_moderator_list
     Rails.cache.delete("user-#{user.id}/has_trusted_role")
-    NotifyMailer.trusted_role_email(user).deliver
+    NotifyMailer.with(user: user).trusted_role_email.deliver_now
   end
 
   def self.add_tag_moderators(user_ids, tag_ids)
@@ -17,7 +17,10 @@ module AssignTagModerator
       add_tag_mod_role(user, tag)
       add_trusted_role(user)
       add_to_chat_channels(user, tag)
-      NotifyMailer.tag_moderator_confirmation_email(user, tag, chat_channel_slug(tag)).deliver
+
+      NotifyMailer.with(user: user, tag: tag, channel_slug: chat_channel_slug(tag)).
+        tag_moderator_confirmation_email.
+        deliver_now
     end
   end
 

--- a/app/labor/email_digest.rb
+++ b/app/labor/email_digest.rb
@@ -1,8 +1,3 @@
-# Usecase would be
-# EmailDigest.send_periodic_digest_email
-# OR
-# EmailDigets.send_periodic_digest_email(Users.first(4))
-
 class EmailDigest
   def self.send_periodic_digest_email(users = [])
     new(users).send_periodic_digest_email
@@ -19,7 +14,9 @@ class EmailDigest
 
       articles = user_email_heuristic.articles_to_send
       begin
-        DigestMailer.digest_email(user, articles).deliver if user.email_digest_periodic == true
+        next unless user.email_digest_periodic?
+
+        DigestMailer.with(user: user, articles: articles).digest_email.deliver_now
       rescue StandardError => e
         Rails.logger.error("Email issue: #{e}")
       end

--- a/app/labor/unread_notifications_emailer.rb
+++ b/app/labor/unread_notifications_emailer.rb
@@ -30,7 +30,7 @@ class UnreadNotificationsEmailer
   end
 
   def send_email
-    NotifyMailer.unread_notifications_email(user).deliver
+    NotifyMailer.with(user: user).unread_notifications_email.deliver_now
   end
 
   private

--- a/app/mailers/digest_mailer.rb
+++ b/app/mailers/digest_mailer.rb
@@ -1,10 +1,11 @@
 class DigestMailer < ApplicationMailer
   default from: -> { email_from("Digest") }
 
-  def digest_email(user, articles)
-    @user = user
-    @articles = articles.first(6)
+  def digest_email
+    @user = params[:user]
+    @articles = params[:articles].first(6)
     @unsubscribe = generate_unsubscribe_token(@user.id, :email_digest_periodic)
+
     subject = generate_title
     mail(to: @user.email, subject: subject)
   end

--- a/app/mailers/verification_mailer.rb
+++ b/app/mailers/verification_mailer.rb
@@ -1,10 +1,13 @@
 class VerificationMailer < ApplicationMailer
-  default from: -> { "#{ApplicationConfig['COMMUNITY_NAME']} Email Verification <#{SiteConfig.email_addresses[:default]}>" }
+  default from: lambda {
+    "#{ApplicationConfig['COMMUNITY_NAME']} Email Verification <#{SiteConfig.email_addresses[:default]}>"
+  }
 
-  def account_ownership_verification_email(params)
+  def account_ownership_verification_email
     @user = User.find(params[:user_id])
     email_authorization = EmailAuthorization.create(user: @user, type_of: "account_ownership")
     @confirmation_token = email_authorization.confirmation_token
+
     mail(to: @user.email, subject: "Verify Your #{ApplicationConfig['COMMUNITY_NAME']} Account Ownership")
   end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -215,6 +215,6 @@ class Message < ApplicationRecord
       chat_channel.last_message_at > 30.minutes.ago ||
       recipient.email_connect_messages == false
 
-    NotifyMailer.with(user: self).new_message_email.deliver_now
+    NotifyMailer.with(message: self).new_message_email.deliver_now
   end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -215,6 +215,6 @@ class Message < ApplicationRecord
       chat_channel.last_message_at > 30.minutes.ago ||
       recipient.email_connect_messages == false
 
-    NotifyMailer.new_message_email(self).deliver
+    NotifyMailer.with(user: self).new_message_email.deliver_now
   end
 end

--- a/app/services/exporter/service.rb
+++ b/app/services/exporter/service.rb
@@ -55,7 +55,7 @@ module Exporter
 
     def send_exports_by_email(zipped_exports)
       zipped_exports.rewind
-      NotifyMailer.export_email(user, zipped_exports.read).deliver
+      NotifyMailer.with(user: user, attachment: zipped_exports.read).export_email.deliver_now
     end
 
     def update_user_export_fields

--- a/app/services/moderator/manage_activity_and_roles.rb
+++ b/app/services/moderator/manage_activity_and_roles.rb
@@ -101,7 +101,7 @@ module Moderator
 
       user.add_role :trusted
       user.update(email_community_mod_newsletter: true)
-      NotifyMailer.trusted_role_email(user).deliver
+      NotifyMailer.with(user: user).trusted_role_email.deliver_now
       MailchimpBot.new(user).manage_community_moderator_list
     end
 

--- a/app/services/users/request_destroy.rb
+++ b/app/services/users/request_destroy.rb
@@ -4,8 +4,10 @@ module Users
 
     def call(user)
       token = SecureRandom.hex(10)
+
       Rails.cache.write("user-destroy-token-#{user.id}", token, expires_in: 12.hours)
-      NotifyMailer.account_deletion_requested_email(user, token).deliver
+
+      NotifyMailer.with(user: user, token: token).account_deletion_requested_email.deliver_now
     end
   end
 end

--- a/app/workers/badge_achievements/send_email_notification_worker.rb
+++ b/app/workers/badge_achievements/send_email_notification_worker.rb
@@ -8,7 +8,7 @@ module BadgeAchievements
       badge_achievement = BadgeAchievement.find_by(id: badge_achievement_id)
       return unless badge_achievement
 
-      NotifyMailer.new_badge_email(badge_achievement).deliver_now
+      NotifyMailer.with(badge_achievement: badge_achievement).new_badge_email.deliver_now
     end
   end
 end

--- a/app/workers/comments/send_email_notification_worker.rb
+++ b/app/workers/comments/send_email_notification_worker.rb
@@ -6,7 +6,7 @@ module Comments
 
     def perform(comment_id)
       comment = Comment.find_by(id: comment_id)
-      NotifyMailer.new_reply_email(comment).deliver_now if comment
+      NotifyMailer.with(comment: comment).new_reply_email.deliver_now if comment
     end
   end
 end

--- a/app/workers/follows/send_email_notification_worker.rb
+++ b/app/workers/follows/send_email_notification_worker.rb
@@ -11,7 +11,7 @@ module Follows
         where("sent_at > ?", rand(15..35).hours.ago).
         where("subject LIKE ?", "%#{NotifyMailer::SUBJECTS[:new_follower_email]}").exists?
 
-      mailer.constantize.new_follower_email(follow).deliver
+      mailer.constantize.with(follow: follow).new_follower_email.deliver_now
     end
   end
 end

--- a/app/workers/mentions/send_email_notification_worker.rb
+++ b/app/workers/mentions/send_email_notification_worker.rb
@@ -5,7 +5,9 @@ module Mentions
 
     def perform(mention_id)
       mention = Mention.find_by(id: mention_id)
-      NotifyMailer.new_mention_email(mention) if mention
+      return unless mention
+
+      NotifyMailer.with(mention: mention).new_mention_email
     end
   end
 end

--- a/app/workers/users/delete_worker.rb
+++ b/app/workers/users/delete_worker.rb
@@ -11,7 +11,7 @@ module Users
       Users::Delete.call(user)
       return if admin_delete || user.email.blank?
 
-      NotifyMailer.account_deleted_email(user).deliver
+      NotifyMailer.with(user: user).account_deleted_email.deliver_now
     rescue StandardError => e
       DatadogStatsClient.count("users.delete", 1, tags: ["action:failed", "user_id:#{user.id}"])
       Rails.logger.error("Error while deleting user: #{e}")

--- a/config/initializers/new_framework_defaults_6_0.rb
+++ b/config/initializers/new_framework_defaults_6_0.rb
@@ -37,7 +37,7 @@
 # If you send mail in the background, job workers need to have a copy of
 # MailDeliveryJob to ensure all delivery jobs are processed properly.
 # Make sure your entire app is migrated and stable on 6.0 before using this setting.
-# Rails.application.config.action_mailer.delivery_job = "ActionMailer::MailDeliveryJob"
+Rails.application.config.action_mailer.delivery_job = "ActionMailer::MailDeliveryJob"
 
 # Enable the same cache key to be reused when the object being cached of type
 # `ActiveRecord::Relation` changes by moving the volatile information (max updated at and count)

--- a/spec/labor/email_digest_spec.rb
+++ b/spec/labor/email_digest_spec.rb
@@ -1,33 +1,30 @@
 require "rails_helper"
 
-class FakeDelegator < ActionMailer::MessageDelivery
-  # TODO: we should replace all usage of .deliver to .deliver_now
-  def deliver(*args)
-    super
-  end
-end
-
 RSpec.describe EmailDigest, type: :labor do
   let(:user) { create(:user, email_digest_periodic: true) }
   let(:author) { create(:user) }
-  let(:mock_delegator) { instance_double("FakeDelegator") }
+
+  let(:mailer) { double }
+  let(:message_delivery) { double }
 
   before do
-    allow(DigestMailer).to receive(:digest_email) { mock_delegator }
-    allow(mock_delegator).to receive(:deliver).and_return(true)
-    user
+    allow(DigestMailer).to receive(:with).and_return(mailer)
+    allow(mailer).to receive(:digest_email).and_return(message_delivery)
+    allow(message_delivery).to receive(:deliver_now)
   end
 
   describe "::send_digest_email" do
     context "when there's article to be sent" do
       before { user.follow(author) }
 
-      it "send digest email when there's atleast 3 hot articles" do
-        create_list(:article, 3, user_id: author.id, public_reactions_count: 20, score: 20)
+      it "send digest email when there are at least 3 hot articles" do
+        articles = create_list(:article, 3, user_id: author.id, public_reactions_count: 20, score: 20)
+
         described_class.send_periodic_digest_email
-        expect(DigestMailer).to have_received(:digest_email).with(
-          user, [instance_of(Article), instance_of(Article), instance_of(Article)]
-        )
+
+        expect(DigestMailer).to have_received(:with).with(user: user, articles: articles)
+        expect(mailer).to have_received(:digest_email)
+        expect(message_delivery).to have_received(:deliver_now)
       end
     end
   end

--- a/spec/mailers/digest_mailer_spec.rb
+++ b/spec/mailers/digest_mailer_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe DigestMailer, type: :mailer do
     end
 
     it "works correctly" do
-      email = described_class.digest_email(user, [article])
+      email = described_class.with(user: user, articles: [article]).digest_email
 
       expect(email.subject).not_to be_nil
       expect(email.to).to eq([user.email])
@@ -19,12 +19,12 @@ RSpec.describe DigestMailer, type: :mailer do
     end
 
     it "includes the tracking pixel" do
-      email = described_class.digest_email(user, [article])
+      email = described_class.with(user: user, articles: [article]).digest_email
       expect(email.body).to include("open.gif")
     end
 
     it "includes UTM params" do
-      email = described_class.digest_email(user, [article])
+      email = described_class.with(user: user, articles: [article]).digest_email
       expect(email.body).to include(CGI.escape("utm_medium=email"))
       expect(email.body).to include(CGI.escape("utm_source=digest_mailer"))
       expect(email.body).to include(CGI.escape("utm_campaign=digest_email"))

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe NotifyMailer, type: :mailer do
   let(:comment)   { create(:comment, user_id: user.id, commentable: article) }
 
   describe "#new_reply_email" do
-    let(:email) { described_class.new_reply_email(comment) }
+    let(:email) { described_class.with(comment: comment).new_reply_email }
 
     it "renders proper subject" do
       expected_subject = "#{comment.user.name} replied to your #{comment.parent_type}"
@@ -16,7 +16,8 @@ RSpec.describe NotifyMailer, type: :mailer do
 
     it "renders proper sender" do
       expect(email.from).to eq([SiteConfig.email_addresses[:default]])
-      expect(email["from"].value).to eq("#{ApplicationConfig['COMMUNITY_NAME']} Community <#{SiteConfig.email_addresses[:default]}>")
+      expected_from = "#{ApplicationConfig['COMMUNITY_NAME']} Community <#{SiteConfig.email_addresses[:default]}>"
+      expect(email["from"].value).to eq(expected_from)
     end
 
     it "renders proper receiver" do
@@ -35,7 +36,7 @@ RSpec.describe NotifyMailer, type: :mailer do
   end
 
   describe "#new_follower_email" do
-    let(:email) { described_class.new_follower_email(user2.follows.last) }
+    let(:email) { described_class.with(follow: user2.follows.last).new_follower_email }
 
     before { user2.follow(user) }
 
@@ -45,7 +46,8 @@ RSpec.describe NotifyMailer, type: :mailer do
 
     it "renders proper sender" do
       expect(email.from).to eq([SiteConfig.email_addresses[:default]])
-      expect(email["from"].value).to eq("#{ApplicationConfig['COMMUNITY_NAME']} Community <#{SiteConfig.email_addresses[:default]}>")
+      expected_from = "#{ApplicationConfig['COMMUNITY_NAME']} Community <#{SiteConfig.email_addresses[:default]}>"
+      expect(email["from"].value).to eq(expected_from)
     end
 
     it "renders proper receiver" do
@@ -65,7 +67,7 @@ RSpec.describe NotifyMailer, type: :mailer do
 
   describe "#new_mention_email" do
     let(:mention) { create(:mention, user: user2, mentionable: comment) }
-    let(:email) { described_class.new_mention_email(mention) }
+    let(:email) { described_class.with(mention: mention).new_mention_email }
 
     it "renders proper subject" do
       expect(email.subject).to eq("#{comment.user.name} just mentioned you!")
@@ -73,7 +75,8 @@ RSpec.describe NotifyMailer, type: :mailer do
 
     it "renders proper sender" do
       expect(email.from).to eq([SiteConfig.email_addresses[:default]])
-      expect(email["from"].value).to eq("#{ApplicationConfig['COMMUNITY_NAME']} Community <#{SiteConfig.email_addresses[:default]}>")
+      expected_from = "#{ApplicationConfig['COMMUNITY_NAME']} Community <#{SiteConfig.email_addresses[:default]}>"
+      expect(email["from"].value).to eq(expected_from)
     end
 
     it "renders proper receiver" do
@@ -92,7 +95,7 @@ RSpec.describe NotifyMailer, type: :mailer do
   end
 
   describe "#unread_notifications_email" do
-    let(:email) { described_class.unread_notifications_email(user) }
+    let(:email) { described_class.with(user: user).unread_notifications_email }
 
     it "renders proper subject" do
       expect(email.subject).to eq("🔥 You have 0 unread notifications on #{ApplicationConfig['COMMUNITY_NAME']}")
@@ -100,7 +103,8 @@ RSpec.describe NotifyMailer, type: :mailer do
 
     it "renders proper sender" do
       expect(email.from).to eq([SiteConfig.email_addresses[:default]])
-      expect(email["from"].value).to eq("#{ApplicationConfig['COMMUNITY_NAME']} Community <#{SiteConfig.email_addresses[:default]}>")
+      expected_from = "#{ApplicationConfig['COMMUNITY_NAME']} Community <#{SiteConfig.email_addresses[:default]}>"
+      expect(email["from"].value).to eq(expected_from)
     end
 
     it "renders proper receiver" do
@@ -119,7 +123,7 @@ RSpec.describe NotifyMailer, type: :mailer do
   end
 
   describe "#video_upload_complete_email" do
-    let(:email) { described_class.video_upload_complete_email(article) }
+    let(:email) { described_class.with(article: article).video_upload_complete_email }
 
     it "renders proper subject" do
       expect(email.subject).to eq("Your video upload is complete")
@@ -127,7 +131,8 @@ RSpec.describe NotifyMailer, type: :mailer do
 
     it "renders proper sender" do
       expect(email.from).to eq([SiteConfig.email_addresses[:default]])
-      expect(email["from"].value).to eq("#{ApplicationConfig['COMMUNITY_NAME']} Community <#{SiteConfig.email_addresses[:default]}>")
+      expected_from = "#{ApplicationConfig['COMMUNITY_NAME']} Community <#{SiteConfig.email_addresses[:default]}>"
+      expect(email["from"].value).to eq(expected_from)
     end
 
     it "renders proper receiver" do
@@ -148,7 +153,7 @@ RSpec.describe NotifyMailer, type: :mailer do
   describe "#new_badge_email" do
     let(:badge) { create(:badge) }
     let(:badge_achievement) { create_badge_achievement(user, badge, user2) }
-    let(:email) { described_class.new_badge_email(badge_achievement) }
+    let(:email) { described_class.with(badge_achievement: badge_achievement).new_badge_email }
 
     def create_badge_achievement(user, badge, rewarder)
       BadgeAchievement.create(
@@ -165,7 +170,8 @@ RSpec.describe NotifyMailer, type: :mailer do
 
     it "renders proper sender" do
       expect(email.from).to eq([SiteConfig.email_addresses[:default]])
-      expect(email["from"].value).to eq("#{ApplicationConfig['COMMUNITY_NAME']} Community <#{SiteConfig.email_addresses[:default]}>")
+      expected_from = "#{ApplicationConfig['COMMUNITY_NAME']} Community <#{SiteConfig.email_addresses[:default]}>"
+      expect(email["from"].value).to eq(expected_from)
     end
 
     it "renders proper receiver" do
@@ -268,7 +274,7 @@ RSpec.describe NotifyMailer, type: :mailer do
         feedback_message_id: feedback_message.id
       }
     end
-    let(:email) { described_class.feedback_message_resolution_email(email_params) }
+    let(:email) { described_class.with(email_params).feedback_message_resolution_email }
 
     it "renders proper subject" do
       expect(email.subject).to eq("#{ApplicationConfig['COMMUNITY_NAME']} Report Status Update")
@@ -276,7 +282,8 @@ RSpec.describe NotifyMailer, type: :mailer do
 
     it "renders proper sender" do
       expect(email.from).to eq([SiteConfig.email_addresses[:default]])
-      expect(email["from"].value).to eq("#{ApplicationConfig['COMMUNITY_NAME']} Community <#{SiteConfig.email_addresses[:default]}>")
+      expected_from = "#{ApplicationConfig['COMMUNITY_NAME']} Community <#{SiteConfig.email_addresses[:default]}>"
+      expect(email["from"].value).to eq(expected_from)
     end
 
     it "renders proper receiver" do
@@ -310,7 +317,7 @@ RSpec.describe NotifyMailer, type: :mailer do
         email_body: "Laugh with me, buddy"
       }
     end
-    let(:email) { described_class.user_contact_email(email_params) }
+    let(:email) { described_class.with(email_params).user_contact_email }
 
     it "renders proper subject" do
       expect(email.subject).to eq("Buddy")
@@ -318,7 +325,8 @@ RSpec.describe NotifyMailer, type: :mailer do
 
     it "renders proper sender" do
       expect(email.from).to eq([SiteConfig.email_addresses[:default]])
-      expect(email["from"].value).to eq("#{ApplicationConfig['COMMUNITY_NAME']} Community <#{SiteConfig.email_addresses[:default]}>")
+      expected_from = "#{ApplicationConfig['COMMUNITY_NAME']} Community <#{SiteConfig.email_addresses[:default]}>"
+      expect(email["from"].value).to eq(expected_from)
     end
 
     it "renders proper receiver" do
@@ -337,7 +345,7 @@ RSpec.describe NotifyMailer, type: :mailer do
   describe "#new_message_email" do
     let(:direct_channel) { ChatChannel.create_with_users(users: [user, user2], channel_type: "direct") }
     let(:direct_message) { create(:message, user: user, chat_channel: direct_channel) }
-    let(:email) { described_class.new_message_email(direct_message) }
+    let(:email) { described_class.with(message: direct_message).new_message_email }
 
     it "renders proper subject" do
       expect(email.subject).to eq("#{user.name} just messaged you")
@@ -345,7 +353,8 @@ RSpec.describe NotifyMailer, type: :mailer do
 
     it "renders proper sender" do
       expect(email.from).to eq([SiteConfig.email_addresses[:default]])
-      expect(email["from"].value).to eq("#{ApplicationConfig['COMMUNITY_NAME']} Community <#{SiteConfig.email_addresses[:default]}>")
+      expected_from = "#{ApplicationConfig['COMMUNITY_NAME']} Community <#{SiteConfig.email_addresses[:default]}>"
+      expect(email["from"].value).to eq(expected_from)
     end
 
     it "renders proper receiver" do
@@ -364,7 +373,7 @@ RSpec.describe NotifyMailer, type: :mailer do
   end
 
   describe "#account_deleted_email" do
-    let(:email) { described_class.account_deleted_email(user) }
+    let(:email) { described_class.with(user: user).account_deleted_email }
 
     it "renders proper subject" do
       expect(email.subject).to eq("#{ApplicationConfig['COMMUNITY_NAME']} - Account Deletion Confirmation")
@@ -372,7 +381,8 @@ RSpec.describe NotifyMailer, type: :mailer do
 
     it "renders proper sender" do
       expect(email.from).to eq([SiteConfig.email_addresses[:default]])
-      expect(email["from"].value).to eq("#{ApplicationConfig['COMMUNITY_NAME']} Community <#{SiteConfig.email_addresses[:default]}>")
+      expected_from = "#{ApplicationConfig['COMMUNITY_NAME']} Community <#{SiteConfig.email_addresses[:default]}>"
+      expect(email["from"].value).to eq(expected_from)
     end
 
     it "renders proper receiver" do
@@ -391,7 +401,7 @@ RSpec.describe NotifyMailer, type: :mailer do
   end
 
   describe "#export_email" do
-    let(:email) { described_class.export_email(user, "attachment") }
+    let(:email) { described_class.with(user: user, attachment: "attachment").export_email }
 
     it "renders proper subject" do
       expect(email.subject).to include("export of your content is ready")
@@ -399,7 +409,8 @@ RSpec.describe NotifyMailer, type: :mailer do
 
     it "renders proper sender" do
       expect(email.from).to eq([SiteConfig.email_addresses[:default]])
-      expect(email["from"].value).to eq("#{ApplicationConfig['COMMUNITY_NAME']} Community <#{SiteConfig.email_addresses[:default]}>")
+      expected_from = "#{ApplicationConfig['COMMUNITY_NAME']} Community <#{SiteConfig.email_addresses[:default]}>"
+      expect(email["from"].value).to eq(expected_from)
     end
 
     it "renders proper receiver" do
@@ -428,7 +439,9 @@ RSpec.describe NotifyMailer, type: :mailer do
 
   describe "#tag_moderator_confirmation_email" do
     let(:tag) { create(:tag) }
-    let(:email) { described_class.tag_moderator_confirmation_email(user, tag, "javascript-4l67") }
+    let(:email) do
+      described_class.with(user: user, tag: tag, channel_slug: "javascript-4l67").tag_moderator_confirmation_email
+    end
 
     it "renders proper subject" do
       expect(email.subject).to eq("Congrats! You're the moderator for ##{tag.name}")
@@ -436,7 +449,8 @@ RSpec.describe NotifyMailer, type: :mailer do
 
     it "renders proper sender" do
       expect(email.from).to eq([SiteConfig.email_addresses[:default]])
-      expect(email["from"].value).to eq("#{ApplicationConfig['COMMUNITY_NAME']} Community <#{SiteConfig.email_addresses[:default]}>")
+      expected_from = "#{ApplicationConfig['COMMUNITY_NAME']} Community <#{SiteConfig.email_addresses[:default]}>"
+      expect(email["from"].value).to eq(expected_from)
     end
 
     it "renders proper receiver" do
@@ -456,15 +470,17 @@ RSpec.describe NotifyMailer, type: :mailer do
 
   describe "#trusted_role_email" do
     let(:tag) { create(:tag) }
-    let(:email) { described_class.trusted_role_email(user) }
+    let(:email) { described_class.with(user: user).trusted_role_email }
 
     it "renders proper subject" do
-      expect(email.subject).to eq("You've been upgraded to #{ApplicationConfig['COMMUNITY_NAME']} Community mod status!")
+      expected_subject = "You've been upgraded to #{ApplicationConfig['COMMUNITY_NAME']} Community mod status!"
+      expect(email.subject).to eq(expected_subject)
     end
 
     it "renders proper sender" do
       expect(email.from).to eq([SiteConfig.email_addresses[:default]])
-      expect(email["from"].value).to eq("#{ApplicationConfig['COMMUNITY_NAME']} Community <#{SiteConfig.email_addresses[:default]}>")
+      expected_from = "#{ApplicationConfig['COMMUNITY_NAME']} Community <#{SiteConfig.email_addresses[:default]}>"
+      expect(email["from"].value).to eq(expected_from)
     end
 
     it "renders proper receiver" do
@@ -489,15 +505,21 @@ RSpec.describe NotifyMailer, type: :mailer do
     let(:member_email) { described_class.with(membership: regular_membership, inviter: user).channel_invite_email }
 
     it "renders proper subject" do
-      expect(moderator_email.subject).to eq("You are invited to the #{moderator_membership.chat_channel.channel_name} channel as moderator.")
-      expect(member_email.subject).to eq("You are invited to the #{regular_membership.chat_channel.channel_name} channel.")
+      mod_subject = "You are invited to the #{moderator_membership.chat_channel.channel_name} channel as moderator."
+      expect(moderator_email.subject).to eq(mod_subject)
+
+      member_subject = "You are invited to the #{regular_membership.chat_channel.channel_name} channel."
+      expect(member_email.subject).to eq(member_subject)
     end
 
     it "renders proper sender" do
+      expected_from = "#{ApplicationConfig['COMMUNITY_NAME']} Community <#{SiteConfig.email_addresses[:default]}>"
+
       expect(moderator_email.from).to eq([SiteConfig.email_addresses[:default]])
-      expect(moderator_email["from"].value).to eq("#{ApplicationConfig['COMMUNITY_NAME']} Community <#{SiteConfig.email_addresses[:default]}>")
+      expect(moderator_email["from"].value).to eq(expected_from)
+
       expect(member_email.from).to eq([SiteConfig.email_addresses[:default]])
-      expect(member_email["from"].value).to eq("#{ApplicationConfig['COMMUNITY_NAME']} Community <#{SiteConfig.email_addresses[:default]}>")
+      expect(member_email["from"].value).to eq(expected_from)
     end
 
     it "renders proper receiver" do

--- a/spec/mailers/previews/digest_mailer_preview.rb
+++ b/spec/mailers/previews/digest_mailer_preview.rb
@@ -1,6 +1,6 @@
 # Preview all emails at http://localhost:3000/rails/mailers/digest_mailer
 class DigestMailerPreview < ActionMailer::Preview
   def digest_email
-    DigestMailer.digest_email(User.last, Article.all)
+    DigestMailer.with(user: User.last, articles: Article.all).digest_email
   end
 end

--- a/spec/mailers/previews/notify_mailer_preview.rb
+++ b/spec/mailers/previews/notify_mailer_preview.rb
@@ -1,25 +1,25 @@
 # Preview all emails at http://localhost:3000/rails/mailers/notify_mailer
 class NotifyMailerPreview < ActionMailer::Preview
   def new_reply_email
-    NotifyMailer.new_reply_email(Comment.find(1))
+    NotifyMailer.with(comment: Comment.first).new_reply_email
   end
 
   def new_follower_email
     follow = User.first.follow(User.last)
-    NotifyMailer.new_follower_email(follow)
+    NotifyMailer.with(follow: follow).new_follower_email
   end
 
   def unread_notifications_email
-    NotifyMailer.unread_notifications_email(User.last)
+    NotifyMailer.with(user: User.last).unread_notifications_email
   end
 
   def new_mention_email
     mention = Mention.find_or_create_by(user: User.find(1), mentionable: Comment.find(1))
-    NotifyMailer.new_mention_email(mention)
+    NotifyMailer.with(mention: mention).new_mention_email
   end
 
   def video_upload_complete_email
-    NotifyMailer.video_upload_complete_email(Article.last)
+    NotifyMailer.with(article: Article.last).video_upload_complete_email
   end
 
   def new_badge_email
@@ -29,7 +29,7 @@ class NotifyMailerPreview < ActionMailer::Preview
       rewarder: User.find(2),
       rewarding_context_message: "You made it!",
     )
-    NotifyMailer.new_badge_email(badge_achievement)
+    NotifyMailer.with(badge_achievement: badge_achievement).new_badge_email
   end
 
   def channel_invite_email
@@ -39,11 +39,11 @@ class NotifyMailerPreview < ActionMailer::Preview
   end
 
   def tag_moderator_confirmation_email
-    NotifyMailer.tag_moderator_confirmation_email(User.first, Tag.find(1), nil)
+    NotifyMailer.with(user: User.first, tag: Tag.find(1), channel_slug: nil).tag_moderator_confirmation_email
   end
 
   def trusted_role_email
-    NotifyMailer.trusted_role_email(User.first)
+    NotifyMailer.with(user: User.first).trusted_role_email
   end
 
   def feedback_message_resolution_email
@@ -52,7 +52,9 @@ class NotifyMailerPreview < ActionMailer::Preview
     email_body = <<~HEREDOC
       Hi [*USERNAME*],
 
-      We wanted to say thank you for flagging a [comment/post] that was in violation of the dev.to code of conduct and terms of service. Your action has helped us continue our work of fostering an open and welcoming community.
+      We wanted to say thank you for flagging a [comment/post] that was in violation of the dev.to
+      code of conduct and terms of service. Your action has helped us continue our work of
+      fostering an open and welcoming community.
 
       We've also removed the offending posts and reached out to the offender(s).
 
@@ -67,18 +69,18 @@ class NotifyMailerPreview < ActionMailer::Preview
       email_type: "Reporter",
       feedback_message_id: rand(100)
     }
-    NotifyMailer.feedback_message_resolution_email(params)
+    NotifyMailer.with(params).feedback_message_resolution_email
   end
 
   def new_message_email
-    NotifyMailer.new_message_email(Message.last)
+    NotifyMailer.with(message: Message.last).new_message_email
   end
 
   def account_deleted_email
-    NotifyMailer.account_deleted_email(User.last)
+    NotifyMailer.with(user: User.last).account_deleted_email
   end
 
   def export_email
-    NotifyMailer.export_email(User.last, "attachment")
+    NotifyMailer.with(user: User.last, attachment: "attachment").export_email
   end
 end

--- a/spec/mailers/previews/verification_mailer_preview.rb
+++ b/spec/mailers/previews/verification_mailer_preview.rb
@@ -1,7 +1,6 @@
 # Preview all emails at http://localhost:3000/rails/mailers/verification_mailer
 class VerificationMailerPreview < ActionMailer::Preview
   def account_ownership_verification_email
-    params = { user_id: User.last.id }
-    VerificationMailer.account_ownership_verification_email(params)
+    VerificationMailer.with(user_id: User.last.id).account_ownership_verification_email
   end
 end

--- a/spec/mailers/verification_mailer_spec.rb
+++ b/spec/mailers/verification_mailer_spec.rb
@@ -5,13 +5,13 @@ RSpec.describe VerificationMailer, type: :mailer do
 
   describe "#account_ownership_verification_email" do
     it "works correctly" do
-      params = { user_id: user.id }
-      email = described_class.account_ownership_verification_email(params)
+      email = described_class.with(user_id: user.id).account_ownership_verification_email
 
       expect(email.subject).not_to be_nil
       expect(email.to).to eq([user.email])
       expect(email.from).to eq([SiteConfig.email_addresses[:default]])
-      expect(email["from"].value).to eq("#{ApplicationConfig['COMMUNITY_NAME']} Email Verification <#{SiteConfig.email_addresses[:default]}>")
+      from = "#{ApplicationConfig['COMMUNITY_NAME']} Email Verification <#{SiteConfig.email_addresses[:default]}>"
+      expect(email["from"].value).to eq(from)
     end
   end
 end

--- a/spec/requests/internal/users_spec.rb
+++ b/spec/requests/internal/users_spec.rb
@@ -54,7 +54,13 @@ RSpec.describe "internal/users", type: :request do
   describe "POST internal/users/:id/verify_email_ownership" do
     it "allows a user to verify email ownership" do
       post "/internal/users/#{user.id}/verify_email_ownership", params: { user_id: user.id }
-      verification_link = app_url(verify_email_authorizations_path(confirmation_token: user.email_authorizations.first.confirmation_token, username: user.username))
+
+      path = verify_email_authorizations_path(
+        confirmation_token: user.email_authorizations.first.confirmation_token,
+        username: user.username,
+      )
+      verification_link = app_url(path)
+
       expect(ActionMailer::Base.deliveries.count).to eq(1)
       expect(ActionMailer::Base.deliveries.first.subject).to eq("Verify Your #{ApplicationConfig['COMMUNITY_NAME']} Account Ownership")
       expect(ActionMailer::Base.deliveries.first.text_part.body).to include(verification_link)

--- a/spec/workers/badge_achievements/send_email_notification_worker_spec.rb
+++ b/spec/workers/badge_achievements/send_email_notification_worker_spec.rb
@@ -2,11 +2,20 @@ require "rails_helper"
 
 RSpec.describe BadgeAchievements::SendEmailNotificationWorker, type: :worker do
   let(:worker) { subject }
+  let(:mailer_class) { NotifyMailer }
+  let(:mailer) { double }
+  let(:message_delivery) { double }
 
   # passing in a random badge_achievement_id argument since the worker itself won't be executed
   include_examples "#enqueues_on_correct_queue", "low_priority", [456]
 
   describe "#perform_now" do
+    before do
+      allow(mailer_class).to receive(:with).and_return(mailer)
+      allow(mailer).to receive(:new_badge_email).and_return(message_delivery)
+      allow(message_delivery).to receive(:deliver_now)
+    end
+
     context "with badge achievement" do
       let_it_be(:badge_achievement) { double }
 
@@ -15,14 +24,11 @@ RSpec.describe BadgeAchievements::SendEmailNotificationWorker, type: :worker do
       end
 
       it "sends badge email" do
-        mailer = double
-        allow(mailer).to receive(:deliver_now)
-        allow(NotifyMailer).to receive(:new_badge_email).with(badge_achievement).and_return(mailer)
-
         worker.perform(1)
 
-        expect(NotifyMailer).to have_received(:new_badge_email).with(badge_achievement)
-        expect(mailer).to have_received(:deliver_now)
+        expect(mailer_class).to have_received(:with).with(badge_achievement: badge_achievement)
+        expect(mailer).to have_received(:new_badge_email)
+        expect(message_delivery).to have_received(:deliver_now)
       end
     end
 
@@ -32,11 +38,9 @@ RSpec.describe BadgeAchievements::SendEmailNotificationWorker, type: :worker do
       end
 
       it "does not call NotifyMailer" do
-        allow(NotifyMailer).to receive(:new_badge_email)
-
         worker.perform(nil)
 
-        expect(NotifyMailer).not_to have_received(:new_badge_email)
+        expect(mailer).not_to have_received(:new_badge_email)
       end
     end
   end

--- a/spec/workers/follows/send_email_notification_worker_spec.rb
+++ b/spec/workers/follows/send_email_notification_worker_spec.rb
@@ -1,55 +1,65 @@
 require "rails_helper"
 
-class MockMailer
-  def self.deliver; end
-end
-
 RSpec.describe Follows::SendEmailNotificationWorker, type: :worker do
-  subject(:worker) { described_class }
+  let(:worker) { subject }
+  let(:mailer_class) { NotifyMailer }
+  let(:mailer) { double }
+  let(:message_delivery) { double }
 
   let_it_be(:user) { create(:user) }
   let_it_be(:user2) { create(:user) }
-  let_it_be(:follow) { create(:follow, follower: user, followable: user2) }
 
   describe "#perform" do
     before do
-      allow(NotifyMailer).to receive(:new_follower_email).and_return(MockMailer)
-      allow(MockMailer).to receive(:deliver)
-      worker.perform_async(follow_id)
+      allow(mailer_class).to receive(:with).and_return(mailer)
+      allow(mailer).to receive(:new_follower_email).and_return(message_delivery)
+      allow(message_delivery).to receive(:deliver_now)
     end
 
     context "with follow" do
-      let(:follow_id) { follow.id }
-
       it "sends a new_follower_email" do
-        user2.update_column(:email_follower_notifications, true)
-        worker.drain
+        user2.update_columns(email_follower_notifications: true)
+        follow = user.follow(user2)
 
-        expect(MockMailer).to have_received(:deliver).once
+        sidekiq_perform_enqueued_jobs(only: described_class)
+
+        expect(mailer_class).to have_received(:with).with(follow: follow)
+        expect(mailer).to have_received(:new_follower_email)
+        expect(message_delivery).to have_received(:deliver_now)
       end
 
       it "doesn't send an email if user has disabled notifications" do
-        user2.update_column(:email_follower_notifications, false)
-        worker.drain
+        user2.update_columns(email_follower_notifications: false)
+        follow = user.follow(user2)
 
-        expect(MockMailer).not_to have_received(:deliver)
+        sidekiq_perform_enqueued_jobs(only: described_class)
+
+        expect(mailer_class).not_to have_received(:with).with(follow: follow)
+        expect(mailer).not_to have_received(:new_follower_email)
+        expect(message_delivery).not_to have_received(:deliver_now)
       end
 
       it "doesn't create an EmailMessage if it already exists" do
         subject = "#{user.username} just followed you on #{ApplicationConfig['COMMUNITY_NAME']}"
         EmailMessage.create!(user_id: user2.id, sent_at: Time.current, subject: subject)
 
-        worker.drain
+        user2.update_columns(email_follower_notifications: false)
+        follow = user.follow(user2)
 
-        expect(MockMailer).not_to have_received(:deliver)
+        sidekiq_perform_enqueued_jobs(only: described_class)
+
+        expect(mailer_class).not_to have_received(:with).with(follow: follow)
+        expect(mailer).not_to have_received(:new_follower_email)
+        expect(message_delivery).not_to have_received(:deliver_now)
       end
     end
 
     context "without follow" do
-      let(:follow_id) { nil }
-
       it "does not break" do
-        expect { worker.drain }.not_to raise_error
+        expect do
+          described_class.perform_async(nil)
+          sidekiq_perform_enqueued_jobs(only: described_class)
+        end.not_to raise_error
       end
     end
   end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Switching mailers over to the parameterized syntax (which was already recommended in Rails 5.2) - see https://guides.rubyonrails.org/v5.2/action_mailer_basics.html - and moved over to the new Rails 6 default for both parameterized and non parameterized mailer jobs

## QA Instructions, Screenshots, Recordings

You can turn on the console and send some emails or you can visit the mailer previews:

- http://localhost:3000/rails/mailers/digest_mailer
- http://localhost:3000/rails/mailers/notify_mailer
- http://localhost:3000/rails/mailers/verification_mailer

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
