### PR TITLE
Extract Welcome Broadcast Styling Into Its Own Stylesheet

### DIFF
--- a/app/assets/stylesheets/minimal.scss
+++ b/app/assets/stylesheets/minimal.scss
@@ -17,6 +17,7 @@
 @import 'comments';
 @import 'leaderboard';
 @import 'notifications';
+@import 'notifications-welcome-broadcast';
 @import 'syntax';
 @import 'signup-modal';
 @import 'tags';

--- a/app/assets/stylesheets/notifications-welcome-broadcast.scss
+++ b/app/assets/stylesheets/notifications-welcome-broadcast.scss
@@ -1,6 +1,6 @@
-// TODO[team-delightful]: Refactor nesting in this file
-// in addition to notifications.scss so that nesting is
-// not as deep
+// TODO: [@thepracticaldev/delightful]: Refactor nesting in this file
+// in addition to notifications.scss so that the nesting is
+// not as deep as it currently is
 .notifications-index {
   .home {
     .articles-list {

--- a/app/assets/stylesheets/notifications-welcome-broadcast.scss
+++ b/app/assets/stylesheets/notifications-welcome-broadcast.scss
@@ -1,0 +1,20 @@
+// TODO[team-delightful]: Refactor nesting in this file
+// in addition to notifications.scss so that nesting is
+// not as deep
+.notifications-index {
+  .home {
+    .articles-list {
+      .single-article {
+        .content {
+          &.broadcast-content {
+            .opt-out {
+              padding-top: 24px;
+              font-size: 12px;
+              font-style: italic;
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/notifications.scss
+++ b/app/assets/stylesheets/notifications.scss
@@ -28,7 +28,7 @@
           }
         }
       }
-      // TODO[team-delightful]: Remove .signup-cue-advanced and .sloan
+      // TODO: [@thepracticaldev/delightful]: Remove .signup-cue-advanced and .sloan
       // from stylesheet since it does not appear to be used anywhere
       .signup-cue-advanced {
         text-align: left;

--- a/app/assets/stylesheets/notifications.scss
+++ b/app/assets/stylesheets/notifications.scss
@@ -28,6 +28,8 @@
           }
         }
       }
+      // TODO[team-delightful]: Remove .signup-cue-advanced and .sloan
+      // from stylesheet since it does not appear to be used anywhere
       .signup-cue-advanced {
         text-align: left;
         padding: 30px 25px;
@@ -53,13 +55,6 @@
             a {
               color: $sky-blue;
               font-weight: 500;
-            }
-          }
-          &.broadcast-content {
-            .opt-out {
-              padding-top: 24px;
-              font-size: 12px;
-              font-style: italic;
             }
           }
           &.reaction-content {


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR extracts the styling for Welcome Broadcasts (`.broadcast-content`) into its own stylesheet, `notifications-welcome-broadcast.scss`. Extracting the Welcome Broadcast styles into its own stylesheet will make it easier to revamp our Welcome Notification styling (see #7169).

In addition to this extraction, this PR also adds `notifications-welcome-broadcast.scss` to `minimal.scss` and adds TODOs for future stylesheet iterations.

## Related Tickets & Documents
Related to #7169 

## QA Instructions, Screenshots, Recordings
**To QA these changes, pull down this code and poke around your local notifications to ensure that nothing has been broken:**
<img width="1055" alt="Screen Shot 2020-06-23 at 11 47 31 AM" src="https://user-images.githubusercontent.com/32834804/85437149-5b763380-b547-11ea-9511-637e3e3e57d1.png">

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![files](https://media.giphy.com/media/xTiTnjZAjQipGn9JFS/giphy.gif)
