### PR TITLE
Enabled ESLint canned import rules as well as the import order rule (fixable via --fix)

### DIFF
--- a/app/javascript/.eslintrc.js
+++ b/app/javascript/.eslintrc.js
@@ -4,6 +4,8 @@ module.exports = {
   parser: 'babel-eslint',
   extends: [
     'eslint:recommended',
+    'plugin:import/errors',
+    'plugin:import/warnings',
     'preact',
     'plugin:jsx-a11y/recommended',
     'prettier',
@@ -38,6 +40,7 @@ module.exports = {
   },
   plugins: ['import', 'react', 'jsx-a11y'],
   rules: {
+    'import/order': ['error'],
     'import/prefer-default-export': 'off',
     'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
     'jsx-a11y/label-has-associated-control': [


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This is just another change to our ESLint rules. We're still keeping with recommended rules, this time with the [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import) recommended rules.

Recommended import warnings and errors have been put in place as well as an import order rule. The import order rule enforces an order to imports, but it gets automatically fixed via EsLint's CLI arg `--fix`. This means no friction on a contributor to the code base.

So for example, the snippet below would result in an error because an npm package is imported after a local file.

```javascript
import { h, Component } from 'preact';
import { MyComponent } from './MyComponent';
import PropTypes from 'prop-types';
```

Once committed to the code base though, it gets corrected to the snippet below, assuming you ran the precommit hooks of the repository or explicitly ran `eslint --fix` on your file or your IDE's ESLint plugin handled it.

```javascript
import { h, Component } from 'preact';
import PropTypes from 'prop-types';
import { MyComponent } from './MyComponent';
```

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

![image](https://user-images.githubusercontent.com/833231/85555351-d2690600-b5f3-11ea-8818-a716c5038f8d.png)

To test:

* Change the order of some imports in a file like in the example above.
* Commit the file to the branch
* The imports in the JavaScript or JSX file will be reordered automatically.

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![Actor in a film nodding yes in the woods](https://media.giphy.com/media/NEvPzZ8bd1V4Y/giphy.gif)
