### PR TITLE
Hide notification when comment is hidden

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -221,6 +221,11 @@ class CommentsController < ApplicationController
     authorize @comment
     @comment.hidden_by_commentable_user = true
     @comment&.commentable&.update_column(:any_comments_hidden, true)
+
+    Notification.destroy_by(user_id: current_user.id,
+                            notifiable_type: "Comment",
+                            notifiable_id: params[:comment_id])
+
     if @comment.save
       render json: { hidden: "true" }, status: :ok
     else


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Hide notification when comment is hidden

## Related Tickets & Documents

closes https://github.com/thepracticaldev/dev.to/issues/8788

## QA Instructions, Screenshots, Recordings

![removing-hidden-comments](https://user-images.githubusercontent.com/8092120/85559362-47196000-b647-11ea-98de-cf97c8785698.gif)

## Added tests?

- [ ] yes
- [ ] no, because they aren't needed
- [X] no, because I need help

I could not find test for this hide action or even the controller itself so I might need little help on that.

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed

## What gif best describes this PR or how it makes you feel?

![Happy](https://media1.tenor.com/images/7e919f4dfc9f6e884c273fc61f6dcdd3/tenor.gif?itemid=5617440)
