### PR TITLE
[ModCenter] Make formatDate function more robust for intl date-time formats

### DIFF
--- a/app/javascript/modCenter/singleArticle/util.js
+++ b/app/javascript/modCenter/singleArticle/util.js
@@ -1,20 +1,23 @@
-const time_options = {
+const timeOptions = {
   hour: 'numeric',
   minute: 'numeric',
 };
 
-const date_options = {
+const dateOptions = {
   month: 'short',
   day: 'numeric',
 };
 
-export const formatDate = (timestamp, currentLocale) => {
+const currentLocale = window.navigator.languages
+  ? window.navigator.languages[0]
+  : window.navigator.userLanguage || window.navigator.language;
+
+export const formatDate = (timestamp) => {
   const dateToday = new Date();
   const articlePublished = new Date(timestamp);
-  const locale = currentLocale || 'default';
 
   if (dateToday.toDateString() === articlePublished.toDateString()) {
-    return articlePublished.toLocaleString(locale, time_options);
+    return articlePublished.toLocaleString(currentLocale, timeOptions);
   }
-  return articlePublished.toLocaleString(locale, date_options);
+  return articlePublished.toLocaleString(currentLocale, dateOptions);
 };


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
In the [Tag Moderators](https://dev.to/connect/tag-moderators) channel, user @darksmile92 left a comment (time: June 29, 2:33 AM) about the article dates not appearing correctly in their ModCenter. Reading further, it appears it was a misunderstanding on their part; however, I went ahead and ensured that the ModCenter's `formatDate` utility function properly accounted for the user's locale.


## QA Instructions, Screenshots, Recordings

How Article Date appears for the `en-GB` (Great Britain) locale:
<img width="534" alt="article-date-GB" src="https://user-images.githubusercontent.com/32520970/86160237-74e42600-bad9-11ea-8b4e-6a42cac0f97f.png">



How Article Date appears for the `th-TH` (Thailand) locale:
<img width="549" alt="article-date-Thailand" src="https://user-images.githubusercontent.com/32520970/86160249-79a8da00-bad9-11ea-9d3b-e06522269766.png">


## Added tests?

- [ ] yes
- [X] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed


## [optional] What gif best describes this PR or how it makes you feel?

![Shaq shoulder-shimmying](https://media.giphy.com/media/43VhxnrEOQ44U/giphy.gif)
