### PR TITLE
Add traffic source columns to ahoy visits

### DIFF
--- a/db/migrate/20200624193436_add_traffic_source_columns_to_ahoy_visits.rb
+++ b/db/migrate/20200624193436_add_traffic_source_columns_to_ahoy_visits.rb
@@ -1,0 +1,11 @@
+class AddTrafficSourceColumnsToAhoyVisits < ActiveRecord::Migration[6.0]
+  def change
+    # strong_migrations cannot guarantee safety ofwhat happens inside a change_table
+    # block, so we need to explicitly disable the BulkChangeTable rule here.
+    # rubocop:disable Rails/BulkChangeTable
+    add_column :ahoy_visits, :referrer, :text
+    add_column :ahoy_visits, :referring_domain, :string
+    add_column :ahoy_visits, :landing_page, :text
+    # rubocop:enable Rails/BulkChangeTable
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_18_212422) do
+ActiveRecord::Schema.define(version: 2020_06_24_193436) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,6 +50,9 @@ ActiveRecord::Schema.define(version: 2020_06_18_212422) do
   end
 
   create_table "ahoy_visits", force: :cascade do |t|
+    t.text "landing_page"
+    t.text "referrer"
+    t.string "referring_domain"
     t.datetime "started_at"
     t.bigint "user_id"
     t.string "visit_token"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

When we initially added ahoy in https://github.com/thepracticaldev/dev.to/pull/8758, we decided to limit what data we would track. This was fine (arguably really good, actually!) to start. However, I'm still seeing an inexplicably high number of `Ahoy::Visit`s being recorded [here](https://dev.to/internal/blazer/queries/101-ahoy-visits-per-day).

I've tried [all](https://github.com/thepracticaldev/dev.to/pull/8782) [of](https://github.com/thepracticaldev/dev.to/pull/8872) [the](https://github.com/thepracticaldev/dev.to/pull/8839) [recommended](https://github.com/thepracticaldev/dev.to/pull/8866) configurations to turn off visit tracking, so now I am taking a different approach. I'm adding some columns to track a visit's `landing_page`, `referrer`, and `referring_domain`.

These are [optional ahoy columns](https://github.com/ankane/ahoy/blob/b8aa52946bb533df68b2b83d17975631095263b7/test/internal/db/schema.rb#L15-L17), which I am adding back in now very intentionally to try to figure out where on earth these "unexplained" visits are coming from. 🤔 

## Related Tickets & Documents

See description above for linked PRs.

## QA Instructions, Screenshots, Recordings

This just adds some columns, so the only thing to really QA here is to make sure that my migration can "migrate" successfully! :) 

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
N/A