### PR TITLE
Use normal word breaking rules for code tag in articles

### DIFF
--- a/app/assets/stylesheets/views/article.scss
+++ b/app/assets/stylesheets/views/article.scss
@@ -225,7 +225,7 @@
       vertical-align: 0;
       max-width: 100%;
       line-height: 1.6em;
-      word-break: break-all;
+      word-break: normal;
     }
 
     kbd {


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Words in `<code>` tags break on every char, they should break as regular words.

## Related Tickets & Documents

Closes https://github.com/thepracticaldev/dev.to/issues/8946

## QA Instructions, Screenshots, Recordings

**Before**

![Screenshot_2020-06-28 RunCSS, A Runtime Version of TailwindCSS and Beyond - DEV Community 👩‍💻👨‍💻](https://user-images.githubusercontent.com/146201/85942166-ea0ff980-b927-11ea-98ba-a621642df40c.png)

**After**

![Screenshot_2020-06-28 RunCSS, A Runtime Version of TailwindCSS and Beyond - DEV Community 👩‍💻👨‍💻(1)](https://user-images.githubusercontent.com/146201/85942169-ee3c1700-b927-11ea-99cc-c487fe45e98d.png)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
