### PR TITLE
Disable ahoy.js cookie tracking

### DIFF
--- a/app/assets/javascripts/base.js.erb
+++ b/app/assets/javascripts/base.js.erb
@@ -684,5 +684,11 @@ var instantClick
     revision: "<%= ApplicationConfig['HEROKU_SLUG_COMMIT'] %>"
   });
 
+// INITIALIZE AHOY TRACKING
+// Setting cookies to false matches what we do in ahoy's initializer
+  ahoy.configure({
+    cookies: false
+  });
+
 // Start BaseApp for Page
   initializeBaseApp()


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization (Debugging?)
- [ ] Documentation Update

## Description
We're still getting `ahoy_visits` despite _not_ tracking them on the server side. I am not sure if this change will solve the issue that I'm seeing in terms of the uptick of visits, but I think there are two changes we need to make, setting `trackVisits` to `false`, and setting `cookies` to `false`. I'm going to follow the scientific method and only make one change at a time to see what happens.

**This PR adds `cookies: false` to the ahoy.js configuration.**

According to [the docs](https://github.com/ankane/ahoy#gdpr-compliance-1), if you set `Ahoy.cookies = false`, then you also will need to set `ahoy.configure({cookies: false});`

## Related Tickets & Documents
Blazer query of [growing `ahoy_visits`](https://dev.to/internal/blazer/queries/101-ahoy-visits-per-day).

## QA Instructions, Screenshots, Recordings

All tests should pass, and theoretically, when we deploy this, we should not see a growing number of ahoy visits.

When I tried this locally, I didn't see any new `Ahoy::Visit` instances being created in the `rails console`. But.......I don't really know if that means anything, because I never ran into the issue we're seeing on production when running this locally.

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [x] ~readme~ inline documentation
- [ ] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
N/A
