### PR TITLE
Stop allowing accented characters in tags

### DIFF
--- a/app/javascript/shared/components/tags.jsx
+++ b/app/javascript/shared/components/tags.jsx
@@ -449,6 +449,7 @@ class Tags extends Component {
           onKeyDown={this.handleKeyDown}
           onBlur={this.handleFocusChange}
           onFocus={onFocus}
+          pattern={`${LETTERS_NUMBERS}`}
         />
         {searchResultsHTML}
       </div>

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -82,7 +82,10 @@ class Tag < ActsAsTaggableOn::Tag
 
   def validate_name
     errors.add(:name, "is too long (maximum is 30 characters)") if name.length > 30
-    errors.add(:name, "contains non-alphanumeric characters") unless name.match?(/\A[[:alnum:]]+\z/)
+    # [:alnum] is not used here because it supports diacritical characters.
+    # If we decide to allow diacritics in the future, we should replace the
+    # following regex with [:alnum].
+    errors.add(:name, "contains non-alphanumeric characters") unless name.match?(/\A[[a-z0-9]]+\z/i)
   end
 
   def mod_chat_channel

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -82,10 +82,10 @@ class Tag < ActsAsTaggableOn::Tag
 
   def validate_name
     errors.add(:name, "is too long (maximum is 30 characters)") if name.length > 30
-    # [:alnum] is not used here because it supports diacritical characters.
+    # [:alnum:] is not used here because it supports diacritical characters.
     # If we decide to allow diacritics in the future, we should replace the
-    # following regex with [:alnum].
-    errors.add(:name, "contains non-alphanumeric characters") unless name.match?(/\A[[a-z0-9]]+\z/i)
+    # following regex with [:alnum:].
+    errors.add(:name, "contains non-ASCII characters") unless name.match?(/\A[[a-z0-9]]+\z/i)
   end
 
   def mod_chat_channel

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -46,6 +46,16 @@ RSpec.describe Tag, type: :model do
         tag.name = nil
         expect(tag).not_to be_valid
       end
+
+      it "fails validations if name uses diacritics" do
+        tag.name = "łookatmé"
+        expect(tag).not_to be_valid
+      end
+
+      it "fails validations if name uses non-latin characters" do
+        tag.name = "火"
+        expect(tag).not_to be_valid
+      end
     end
 
     describe "alias_for" do

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -47,13 +47,20 @@ RSpec.describe Tag, type: :model do
         expect(tag).not_to be_valid
       end
 
-      it "fails validations if name uses diacritics" do
-        tag.name = "łookatmé"
+      it "fails validations if name uses non-ASCII characters" do
+        tag.name = "مرحبا"
         expect(tag).not_to be_valid
-      end
 
-      it "fails validations if name uses non-latin characters" do
-        tag.name = "火"
+        tag.name = "你好"
+        expect(tag).not_to be_valid
+
+        tag.name = "Cześć"
+        expect(tag).not_to be_valid
+
+        tag.name = "♩ ♪ ♫ ♬ ♭ ♮ ♯"
+        expect(tag).not_to be_valid
+
+        tag.name = "Test™"
         expect(tag).not_to be_valid
       end
     end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This commit will add strict frontend and backend validation for tags
disallowing accented characters.

## Related Tickets & Documents

Closes #8884

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, as well
as any relevant images for UI changes._

Before:
https://d.pr/v/1xSmcP

After:
![Peek 2020-06-29 20-54](https://user-images.githubusercontent.com/11466782/86074088-cc878080-ba4a-11ea-8a05-667fd17e08f0.gif)

*Note: HTML5 validation won't let you type accented characters, but you can paste them*


## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
