### PR TITLE
Use max_by to get the highest value, for estimated_count 

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -18,7 +18,7 @@ class ApplicationRecord < ActiveRecord::Base
     query = sanitize_sql_array([QUERY_ESTIMATED_COUNT, table_name, table_name])
     result = connection.execute(query)
 
-    count = result.first["count"]
+    count = result.max_by(&:values)["count"] # sometimes is an array of hashes, for ex. [{"count" => 0}, [{"count" => 1000}]
     result.clear # PG::Result is manually managed in memory, we need to release its resources
     count
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
There's a bug in production right now where `User.estimated_count` sometimes returns 0 instead:
![Screen Shot 2020-06-24 at 12 18 36 PM](https://user-images.githubusercontent.com/17884966/85593234-dc4f3100-b614-11ea-8899-f5ef7dba1214.png)

This happens because in production, the Postgres result of the query is (sometimes?) an array of two hashes:

```ruby
[{"count" => 0}, {"count" => 401041}]
```

However I couldn't reproduce this locally, and only had one element in my `result` array. So I decided that `max_by` was the best choice, even though it'll make the method a bit slower.

## QA Instructions, Screenshots, Recordings
1. Go to `rails console`
2. Run `User.estimated_count`
3. Should run successfully

## Added tests?
- [x] no, because I need help. I wasn't sure how to test this, to be honest. There wasn't a test in place specifically checking the returned value, so I assume it's kind of hard and not worthwhile?

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
No, but we'll need to monitor the places where this is used (partnerships page, signed out CTA, and the workers that rely on this method).

## [optional] What gif best describes this PR or how it makes you feel?

![Morty says, "Uh... I'm not sure?" and scratches his head.](https://media.giphy.com/media/ZFhhpKngh5QfcmhIDF/giphy.gif)
