### PR TITLE
Optimization: Default Delete Notifications Older than 3 months

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -117,7 +117,7 @@ class Notification < ApplicationRecord
       Notifications::UpdateWorker.perform_async(notifiable.id, notifiable.class.name, action)
     end
 
-    def fast_destroy_old_notifications(destroy_before_timestamp = 4.months.ago)
+    def fast_destroy_old_notifications(destroy_before_timestamp = 3.months.ago)
       sql = <<-SQL
         DELETE FROM notifications
         WHERE notifications.id IN (


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
the Notifications table has gotten quite large so we have decided to shrink the time we hold on to notification to 3 months to reduce its size and help performance. 