### PR TITLE
Avoid running service workers on ios

### DIFF
--- a/app/views/service_worker/index.js.erb
+++ b/app/views/service_worker/index.js.erb
@@ -7,7 +7,10 @@
 
   self.addEventListener('install', event => {
     self.skipWaiting();
-
+    if (/iPhone|CriOS|iPad/i.test(navigator.userAgent)) {
+       // iOS seems to have issues.
+       return;
+    }
     // Populate initial serviceworker cache.
     event.waitUntil(
       caches.open(staticCacheName)
@@ -86,8 +89,8 @@
 
   self.addEventListener('fetch', event => {
     const url = new URL(event.request.url);
-    if (/iPhone|CriOS|iPad/i.test(navigator.userAgent) && event.request.referrer.includes('t.co')) {
-       // Twitter on iOS seems to cause problems
+    if (/iPhone|CriOS|iPad/i.test(navigator.userAgent)) {
+       // iOS seems to have issues.
        return;
     }
     if (url.origin === location.origin) {


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We seem to have a lot more issues with service workers on iOS safari than anywhere else. I think it's probably best to avoid that platform for now. It already had the worst support.