### PR TITLE
Delete box-shadow to .github-repos class

### DIFF
--- a/app/assets/stylesheets/settings.scss
+++ b/app/assets/stylesheets/settings.scss
@@ -7,7 +7,6 @@ $input-width: 650px;
   max-height: 400px;
   overflow-y: auto;
   background: var(--card-bg);
-  box-shadow: $shadow;
   &.loading-repos {
     height: 400px;
     background: white url(image-src('loading-ellipsis.svg')) no-repeat center


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Delete `box-shadow` to `.github-repos` class. Why? Could be less visible boxes to [settings](https://dev.to/settings/integrations). Two boxes for GitHub integration is too much.
 
## Screenshots

| :no_good: | :+1: |
|:-:|:-:|
| ![image](https://user-images.githubusercontent.com/14293805/86523866-2933d280-be73-11ea-8ff5-83363bc0a508.png)|![image](https://user-images.githubusercontent.com/14293805/86523874-3f419300-be73-11ea-93c7-f97fdd3cbb58.png)|


## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

