### PR TITLE
Change Highlight Tags to mark instead of em

### DIFF
--- a/app/services/search/query_builders/feed_content.rb
+++ b/app/services/search/query_builders/feed_content.rb
@@ -85,7 +85,7 @@ module Search
       end
 
       def add_highlight_fields
-        highlight_fields = { encoder: "html", fields: {} }
+        highlight_fields = { encoder: "html", pre_tags: "<mark>", post_tags: "</mark>", fields: {} }
         HIGHLIGHT_FIELDS.each do |field_name|
           # This hash can be filled with options to further customize our highlighting
           # https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#request-body-search-highlighting

--- a/spec/services/broadcasts/welcome_notification/generator_spec.rb
+++ b/spec/services/broadcasts/welcome_notification/generator_spec.rb
@@ -17,16 +17,11 @@ RSpec.describe Broadcasts::WelcomeNotification::Generator, type: :service do
     omniauth_mock_providers_payload
     allow(Notification).to receive(:send_welcome_notification).and_call_original
     allow(User).to receive(:mascot_account).and_return(mascot_account)
-    SiteConfig.staff_user_id = mascot_account.id
-  end
-
-  after do
-    # SiteConfig.clear_cache should work here but for some reason it isn't
-    SiteConfig.staff_user_id = 1
+    allow(SiteConfig).to receive(:staff_user_id).and_return(mascot_account.id)
   end
 
   it "requires a valid user id" do
-    expect { described_class.call(1) }.to raise_error(ActiveRecord::RecordNotFound)
+    expect { described_class.call(User.last.id + 100) }.to raise_error(ActiveRecord::RecordNotFound)
   end
 
   describe "::call" do

--- a/spec/services/search/feed_content_spec.rb
+++ b/spec/services/search/feed_content_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Search::FeedContent, type: :service do
       feed_docs = described_class.search_documents(params: query_params)
       expect(feed_docs.count).to eq(2)
       doc_highlights = feed_docs.map { |t| t.dig("highlight", "body_text") }.flatten
-      expect(doc_highlights).to include("I <em>love</em> <em>ruby</em>", "<em>Ruby</em> Tuesday is <em>love</em>")
+      expect(doc_highlights).to include("I <mark>love</mark> <mark>ruby</mark>", "<mark>Ruby</mark> Tuesday is <mark>love</mark>")
     end
 
     it "returns fields necessary for the view" do

--- a/spec/system/search/display_comments_search_spec.rb
+++ b/spec/system/search/display_comments_search_spec.rb
@@ -10,6 +10,6 @@ RSpec.describe "Display articles search spec", type: :system, js: true, elastics
     visit "/search?q=#{url_encoded_query}&filters=class_name:Comment"
 
     expect(page.find(".crayons-story__snippet")["innerHTML"]).
-      to eq("…&lt;<em>marquee</em>='<em>alert</em>(<em>document.cookie</em>)'&gt;<em>XSS</em>…")
+      to eq("…&lt;<mark>marquee</mark>='<mark>alert</mark>(<mark>document.cookie</mark>)'&gt;<mark>XSS</mark>…")
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
In order to get highlighting from Elasticsearch to work with dark mode we need to switch from using `<em>` to highlight matches to `<mark>`. Luckily Elasticsearch has [a setting for this](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#highlighting-settings)

<img width="525" alt="Screen Shot 2020-07-03 at 9 11 17 AM" src="https://user-images.githubusercontent.com/1813380/86472822-65492500-bd05-11ea-8ba1-009ff2c8bd2f.png">

I also snuck in a Broadcast spec fix that was popping up. cc @vaidehijoshi 
```
  1) Broadcasts::WelcomeNotification::Generator requires a valid user id
     Failure/Error: expect { described_class.call(1) }.to raise_error(ActiveRecord::RecordNotFound)
       expected ActiveRecord::RecordNotFound but nothing was raised
     # ./spec/services/broadcasts/welcome_notification/generator_spec.rb:29:in `block (2 levels) in <top (required)>'
     # ./spec/rails_helper.rb:134:in `block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:134:in `block (2 levels) in <top (required)>
```

## QA Instructions, Screenshots, Recordings
Run a search and verify that the highlighted works are using mark instead of em

## Added tests?
- [x] updated

![alt_text](https://media2.giphy.com/media/3oxRmmB2KwO5f8pyyA/giphy.gif)
