### PR TITLE
Update Honeybadger to ignore ResizeObserver

### DIFF
--- a/app/assets/javascripts/base.js.erb
+++ b/app/assets/javascripts/base.js.erb
@@ -675,7 +675,8 @@ var instantClick
   Honeybadger.configure({
     apiKey: "<%= ApplicationConfig['HONEYBADGER_JS_API_KEY'] %>",
     environment: "<%= Rails.env %>",
-    revision: "<%= ApplicationConfig['HEROKU_SLUG_COMMIT'] %>"
+    revision: "<%= ApplicationConfig['HEROKU_SLUG_COMMIT'] %>",
+    ignorePatterns: [/ResizeObserver/i],
   });
 
 // INITIALIZE AHOY TRACKING


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] DX

## Description
We're getting a bunch of ResizeObserver errors but it is in no way related to our app. I already ignored an error on honeybadger itself, but this will block all future variations of ResizeObserver error.

## Related Tickets & Documents
https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded

## QA Instructions, Screenshots, Recordings
n/a

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
Monitor Honeybadger
