### PR TITLE
Flaky Spec Fix: Use Host Only For Allowing Webmock Connections

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -47,10 +47,10 @@ ActiveRecord::Migration.maintain_test_schema!
 # allow browser websites, so that "webdrivers" can access their binaries
 # see <https://github.com/titusfortner/webdrivers/wiki/Using-with-VCR-or-WebMock>
 allowed_sites = [
-  "https://chromedriver.storage.googleapis.com",
-  "https://github.com/mozilla/geckodriver/releases",
-  "https://selenium-release.storage.googleapis.com",
-  "https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver",
+  "chromedriver.storage.googleapis.com",
+  "github.com/mozilla/geckodriver/releases",
+  "selenium-release.storage.googleapis.com",
+  "developer.microsoft.com/en-us/microsoft-edge/tools/webdriver",
   "api.knapsackpro.com",
 ]
 WebMock.disable_net_connect!(allow_localhost: true, allow: allowed_sites)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
By removing the scheme here `allow` will then be able to match [only using the host](https://github.com/bblimke/webmock/blob/e386be1cb3652c83d76fec57847ea4bed581b992/lib/webmock/webmock.rb#L79) without worrying about the rest of the URL. This will allow URLs like `https://chromedriver.storage.googleapis.com/LATEST_RELEASE_83.0.4103` to be allowed even though we dont explicitly list that URL.
Fixes:
```
1st Try error in ./spec/system/articles/user_creates_an_article_spec.rb:16:
Real HTTP connections are disabled. Unregistered request: GET https://chromedriver.storage.googleapis.com/LATEST_RELEASE_83.0.4103 with headers {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Host'=>'chromedriver.storage.googleapis.com', 'User-Agent'=>'Ruby'}
You can stub this request with the following snippet:
stub_request(:get, "https://chromedriver.storage.googleapis.com/LATEST_RELEASE_83.0.4103").
  with(
    headers: {
	  'Accept'=>'*/*',
	  'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
	  'Host'=>'chromedriver.storage.googleapis.com',
	  'User-Agent'=>'Ruby'
    }).
  to_return(status: 200, body: "", headers: {})
```

@snackattas 

![alt_text](https://media3.giphy.com/media/yx400dIdkwWdsCgWYp/giphy.gif)
