### PR TITLE
Paginate /dashboard posts

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -22,7 +22,11 @@ class DashboardsController < ApplicationController
       @articles = target.articles.includes(:organization)
     end
 
+    @reactions_count = @articles.sum(&:public_reactions_count)
+    @page_views_count = @articles.sum(&:page_views_count)
+
     @articles = @articles.sorting(params[:sort]).decorate
+    @articles = Kaminari.paginate_array(@articles).page(params[:page]).per(50)
 
     # Updates analytics in background if appropriate
     update_analytics = @articles && SiteConfig.ga_fetch_rate < 50 # Rate limited, sometimes we throttle down

--- a/app/views/dashboards/_analytics.html.erb
+++ b/app/views/dashboards/_analytics.html.erb
@@ -1,8 +1,8 @@
-<% num_views = @articles.sum(&:page_views_count) %>
+<% num_views = @page_views_count %>
 
 <div class="dashboard-analytics-header-wrapper">
   <div class="dashboard-analytics-header">
-    <span><%= number_with_delimiter(@articles.sum(&:public_reactions_count), delimeter: ",") %></span>
+    <span><%= number_with_delimiter(@reactions_count, delimeter: ",") %></span>
     <div class="dashboard-analytics-sub-indicator">
       <img src="<%= asset_path "emoji/emoji-one-heart.png" %>" alt="heart" />
       <img src="<%= asset_path "emoji/emoji-one-unicorn.png" %>" alt="unicorn" />

--- a/app/views/dashboards/_dashboard_article_row.html.erb
+++ b/app/views/dashboards/_dashboard_article_row.html.erb
@@ -100,10 +100,6 @@
     <% elsif @user == article.user %>
       <a href="<%= article.path %>/delete_confirm" data-no-instant class="crayons-btn crayons-btn--ghost-danger crayons-btn--s">Delete</a>
     <% end %>
-    <% if @current_user_pro %>
-      <a href="<%= article.path %>/stats" class="crayons-btn crayons-btn--ghost crayons-btn--s">Stats</a>
-    <% end %>
-
     <a href="<%= article.path %>/edit" class="crayons-btn crayons-btn--ghost crayons-btn--s">Edit</a>
 
     <div class="js-dashboard-row-more relative inline-block">
@@ -112,6 +108,9 @@
       </button>
 
       <div class="crayons-dropdown top-100 right-0 z-10 align-left js-dashboard-row-more-dropdown">
+        <% if @current_user_pro %>
+          <a href="<%= article.path %>/stats" class="crayons-link crayons-link--block w-100 border-0 bg-transparent">Stats</a>
+        <% end %>
         <%= form_for(article, method: :patch, remote: true, authenticity_token: true, html: { "data-type": "json", class: "js-archive-toggle" }) do |f| %>
           <%= f.hidden_field :archived, value: !article.archived %>
 

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -65,10 +65,7 @@
       </tbody>
     </table>
     <div class="mb-4 pl-3">
-      <% current_internal_param = params[:i] # ?i=i is a special hidden param which should not be passed to paginate %>
-      <% params[:i] = nil %>
-        <%= paginate @articles %>
-      <% params[:i] = current_internal_param %>
+      <%= paginate @articles, params: { i: nil } %>
     </div>
   <% else %>
     <div class="no-articles">

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -42,7 +42,7 @@
         <a class="video-upload-cta cta" href="/listings/dashboard" data-no-instant>
           Create/Manage Listings
         </a>
-      <%= select_tag "dashhboard_sort", options_for_select(sort_options, params[:sort]), 'aria-label': 'Sort By' %>
+      <%= select_tag "dashhboard_sort", options_for_select(sort_options, params[:sort]), 'aria-label': "Sort By" %>
       <% if @articles.any? {|article| article.archived } %>
         <%= link_to "Show archived", "javascript:;", id: "toggleArchivedLink" %>
       <% end %>
@@ -64,7 +64,12 @@
         <% end %>
       </tbody>
     </table>
-
+    <div class="mb-4 pl-3">
+      <% current_internal_param = params[:i] # ?i=i is a special hidden param which should not be passed to paginate %>
+      <% params[:i] = nil %>
+        <%= paginate @articles %>
+      <% params[:i] = current_internal_param %>
+    </div>
   <% else %>
     <div class="no-articles">
       <h3>This is where you can manage your posts, but you haven't written anything yet.</h3>

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -37,6 +37,18 @@ RSpec.describe "Dashboards", type: :request do
         get "/dashboard"
         expect(response.body).to include "Delete"
       end
+
+      it "renders pagination if minimum amount of posts" do
+        create_list(:article, 52, user: user)
+        get "/dashboard"
+        expect(response.body).to include "pagination"
+      end
+
+      it "does not render pagination if less than one full page" do
+        create_list(:article, 3, user: user)
+        get "/dashboard"
+        expect(response.body).not_to include "pagination"
+      end
     end
 
     context "when logged in as a super admin" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The dashboard on _my_ account has gotten _super_ slow just due to the raw number of posts that we are rendering all at once if you have _many_ posts. So this wouldn't be an issue for most, but some users (power users) have a really really slow dashboard.

This reduces that worst case scenario by rendering 50 posts at a time.

We use the Kaminari gem which comes with this helper which generates its own classes. Not exactly the most crayons-friendly situation, but we could switch to custom implementation later. I think the plain text links are solid here.

<img width="476" alt="Screen Shot 2020-06-23 at 4 33 07 PM" src="https://user-images.githubusercontent.com/3102842/85458785-7ceb1580-b56f-11ea-9d2f-a5666bf0948c.png">
