### PR TITLE
Unique IDs for hidden article_archived fields

### DIFF
--- a/app/views/dashboards/_dashboard_article_row.html.erb
+++ b/app/views/dashboards/_dashboard_article_row.html.erb
@@ -99,7 +99,7 @@
           <a href="<%= article.path %>/stats" class="crayons-link crayons-link--block w-100 border-0 bg-transparent">Stats</a>
         <% end %>
         <%= form_for(article, method: :patch, remote: true, authenticity_token: true, html: { "data-type": "json", class: "js-archive-toggle" }) do |f| %>
-          <%= f.hidden_field :archived, value: !article.archived %>
+          <%= f.hidden_field :archived, value: !article.archived, id: "article_archived_#{article.id}" %>
 
           <button type="submit" class="crayons-link crayons-link--block w-100 border-0 bg-transparent">
             <%= article.archived ? "Unarchive post" : "Archive post" %>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [X] Bug Fix (sort of)

## Description

On our dashboard the IDs for the hidden fields denoting whether or not an article is archived had non unique IDs, which leads to messages like this in the Chrome devtools:

> [DOM] Found 15 elements with non-unique id #article_archived

IDs should be unique so this PR fixes that by appending the article's id.

## Related Tickets & Documents

Closes #8941

## QA Instructions, Screenshots, Recordings

1. Go to the article dashboard (`/dashboard`)
2. Inspect the `id` attributes of the hidden `input` tags with name `article[archived]`

<img width="146" alt="Screen Shot 2020-07-01 at 14 04 36" src="https://user-images.githubusercontent.com/47985/86213783-69a9fc80-bba4-11ea-9f03-1aa656ae3fcd.png">

## Added tests?

- [X] no, because they aren't needed

## Added to documentation?

- [x] no documentation needed
