### PR TITLE
Only clear negative reactions when using thumbsup

### DIFF
--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -142,7 +142,7 @@ class ReactionsController < ApplicationController
 
   def clear_moderator_reactions(id, type, mod, category)
     reactions = if category == "thumbsup"
-                  Reaction.where(reactable_id: id, reactable_type: type, user: mod).where.not(category: category)
+                  Reaction.where(reactable_id: id, reactable_type: type, user: mod, category: NEGATIVE_CATEGORIES)
                 elsif category.in?(NEGATIVE_CATEGORIES)
                   Reaction.where(reactable_id: id, reactable_type: type, user: mod, category: "thumbsup")
                 end

--- a/spec/requests/moderations_spec.rb
+++ b/spec/requests/moderations_spec.rb
@@ -61,14 +61,14 @@ RSpec.describe "Moderations", type: :request do
     it "grants access to /mod index with articles" do
       article = create(:article, published: true)
       get "/mod"
-      expect(response.body).to include(article.title)
+      expect(response.body).to include(CGI.escapeHTML(article.title))
     end
 
     it "grants access to /mod/:tag index with articles" do
       create(:article, published: true)
       get "/mod/#{article.tags.first}"
       expect(response.body).to include("#" + article.tags.first.name)
-      expect(response.body).to include(article.title)
+      expect(response.body).to include(CGI.escapeHTML(article.title))
     end
 
     it "returns not found for inappropriate tags" do

--- a/spec/requests/reactions_spec.rb
+++ b/spec/requests/reactions_spec.rb
@@ -211,6 +211,7 @@ RSpec.describe "Reactions", type: :request do
 
     context "when creating thumbsup" do
       before do
+        user.add_role(:trusted)
         sign_in user
       end
 
@@ -230,6 +231,7 @@ RSpec.describe "Reactions", type: :request do
 
     context "when creating thumbsdown" do
       before do
+        user.add_role(:trusted)
         sign_in user
       end
 

--- a/spec/requests/reactions_spec.rb
+++ b/spec/requests/reactions_spec.rb
@@ -209,6 +209,46 @@ RSpec.describe "Reactions", type: :request do
       end
     end
 
+    context "when creating thumbsup" do
+      before do
+        sign_in user
+      end
+
+      it "clears thumbsdown comments but not like" do
+        create(:reaction, reactable: article, user: user, points: 1, category: "like")
+        create(:reaction, reactable: article, user: user, points: 1, category: "thumbsdown")
+        post "/reactions", params: {
+          reactable_id: article.id,
+          reactable_type: "Article",
+          category: "thumbsup"
+        }
+        expect(Reaction.where(category: "thumbsup").size).to be 1
+        expect(Reaction.where(category: "thumbsdown").size).to be 0
+        expect(Reaction.where(category: "like").size).to be 1
+      end
+    end
+
+    context "when creating thumbsdown" do
+      before do
+        sign_in user
+      end
+
+      it "clears thumbsup comments but not vomit or like" do
+        create(:reaction, reactable: article, user: user, points: 1, category: "vomit")
+        create(:reaction, reactable: article, user: user, points: 1, category: "thumbsup")
+        create(:reaction, reactable: article, user: user, points: 1, category: "like")
+        post "/reactions", params: {
+          reactable_id: article.id,
+          reactable_type: "Article",
+          category: "thumbsdown"
+        }
+        expect(Reaction.where(category: "thumbsdown").size).to be 1
+        expect(Reaction.where(category: "thumbsup").size).to be 0
+        expect(Reaction.where(category: "like").size).to be 1
+        expect(Reaction.where(category: "vomit").size).to be 1
+      end
+    end
+
     context "when vomiting on a user" do
       before do
         sign_in trusted_user


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Currently we remove mod reactions when a new reaction is created, but unless I'm mistaken about what the intended behavior should be, we should _not_ be removing non-mod reactions.