### PR TITLE
Flaky Spec/Bug Fix:Dont Send Mod Notification if No Commentable

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -81,6 +81,7 @@ class Notification < ApplicationRecord
 
     def send_moderation_notification(notifiable)
       # TODO: make this work for articles in the future. only works for comments right now
+      return unless notifiable.commentable
       return if UserBlock.blocking?(notifiable.commentable.user_id, notifiable.user_id)
 
       Notifications::ModerationNotificationWorker.perform_async(notifiable.id)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This popped up as a flaky spec failure where commentable was missing when we went to send the mod notification. To be honest, this scenario could occur as well in the app if a user submits a comment and then the article is deleted at nearly the same time. We support comments without commentable's so this change helps support that in addition to fixing the flaky spec. 
```
  1) Comments DELETE /comments/:comment_id deletes a comment if the article has been deleted
     Failure/Error: return if UserBlock.blocking?(notifiable.commentable.user_id, notifiable.user_id)
     NoMethodError:
       undefined method `user_id' for nil:NilClass
     # ./app/models/notification.rb:84:in `send_moderation_notification'
     # ./app/models/comment.rb:150:in `send_to_moderator'
     # ./app/controllers/comments_controller.rb:176:in `destroy'
     # ./spec/requests/comments_spec.rb:360:in `block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:136:in `block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:136:in `block (2 levels) in <top (required)>'
```
@snackattas 

## Added tests?
- [x] no, because they aren't needed


![alt_text](https://media1.tenor.com/images/af2b8939ad833bdd25e97a5a05ec22ac/tenor.gif?itemid=5740877)
