### PR TITLE
Discoverable channel will open CTA to request join if not available

### DIFF
--- a/app/javascript/chat/channels.jsx
+++ b/app/javascript/chat/channels.jsx
@@ -28,6 +28,9 @@ const Channels = ({
           channel={channel}
           discoverableChannel
           triggerActiveContent={triggerActiveContent}
+          isActiveChannel={
+            parseInt(activeChannelId, 10) === channel.chat_channel_id
+          }
         />
       );
     },

--- a/app/javascript/chat/chat.jsx
+++ b/app/javascript/chat/chat.jsx
@@ -146,6 +146,9 @@ export default class Chat extends Component {
         searchType: '',
         paginationNumber: channelPaginationNum,
       };
+      if (activeChannelId !== null) {
+        searchParams.searchType = 'discoverable';
+      }
       getChannels(searchParams, filters, this.loadChannels);
       getUnopenedChannelIds(this.markUnopenedChannelIds);
     }

--- a/app/javascript/chat/components/channelButton.jsx
+++ b/app/javascript/chat/components/channelButton.jsx
@@ -1,81 +1,89 @@
-import { h } from 'preact';
+import { h, Component, createRef } from 'preact';
 import PropTypes from 'prop-types';
 
-const ChannelButton = ({
-  channel,
-  handleSwitchChannel,
-  otherClassname,
-  newMessagesIndicator,
-  isUnopened,
-  discoverableChannel,
-  triggerActiveContent,
-}) => {
-  return (
-    <button
-      type="button"
-      key={channel.id}
-      className="chatchanneltabbutton"
-      onClick={discoverableChannel ? triggerActiveContent : handleSwitchChannel}
-      data-content="sidecar-channel-request"
-      data-channel-id={channel.chat_channel_id}
-      data-channel-slug={channel.channel_modified_slug}
-      data-channel-status={channel.status}
-      data-channel-name={channel.channel_name}
-    >
-      <span
-        className={
-          discoverableChannel
-            ? 'chatchanneltab chatchanneltab--inactive'
-            : `chatchanneltab ${otherClassname} chatchanneltab--${newMessagesIndicator}`
+class ChannelButton extends Component {
+  buttonRef = createRef();
+
+  componentDidMount() {
+    const { isActiveChannel = false } = this.props;
+
+    if (isActiveChannel) {
+      this.buttonRef.current.click();
+    }
+  }
+
+  render() {
+    const {
+      channel,
+      handleSwitchChannel,
+      otherClassname,
+      newMessagesIndicator,
+      isUnopened,
+      discoverableChannel,
+      triggerActiveContent,
+    } = this.props;
+
+    return (
+      <button
+        type="button"
+        ref={this.buttonRef}
+        key={channel.id}
+        className="chatchanneltabbutton"
+        onClick={
+          discoverableChannel ? triggerActiveContent : handleSwitchChannel
         }
-        data-channel-id={channel.chat_channel_id}
         data-content="sidecar-channel-request"
+        data-channel-id={channel.chat_channel_id}
         data-channel-slug={channel.channel_modified_slug}
         data-channel-status={channel.status}
         data-channel-name={channel.channel_name}
-        style={{
-          border: `1px solid ${channel.channel_color}`,
-          boxShadow: `3px 3px 0px ${channel.channel_color}`,
-        }}
       >
         <span
-          data-channel-slug={channel.channel_modified_slug}
           className={
             discoverableChannel
-              ? 'chatchanneltabindicator'
-              : `chatchanneltabindicator chatchanneltabindicator--${newMessagesIndicator}`
+              ? 'chatchanneltab chatchanneltab--inactive'
+              : `chatchanneltab ${otherClassname} chatchanneltab--${newMessagesIndicator}`
           }
           data-channel-id={channel.chat_channel_id}
-        >
-          <img
-            src={channel.channel_image}
-            alt="pic"
-            className={
-              channel.channel_type === 'direct'
-                ? 'chatchanneltabindicatordirectimage'
-                : 'chatchanneltabindicatordirectimage invert-channel-image'
-            }
-          />
-        </span>
-        {isUnopened ? (
-          <span className="crayons-indicator crayons-indicator--accent crayons-indicator--bullet" />
-        ) : (
-          ''
-        )}
-        <span
+          data-content="sidecar-channel-request"
           data-channel-slug={channel.channel_modified_slug}
-          className="chatchanneltab__name"
-          data-channel-id={channel.chat_channel_id}
           data-channel-status={channel.status}
           data-channel-name={channel.channel_name}
-          data-content="sidecar-channel-request"
+          style={{
+            border: `1px solid ${channel.channel_color}`,
+            boxShadow: `3px 3px 0px ${channel.channel_color}`,
+          }}
         >
+          <span
+            data-channel-slug={channel.channel_modified_slug}
+            className={
+              discoverableChannel
+                ? 'chatchanneltabindicator'
+                : `chatchanneltabindicator chatchanneltabindicator--${newMessagesIndicator}`
+            }
+            data-channel-id={channel.chat_channel_id}
+          >
+            <img
+              src={channel.channel_image}
+              alt="pic"
+              className={
+                channel.channel_type === 'direct'
+                  ? 'chatchanneltabindicatordirectimage'
+                  : 'chatchanneltabindicatordirectimage invert-channel-image'
+              }
+            />
+          </span>
+          {isUnopened ? (
+            <span className="crayons-indicator crayons-indicator--accent crayons-indicator--bullet" />
+          ) : (
+            ''
+          )}
           {channel.channel_name}
         </span>
-      </span>
-    </button>
-  );
-};
+      </button>
+    );
+  }
+}
 
 ChannelButton.propTypes = {
   channel: PropTypes.shape({

--- a/app/javascript/chat/components/channelButton.jsx
+++ b/app/javascript/chat/components/channelButton.jsx
@@ -12,6 +12,32 @@ class ChannelButton extends Component {
     }
   }
 
+  renderChannelImage = () => {
+    const { channel, newMessagesIndicator, discoverableChannel } = this.props;
+
+    return (
+      <span
+        data-channel-slug={channel.channel_modified_slug}
+        className={
+          discoverableChannel
+            ? 'chatchanneltabindicator'
+            : `chatchanneltabindicator chatchanneltabindicator--${newMessagesIndicator}`
+        }
+        data-channel-id={channel.chat_channel_id}
+      >
+        <img
+          src={channel.channel_image}
+          alt="pic"
+          className={
+            channel.channel_type === 'direct'
+              ? 'chatchanneltabindicatordirectimage'
+              : 'chatchanneltabindicatordirectimage invert-channel-image'
+          }
+        />
+      </span>
+    );
+  };
+
   render() {
     const {
       channel,
@@ -54,25 +80,7 @@ class ChannelButton extends Component {
             boxShadow: `3px 3px 0px ${channel.channel_color}`,
           }}
         >
-          <span
-            data-channel-slug={channel.channel_modified_slug}
-            className={
-              discoverableChannel
-                ? 'chatchanneltabindicator'
-                : `chatchanneltabindicator chatchanneltabindicator--${newMessagesIndicator}`
-            }
-            data-channel-id={channel.chat_channel_id}
-          >
-            <img
-              src={channel.channel_image}
-              alt="pic"
-              className={
-                channel.channel_type === 'direct'
-                  ? 'chatchanneltabindicatordirectimage'
-                  : 'chatchanneltabindicatordirectimage invert-channel-image'
-              }
-            />
-          </span>
+          {this.renderChannelImage()}
           {isUnopened ? (
             <span className="crayons-indicator crayons-indicator--accent crayons-indicator--bullet" />
           ) : (


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When a user tries to directly load the URL for a discoverable Connect channel in which they are not members already we should present the CTA to request access.

This PR triggers a click on the `ChannelButton` component after it's mounted if it corresponds to the active channel

## QA Instructions, Screenshots, Recordings

With a discoverable channel that you are not a member of yet, follow the link directly to that channel and the CTA to request access should appear automatically.

Video sample of the test:

https://share.getcloudapp.com/JruLO8v7

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

