### PR TITLE
Add secondary_logo_url to SiteConfig

### DIFF
--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -59,6 +59,7 @@ class SiteConfig < RailsSettings::Base
   field :logo_png, type: :string, default: "https://practicaldev-herokuapp-com.freetls.fastly.net/assets/devlogo-pwa-512.png"
   field :logo_svg, type: :string, default: ""
   field :primary_sticker_image_url, type: :string, default: "https://practicaldev-herokuapp-com.freetls.fastly.net/assets/rainbowdev.svg"
+  field :secondary_logo_url, type: :string
 
   # Mascot
   field :mascot_user_id, type: :integer, default: 1


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

## Related Tickets & Documents

As discussed in PR #8435, we're going to add this config variable first so @thepracticaldev/sre can set a default before the other PR gets merged.

## QA Instructions, Screenshots, Recordings

n/a

## Added tests?

- [x] no, because they aren't needed

## Added to documentation?

- [x] no documentation needed

## Are there any post deployment tasks we need to perform?

* [ ] Set this variable to `"https://practicaldev-herokuapp-com.freetls.fastly.net/assets/rainbowdev.svg"`
