### PR TITLE
Update Honeybadger's assetsUrl

### DIFF
--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -58,7 +58,7 @@ if (process.env.HONEYBADGER_API_KEY) {
     'HoneybadgerSourceMap',
     new HoneybadgerSourceMapPlugin({
       apiKey: process.env.HONEYBADGER_API_KEY,
-      assetsUrl: `${process.env.APP_PROTOCOL}${process.env.APP_DOMAIN}/packs/js`,
+      assetsUrl: `${process.env.APP_PROTOCOL}${process.env.APP_DOMAIN}/packs`,
       silent: false,
       ignoreErrors: false,
       revision: process.env.HEROKU_SLUG_COMMIT || 'master'

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -53,12 +53,12 @@ environment.loaders.delete('nodeModules');
 
 environment.loaders.append('erb', erb);
 
-if (process.env.HONEYBADGER_API_KEY) {
+if (process.env.HONEYBADGER_API_KEY && process.env.ASSETS_URL) {
   environment.plugins.append(
     'HoneybadgerSourceMap',
     new HoneybadgerSourceMapPlugin({
       apiKey: process.env.HONEYBADGER_API_KEY,
-      assetsUrl: `${process.env.APP_PROTOCOL}${process.env.APP_DOMAIN}/packs`,
+      assetsUrl: process.env.ASSETS_URL,
       silent: false,
       ignoreErrors: false,
       revision: process.env.HEROKU_SLUG_COMMIT || 'master'


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] DX

## Description
According to their [troubleshooting section ](https://docs.honeybadger.io/lib/javascript/support/troubleshooting.html#if-you-are-uploading-your-source-map)
> Does the Minified URL for your source map match the minified URL in your JavaScript stack trace? The URLs must match exactly, with the exception of wildcards and query strings (which are ignored).

With that, I can no longer rely on `APP_PROTOCL` and `APP_DOMAIN` because all the errors stack traces are not coming from `dev.to` urls. I have to set a new env var `ASSETS_URL` (already added on Heroku) for this new purpose.
🤞 
## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/pull/8899
## QA Instructions, Screenshots, Recordings
On production ☠️ 

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a
