### PR TITLE
Skip ahoy visit tracking in ApplicationMetalController

### DIFF
--- a/app/controllers/application_metal_controller.rb
+++ b/app/controllers/application_metal_controller.rb
@@ -7,6 +7,7 @@ class ApplicationMetalController < ActionController::Metal
   # ActionController modules which may not be used in each controller can go in
   # the specific controller.
 
+  skip_before_action :track_ahoy_visit
   protect_from_forgery with: :exception, prepend: true unless Rails.env.test?
 
   include SessionCurrentUser


### PR DESCRIPTION
#8001  What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
Continuing my quest to try to figure out [why we're still getting more `ahoy_visits` than expected](https://dev.to/internal/blazer/queries/101-ahoy-visits-per-day). I merged [a fix](https://github.com/thepracticaldev/dev.to/pull/8843) to ahoy's configuration yesterday, and that seems to correlate with the uptick in recorded visits that we're seeing.

We already [skip ahoy tracking](https://github.com/thepracticaldev/dev.to/blob/ded5e245fdaed820dd4135373be86b98ca8de10b/app/controllers/application_controller.rb#L2) in `ApplicationController`, but `ApplicationMetalController` does not inherit from that. So, I'm adding in this guard to see if it helps reduce the number of `ahoy_visits` that we're currently recording.

## Related Tickets & Documents
Some [blazer data](https://dev.to/internal/blazer/queries/101-ahoy-visits-per-day) on our ahoy visits.

## QA Instructions, Screenshots, Recordings

Make sure the tests pass, and if you really feel inclined, you can try to hit an endpoint that inherits from `ApplicationMetalController` locally and see that no new `Ahoy::Visit`s are created.

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## Are there any post deployment tasks we need to perform?
N/A
