### PR TITLE
Disable ahoy.js visit tracking on server-side

### DIFF
--- a/app/assets/javascripts/base.js.erb
+++ b/app/assets/javascripts/base.js.erb
@@ -685,9 +685,11 @@ var instantClick
   });
 
 // INITIALIZE AHOY TRACKING
-// Setting cookies to false matches what we do in ahoy's initializer
+// Setting cookies to false matches what we do in ahoy's initializer.
+// Setting trackVisits to false prevents ahoy from creating a visit on the server-side.
   ahoy.configure({
-    cookies: false
+    cookies: false,
+    trackVisits: false
   });
 
 // Start BaseApp for Page


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization (Debugging?)
- [ ] Documentation Update

## Description

This PR is a continuation of https://github.com/thepracticaldev/dev.to/pull/8866. There are still `ahoy_visits` being created; I actually don't think this configuration is going to help us but I want to try it out since I want to eliminate the JS side of this completely while investigating these "ghost" visits.

According to [the docs](https://github.com/ankane/ahoy.js#configuration):
> When `trackVisits` is set to `false`, Ahoy.js will not attempt to create a visit on the server, but assumes that the server itself will return visit and visitor cookies._

**This PR adds `trackVisits: false` to the ahoy.js configuration.**

## Related Tickets & Documents
Blazer query of [growing `ahoy_visits`](https://dev.to/internal/blazer/queries/101-ahoy-visits-per-day).

## QA Instructions, Screenshots, Recordings

All tests should pass, and theoretically, when we deploy this, we should not see a growing number of ahoy visits.

When I tried this locally, I didn't see any new `Ahoy::Visit` instances being created in the `rails console`. But.......I don't really know if that means anything, because I never ran into the issue we're seeing on production when running this locally.

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [x] ~readme~ inline documentation
- [ ] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
N/A
