### PR TITLE
Use fragment for linking to comments for SEO

### DIFF
--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -84,7 +84,7 @@
         <% unless @root_comment.is_root? %>
           <a href="<%= @root_comment.root.path %>">TOP OF THREAD</a>
         <% end %>
-        <a href="<%= @commentable.path %>/comments">FULL DISCUSSION</a>
+        <a href="<%= @commentable.path %><%= user_signed_in? ? "/" : "#" %>comments">FULL DISCUSSION</a>
       </span>
     </div>
   <% else %>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This is a _small_ adjustment which links to `#comments` for non-logged-in users because this is better for SEO than `/comments` because `/comments` is its own URL sucking away link juice.

This is a small fix which won't impact a lot of things, but since not _all_ comments are visible in the `#comments` version at the moment it doesn't make sense to make this a wholesale change all at once.