### PR TITLE
Feature: Setup Admin Area to Update Vault Secrets

### DIFF
--- a/app/controllers/internal/application_controller.rb
+++ b/app/controllers/internal/application_controller.rb
@@ -28,6 +28,7 @@ class Internal::ApplicationController < ApplicationController
     { name: "tags",               controller: "tags" },
     { name: "tools",              controller: "tools" },
     { name: "users",              controller: "users" },
+    { name: "vault secrets",      controller: "secrets" },
     { name: "webhooks",           controller: "webhook_endpoints" },
     { name: "welcome",            controller: "welcome" },
   ].sort_by { |menu_item| menu_item[:name] }.freeze

--- a/app/controllers/internal/secrets_controller.rb
+++ b/app/controllers/internal/secrets_controller.rb
@@ -1,0 +1,33 @@
+class Internal::SecretsController < Internal::ApplicationController
+  layout "internal"
+
+  before_action :validate_settable_secret, only: [:update]
+  after_action only: [:update] do
+    Audit::Logger.log(:internal, current_user, params.dup)
+  end
+
+  def index
+    @vault_enabled = AppSecrets.vault_enabled?
+    @secrets = AppSecrets::SETTABLE_SECRETS.map do |key|
+      secret_value = AppSecrets[key]
+      secret_value = secret_value.present? ? "#{secret_value.first(8)}******" : "Not In Vault"
+      [key, secret_value]
+    end
+  end
+
+  def update
+    AppSecrets[params[:key_name]] = params[:key_value]
+
+    flash[:success] = "Secret #{params[:key_name]} was successfully updated in Vault."
+    redirect_to internal_secrets_path
+  end
+
+  private
+
+  def validate_settable_secret
+    update_param = params.permit(*AppSecrets::SETTABLE_SECRETS)
+    params[:key_name], params[:key_value] = update_param.to_h.to_a.first
+
+    bad_request unless update_param.present? && params[:key_name].is_a?(String) && params[:key_value].is_a?(String)
+  end
+end

--- a/app/lib/app_secrets.rb
+++ b/app/lib/app_secrets.rb
@@ -1,6 +1,12 @@
 class AppSecrets
+  SETTABLE_SECRETS = %w[
+    SLACK_CHANNEL
+    SLACK_DEPLOY_CHANNEL
+    SLACK_WEBHOOK_URL
+  ].freeze
+
   def self.[](key)
-    result = Vault.kv(namespace).read(key)&.data&.fetch(:value) if ENV["VAULT_TOKEN"].present?
+    result = Vault.kv(namespace).read(key)&.data&.fetch(:value) if vault_enabled?
     result ||= ApplicationConfig[key]
 
     result
@@ -10,6 +16,10 @@ class AppSecrets
 
   def self.[]=(key, value)
     Vault.kv(namespace).write(key, value: value)
+  end
+
+  def self.vault_enabled?
+    ENV["VAULT_TOKEN"].present?
   end
 
   def self.namespace

--- a/app/models/secret.rb
+++ b/app/models/secret.rb
@@ -1,0 +1,7 @@
+class Secret < ApplicationRecord
+  # This class exists to take advantage of Rolify for limiting authorization
+  # on internal vault secrets.
+  # NOTE: It is not backed by a database table and should not be expected to
+  # function like a traditional Rails model
+  resourcify
+end

--- a/app/views/internal/secrets/index.html.erb
+++ b/app/views/internal/secrets/index.html.erb
@@ -1,0 +1,29 @@
+<% if !@vault_enabled %>
+  <div class="alert alert-warning" role="alert">
+    <p>
+      Vault is not currently setup for your application. This means your secrets are being stored as ENV variables and cannot be updated here. To update them you will need to update the appropriate files in your environment.
+    <p>
+  </div>
+<% end %>
+
+<table class="table">
+  <thead>
+    <tr>
+      <th scope="col">Secret Name</th>
+      <th scope="col">Secret Value</th>
+      <th scope="col">Action</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @secrets.each do |key, partial_value| %>
+      <tr>
+        <%= form_with(url: "/internal/secrets", method: "PUT", local: true) do %>
+          <td><%= label_tag key, key %></td>
+          <td><%= text_field_tag key, partial_value %></td>
+          <td>
+            <%= submit_tag("Update", data: { confirm: "My username is @#{current_user.username} and I want to update this Vault Secret." }, disabled: !@vault_enabled) %></td>
+        <% end %>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -106,6 +106,8 @@ Rails.application.routes.draw do
     resources :badges, only: :index
     post "badges/award_badges", to: "badges#award_badges"
     resources :path_redirects, only: %i[new create index edit update destroy]
