### PR TITLE
Allow internal chat channels to be searched by their name

### DIFF
--- a/app/controllers/internal/chat_channels_controller.rb
+++ b/app/controllers/internal/chat_channels_controller.rb
@@ -2,7 +2,8 @@ class Internal::ChatChannelsController < Internal::ApplicationController
   layout "internal"
 
   def index
-    @group_chat_channels = ChatChannel.where(channel_type: "invite_only").includes(:users).page(params[:page]).per(50)
+    @q = ChatChannel.where(channel_type: "invite_only").includes(:users).ransack(params[:q])
+    @group_chat_channels = @q.result.page(params[:page]).per(50)
   end
 
   def create

--- a/app/views/internal/chat_channels/index.html.erb
+++ b/app/views/internal/chat_channels/index.html.erb
@@ -14,13 +14,26 @@
 </div>
 
 <h2>Group Connect Channels</h2>
+<div class="row m-3">
+  <div class="col">
+  </div>
+  <div class="col">
+    <%= search_form_for @q, url: internal_chat_channels_path, class: "form-inline justify-content-end" do |f| %>
+
+      <%= f.label :channel_name_cont, "Channel Name", class: "sr-only" %>
+      <%= f.search_field :channel_name_cont, placeholder: "Channel Name", class: "form-control mx-3" %>
+
+      <%= f.submit "Search", class: "btn btn-secondary" %>
+    <% end %>
+  </div>
+</div>
 
 <%= paginate @group_chat_channels %>
 
 <table class="table">
   <thead>
     <tr>
-      <th scope="col">Name</th>
+      <th scope="col">Channel Name</th>
       <th scope="col">Users</th>
       <th scope="col">Add Users</th>
     </tr>

--- a/spec/system/internal/admin_manages_chat_channels_spec.rb
+++ b/spec/system/internal/admin_manages_chat_channels_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe "Admin manages chat channels", type: :system do
   end
 
   context "when searching for chat channels" do
-    let(:chat_channel1) { build_stubbed(:chat_channel, channel_name: "Interesting chat", channel_type: "invite_only") }
-    let(:chat_channel2) { build_stubbed(:chat_channel, channel_name: "Boring chat", channel_type: "invite_only") }
+    let(:chat_channel1) { create(:chat_channel, channel_name: "Interesting chat", channel_type: "invite_only") }
+    let(:chat_channel2) { create(:chat_channel, channel_name: "Boring chat", channel_type: "invite_only") }
 
     before do
       clear_search_box

--- a/spec/system/internal/admin_manages_chat_channels_spec.rb
+++ b/spec/system/internal/admin_manages_chat_channels_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe "Admin manages chat channels", type: :system do
+  let(:admin) { create(:user, :super_admin) }
+
+  def clear_search_box
+    fill_in "q_channel_name_cont", with: ""
+  end
+
+  before do
+    sign_in admin
+    visit internal_chat_channels_path
+  end
+
+  it "loads the view" do
+    expect(page).to have_content("Chat Channels")
+    expect(page).to have_content("Create New Connect Channel")
+    expect(page).to have_content("Group Connect Channels")
+  end
+
+  context "when creating a chat channel" do
+    it "creates a chat channel" do
+      fill_in "chat_channel_channel_name", with: "Cool chat"
+      fill_in "chat_channel_usernames_string", with: admin.username.to_s
+      click_on "Create Chat channel"
+
+      expect(page.body).to have_link("Cool chat")
+    end
+  end
+
+  context "when searching for chat channels" do
+    let(:chat_channel1) { build_stubbed(:chat_channel, channel_name: "Interesting chat", channel_type: "invite_only") }
+    let(:chat_channel2) { build_stubbed(:chat_channel, channel_name: "Boring chat", channel_type: "invite_only") }
+
+    before do
+      clear_search_box
+    end
+
+    it "searches chat channels" do
+      fill_in "q_channel_name_cont", with: chat_channel1.channel_name.to_s
+      click_on "Search"
+
+      expect(page.body).to have_link(chat_channel1.channel_name)
+      expect(page.body).not_to have_link(chat_channel2.channel_name)
+    end
+  end
+end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR allows for users to search internal chat channels by their name.

## Related Tickets & Documents

Fixes #8997.

## QA Instructions, Screenshots, Recordings

![UI for the search feature](https://user-images.githubusercontent.com/26309166/86125794-85969b00-badd-11ea-9ec3-80291efba2e4.png)

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

Nope.

## [optional] What gif best describes this PR or how it makes you feel?

![Search gif](https://media.giphy.com/media/xGdvlOVSWaDvi/giphy.gif)
