### PR TITLE
Fix typo in dashboard sort element name

### DIFF
--- a/app/assets/javascripts/initializers/initializeDashboardSort.js
+++ b/app/assets/javascripts/initializers/initializeDashboardSort.js
@@ -1,11 +1,11 @@
 'use strict';
 
 function initializeDashboardSort() {
-  if (document.getElementById('dashhboard_sort')) {
-    document
-      .getElementById('dashhboard_sort')
-      .addEventListener('change', event => {
-        window.location = '/dashboard?sort=' + event.target.value;
-      });
+  const dashboardSorter = document.getElementById('dashboard_sort');
+
+  if (dashboardSorter) {
+    dashboardSorter.addEventListener('change', (event) => {
+      window.location.assign(`/dashboard?sort=${event.target.value}`);
+    });
   }
 }

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -42,7 +42,7 @@
         <a class="video-upload-cta cta" href="/listings/dashboard" data-no-instant>
           Create/Manage Listings
         </a>
-      <%= select_tag "dashhboard_sort", options_for_select(sort_options, params[:sort]), 'aria-label': "Sort By" %>
+      <%= select_tag "dashboard_sort", options_for_select(sort_options, params[:sort]), 'aria-label': "Sort By" %>
       <% if @articles.any? {|article| article.archived } %>
         <%= link_to "Show archived", "javascript:;", id: "toggleArchivedLink" %>
       <% end %>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

@joshpuetz caught `dashhboard_sort` so I replaced it with `dashboard_sort` and also cleaned up the initializer

## Related Tickets & Documents

https://github.com/thepracticaldev/dev.to/pull/8868/files#r444518992

## QA Instructions, Screenshots, Recordings

Open the dashboard and click on the sorting dropdown

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
