### PR TITLE
Hide secret code from input history

### DIFF
--- a/app/views/users/_org_non_member.html.erb
+++ b/app/views/users/_org_non_member.html.erb
@@ -6,7 +6,7 @@
     <div class="crayons-field mb-6">
       <%= label_tag :org_secret, "Secret code", class: "crayons-field__label" %>
       <p class="crayons-field__description">Provided to you by an org admin</p>
-      <%= text_field_tag :org_secret, nil, placeholder: "...", class: "crayons-textfield" %>
+      <%= text_field_tag :org_secret, nil, placeholder: "...", class: "crayons-textfield", autocomplete: "off" %>
     </div>
 
     <button class="crayons-btn" type="submit">Join Organization</button>


### PR DESCRIPTION
Currently, the secret code will show up in the input history. That, I think, means that anyone that can open that page in a shared browser instance could join the org.

NOTE: I'm not a Ruby developer, so I'm only guessing that this change will resolve the issue. The intent is to add `autocomplete="off"` to the text input. [More information about the autocomplete attribute can be found here](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete)