### PR TITLE
Show org dropdown for postless users

### DIFF
--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -18,7 +18,7 @@
 
         <div class="flex flex-wrap">
           <% if params[:which] != "organization" %>
-            <% if @articles.any?(:archived) %>
+            <% if @articles.any?(&:archived) %>
               <%= link_to "Show archived", "javascript:;", id: "toggleArchivedLink", class: "crayons-btn crayons-btn--outlined ml-2 whitespace-nowrap my-1" %>
             <% end %>
             <% if @articles.any? %>

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -12,7 +12,7 @@
       <%= render "actions" %>
     </aside>
 
-    <div class="crayons-layout__content">
+    <div class="crayons-layout__content flex flex-col">
       <div class="flex items-center justify-between mb-3">
         <h2 class="hidden m:block fs-l fw-heavy">Posts</h2>
 
@@ -21,8 +21,9 @@
             <% if @articles.any?(:archived) %>
               <%= link_to "Show archived", "javascript:;", id: "toggleArchivedLink", class: "crayons-btn crayons-btn--outlined ml-2 whitespace-nowrap my-1" %>
             <% end %>
-
-            <%= select_tag "dashboard_sort", options_for_select(sort_options, params[:sort]), 'aria-label': "Sort By", class: "crayons-select w-auto ml-2 my-1" %>
+            <% if @articles.any? %>
+              <%= select_tag "dashboard_sort", options_for_select(sort_options, params[:sort]), 'aria-label': "Sort By", class: "crayons-select w-auto ml-2 my-1" %>
+            <% end %>
           <% end %>
 
           <% if @organizations && @organizations.size > 0 && (params[:which].blank? || params[:which] == "organization") %>
@@ -52,7 +53,7 @@
         </div>
 
       <% else %>
-        <div class="p-9 crayons-card crayons-card--secondary align-center fs-l h-100 flex items-center justify-center">
+        <div class="p-6 m:p-9 crayons-card crayons-card--secondary align-center fs-l h-100 flex items-center justify-center flex-1">
           <div>
             <%= image_tag(cl_image_path(SiteConfig.mascot_image_url,
                                         type: "fetch",

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -13,30 +13,30 @@
     </aside>
 
     <div class="crayons-layout__content">
-      <% if @articles.any? %>
-        <div class="flex items-center justify-between mb-3">
-          <h2 class="hidden m:block fs-l fw-heavy">Posts</h2>
+      <div class="flex items-center justify-between mb-3">
+        <h2 class="hidden m:block fs-l fw-heavy">Posts</h2>
 
-          <div class="flex flex-wrap">
-            <% if params[:which] != "organization" %>
-              <% if @articles.any? {|article| article.archived } %>
-                <%= link_to "Show archived", "javascript:;", id: "toggleArchivedLink", class: "crayons-btn crayons-btn--outlined ml-2 whitespace-nowrap my-1" %>
+        <div class="flex flex-wrap">
+          <% if params[:which] != "organization" %>
+            <% if @articles.any?(:archived) %>
+              <%= link_to "Show archived", "javascript:;", id: "toggleArchivedLink", class: "crayons-btn crayons-btn--outlined ml-2 whitespace-nowrap my-1" %>
+            <% end %>
+
+            <%= select_tag "dashboard_sort", options_for_select(sort_options, params[:sort]), 'aria-label': "Sort By", class: "crayons-select w-auto ml-2 my-1" %>
+          <% end %>
+
+          <% if @organizations && @organizations.size > 0 && (params[:which].blank? || params[:which] == "organization") %>
+            <select id="dashboard_author" class="crayons-select w-auto ml-2 my-1">
+              <option value="/dashboard" <%= "selected" if params[:which].blank? %>>Personal</option>
+              <% @organizations.each do |org| %>
+                <option value="/dashboard/organization/<%= org.id %>" <%= "selected" if params[:org_id].to_i == org.id %>><%= org.name %> (<%= org.articles_count %>)</option>
               <% end %>
-
-              <%= select_tag "dashboard_sort", options_for_select(sort_options, params[:sort]), 'aria-label': "Sort By", class: "crayons-select w-auto ml-2 my-1" %>
-            <% end %>
-
-            <% if @organizations && @organizations.size > 0 && (params[:which].blank? || params[:which] == "organization") %>
-              <select id="dashboard_author" class="crayons-select w-auto ml-2 my-1">
-                <option value="/dashboard" <%= "selected" if params[:which].blank? %>>Personal</option>
-                <% @organizations.each do |org| %>
-                  <option value="/dashboard/organization/<%= org.id %>" <%= "selected" if params[:org_id].to_i == org.id %>><%= org.name %> (<%= org.articles_count %>)</option>
-                <% end %>
-              </select>
-            <% end %>
-          </div>
+            </select>
+          <% end %>
         </div>
+      </div>
 
+      <% if @articles.any? %>
         <div class="crayons-card mb-6">
           <% @articles.each do |article| %>
             <% if params[:which] == "organization" %>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Description

In `app/views/dashboards/show.html.erb` we have an `if` that removes some UI elements (post sort order and more) if the user has no posts. Alas the removed elements also include the org switcher, so org admins who don't have posts of their own won't be able to switch. I moved the `if` around as PoC, but has issues too:

1. There's now no margin between the content and the footer when the user has no posts.
2. We're displaying the sort order dropdown even if there are no articles.

I'll leave it up to @ludwiczakpawel what to do with this, i.e. add some styling here or close out this PR and open a better one, as I'm about to go offline.

## Related Tickets & Documents

Closes #9066 

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, as well
as any relevant images for UI changes._

## Added tests?

- [ ] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [ ] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
