### PR TITLE
Feature: Introduce KnapsackPro Queue Mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: required
 language: ruby
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,13 +63,13 @@ script:
   - bundle exec rails webpacker:compile
   - bundle exec rails db:schema:load
   - './cc-test-reporter before-build'
-  - 'bin/knapsack_pro_rspec'
-  - '[ ! -f .approvals ] || bundle exec approvals verify --ask false'
   - if [ "$KNAPSACK_PRO_CI_NODE_INDEX" == "0" ]; then yarn test --colors; fi
   - if [ "$KNAPSACK_PRO_CI_NODE_INDEX" == "0" ]; then ./cc-test-reporter format-coverage -t lcov -o coverage/codeclimate.lcov.json; fi
   - if [ "$KNAPSACK_PRO_CI_NODE_INDEX" == "1" ]; then bundle exec bundle-audit check --update --ignore CVE-2015-9284; fi
   - if [ "$KNAPSACK_PRO_CI_NODE_INDEX" == "1" ]; then yarn build-storybook; fi
   - if [ "$KNAPSACK_PRO_CI_NODE_INDEX" == "2" ]; then bundle exec rails runner -e production 'puts "App booted successfully"'; fi
+  - 'bin/knapsack_pro_rspec'
+  - '[ ! -f .approvals ] || bundle exec approvals verify --ask false'
 after_script:
   - ./cc-test-reporter format-coverage -t simplecov -o ./coverage/codeclimate.$KNAPSACK_PRO_CI_NODE_INDEX.json ./coverage/spec/.resultset.json
   - ./cc-test-reporter sum-coverage --output - --parts $COVERAGE_REPORTS_TOTAL coverage/codeclimate.*.json | ./cc-test-reporter upload-coverage --input -

--- a/bin/knapsack_pro_rspec
+++ b/bin/knapsack_pro_rspec
@@ -4,5 +4,5 @@ if [ "$KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC" = "" ]; then
     KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC=disabled-for-fork \
     bundle exec rake knapsack_pro:rspec # use Regular Mode here always
 else
-  bundle exec rake knapsack_pro:rspec
+  bundle exec rake knapsack_pro:queue:rspec
 fi


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
This PR enables [Queue mode for KnapsackPro](https://youtu.be/hUEB1XDKEFY). In Regular Mode KnapsackPro will make a single call on each node at the beginning of a CI run to request a set of specs based on historical timing data. In our case since we have 3 nodes, we get 3 batches that are as even as possible. However, as the tests run, one batch may hit some retries or failed specs and end up being much slower than the others. Queue Mode helps mitigate this problem. 

In Queue Mode, each node will start by pulling a small set of a few specs. Once those specs are run then the node will pull another few specs. This will occur until all the specs in our suite have been run. By doing it this way, if one node is cranking through specs quickly then we will end up sending more specs to it rather than it finishing early and having to wait on the other nodes. 

The downside here, in terms of our test suite, is that likely more flaky specs are going to pop up. **I feel** like our suite has come a long way thanks to KnapsackPro already lightly introducing some randomness to the spec ordering and that its ready to handle this next step.  Totally open to any other thoughts people have though if you disagree!

@snackattas @ArturT
 
## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/9#card-40829203

![alt_text](https://media.tenor.com/images/7691f0796e33130f60cc26f91ea91325/tenor.gif)
