### PR TITLE
Fixes archived button in dashboard for PWA

### DIFF
--- a/app/assets/javascripts/initializers/initializeArchivedPostFilter.js
+++ b/app/assets/javascripts/initializers/initializeArchivedPostFilter.js
@@ -21,6 +21,7 @@ function hideArchivedPosts() {
 }
 
 function toggleArchivedPosts(e) {
+  e.preventDefault();
   var link = e.target;
 
   if (link.innerHTML.match(/Show/)) {


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixes the problem found in #8911 

## Related Tickets & Documents

#8911 

## QA Instructions, Screenshots, Recordings

When using the PWA the button to toggle (show/hide) archived posts used to open in a new tab (with a bad URL). It now looks like this:

https://share.getcloudapp.com/6qu2vnNm

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![robot hand](https://media.giphy.com/media/XRmOpxguswSvC/giphy.gif)