+    resources :secrets, only: %i[index]
+    put "secrets", to: "secrets#update"
   end
 
   namespace :stories, defaults: { format: "json" } do

--- a/spec/requests/internal/secrets_spec.rb
+++ b/spec/requests/internal/secrets_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+RSpec.describe "/internal/secrets", type: :request do
+  before do
+    allow(AppSecrets).to receive(:vault_enabled?).and_return(true)
+    allow(AppSecrets).to receive(:[]=)
+  end
+
+  context "when the user is not an admin" do
+    it "blocks the request" do
+      user = create(:user)
+      sign_in user
+
+      expect do
+        get internal_secrets_path
+      end.to raise_error(Pundit::NotAuthorizedError)
+    end
+  end
+
+  context "when the user is an admin" do
+    let(:admin) { create(:user, :admin) }
+
+    before { sign_in admin }
+
+    describe "GET /internal/secrets" do
+      it "renders with status 200" do
+        get internal_secrets_path
+        expect(response.status).to eq 200
+      end
+
+      it "displays an alert when Vault is not enabled" do
+        allow(AppSecrets).to receive(:vault_enabled?).and_return(false)
+        get internal_secrets_path
+        expect(response.body).to include("Vault is not currently setup for your application")
+      end
+    end
+
+    describe "PUT /internal/secrets" do
+      let(:valid_secret) { AppSecrets::SETTABLE_SECRETS.first }
+      let(:valid_params) { { valid_secret => "SECRET_VALUE" } }
+
+      it "successfully sets a secret and shows flash message" do
+        allow(AppSecrets).to receive(:[]=)
+        put internal_secrets_path, params: valid_params
+        expect(response.status).to eq 302
+        expect(AppSecrets).to have_received(:[]=).with(valid_secret, "SECRET_VALUE")
+        expect(flash[:success]).to include("Secret #{valid_secret} was successfully updated in Vault")
+      end
+
+      it "returns a bad_request with invalid params" do
+        put internal_secrets_path, params: {}
+        expect(response.status).to eq 400
+      end
+
+      it "creates an audit log" do
+        Audit::Subscribe.listen :internal
+        expect do
+          put internal_secrets_path, params: valid_params
+        end.to change(AuditLog, :count).by(1)
+        Audit::Subscribe.forget :internal
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
This PR gives admins the ability to update secrets in Vault from our internal namespace. If Vault is not enabled for an application then we will simply list the secrets with a warning. NOTE: These three keys are probably much better suited for SiteConfig but I wanted something low risk to test the first run of Vault with and I figured these were a good choice. With that said **Vault is still DISABLED** on dev. This PR is simply putting in place the infrastructure to update it once its activated. 

Vault Enabled
![Screen Shot 2020-06-26 at 2 24 19 PM](https://user-images.githubusercontent.com/1813380/85893741-0c373980-b7b9-11ea-99e9-22412c0c1d6d.png)

Vault Disabled
![Screen Shot 2020-06-26 at 2 24 33 PM](https://user-images.githubusercontent.com/1813380/85893742-0c373980-b7b9-11ea-9700-2cf7de2694a9.png)

Vault Secret Updated
![Screen Shot 2020-06-26 at 3 37 30 PM](https://user-images.githubusercontent.com/1813380/85899003-faf32a80-b7c2-11ea-9236-4ee5c99d21a5.png)

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/9#card-40734891

## QA Instructions
If you would like to test this PR you will first need to setup Vault as explained in #8936. Once you have it all setup visit `http://localhost:3000/internal/secrets` and try updating secrets. 

To test what happens when Vault is disabled you can either visit that URL without setting up Vault OR comment out the Vault token in your `application.yml` file. 

## Added tests?
- [x] yes

![alt_text](https://media0.giphy.com/media/l0G17R0PwQRo0PFrG/source.gif)
