### PR TITLE
Link to tracking docs from gitdocs sidebar

### DIFF
--- a/docs/backend/readme.md
+++ b/docs/backend/readme.md
@@ -17,6 +17,7 @@ items:
   - notification.md
   - scheduled-jobs.md
   - metrics.md
+  - tracking.md
 ---
 
 # Backend Guide

--- a/docs/backend/tracking.md
+++ b/docs/backend/tracking.md
@@ -1,5 +1,5 @@
 ---
-title: Backend Tracking
+title: Tracking
 ---
 
 ## Visits & Events

--- a/docs/frontend/readme.md
+++ b/docs/frontend/readme.md
@@ -10,6 +10,7 @@ items:
   - linting-formatting.md
   - liquid-tags.md
   - debugging.md
+  - tracking.md
 ---
 
 # Frontend Guide

--- a/docs/frontend/tracking.md
+++ b/docs/frontend/tracking.md
@@ -1,5 +1,5 @@
 ---
-title: Frontend Tracking
+title: Tracking
 ---
 
 ## Ahoy.js


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

I added [tracking documentation](https://github.com/thepracticaldev/dev.to/pull/8914) but totally forgot to actually _link_ to it from the sidebar for the frontend and backend sections' readme's! This fixes that so that folks can actually _get to_ the docs :)

## Related Tickets & Documents

Builds on https://github.com/thepracticaldev/dev.to/pull/8914.

## QA Instructions, Screenshots, Recordings

Here's what this will now look like when we link to the docs (my local version):

Frontend sidebar:
<img width="1271" alt="Screen Shot 2020-06-25 at 12 47 33 PM" src="https://user-images.githubusercontent.com/6921610/85788900-8779ec00-b6e2-11ea-9726-38f232e32e56.png">

Backend sidebar:
<img width="1340" alt="Screen Shot 2020-06-25 at 12 47 56 PM" src="https://user-images.githubusercontent.com/6921610/85788839-6f09d180-b6e2-11ea-80af-391f2f30affe.png">


## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [x] docs.dev.to
- [ ] readme
- [ ] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
N/A

