### PR TITLE
Remove report-abuse link from base HTML document into JavaScript

### DIFF
--- a/app/assets/javascripts/initializers/initializeCommentDropdown.js
+++ b/app/assets/javascripts/initializers/initializeCommentDropdown.js
@@ -110,6 +110,7 @@ function initializeCommentDropdown() {
     var dropdownContent = button.parentElement.getElementsByClassName(
       'crayons-dropdown',
     )[0];
+    finalizeAbuseReportLink(dropdownContent);
     if (dropdownContent.classList.contains('block')) {
       dropdownContent.classList.remove('block');
       removeClickListener();
@@ -127,6 +128,12 @@ function initializeCommentDropdown() {
         clipboardCopyElement.addEventListener('click', copyText);
       }
     }
+  }
+
+  function finalizeAbuseReportLink(dropdownContent) {
+    // Add actual link location (SEO doesn't like these "useless" links, so adding in here instead of in HTML)
+    var reportAbuseLink = dropdownContent.querySelector('.report-abuse-link-wrapper');
+    reportAbuseLink.innerHTML = `<a href="${reportAbuseLink.dataset.path}" class="crayons-link crayons-link--block">Report Abuse</a>`
   }
 
   function addDropdownListener(dropdown) {

--- a/app/assets/javascripts/initializers/initializeUserProfilePage.js
+++ b/app/assets/javascripts/initializers/initializeUserProfilePage.js
@@ -14,6 +14,10 @@ function initializeUserProfilePage() {
         const userProfileDropdownMenu = document.getElementById('user-profile-dropdownmenu');
         userProfileDropdownButton.addEventListener('click', () => {
           userProfileDropdownMenu.classList.toggle('showing');
+
+          // Add actual link location (SEO doesn't like these "useless" links, so adding in here instead of in HTML)
+          var reportAbuseLink = profileDropdownDiv.querySelector('.report-abuse-link-wrapper');
+          reportAbuseLink.innerHTML = `<a href="${reportAbuseLink.dataset.path}" class="crayons-link crayons-link--block">Report Abuse</a>`      
         });
       }
     }

--- a/app/views/comments/_comment_proper.html.erb
+++ b/app/views/comments/_comment_proper.html.erb
@@ -63,12 +63,12 @@
             </span>
             <% action = comment.hidden_by_commentable_user ? "Unhide" : "Hide" %>
             <span class="comment-actions hidden" data-action="hide-button" data-commentable-user-id="<%= commentable.user_id %>" data-user-id="<%= comment.user_id %>" style="display: none; width: 100%;">
-              <button class="crayons-link crayons-link--block hide-comment" data-hide-type="<%= action.downcase %>" data-comment-id="<%= comment.id %>">
+              <a href="#" class="crayons-link crayons-link--block hide-comment" data-hide-type="<%= action.downcase %>" data-comment-id="<%= comment.id %>">
                 <%= action %>
-              </button>
+              </a>
             </span>
             <span class="mod-actions hidden mod-actions-comment-button" data-path="<%= comment.path %>/mod"></span>
-            <a href="/report-abuse?url=<%= comment_url(comment) %>" class="crayons-link crayons-link--block">Report Abuse</a>
+            <span class="report-abuse-link-wrapper" data-path="/report-abuse?url=<%= comment_url(comment) %>"></span>
           </div>
         </div>
       </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -161,7 +161,7 @@
         <% if user_signed_in? %>
           <%= javascript_packs_with_chunks_tag "profileDropdown", defer: true %>
         <% end %>
-        <a href="/report-abuse?url=<%= user_url(@user) %>">Report Abuse</a>
+        <span class="report-abuse-link-wrapper" data-path="/report-abuse?url=<%= user_url(@user) %>"></span>
       </div>
     </div>
   </div>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Every comment has a "report abuse" link, which Google sees as useless and a waste of crawler resources since this isn't a link to new "content".


<img width="913" alt="Screen Shot 2020-07-01 at 2 52 25 PM" src="https://user-images.githubusercontent.com/3102842/86280868-9c56f380-bbaa-11ea-83ab-3fe4c5be5864.png">

So this PR moves that functionality such that the link does not exist until the user clicks on the dropdown menu.

In this PR, I also fixed some styling for the "hide" button, which is currently not correct.

<img width="395" alt="Screen Shot 2020-07-01 at 2 50 29 PM" src="https://user-images.githubusercontent.com/3102842/86280888-a37e0180-bbaa-11ea-8835-a35d401690b5.png">
