### PR TITLE
Bug Fix: Return An Empty Array if Error Occurs in RSS Reader

### DIFF
--- a/app/services/rss_reader.rb
+++ b/app/services/rss_reader.rb
@@ -61,6 +61,7 @@ class RssReader
         error: e
       },
     )
+    []
   end
 
   def get_item_count_error(feed)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
I am knee-deep in this spec trying to fix some other issues and the solution to this error we have been seeing for a long time just hit me. Figured I would throw out a fix for it. 

Fixes: https://app.honeybadger.io/fault/66984/da4122ad1fd544ac460dbd445a3b1dd7
```
TypeError:
       no implicit conversion of true into Array
     # ./app/services/rss_reader.rb:14:in `concat'
     # ./app/services/rss_reader.rb:14:in `block in get_all_articles'
     # ./app/services/rss_reader.rb:9:in `get_all_articles'
```

<img width="1080" alt="Screen Shot 2020-06-23 at 1 30 22 PM" src="https://user-images.githubusercontent.com/1813380/85442384-b9aa1300-b555-11ea-8a5c-57fdb975d49b.png">

![alt_text](https://media1.tenor.com/images/5dcf3d677cc45bba6d7b4fc582cccf9f/tenor.gif?itemid=15335438)
