### PR TITLE
Track an event's target when clicking on a welcome notification

### DIFF
--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -26,12 +26,16 @@
    * @param {Event} The click event on the notification.
    */
   function trackNotification(event) {
-    const { parentElement: { id: title }, text } = event.target;
+    const target = event.target;
+    const { parentElement: { id: title }, text } = target;
+
+    // TODO: [@thepracticaldev/delightful]: This event doesn't appear to be firing on Honeybadger.
+    // We probably want to remove it eventually if we continually don't see it being triggered.
     if (!title) {
       Honeybadger.notify(`Could not find parentElement.id when clicking on event target text: ${text}`);
     }
 
-    ahoy.track("Clicked Welcome Notification", { title, text });
+    ahoy.track("Clicked Welcome Notification", { title, text, target: target.toString() });
   }
 </script>
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

This builds on https://github.com/thepracticaldev/dev.to/pull/8831 (please read the PR's description for the full context).

The issue I am trying to debug is why this sometimes happens when a user clicks on a welcome notification link:
<img width="1192" alt="Screen_Shot_2020-06-24_at_12_16_35_PM" src="https://user-images.githubusercontent.com/6921610/85617942-e5400280-b614-11ea-98d7-e9e58dc9fd8f.png">

The Honeybadger call to `notify` in the JS function for tracking a click event on a welcome notification is not reliable right now since our [JS Honeybadger project](https://app.honeybadger.io/projects/67192/faults?q=-is%3Aresolved+-is%3Aignored) does not reliably send _all_ of the frontend errors (because we send too many and get rate limited 😓).

Since I can't rely on the call to `notify`, I need to be able to debug this in another way. My solution is to 

## Related Tickets & Documents

[Relevant Blazer query](https://dev.to/internal/blazer/queries/96-welcome-notification-events)

## QA Instructions, Screenshots, Recordings

All tests should pass, all this should really do is log the click `event`'s target when we call `ahoy.track`.

In the JS console, if you click on a welcome notification that has tracking enabled, you should see something like this:
```javascript
{
  name: "Clicked Welcome Notification",
  properties: {
    title: "welcome_notification_welcome_thread",
    text: "the welcome thread",
    target: "http://localhost:3000/welcome"
  }
time: 1593026829.354
__proto__: Object
```

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## Are there any post deployment tasks we need to perform?
N/A