### PR TITLE
Remove Vault ENV variables from Envfile so they arent Required in Prod

### DIFF
--- a/Envfile
+++ b/Envfile
@@ -164,12 +164,6 @@ variable :TWITCH_WEBHOOK_SECRET, :String, default: "Optional"
 # (https://api.stackexchange.com/docs)
 variable :STACK_EXCHANGE_APP_KEY, :String, default: ""
 
-# Vault for storing secrets
-# (https://learn.hashicorp.com/vault)
-variable :VAULT_ADDR, :String, default: "http://127.0.0.1:8200"
-variable :VAULT_TOKEN, :String, default: ""
-variable :VAULT_SSL_VERIFY, :Boolean, default: true
-
 group :production do
   variable :SECRET_KEY_BASE, :String
 

--- a/app/lib/app_secrets.rb
+++ b/app/lib/app_secrets.rb
@@ -1,6 +1,6 @@
 class AppSecrets
   def self.[](key)
-    result = Vault.kv(namespace).read(key)&.data&.fetch(:value) if ApplicationConfig["VAULT_TOKEN"].present?
+    result = Vault.kv(namespace).read(key)&.data&.fetch(:value) if ENV["VAULT_TOKEN"].present?
     result ||= ApplicationConfig[key]
 
     result

--- a/config/initializers/vault.rb
+++ b/config/initializers/vault.rb
@@ -1,11 +1,11 @@
 Vault.configure do |config|
   # The address of the Vault server, also read as
-  config.address = ApplicationConfig["VAULT_ADDR"]
+  config.address = ENV["VAULT_ADDR"] || "http://127.0.0.1:8200"
 
   # The policy token to authenticate with Vault
   # Each app will get its own policy https://learn.hashicorp.com/vault/getting-started/policies#overview
   # Each policy comes with its own token to give the app access to ONLY its secrets
-  config.token = ApplicationConfig["VAULT_TOKEN"]
+  config.token = ENV["VAULT_TOKEN"]
 
   # Mimic Paths for communities
 
@@ -26,7 +26,7 @@ Vault.configure do |config|
   # config.ssl_pem_contents = "-----BEGIN ENCRYPTED..."
 
   # Use SSL verification, also read as ENV["VAULT_SSL_VERIFY"]
-  config.ssl_verify = ApplicationConfig["VAULT_SSL_VERIFY"]
+  config.ssl_verify = ENV["VAULT_SSL_VERIFY"] || true
 
   # Timeout the connection after a certain amount of time (seconds), also read
   # as ENV["VAULT_TIMEOUT"]

--- a/spec/lib/app_secrets_spec.rb
+++ b/spec/lib/app_secrets_spec.rb
@@ -10,12 +10,13 @@ RSpec.describe AppSecrets, type: :lib do
     allow(described_class).to receive(:namespace).and_return(namespace)
     allow(Vault).to receive(:kv) { vault_stub }
     allow(ApplicationConfig).to receive(:[])
+    allow(ENV).to receive(:[])
   end
 
   describe "[]" do
     context "with VAULT_TOKEN present" do
       before do
-        allow(ApplicationConfig).to receive(:[]).with("VAULT_TOKEN").and_return("present")
+        allow(ENV).to receive(:[]).with("VAULT_TOKEN").and_return("present")
       end
 
       it "fetches keys from Vault" do


### PR DESCRIPTION
Envied is setup so that anything we add to the Envfile is REQUIRED to be present in Production which is not what I want for option Vault variables. I always forget this detail 🤦‍♀️  This removes the from the file so the app can load without them present. 

![alt_text](https://media1.giphy.com/media/VeSvZhPrqgZxx2KpOA/200.gif)
