### PR TITLE
Added pragmaFrag so terse Fragment syntax, `<></>`, can be used in Preact

### DIFF
--- a/app/javascript/article-form/components/ArticleCoverImage.jsx
+++ b/app/javascript/article-form/components/ArticleCoverImage.jsx
@@ -1,4 +1,4 @@
-import { h, Component, Fragment } from 'preact';
+import { h, Component } from 'preact';
 import PropTypes from 'prop-types';
 import { generateMainImage } from '../actions';
 import { validateFileInputs } from '../../packs/validateFileInputs';
@@ -75,7 +75,7 @@ export class ArticleCoverImage extends Component {
               <Spinner /> Uploading...
             </span>
           ) : (
-            <Fragment>
+            <>
               <Button variant="outlined" className="mr-2 whitespace-nowrap">
                 <label htmlFor="cover-image-input">{uploadLabel}</label>
                 <input
@@ -95,7 +95,7 @@ export class ArticleCoverImage extends Component {
                   Remove
                 </Button>
               )}
-            </Fragment>
+            </>
           )}
         </div>
         {uploadError && (

--- a/babel.config.js
+++ b/babel.config.js
@@ -54,6 +54,7 @@ module.exports = function (api) {
         '@babel/plugin-transform-react-jsx',
         {
           pragma: 'h',
+          pragmaFrag: '"Fragment"',
         },
       ],
     ].filter(Boolean),


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds support for [terse fragment syntax support](https://babeljs.io/docs/en/next/babel-plugin-transform-react-jsx.html#pragmafrag) in Preact.

New to fragments? The Preact docs [have you covered](https://preactjs.com/guide/v10/components/#fragments).

## Related Tickets & Documents

https://github.com/thepracticaldev/dev.to/pull/9041#discussion_r448047306

## QA Instructions, Screenshots, Recordings

N/A. As long as webpack bundles without erroring out, this Babel configuration addition is good.

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![Tetris game building a heart with the pieces](https://media.giphy.com/media/f7STAwvEml1eIf0FEq/giphy.gif)
