### PR TITLE
Fix available credits count in dashboard

### DIFF
--- a/app/views/dashboards/_analytics.html.erb
+++ b/app/views/dashboards/_analytics.html.erb
@@ -12,12 +12,12 @@
   </div>
 
   <div class="crayons-card crayons-card--secondary p-3 m:p-6">
-    <strong class="fs-2xl m:fs-3xl lh-tight color-base-90"><%= @user.listings.count %></strong>
+    <strong class="fs-2xl m:fs-3xl lh-tight color-base-90"><%= @user.listings.size %></strong>
     <span class="color-base-60 block">Listings created</span>
   </div>
 
   <div class="crayons-card crayons-card--secondary p-3 m:p-6">
-    <strong class="fs-2xl m:fs-3xl lh-tight color-base-90"><%= @user.credits.count %></strong>
+    <strong class="fs-2xl m:fs-3xl lh-tight color-base-90"><%= @user.unspent_credits_count %></strong>
     <span class="color-base-60 block">Credits available</span>
   </div>
 </div>

--- a/spec/system/dashboards/user_visits_dashboard_spec.rb
+++ b/spec/system/dashboards/user_visits_dashboard_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe "Dashboard", type: :system, js: true do
+  let(:user) { create(:user) }
+  let(:listing) { create(:listing) }
+
+  before do
+    sign_in user
+  end
+
+  context "when looking at analytics counters" do
+    it "shows the count of unspent credits" do
+      Credit.add_to(user, 2)
+
+      Credits::Buyer.call(
+        purchaser: user,
+        purchase: listing,
+        cost: 1,
+      )
+      Credit.counter_culture_fix_counts
+      user.reload
+
+      visit dashboard_path
+
+      within "main > header" do
+        expect(page).to have_text("1")
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We're showing the total amount of credits, including those spent, instead of only the available ones

## Related Tickets & Documents

Closes https://github.com/thepracticaldev/dev.to/issues/8924

## QA Instructions, Screenshots, Recordings

1. use `Credit.add_to(user, AMOUNT)` to add yourself credits
1. create a new listing and purchase it with said credits
1. go to http://localhost:3000/dashboard and make sure the count is accurate and it's the same as http://localhost:3000/credits and http://localhost:3000/listings/dashboard

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
