### PR TITLE
Override header padding for internal

### DIFF
--- a/app/assets/stylesheets/internal/layout.scss
+++ b/app/assets/stylesheets/internal/layout.scss
@@ -79,3 +79,7 @@
     background: $light-medium-gray;
   }
 }
+
+body {
+  padding-top: 0;
+}


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Noticed this weird space in `/internal`. :smile:

It's there to make space for the header elsewhere on the site, but that isn't necessary in internal.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, as well
as any relevant images for UI changes._

Before:
![image](https://user-images.githubusercontent.com/11466782/86040085-05066a80-ba09-11ea-979a-2f753825ec87.png)

After:
![image](https://user-images.githubusercontent.com/11466782/86040118-13548680-ba09-11ea-9ae3-4cafe36e5514.png)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
