### PR TITLE
Bug Fix: Specify Version of libcurl4-openssl-dev for Github Action

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -21,7 +21,7 @@ jobs:
           ruby-version: 2.7.1
       - name: Installing additional dependencies
         run: |
-          sudo apt-get install postgresql-client libpq-dev libcurl4-openssl-dev
+          sudo apt-get install postgresql-client libpq-dev libcurl4-openssl-dev=7.58.0-2ubuntu3.9
       - name: Bundle install
         run: |
           gem install bundler


### PR DESCRIPTION
[Packages available for libcurl4-openssl-dev](http://security.ubuntu.com/ubuntu/pool/main/c/curl/)
Attempt to fix
```
 Installing additional dependencies10s
##[error]Process completed with exit code 100.
Run sudo apt-get install postgresql-client libpq-dev libcurl4-openssl-dev
Reading package lists...
Building dependency tree...
Reading state information...
libpq-dev is already the newest version (12.3-1.pgdg18.04+1).
postgresql-client is already the newest version (12+215.pgdg18.04+1).
Suggested packages:
  libcurl4-doc libidn11-dev libkrb5-dev libldap2-dev librtmp-dev libssh2-1-dev
The following NEW packages will be installed:
  libcurl4-openssl-dev
0 upgraded, 1 newly installed, 0 to remove and 11 not upgraded.
Need to get 294 kB of archives.
After this operation, 1399 kB of additional disk space will be used.
Ign:1 http://azure.archive.ubuntu.com/ubuntu bionic-updates/main amd64 libcurl4-openssl-dev amd64 7.58.0-2ubuntu3.8
Err:1 http://security.ubuntu.com/ubuntu bionic-updates/main amd64 libcurl4-openssl-dev amd64 7.58.0-2ubuntu3.8
  404  Not Found [IP: 52.177.174.250 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/c/curl/libcurl4-openssl-dev_7.58.0-2ubuntu3.8_amd64.deb  404  Not Found [IP: 52.177.174.250 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
##[error]Process completed with exit code 100.
```

![alt_text](gif_link)
