### PR TITLE
Allow organization owners to use the Automatic Rebase workflow

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -6,7 +6,10 @@ name: Automatic Rebase
 jobs:
   rebase:
     name: Rebase
-    if: github.event.issue.pull_request != '' && startsWith(github.event.comment.body, '/rebase') && github.event.comment.author_association == 'MEMBER'
+    if: contains(github.event.comment.html_url, '/pull/') &&
+      startsWith(github.event.comment.body, '/rebase') &&
+      (github.event.comment.author_association == 'MEMBER' ||
+      github.event.comment.author_association == 'OWNER')
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -1,4 +1,9 @@
-# https://github.com/marketplace/actions/automatic-rebase  (https://github.com/cirrus-actions/rebase)
+# This workflow allows an organization member or owner to kickoff an automated
+# rebase by commenting on a pull request with "/rebase". In order for the
+# workflow to run, organization membership must be set to public!
+
+# https://github.com/marketplace/actions/automatic-rebase (https://github.com/cirrus-actions/rebase)
+
 on:
   issue_comment:
     types: [created]


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

I think that as it is currently written, @benhalpern or other org owners couldn't actually kick off the automatic rebase workflow added in #9018. This should fix that issue!

Additionally, I changed the logic for determining if the comment was on a pull request, this method relies on the URL, but I believe it's more explicit and more readable than the previous method.

It also adds an explanatory comment to the yaml file, documenting that one's organization membership must be public for the workflow to trigger.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, as well
as any relevant images for UI changes._

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
