### PR TITLE
UserSubscription liquid tag update & re-enable JS

### DIFF
--- a/app/liquid_tags/user_subscription_tag.rb
+++ b/app/liquid_tags/user_subscription_tag.rb
@@ -14,27 +14,61 @@ class UserSubscriptionTag < LiquidTagBase
     // Hiding/showing elements
     // ***************************************
     function clearSubscriptionArea() {
-      document.getElementById('subscription-signed-in')?.classList.add("hidden");
-      document.getElementById('subscription-signed-out')?.classList.add("hidden");
-      document.getElementById('response-message')?.classList.add("hidden");
-      document.getElementById('subscriber-apple-auth')?.classList.add("hidden");
+      const subscriptionSignedIn = document.getElementById('subscription-signed-in');
+      if (subscriptionSignedIn) {
+        subscriptionSignedIn.classList.add("hidden");
+      }
+
+      const subscriptionSignedOut = document.getElementById('subscription-signed-out');
+      if (subscriptionSignedOut) {
+        subscriptionSignedOut.classList.add("hidden");
+      }
+
+      const responseMessage = document.getElementById('response-message');
+      if (responseMessage) {
+        responseMessage.classList.add("hidden");
+      }
+
+      const subscriberAppleAuth = document.getElementById('subscriber-apple-auth');
+      if (subscriberAppleAuth) {
+        subscriberAppleAuth.classList.add("hidden");
+      }
 
       hideConfirmationModal();
     }
 
     function showSignedIn() {
       clearSubscriptionArea();
-      document.getElementById('subscription-signed-in')?.classList.remove("hidden");
-      document.getElementById('profile-images')?.classList.remove("signed-out");
-      document.getElementById('profile-images')?.classList.add("signed-in");
+      const subscriptionSignedIn = document.getElementById('subscription-signed-in');
+      if (subscriptionSignedIn) {
+        subscriptionSignedIn.classList.remove("hidden");
+      }
+
+      const profileImages = document.getElementById('profile-images');
+      if (profileImages) {
+        profileImages.classList.remove("signed-out");
+        profileImages.classList.add("signed-in");
+      }
     }
 
     function showSignedOut() {
       clearSubscriptionArea();
-      document.getElementById('subscription-signed-out')?.classList.remove("hidden");
-      document.getElementById('profile-images')?.classList.remove("signed-in");
-      document.getElementById('profile-images')?.classList.add("signed-out");
-      document.querySelector('.ltag__user-subscription-tag__subscriber-profile-image')?.classList.add("hidden");
+
+      const subscriptionSignedOut = document.getElementById('subscription-signed-out');
+      if (subscriptionSignedOut) {
+        subscriptionSignedOut.classList.remove("hidden");
+      }
+
+      const profileImages = document.getElementById('profile-images');
+      if (profileImages) {
+        profileImages.classList.remove("signed-in");
+        profileImages.classList.add("signed-out");
+      }
+
+      const subscriberProfileImage = document.querySelector('.ltag__user-subscription-tag__subscriber-profile-image');
+      if (subscriberProfileImage) {
+        subscriberProfileImage.classList.add("hidden");
+      }
     }
 
     function showResponseMessage(noticeType, msg) {
@@ -49,7 +83,15 @@ class UserSubscriptionTag < LiquidTagBase
 
     function showAppleAuthMessage() {
       clearSubscriptionArea();
-      document.getElementById('subscriber-apple-auth')?.classList.remove("hidden");
+      const subscriber = userData();
+      if (subscriber) {
+        updateProfileImages('.ltag__user-subscription-tag__subscriber-profile-image', subscriber);
+      }
+
+      const subscriberAppleAuth = document.getElementById('subscriber-apple-auth');
+      if (subscriberAppleAuth) {
+        subscriberAppleAuth.classList.remove("hidden");
+      }
     }
 
     function showSubscribed() {
@@ -60,18 +102,23 @@ class UserSubscriptionTag < LiquidTagBase
     }
 
     function showConfirmationModal() {
-      document.getElementById('user-subscription-confirmation-modal')?.classList.remove("hidden");
+      const confirmationModal = document.getElementById('user-subscription-confirmation-modal');
+      if (confirmationModal) {
+        confirmationModal.classList.remove("hidden");
+      }
     }
 
     function hideConfirmationModal() {
-      document.getElementById('user-subscription-confirmation-modal')?.classList.add("hidden");
+      const confirmationModal = document.getElementById('user-subscription-confirmation-modal');
+      if (confirmationModal) {
+        confirmationModal.classList.add("hidden");
+      }
     }
 
     // Updating DOM elements
     // ***************************************
     function updateSubscriberData() {
       const subscriber = userData();
-
       if (subscriber.email) {
         updateElementsTextContent('.ltag__user-subscription-tag__subscriber-email', subscriber.email);
       }
@@ -99,29 +146,42 @@ class UserSubscriptionTag < LiquidTagBase
     // Adding event listeners for 'click'
     // ***************************************
     function addSignInClickHandler() {
-      document.getElementById('sign-in-btn')?.addEventListener('click', function(e) {
-        if (typeof showModal !== 'undefined') {
+      const signInBtn = document.getElementById('sign-in-btn');
+      if (signInBtn && typeof showModal !== 'undefined') {
+        signInBtn.addEventListener('click', function(e) {
           showModal('email_signup');
-        }
-      });
+        });
+      }
     }
 
     function addConfirmationModalClickHandlers() {
-      document.getElementById('subscribe-btn')?.addEventListener('click', function(e) {
-        showConfirmationModal();
-      });
+      const subscribeBtn = document.getElementById('subscribe-btn');
+      if (subscribeBtn) {
+        subscribeBtn.addEventListener('click', function(e) {
+          showConfirmationModal();
+        });
+      }
 
-      document.getElementById('cancel-btn')?.addEventListener('click', function(e) {
-        hideConfirmationModal();
-      });
+      const cancelBtn = document.getElementById('cancel-btn');
+      if (cancelBtn) {
+        cancelBtn.addEventListener('click', function(e) {
+          hideConfirmationModal();
+        });
+      }
 
-      document.getElementById('close-confirmation-modal')?.addEventListener('click', function(e) {
-        hideConfirmationModal();
-      });
+      const closeConfirmationModal = document.getElementById('close-confirmation-modal');
+      if (closeConfirmationModal) {
+        closeConfirmationModal.addEventListener('click', function(e) {
+          hideConfirmationModal();
+        });
+      }
 
-      document.getElementById('confirmation-btn')?.addEventListener('click', function(e) {
-        handleSubscription();
-      });
+      const confirmationModal = document.getElementById('confirmation-btn')
+      if (confirmationModal) {
+        confirmationModal.addEventListener('click', function(e) {
+          handleSubscription();
+        });
+      }
     }
 
     // API calls
@@ -133,7 +193,9 @@ class UserSubscriptionTag < LiquidTagBase
         'Content-Type': 'application/json',
       }
 
-      const articleId = document.getElementById('article-body')?.dataset.articleId;
+      const articleBody = document.getElementById('article-body');
+      const articleId = (articleBody ? articleBody.dataset.articleId : null);
+
       const subscriber = userData();
       const body = JSON.stringify(
           {
@@ -156,7 +218,8 @@ class UserSubscriptionTag < LiquidTagBase
     }
 
     function fetchIsSubscribed() {
-      const articleId = document.getElementById('article-body')?.dataset.articleId;
+      const articleBody = document.getElementById('article-body');
+      const articleId = (articleBody ? articleBody.dataset.articleId : null);
 
       const params = new URLSearchParams({
         source_type: 'Article',
@@ -187,7 +250,8 @@ class UserSubscriptionTag < LiquidTagBase
     function handleSubscription() {
       submitSubscription().then(function(response) {
         if (response.success) {
-          const authorUsername = document.getElementById('user-subscription-tag')?.dataset.authorUsername;
+          const userSubscriptionTag = document.getElementById('user-subscription-tag');
+          const authorUsername = (userSubscriptionTag ? userSubscriptionTag.dataset.authorUsername : null);
           const successMsg = `You are now subscribed and may receive emails from ${authorUsername}`;
           showResponseMessage('success', successMsg);
         } else {
@@ -199,7 +263,7 @@ class UserSubscriptionTag < LiquidTagBase
     function checkIfSubscribed() {
       fetchIsSubscribed().then(function(response) {
         const subscriber = userData();
-        const isSubscriberAuthedWithApple = subscriber.email?.endsWith('@privaterelay.appleid.com');
+        const isSubscriberAuthedWithApple = (subscriber.email ? subscriber.email.endsWith('@privaterelay.appleid.com') : false);
 
         if (response.is_subscribed) {
           showSubscribed();

--- a/app/liquid_tags/user_subscription_tag.rb
+++ b/app/liquid_tags/user_subscription_tag.rb
@@ -13,43 +13,33 @@ class UserSubscriptionTag < LiquidTagBase
 
     // Hiding/showing elements
     // ***************************************
-
-    const subscriptionSignedIn = document.getElementById('subscription-signed-in');
-    const subscriptionSignedOut = document.getElementById('subscription-signed-out');
-    const responseMessage = document.getElementById('response-message');
-    const subscriberAppleAuth = document.getElementById('subscriber-apple-auth');
-    const confirmationModal = document.getElementById('user-subscription-confirmation-modal');
-    const profileImageContainer = document.getElementById('profile-images');
-    const subscriberImageContainer = document.querySelector('.ltag__user-subscription-tag__subscriber-profile-image');
-
     function clearSubscriptionArea() {
-      subscriptionSignedIn?.classList.add("hidden");
-      subscriptionSignedOut?.classList.add("hidden");
-      responseMessage?.classList.add("hidden");
-      subscriberAppleAuth?.classList.add("hidden");
+      document.getElementById('subscription-signed-in')?.classList.add("hidden");
+      document.getElementById('subscription-signed-out')?.classList.add("hidden");
+      document.getElementById('response-message')?.classList.add("hidden");
+      document.getElementById('subscriber-apple-auth')?.classList.add("hidden");
 
       hideConfirmationModal();
     }
 
     function showSignedIn() {
       clearSubscriptionArea();
-
-      subscriptionSignedIn?.classList.remove("hidden");
-      profileImageContainer?.classList.remove("signed-out");
-      profileImageContainer?.classList.add("signed-in");
+      document.getElementById('subscription-signed-in')?.classList.remove("hidden");
+      document.getElementById('profile-images')?.classList.remove("signed-out");
+      document.getElementById('profile-images')?.classList.add("signed-in");
     }
 
     function showSignedOut() {
       clearSubscriptionArea();
-      subscriptionSignedOut?.classList.remove("hidden");
-      profileImageContainer?.classList.remove("signed-in");
-      profileImageContainer?.classList.add("signed-out");
-      subscriberImageContainer?.classList.add("hidden");
+      document.getElementById('subscription-signed-out')?.classList.remove("hidden");
+      document.getElementById('profile-images')?.classList.remove("signed-in");
+      document.getElementById('profile-images')?.classList.add("signed-out");
+      document.querySelector('.ltag__user-subscription-tag__subscriber-profile-image')?.classList.add("hidden");
     }
 
     function showResponseMessage(noticeType, msg) {
       clearSubscriptionArea();
-
+      const responseMessage = document.getElementById('response-message');
       if (responseMessage) {
         responseMessage.classList.remove("hidden");
         responseMessage.classList.add(`crayons-notice--${noticeType}`);
@@ -59,7 +49,7 @@ class UserSubscriptionTag < LiquidTagBase
 
     function showAppleAuthMessage() {
       clearSubscriptionArea();
-      subscriberAppleAuth?.classList.remove("hidden");
+      document.getElementById('subscriber-apple-auth')?.classList.remove("hidden");
     }
 
     function showSubscribed() {
@@ -70,11 +60,11 @@ class UserSubscriptionTag < LiquidTagBase
     }
 
     function showConfirmationModal() {
-      confirmationModal?.classList.remove("hidden");
+      document.getElementById('user-subscription-confirmation-modal')?.classList.remove("hidden");
     }
 
     function hideConfirmationModal() {
-      confirmationModal?.classList.add("hidden");
+      document.getElementById('user-subscription-confirmation-modal')?.classList.add("hidden");
     }
 
     // Updating DOM elements

--- a/app/liquid_tags/user_subscription_tag.rb
+++ b/app/liquid_tags/user_subscription_tag.rb
@@ -23,10 +23,10 @@ class UserSubscriptionTag < LiquidTagBase
     const subscriberImageContainer = document.querySelector('.ltag__user-subscription-tag__subscriber-profile-image');
 
     function clearSubscriptionArea() {
-      subscriptionSignedIn.classList.add("hidden");
-      subscriptionSignedOut.classList.add("hidden");
-      responseMessage.classList.add("hidden");
-      subscriberAppleAuth.classList.add("hidden");
+      subscriptionSignedIn?.classList.add("hidden");
+      subscriptionSignedOut?.classList.add("hidden");
+      responseMessage?.classList.add("hidden");
+      subscriberAppleAuth?.classList.add("hidden");
 
       hideConfirmationModal();
     }
@@ -34,41 +34,47 @@ class UserSubscriptionTag < LiquidTagBase
     function showSignedIn() {
       clearSubscriptionArea();
 
-      subscriptionSignedIn.classList.remove("hidden");
-      profileImageContainer.classList.remove("signed-out");
+      subscriptionSignedIn?.classList.remove("hidden");
+      profileImageContainer?.classList.remove("signed-out");
+      profileImageContainer?.classList.add("signed-in");
     }
 
     function showSignedOut() {
       clearSubscriptionArea();
-      subscriptionSignedOut.classList.remove("hidden");
+      subscriptionSignedOut?.classList.remove("hidden");
+      profileImageContainer?.classList.remove("signed-in");
+      profileImageContainer?.classList.add("signed-out");
+      subscriberImageContainer?.classList.add("hidden");
     }
 
     function showResponseMessage(noticeType, msg) {
       clearSubscriptionArea();
 
-      responseMessage.classList.remove("hidden");
-      responseMessage.classList.add(`crayons-notice--${noticeType}`);
-      responseMessage.textContent = msg;
+      if (responseMessage) {
+        responseMessage.classList.remove("hidden");
+        responseMessage.classList.add(`crayons-notice--${noticeType}`);
+        responseMessage.textContent = msg;
+      }
     }
 
     function showAppleAuthMessage() {
       clearSubscriptionArea();
-      subscriberAppleAuth.classList.remove("hidden");
+      subscriberAppleAuth?.classList.remove("hidden");
     }
 
     function showSubscribed() {
       updateSubscriberData();
-      const authorUsername = document.getElementById('user-subscription-tag').dataset.authorUsername;
+      const authorUsername = document.getElementById('user-subscription-tag')?.dataset.authorUsername;
       const alreadySubscribedMsg = `You are already subscribed.`;
       showResponseMessage('success', alreadySubscribedMsg);
     }
 
     function showConfirmationModal() {
-      confirmationModal.classList.remove("hidden");
+      confirmationModal?.classList.remove("hidden");
     }
 
     function hideConfirmationModal() {
-      confirmationModal.classList.add("hidden");
+      confirmationModal?.classList.add("hidden");
     }
 
     // Updating DOM elements
@@ -76,10 +82,11 @@ class UserSubscriptionTag < LiquidTagBase
     function updateSubscriberData() {
       const subscriber = userData();
 
-      if (subscriber) {
+      if (subscriber.email) {
         updateElementsTextContent('.ltag__user-subscription-tag__subscriber-email', subscriber.email);
-        updateProfileImages('.ltag__user-subscription-tag__subscriber-profile-image', subscriber);
       }
+
+      updateProfileImages('.ltag__user-subscription-tag__subscriber-profile-image', subscriber);
     }
 
     function updateElementsTextContent(identifier, value) {
@@ -102,7 +109,7 @@ class UserSubscriptionTag < LiquidTagBase
     // Adding event listeners for 'click'
     // ***************************************
     function addSignInClickHandler() {
-      document.getElementById('sign-in-btn').addEventListener('click', function(e) {
+      document.getElementById('sign-in-btn')?.addEventListener('click', function(e) {
         if (typeof showModal !== 'undefined') {
           showModal('email_signup');
         }
@@ -110,19 +117,19 @@ class UserSubscriptionTag < LiquidTagBase
     }
 
     function addConfirmationModalClickHandlers() {
-      document.getElementById('subscribe-btn').addEventListener('click', function(e) {
+      document.getElementById('subscribe-btn')?.addEventListener('click', function(e) {
         showConfirmationModal();
       });
 
-      document.getElementById('cancel-btn').addEventListener('click', function(e) {
+      document.getElementById('cancel-btn')?.addEventListener('click', function(e) {
         hideConfirmationModal();
       });
 
-      document.getElementById('close-confirmation-modal').addEventListener('click', function(e) {
+      document.getElementById('close-confirmation-modal')?.addEventListener('click', function(e) {
         hideConfirmationModal();
       });
 
-      document.getElementById('confirmation-btn').addEventListener('click', function(e) {
+      document.getElementById('confirmation-btn')?.addEventListener('click', function(e) {
         handleSubscription();
       });
     }
@@ -136,7 +143,7 @@ class UserSubscriptionTag < LiquidTagBase
         'Content-Type': 'application/json',
       }
 
-      const articleId = document.getElementById('article-body').dataset.articleId;
+      const articleId = document.getElementById('article-body')?.dataset.articleId;
       const subscriber = userData();
       const body = JSON.stringify(
           {
@@ -159,7 +166,7 @@ class UserSubscriptionTag < LiquidTagBase
     }
 
     function fetchIsSubscribed() {
-      const articleId = document.getElementById('article-body').dataset.articleId;
+      const articleId = document.getElementById('article-body')?.dataset.articleId;
 
       const params = new URLSearchParams({
         source_type: 'Article',
@@ -190,7 +197,7 @@ class UserSubscriptionTag < LiquidTagBase
     function handleSubscription() {
       submitSubscription().then(function(response) {
         if (response.success) {
-          const authorUsername = document.getElementById('user-subscription-tag').dataset.authorUsername;
+          const authorUsername = document.getElementById('user-subscription-tag')?.dataset.authorUsername;
           const successMsg = `You are now subscribed and may receive emails from ${authorUsername}`;
           showResponseMessage('success', successMsg);
         } else {
@@ -202,7 +209,7 @@ class UserSubscriptionTag < LiquidTagBase
     function checkIfSubscribed() {
       fetchIsSubscribed().then(function(response) {
         const subscriber = userData();
-        const isSubscriberAuthedWithApple = subscriber.email.endsWith('@privaterelay.appleid.com');
+        const isSubscriberAuthedWithApple = subscriber.email?.endsWith('@privaterelay.appleid.com');
 
         if (response.is_subscribed) {
           showSubscribed();
@@ -218,8 +225,6 @@ class UserSubscriptionTag < LiquidTagBase
     if (isUserSignedIn()) {
       showSignedIn();
       addConfirmationModalClickHandlers();
-      profileImageContainer.classList.remove("signed-out");
-      profileImageContainer.classList.add("signed-in");
 
       // We need access to some DOM elements (i.e. csrf token, article id, userData, etc.)
       document.addEventListener('DOMContentLoaded', function() {
@@ -228,9 +233,6 @@ class UserSubscriptionTag < LiquidTagBase
     } else {
       showSignedOut();
       addSignInClickHandler();
-      profileImageContainer.classList.remove("signed-in");
-      profileImageContainer.classList.add("signed-out");
-      subscriberImageContainer.classList.add("hidden");
     }
   JAVASCRIPT
 

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -254,6 +254,6 @@
     <%== PollTag.script %>
     <%== RunkitTag.script %>
     <%== TweetTag.script %>
-    <%#== UserSubscriptionTag.script %>
+    <%== UserSubscriptionTag.script %>
   </script>
 <% end %>

--- a/app/views/liquids/_user_subscription.html.erb
+++ b/app/views/liquids/_user_subscription.html.erb
@@ -43,7 +43,7 @@
         </div>
 
         <div class="ltag__user-subscription-tag__apple-auth fs-s hidden" id="subscriber-apple-auth">
-          <button disabled class="crayons-btn" id="subscribe-btn">Subscribe</button>
+          <button disabled class="crayons-btn" id="apple-subscribe-btn">Subscribe</button>
           <div class="fs-s" id="apple-auth-message">
             Hey, there! It looks like when you created your DEV account you signed
             up with Apple using a private relay email address. If you'd like to

--- a/app/views/liquids/_user_subscription.html.erb
+++ b/app/views/liquids/_user_subscription.html.erb
@@ -71,9 +71,8 @@
           </header>
           <div class="crayons-modal__box__body">
             <p id="confirmation-text" class="fs-base mb-4 mt-0">
-              You'll share your email address
-              <span class="ltag__user-subscription-tag__subscriber-email"></span>
-              with
+              You'll share your email address<span class="ltag__user-subscription-tag__subscriber-email"></span>,
+              username, name, and DEV profile URL with
               <span class="ltag__user-subscription-tag__author-username fw-medium"><%= author_username %></span>.
               Once you do this, you cannot undo this.
             <p>

--- a/spec/liquid_tags/user_subscription_tag_spec.rb
+++ b/spec/liquid_tags/user_subscription_tag_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe UserSubscriptionTag, type: :liquid_tag, js: true do
+  setup { Liquid::Template.register_tag("user_subscription", described_class) }
+
+  let(:subscriber) { create(:user) }
+  let(:author) { create(:user, :super_admin) }
+  let(:source) { create(:article, user: author) }
+  let(:liquid_tag_options) { { source: source, user: source.user } }
+
+  def generate_user_subscription_tag(cta_text = nil)
+    Liquid::Template.parse("{% user_subscription #{cta_text} %}", liquid_tag_options)
+  end
+
+  context "when rendering" do
+    it "renders default data correctly" do
+      cta_text = "Some sweet CTA text"
+      liquid = generate_user_subscription_tag(cta_text)
+      expect(liquid.render).to include(CGI.escapeHTML(cta_text))
+      expect(liquid.render).to include(CGI.escapeHTML(author.username))
+      expect(liquid.render).to include(CGI.escapeHTML(author.profile_image_90))
+    end
+
+    it "displays signed out view by default" do
+    end
+  end
+
+  context "when signed in" do
+    it "goes through the subscribe flow" do
+    end
+  end
+
+  context "when signed out" do
+    it "prompts a user to sign in when they're signed out" do
+    end
+  end
+
+  context "when there's an error subscribing" do
+    it "shows the error flow when there's an error creating a subscription" do
+    end
+  end
+
+  context "when a user has an Apple private relay email address" do
+    it "prompts the user to update their email address" do
+    end
+  end
+end

--- a/spec/liquid_tags/user_subscription_tag_spec.rb
+++ b/spec/liquid_tags/user_subscription_tag_spec.rb
@@ -1,47 +1,107 @@
 require "rails_helper"
 
-RSpec.describe UserSubscriptionTag, type: :liquid_tag, js: true do
+RSpec.describe UserSubscriptionTag, type: :liquid_tag do
   setup { Liquid::Template.register_tag("user_subscription", described_class) }
 
   let(:subscriber) { create(:user) }
-  let(:author) { create(:user, :super_admin) }
-  let(:source) { create(:article, user: author) }
-  let(:liquid_tag_options) { { source: source, user: source.user } }
-
-  def generate_user_subscription_tag(cta_text = nil)
-    Liquid::Template.parse("{% user_subscription #{cta_text} %}", liquid_tag_options)
-  end
+  let(:author) { create(:user, :super_admin) } # TODO: (Alex Smith) - update roles before release
+  let(:article_with_user_subscription_tag) { create(:article, :with_user_subscription_tag_role_user, with_user_subscription_tag: true) }
 
   context "when rendering" do
     it "renders default data correctly" do
+      source = create(:article, user: author)
+      liquid_tag_options = { source: source, user: source.user }
       cta_text = "Some sweet CTA text"
-      liquid = generate_user_subscription_tag(cta_text)
-      expect(liquid.render).to include(CGI.escapeHTML(cta_text))
-      expect(liquid.render).to include(CGI.escapeHTML(author.username))
-      expect(liquid.render).to include(CGI.escapeHTML(author.profile_image_90))
+      liquid_tag = Liquid::Template.parse("{% user_subscription #{cta_text} %}", liquid_tag_options).render
+      expect(liquid_tag).to include(CGI.escapeHTML(cta_text))
+      expect(liquid_tag).to include(CGI.escapeHTML(author.username))
+      expect(liquid_tag).to include(CGI.escapeHTML(author.profile_image_90))
     end
 
-    it "displays signed out view by default" do
-    end
-  end
+    it "displays signed out view by default", type: :system, js: true do
+      sign_in author
+      visit "/new" # Preview behaves differently - we don't load liquid tag scripts
+      fill_in "article_body_markdown", with: "{% user_subscription Some sweet CTA text %}"
+      page.execute_script("window.scrollTo(0, -100000)")
+      find("button", text: /\APreview\z/).click
 
-  context "when signed in" do
-    it "goes through the subscribe flow" do
-    end
-  end
-
-  context "when signed out" do
-    it "prompts a user to sign in when they're signed out" do
-    end
-  end
-
-  context "when there's an error subscribing" do
-    it "shows the error flow when there's an error creating a subscription" do
+      expect(page).to have_css("#subscription-signed-in", visible: :hidden)
+      expect(page).to have_css("#subscription-signed-out", visible: :visible)
+      expect(page).to have_css("img.ltag__user-subscription-tag__author-profile-image[src='#{author.profile_image_90}']")
     end
   end
 
-  context "when a user has an Apple private relay email address" do
+  context "when signed in", type: :system, js: true do
+    before do
+      sign_in subscriber
+      visit article_with_user_subscription_tag.path
+    end
+
+    it "shows the signed in UX" do
+      expect(page).to have_css("#subscription-signed-out", visible: :hidden)
+      expect(page).to have_css("#subscription-signed-in", visible: :visible)
+      expect(page).to have_css("img.ltag__user-subscription-tag__subscriber-profile-image[src='#{subscriber.profile_image_90}']")
+    end
+
+    it "asks the user to confirm their subscription" do
+      expect(page).to have_css("#user-subscription-confirmation-modal", visible: :hidden)
+      click_button("Subscribe", id: "subscribe-btn")
+      expect(page).to have_css("#user-subscription-confirmation-modal", visible: :visible)
+    end
+
+    it "displays a sucess mesage when a subscription is created" do
+      expect(page).to have_css("#response-message", visible: :hidden)
+      click_button("Subscribe", id: "subscribe-btn")
+      click_button("Confirm subscription", id: "confirmation-btn")
+      expect(page).to have_css("#response-message.crayons-notice--success", visible: :visible)
+
+      within "#response-message" do
+        expect(page).to have_text("You are now subscribed")
+      end
+    end
+
+    it "displays errors when there's an error creating a subscription" do
+      # Create a subscription so it causes an error by already being subscribed
+      create(:user_subscription,
+             subscriber_id: subscriber.id,
+             subscriber_email: subscriber.email,
+             author_id: article_with_user_subscription_tag.user_id,
+             user_subscription_sourceable: article_with_user_subscription_tag)
+
+      expect(page).to have_css("#response-message", visible: :hidden)
+      click_button("Subscribe", id: "subscribe-btn")
+      click_button("Confirm subscription", id: "confirmation-btn")
+      expect(page).to have_css("#response-message.crayons-notice--danger", visible: :visible)
+
+      within "#response-message" do
+        expect(page).to have_text("Subscriber has already been taken")
+      end
+    end
+  end
+
+  context "when signed out", type: :sytem, js: true do
+    before { visit article_with_user_subscription_tag.path }
+
+    it "prompts a user to sign in when they're signed out", type: :system, js: true do
+      expect(page).to have_css("#subscription-signed-out", visible: :visible)
+      expect(page).to have_css("#subscription-signed-in", visible: :hidden)
+    end
+  end
+
+  # TODO: [@thepracticaldev/delightful]: re-enable this once email confirmation is re-enabled
+  xcontext "when a user has an Apple private relay email address", type: :system, js: true do
     it "prompts the user to update their email address" do
+      subscriber_with_apple_relay = create(:user, email: "test@privaterelay.appleid.com")
+      sign_in subscriber_with_apple_relay
+      visit article_with_user_subscription_tag.path
+
+      expect(page).to have_css("#subscription-signed-out", visible: :hidden)
+      expect(page).to have_css("#subscription-signed-in", visible: :hidden)
+      expect(page).to have_css("#subscriber-apple-auth", visible: :visible)
+
+      within "#subscriber-apple-auth" do
+        expect(page).to have_button("Subscribe", disabled: true, visible: :visible)
+      end
     end
   end
 end

--- a/spec/liquid_tags/user_subscription_tag_spec.rb
+++ b/spec/liquid_tags/user_subscription_tag_spec.rb
@@ -110,15 +110,17 @@ RSpec.describe UserSubscriptionTag, type: :liquid_tag do
     end
   end
 
-  # TODO: [@thepracticaldev/delightful]: re-enable this once email confirmation is re-enabled
+  # TODO: [@thepracticaldev/delightful]: re-enable this once email confirmation
+  # is re-enabled and confirm it isn't flaky.
   xcontext "when a user has an Apple private relay email address", type: :system, js: true do
     it "prompts the user to update their email address" do
-      subscriber_with_apple_relay = create(:user, email: "test@privaterelay.appleid.com")
-      sign_in subscriber_with_apple_relay
+      allow(subscriber).to receive(:email).and_return("test@privaterelay.appleid.com")
+      sign_in subscriber
       visit article_with_user_subscription_tag.path
 
       expect(page).to have_css("#subscription-signed-out", visible: :hidden)
       expect(page).to have_css("#subscription-signed-in", visible: :hidden)
+      expect(page).to have_css("#response-message", visible: :hidden)
       expect(page).to have_css("#subscriber-apple-auth", visible: :visible)
 
       within "#subscriber-apple-auth" do

--- a/spec/liquid_tags/user_subscription_tag_spec.rb
+++ b/spec/liquid_tags/user_subscription_tag_spec.rb
@@ -26,6 +26,8 @@ RSpec.describe UserSubscriptionTag, type: :liquid_tag do
       find("button", text: /\APreview\z/).click
 
       expect(page).to have_css("#subscription-signed-in", visible: :hidden)
+      expect(page).to have_css("#subscriber-apple-auth", visible: :hidden)
+      expect(page).to have_css("#response-message", visible: :hidden)
       expect(page).to have_css("#subscription-signed-out", visible: :visible)
       expect(page).to have_css("img.ltag__user-subscription-tag__author-profile-image[src='#{author.profile_image_90}']")
     end
@@ -39,6 +41,8 @@ RSpec.describe UserSubscriptionTag, type: :liquid_tag do
 
     it "shows the signed in UX" do
       expect(page).to have_css("#subscription-signed-out", visible: :hidden)
+      expect(page).to have_css("#subscriber-apple-auth", visible: :hidden)
+      expect(page).to have_css("#response-message", visible: :hidden)
       expect(page).to have_css("#subscription-signed-in", visible: :visible)
       expect(page).to have_css("img.ltag__user-subscription-tag__subscriber-profile-image[src='#{subscriber.profile_image_90}']")
     end
@@ -50,9 +54,13 @@ RSpec.describe UserSubscriptionTag, type: :liquid_tag do
     end
 
     it "displays a sucess mesage when a subscription is created" do
+      expect(page).to have_css("#subscription-signed-out", visible: :hidden)
+      expect(page).to have_css("#subscriber-apple-auth", visible: :hidden)
       expect(page).to have_css("#response-message", visible: :hidden)
+      expect(page).to have_css("#subscription-signed-in", visible: :visible)
       click_button("Subscribe", id: "subscribe-btn")
       click_button("Confirm subscription", id: "confirmation-btn")
+      expect(page).to have_css("#subscription-signed-in", visible: :hidden)
       expect(page).to have_css("#response-message.crayons-notice--success", visible: :visible)
 
       within "#response-message" do
@@ -62,19 +70,31 @@ RSpec.describe UserSubscriptionTag, type: :liquid_tag do
 
     it "displays errors when there's an error creating a subscription" do
       # Create a subscription so it causes an error by already being subscribed
-      create(:user_subscription,
-             subscriber_id: subscriber.id,
-             subscriber_email: subscriber.email,
-             author_id: article_with_user_subscription_tag.user_id,
-             user_subscription_sourceable: article_with_user_subscription_tag)
-
+      create(:user_subscription, subscriber_id: subscriber.id, subscriber_email: subscriber.email, author_id: article_with_user_subscription_tag.user_id, user_subscription_sourceable: article_with_user_subscription_tag)
+      expect(page).to have_css("#subscription-signed-out", visible: :hidden)
+      expect(page).to have_css("#subscriber-apple-auth", visible: :hidden)
       expect(page).to have_css("#response-message", visible: :hidden)
+      expect(page).to have_css("#subscription-signed-in", visible: :visible)
       click_button("Subscribe", id: "subscribe-btn")
       click_button("Confirm subscription", id: "confirmation-btn")
+      expect(page).to have_css("#subscription-signed-in", visible: :hidden)
       expect(page).to have_css("#response-message.crayons-notice--danger", visible: :visible)
 
       within "#response-message" do
         expect(page).to have_text("Subscriber has already been taken")
+      end
+    end
+
+    it "tells the user they're already subscribed by default if they're already subscribed" do
+      create(:user_subscription, subscriber_id: subscriber.id, subscriber_email: subscriber.email, author_id: article_with_user_subscription_tag.user_id, user_subscription_sourceable: article_with_user_subscription_tag)
+      visit article_with_user_subscription_tag.path
+      expect(page).to have_css("#subscription-signed-out", visible: :hidden)
+      expect(page).to have_css("#subscription-signed-in", visible: :hidden)
+      expect(page).to have_css("#subscriber-apple-auth", visible: :hidden)
+      expect(page).to have_css("#response-message.crayons-notice--success", visible: :visible)
+
+      within "#response-message" do
+        expect(page).to have_text("You are already subscribed.")
       end
     end
   end
@@ -83,8 +103,10 @@ RSpec.describe UserSubscriptionTag, type: :liquid_tag do
     before { visit article_with_user_subscription_tag.path }
 
     it "prompts a user to sign in when they're signed out", type: :system, js: true do
-      expect(page).to have_css("#subscription-signed-out", visible: :visible)
       expect(page).to have_css("#subscription-signed-in", visible: :hidden)
+      expect(page).to have_css("#response-message", visible: :hidden)
+      expect(page).to have_css("#subscriber-apple-auth", visible: :hidden)
+      expect(page).to have_css("#subscription-signed-out", visible: :visible)
     end
   end
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
This PR cleans up the UserSubscription liquid tag now that we have designs/markup completed. The updates include:
- Making the availability of the subscriber's email completely conditional now that we've postponed that functionality.
- Make the JS null safe.
- Specs 🎉 . Given the way we handle JS for liquid tags with "raw strings", I chose to use Capybara to test this tag.

## Related Tickets & Documents
Closes #9023 

## QA Instructions, Screenshots, Recordings
**Open up your browser console and navigate around (i.e. click articles that don't have this liquid tag) and make sure you don't see any JS errors related to the liquid tag.** You'll likely see a few errors related to 3rd party services like Pusher or Cloudinary, but you shouldn't see any from this tag, especially about `null` references.

**Steps**
1. Make sure you're signed in locally as an admin user.
2. Write a post and include the liquid tag `{% user_subscription Some sweet CTA text %}`.
3. Preview and publish your Article.
4. View your Article.
5. Subscribe to yourself (allowing this behavior is intentional).
6. Refresh the Article (you should still see confirmation that you're already subscribed).
7. Sign out.
8. Revisit the Article (you should see the "sign-in" UX).
9. Sign back in via the `Sign in` button (you should see confirmation that you're already subscribed).

That's it 🎉 .

_Heads up: if you are testing and using an article you previously created locally with this liquid tag, you need to edit the article and re-publish/re-save it so the new markup is rendered._

## Added tests?
- [x] yes

## Added to documentation?
- [x] no documentation needed - _I'll include documentation for this liquid tag in the final PR_

![exhausted_gif](https://media.giphy.com/media/HwmDZaI4YEeZ2/giphy.gif)
