### PR TITLE
Now frontend code is linted before running tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "postbuild-storybook": "npm run generate-themes-storybook",
     "prestorybook": "npm run generate-themes-storybook",
     "storybook": "start-storybook -p 6006 -c app/javascript/.storybook -s app/assets,app/javascript/storybook-static",
+    "lint:frontend": "eslint app/assets/javascripts/**/*.js app/javascript/**/*.jsx app/javascript/**/*.js",
+    "pretest": "npm run lint:frontend",
     "test": "jest app/javascript/ --coverage",
     "test:watch": "jest app/javascript/ --watch"
   },


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We've reached the state in the frontend codebase where we no longer have any lint errors. To keep the code maintainable, builds will fail now if a lint error is discovered in frontend code. This was discussed briefly on our internal Slack and there appeared to be no pushback on this.

## Related Tickets & Documents

#3777, #2470

## QA Instructions, Screenshots, Recordings

N/A

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![Michael from the office saying "Clean up on aisle five."](https://media.giphy.com/media/OTszKBXzfG5e8/giphy.gif)
