### PR TITLE
Optimize WelcomeNotification::Generator by only querying when necessary

### DIFF
--- a/app/services/broadcasts/welcome_notification/generator.rb
+++ b/app/services/broadcasts/welcome_notification/generator.rb
@@ -28,7 +28,7 @@ module Broadcasts
       attr_reader :user, :notification_enqueued
 
       def send_welcome_notification
-        return if received_notification?(welcome_broadcast) || commented_on_welcome_thread? || user.created_at > 3.hours.ago
+        return if user.created_at > 3.hours.ago || received_notification?(welcome_broadcast) || commented_on_welcome_thread?
 
         Notification.send_welcome_notification(user.id, welcome_broadcast.id)
         # Setting @notification_enqueued here prevents us from sending a user two welcome notifications in one day.
@@ -36,35 +36,35 @@ module Broadcasts
       end
 
       def send_authentication_notification
-        return if authenticated_with_all_providers? || received_notification?(authentication_broadcast) || user.created_at > 1.day.ago
+        return if user.created_at > 1.day.ago || authenticated_with_all_providers? || received_notification?(authentication_broadcast)
 
         Notification.send_welcome_notification(user.id, authentication_broadcast.id)
         @notification_enqueued = true
       end
 
       def send_feed_customization_notification
-        return if user_is_following_tags? || received_notification?(customize_feed_broadcast) || user.created_at > 3.days.ago
+        return if user.created_at > 3.days.ago || user_is_following_tags? || received_notification?(customize_feed_broadcast)
 
         Notification.send_welcome_notification(user.id, customize_feed_broadcast.id)
         @notification_enqueued = true
       end
 
       def send_ux_customization_notification
-        return if received_notification?(customize_ux_broadcast) || user.created_at > 5.days.ago
+        return if user.created_at > 5.days.ago || received_notification?(customize_ux_broadcast)
 
         Notification.send_welcome_notification(user.id, customize_ux_broadcast.id)
         @notification_enqueued = true
       end
 
       def send_discuss_and_ask_notification
-        return if (asked_a_question && started_a_discussion) || received_notification?(discuss_and_ask_broadcast) || user.created_at > 6.days.ago
+        return if user.created_at > 6.days.ago || (asked_a_question && started_a_discussion) || received_notification?(discuss_and_ask_broadcast)
 
         Notification.send_welcome_notification(user.id, discuss_and_ask_broadcast.id)
         @notification_enqueued = true
       end
 
       def send_download_app_notification
-        return if received_notification?(download_app_broadcast) || user.created_at > 7.days.ago
+        return if user.created_at > 7.days.ago || received_notification?(download_app_broadcast)
 
         Notification.send_welcome_notification(user.id, download_app_broadcast.id)
         @notification_enqueued = true


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Currently, the `Broadcasts::WelcomeNotification::Generator` checks a few things when it runs (once a day) before sending out welcome notifications to new users. Specifically, for each notification, it checks whether the user has already received a notification for a broadcast, as well as whether the user's `created_at` is beyond a certain date or not. Sometimes, the generator also checks for some other conditions to be met, as well.

The generator already has access to the `user` when it runs, so checking the `user.created_at` is a relatively low-effort task, and doesn't require querying the database. However, checking whether a notification for a broadcast _already exists or not_ requires querying the DB. Currently, we're doing the DB query before checking the user's `created_at`, which sometimes means we are querying when we don't even have to (if the user's `created_at` doesn't match what is in the conditional, why bother querying the database?).

This PR reorders when these checks happen so that we always lean on checking the user's `created_at` _before_ going ahead and making any other additional queries.

## Related Tickets & Documents
N/A

## QA Instructions, Screenshots, Recordings

Nothing major in terms of QA-ing here; the tests should all pass, and the only change should be a re-ordering of the conditional logic.

## Added tests?

- [ ] yes
- [x] no, because they aren't needed **(current tests cover this)**
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
