### PR TITLE
Do not render active announcements in iframes

### DIFF
--- a/app/assets/javascripts/initializers/initializeBroadcast.js
+++ b/app/assets/javascripts/initializers/initializeBroadcast.js
@@ -83,9 +83,10 @@ function renderBroadcast(broadcastElement, data) {
 
 /**
  * A function to determine if a broadcast should render.
- * Does not render a broadcast on the `/new` route, if the current user
- * has opted-out, if the broadcast has already been inserted, or
- * if the key for the broadcast's title exists in localStorage.
+ * Does not render a broadcast on the `/new` route or the mod tools panel.
+ * Does not render a broadcast if the current user has opted-out,
+ * if the broadcast has already been inserted, or if the key for
+ * the broadcast's title exists in localStorage.
  *
  * If the broadcast exists in the DOM but was hidden by the articleForm,
  * the function will re-display it again by adding a class.
@@ -93,7 +94,10 @@ function renderBroadcast(broadcastElement, data) {
  * @function initializeBroadcast
  */
 function initializeBroadcast() {
-  if (window.location.pathname === '/new') {
+  const pathname = window.location.pathname;
+  // The mod actions panel uses an iframe, which attempts to re-render the broadcast.
+  // By checking for `actions_panel` in the path, we can avoid this double render.
+  if (pathname === '/new' || pathname.includes('actions_panel')) {
     return;
   }
 

--- a/app/assets/javascripts/initializers/initializeBroadcast.js
+++ b/app/assets/javascripts/initializers/initializeBroadcast.js
@@ -83,7 +83,7 @@ function renderBroadcast(broadcastElement, data) {
 
 /**
  * A function to determine if a broadcast should render.
- * Does not render a broadcast on the `/new` route or the mod tools panel.
+ * Does not render a broadcast on the `/new` route or in an iframe.
  * Does not render a broadcast if the current user has opted-out,
  * if the broadcast has already been inserted, or if the key for
  * the broadcast's title exists in localStorage.
@@ -94,12 +94,9 @@ function renderBroadcast(broadcastElement, data) {
  * @function initializeBroadcast
  */
 function initializeBroadcast() {
-  const pathname = window.location.pathname;
-  // The mod actions panel uses an iframe, which attempts to re-render the broadcast.
-  // By checking for `actions_panel` in the path, we can avoid this double render.
-  // TODO: [@thepracticaldev/delightful]: Refactor how we decide when to render the broadcast
-  // across the site given that this check will need to happen every time we use iframes.
-  if (pathname === '/new' || pathname.includes('actions_panel')) {
+  // Iframes will attempt to re-render a broadcast, so we want to explicitly
+  // avoid initializing one if we are within `window.frameElement`.
+  if (window.frameElement || window.location.pathname === '/new') {
     return;
   }
 

--- a/app/assets/javascripts/initializers/initializeBroadcast.js
+++ b/app/assets/javascripts/initializers/initializeBroadcast.js
@@ -97,6 +97,8 @@ function initializeBroadcast() {
   const pathname = window.location.pathname;
   // The mod actions panel uses an iframe, which attempts to re-render the broadcast.
   // By checking for `actions_panel` in the path, we can avoid this double render.
+  // TODO: [@thepracticaldev/delightful]: Refactor how we decide when to render the broadcast
+  // across the site given that this check will need to happen every time we use iframes.
   if (pathname === '/new' || pathname.includes('actions_panel')) {
     return;
   }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Because of the way that the mod tools sidebar relies on iframes, any active broadcasts were being rendered twice: once on the main site, and once within the mod tools iframe, which re-invoked all the initializers and their JavaScript when the iframe itself re-rendered. Unfortunately, iframes also create their _own_ window context, which means that this issue can't simply be solved by setting a flag on the window (in other words, something like `window.broadcastVisible` wouldn't work!).

The best solution here is to not re-invoke the `initializeBroadcast` function if its caller is the mod tools sidebar; the best way to determine that is by using the path, which will include `actions_panel` within it. 😓 

## Related Tickets & Documents
Closes https://github.com/thepracticaldev/dev.to/issues/8774.

## QA Instructions, Screenshots, Recordings

Before this change:
<img width="1684" alt="Screen Shot 2020-06-29 at 7 59 01 AM" src="https://user-images.githubusercontent.com/6921610/86023307-5b12e800-b9e0-11ea-8cbf-e5693066275f.png">

After this change:
<img width="1684" alt="Screen Shot 2020-06-29 at 7 58 45 AM" src="https://user-images.githubusercontent.com/6921610/86023322-62d28c80-b9e0-11ea-8a34-e08ff60a8a42.png">


## Added tests?

- [ ] yes
- [x] no, because they aren't needed _(I opted to not write tests for this specific functionality since it sounds like the mod actions panel will be re-written in preact soon, which means that this check won't be necessary at that point.)_
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [x] ~readme~ inline documentation
- [ ] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
N/A

## [optional] What gif best describes this PR or how it makes you feel?

![le sigh](https://media0.giphy.com/media/xT8qBrxsVTvz5LYx7q/giphy.webp?cid=5a38a5a2ff8c03e00729e1ab99f9b87b0e01471b1cca0ad2&rid=giphy.webp)
