### PR TITLE
Flaky Spec Fix: Make Sure to Allow All Sites After Suite

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -173,9 +173,7 @@ RSpec.configure do |config|
   config.after(:suite) do
     WebMock.disable_net_connect!(
       allow_localhost: true,
-      allow: [
-        "api.knapsackpro.com",
-      ],
+      allow: allowed_sites,
     )
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
I thought I had finally put the following spec failure behind us but then it popped up again as soon as I turned on queue mode. So I went back to digging and remembered that with queue mode we are resetting `WebMock` between suite runs(batches of tests). When we do that we need to ensure we still allow all the sites we originally allow at the beginning when the code is loaded and not just "api.knapsackpro.com".  
Fixes this in queue mode: 
```
1st Try error in ./spec/system/articles/user_creates_an_article_spec.rb:16:
Real HTTP connections are disabled. Unregistered request: GET https://chromedriver.storage.googleapis.com/LATEST_RELEASE_83.0.4103 with headers {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Host'=>'chromedriver.storage.googleapis.com', 'User-Agent'=>'Ruby'}
You can stub this request with the following snippet:
stub_request(:get, "https://chromedriver.storage.googleapis.com/LATEST_RELEASE_83.0.4103").
  with(
    headers: {
	  'Accept'=>'*/*',
	  'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
	  'Host'=>'chromedriver.storage.googleapis.com',
	  'User-Agent'=>'Ruby'
    }).
  to_return(status: 200, body: "", headers: {})
```

@snackattas 

![alt_text](https://media2.giphy.com/media/DUtVdGeIU8lmo/giphy.gif)
