### PR TITLE
fix `rbenv install` failing for windows docs

### DIFF
--- a/docs/installation/windows.md
+++ b/docs/installation/windows.md
@@ -29,16 +29,19 @@ Once you've got this installed and after rebooting,
 On your first run, the system will ask for username and password. Take note of
 both since it will be used for `sudo` commands.
 
-### Ruby on WSL
+### Installing rbenv
 
-First, install Ruby language dependencies:
+`rbenv` is a version manager for Ruby applications which allows one to garuntee
+that the Ruby version in development environment matches production. First,
+install Ruby language dependencies before installing `rbenv`:
 
 ```shell
 sudo apt-get update
 sudo apt-get install git-core curl zlib1g-dev build-essential libssl-dev libreadline-dev libyaml-dev libsqlite3-dev sqlite3 libxml2-dev libxslt1-dev libcurl4-openssl-dev software-properties-common libffi-dev
 ```
 
-For installing Ruby, we recommend using [rbenv](https://github.com/rbenv/rbenv):
+Now, we install [rbenv](https://github.com/rbenv/rbenv) using the following
+commands:
 
 ```shell
 cd
@@ -50,6 +53,13 @@ exec $SHELL
 git clone https://github.com/rbenv/ruby-build.git ~/.rbenv/plugins/ruby-build
 echo 'export PATH="$HOME/.rbenv/plugins/ruby-build/bin:$PATH"' >> ~/.bashrc
 exec $SHELL
+```
+
+One can verify `rbenv` installation using the `rbenv-doctor` script with the
+following commands:
+
+```shell
+curl -fsSL https://github.com/rbenv/rbenv-installer/raw/master/bin/rbenv-doctor | bash
 ```
 
 ### Installing Node
@@ -142,7 +152,7 @@ NOTE: Make sure to download **the OSS version**, `elasticsearch-oss`.
 1. Clone your forked repository, eg.
    `git clone https://github.com/<your-username>/dev.to.git`
 1. Open the cloned dev.to folder in terminal with `cd dev.to`. Next, install
-   ruby with the following commands.
+   Ruby with the following commands:
    ```shell
    rbenv install $(cat .ruby-version)
    rbenv global $(cat .ruby-version)

--- a/docs/installation/windows.md
+++ b/docs/installation/windows.md
@@ -50,13 +50,9 @@ exec $SHELL
 git clone https://github.com/rbenv/ruby-build.git ~/.rbenv/plugins/ruby-build
 echo 'export PATH="$HOME/.rbenv/plugins/ruby-build/bin:$PATH"' >> ~/.bashrc
 exec $SHELL
-
-rbenv install $(cat .ruby-version)
-rbenv global $(cat .ruby-version)
-ruby -v
 ```
 
-### Installing Rails
+### Installing Node
 
 As a pre-requisite to install Rails, we're going to need to install a JavaScript
 runtime like Node.js.
@@ -76,20 +72,6 @@ for further details.
 
 If `npm -v` gives `Syntax error: word unexpected (expecting "in")`, restart the
 terminal and try again.
-
-And now, for rails itself:
-
-```shell
-gem install rails -v 5.2.4.2
-```
-
-Then run `rbenv rehash` to make the Rails executable available. Check it out by
-using `rails -v` command
-
-```shell
-rbenv rehash
-rails -v
-```
 
 ### Yarn
 
@@ -159,6 +141,13 @@ NOTE: Make sure to download **the OSS version**, `elasticsearch-oss`.
 1. Fork DEV's repository, eg. <https://github.com/thepracticaldev/dev.to/fork>
 1. Clone your forked repository, eg.
    `git clone https://github.com/<your-username>/dev.to.git`
+1. Open the cloned dev.to folder in terminal with `cd dev.to`. Next, install
+   ruby with the following commands.
+   ```shell
+   rbenv install $(cat .ruby-version)
+   rbenv global $(cat .ruby-version)
+   ruby -v
+   ```
 1. Install bundler with `gem install bundler`
 1. Set up your environment variables/secrets
 

--- a/docs/installation/windows.md
+++ b/docs/installation/windows.md
@@ -31,7 +31,7 @@ both since it will be used for `sudo` commands.
 
 ### Installing rbenv
 
-`rbenv` is a version manager for Ruby applications which allows one to garuntee
+`rbenv` is a version manager for Ruby applications which allows one to guarantee
 that the Ruby version in development environment matches production. First,
 install Ruby language dependencies before installing `rbenv`:
 
@@ -194,13 +194,13 @@ NOTE: Make sure to download **the OSS version**, `elasticsearch-oss`.
    > `setup`.
    >
    > - Its first task is to install the `bundler` gem. Next, it will make
-   >   `bundler` install all the gems , including `Rails`, located in `Gemfile`
+   >   `bundler` install all the gems, including `Rails`, located in `Gemfile`
    >   in the root of the repository. It also installs `foreman`.
    > - It then installs javascript dependencies using the script in `bin/yarn`
    >   file. These dependencies are located in `package.json` in the root of the
    >   repository.
    > - Next, it uses various Rake files located inside the `lib` folder to setup
-   >   ElasticSearch environment , PostgreSQL database creation and updation.
+   >   ElasticSearch environment, PostgreSQL database creation and updation.
    > - Finally it cleans up all the log files and restarts the Puma server.
 
 ### Possible error messages

--- a/docs/installation/windows.md
+++ b/docs/installation/windows.md
@@ -179,6 +179,19 @@ NOTE: Make sure to download **the OSS version**, `elasticsearch-oss`.
      certain keys, so you may be able to add them as you go.
 
 1. Run `bin/setup`
+   > The `bin/setup` script is responsible for installing a varienty of
+   > dependencies. One can find it inside the `bin` folder by the name of
+   > `setup`.
+   >
+   > - Its first task is to install the `bundler` gem. Next, it will make
+   >   `bundler` install all the gems , including `Rails`, located in `Gemfile`
+   >   in the root of the repository. It also installs `foreman`.
+   > - It then installs javascript dependencies using the script in `bin/yarn`
+   >   file. These dependencies are located in `package.json` in the root of the
+   >   repository.
+   > - Next, it uses various Rake files located inside the `lib` folder to setup
+   >   ElasticSearch environment , PostgreSQL database creation and updation.
+   > - Finally it cleans up all the log files and restarts the Puma server.
 
 ### Possible error messages
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description
- move `rbenv install` and `rbenv global` to after repository clone
- remove rails install, as `bin/setup` handles it and since ruby is installed after clone, the command wouldn't work earlier in the docs.
## Related Tickets & Documents
Fixes #8186 

## QA Instructions, Screenshots, Recordings
For Testing purposes, one would have to perform a clean install on a new `WSL` environment while making sure none of the prerequisites which are to be installed on Linux are served via windows, e.g. Yarn.


## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [x] docs.dev.to
- [ ] readme
- [ ] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![Building a bridge towards dev fully running on windows](https://media.giphy.com/media/4K1Nalbz0cVc5HRl1g/giphy.gif)
