### PR TITLE
Initial Proof of Concept: Code block "lightbox"

### DIFF
--- a/app/assets/stylesheets/syntax.scss
+++ b/app/assets/stylesheets/syntax.scss
@@ -13,6 +13,7 @@
 
 pre:not(.highlight),
 div.highlight {
+  position: relative;
   background: var(--syntax-background-color);
   color: var(--syntax-text-color);
   font-size: 80%;
@@ -22,6 +23,14 @@ div.highlight {
   white-space: pre;
   overflow-x: scroll;
   -webkit-overflow-scrolling: touch;
+  &.crayons-fullscreen {
+    position: fixed;
+    top: calc(50px + 3vh);
+    left: calc(5px + 3vw);
+    bottom: 3vh;
+    right: calc(5px + 3vh);
+    z-index: 150;
+  }
 
   code {
     font-size: 100%;
@@ -31,6 +40,30 @@ div.highlight {
   @media (min-width: $breakpoint-m) {
     padding: var(--su-6);
   }
+
+  button {
+    right: 4px;
+    top: 4px;
+    height: 19px;
+    display: none;
+    position: absolute;
+  }
+  &:hover {
+    button {
+      display: block;
+    }
+  }
+}
+
+// *Definitely* doesn't belong here, just tossed it here and probably should be the fully-reusable modal bg.
+.crayons-fullscreenbg {
+  background: rgba(0,0,0,0.8);
+  left: 0;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  position: fixed;
+  z-index: 149;
 }
 
 code {

--- a/app/javascript/packs/articlePage.jsx
+++ b/app/javascript/packs/articlePage.jsx
@@ -20,6 +20,24 @@ const userDataIntervalID = setInterval(async () => {
     return;
   }
 
+  // Somewhat works. Not elegent or fully functional.
+  const codeBlocks = document.querySelectorAll('div.highlight');
+
+  codeBlocks.forEach(block => {
+    block.insertAdjacentHTML('beforeend', '<button class="crayons-btn crayons-btn--secondary crayons-btn--icon crayons-btn--s pt-0"><svg data-content="fullscreen" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="15" height="15"><path data-content="fullscreen" fill="none" d="M0 0h24v24H0z"></path><path data-content="fullscreen" d="M20 3h2v6h-2V5h-4V3h4zM4 3h4v2H4v4H2V3h2zm16 16v-4h2v6h-6v-2h4zM4 19h4v2H2v-6h2v4z"></path></svg></button>');
+    block.querySelector('button').onclick = (e) => {
+      document.body.classList.toggle('modal-open');
+      if (document.body.classList.contains('modal-open')) {
+        block.classList.add('crayons-fullscreen');
+        block.insertAdjacentHTML('beforeBegin', '<div class="crayons-fullscreenbg"></div>');
+      } else {
+        block.classList.remove('crayons-fullscreen');
+        //crayons-fullscreenbg is just a random placeholder.
+        document.querySelector('.crayons-fullscreenbg').style.display = 'none';
+      }
+    }
+  });
+  
   if (userStatus === 'logged-in' && user !== null) {
     // Load the comment subscription button for logged on users.
     clearInterval(userDataIntervalID);


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Sometimes code is hard to read when it is constrained to a narrow box within a post. This PR gives an expansion button. We can re-use most of this functionality for images and other "expandable" content. But since Forem's main app is DEV, I think focusing on the code reading functionality makes sense.

This is not yet fully functional. Getting it working is easy, but I definitely want to get the crayons part right want to wait on input there. For now I just tossed in some dummy classes.

Here it is in action...

![](https://im4.ezgif.com/tmp/ezgif-4-31f55282d483.gif)