### PR TITLE
Filter only ordinary tables in estimated count

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -3,12 +3,15 @@ class ApplicationRecord < ActiveRecord::Base
 
   include Purgeable
 
+  # see <https://www.postgresql.org/docs/11/catalog-pg-class.html> for details
+  # on the `pg_class` table
   QUERY_ESTIMATED_COUNT = <<~SQL.squish.freeze
     SELECT (
       (reltuples / GREATEST(relpages, 1)) *
       (pg_relation_size(?) / (GREATEST(current_setting('block_size')::integer, 1)))
     )::bigint AS count
-    FROM pg_class WHERE relname = ?;
+    FROM pg_class
+    WHERE relname = ? AND relkind = 'r';
   SQL
 
   # Computes an estimated count of the number of rows using stats collected by VACUUM

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -18,7 +18,7 @@ class ApplicationRecord < ActiveRecord::Base
     query = sanitize_sql_array([QUERY_ESTIMATED_COUNT, table_name, table_name])
     result = connection.execute(query)
 
-    count = result.max_by(&:values)["count"] # sometimes is an array of hashes, for ex. [{"count" => 0}, [{"count" => 1000}]
+    count = result.first["count"]
     result.clear # PG::Result is manually managed in memory, we need to release its resources
     count
   end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Follow up to #8890. Our production DB has views created by Blazer, we query by also filtering out only ordinary tables:

From https://www.postgresql.org/docs/11/catalog-pg-class.html

```text
relkind | char |   | r = ordinary table, i = index, S = sequence, t = TOAST table, v = view, m = materialized view, c = composite type, f = foreign table, p = partitioned table, I = partitioned index
```

## Related Tickets & Documents

#8890 

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
