### PR TITLE
Fix pro link for organization users

### DIFF
--- a/app/views/dashboards/_actions.html.erb
+++ b/app/views/dashboards/_actions.html.erb
@@ -1,4 +1,3 @@
-
 <nav class="hidden m:block">
   <a class="crayons-link crayons-link--block <%= "crayons-link--current" if params[:action] == "show" && (params[:which] == "organization" || params[:which].blank?) %>" href="/dashboard">
     Posts

--- a/app/views/dashboards/_actions.html.erb
+++ b/app/views/dashboards/_actions.html.erb
@@ -1,3 +1,4 @@
+
 <nav class="hidden m:block">
   <a class="crayons-link crayons-link--block <%= "crayons-link--current" if params[:action] == "show" && (params[:which] == "organization" || params[:which].blank?) %>" href="/dashboard">
     Posts
@@ -34,21 +35,20 @@
     <%= inline_svg_tag("external-link.svg", aria: true, class: "crayons-icon", title: "Moderation") %>
   </a>
 
-  <% if @user.has_role? :pro %>
-    <a class="crayons-link crayons-link--block" href="/dashboard/pro">
+  <% if @current_user_pro %>
+    <a class="crayons-link crayons-link--block" href="<%= dashboard_pro_path %>">
       Pro Analytics
     </a>
-  <% end %>
 
-  <% if @organizations && (params[:which].blank? || params[:which] == "organization") %>
-    <% @organizations.each do |org| %>
-      <a class="crayons-link crayons-link--block" href="/dashboard/pro/org/<%= org.id %>">Pro Analytics for <%= org.name %></a>
+    <% if @organizations && (params[:which].blank? || params[:which] == "organization") %>
+      <% @organizations.each do |org| %>
+        <a class="crayons-link crayons-link--block" href="<%= dashboard_pro_org_path(org.id) %>">Pro Analytics for <%= org.name %></a>
+      <% end %>
     <% end %>
   <% end %>
 
-  <% if current_user.created_at < 2.weeks.ago %>
-    <a class="crayons-btn crayons-btn--secondary w-100 mt-4" href="/videos/new" data-no-instant>
-      Upload a video
+  <% if policy(:video).new? %>
+    <a class="crayons-btn crayons-btn--secondary w-100 mt-4" href="<%= new_video_path %>" data-no-instant> Upload a video
     </a>
   <% end %>
 </nav>

--- a/app/views/dashboards/_actions_mobile.html.erb
+++ b/app/views/dashboards/_actions_mobile.html.erb
@@ -8,18 +8,19 @@
     <option value="/dashboard/following_podcasts" <%= "selected" if params[:action] == "following_podcasts" %>>Following podcasts (<%= @user.following_podcasts_count %>)</option>
 
     <option value="/listings/dashboard">Listings</option>
-    <% if @user.has_role? :pro %>
-      <option value="/dashboard/pro">Pro Analytics</option>
-    <% end %>
 
-    <% if @organizations && (params[:which].blank? || params[:which] == "organization") %>
-      <% @organizations.each do |org| %>
-        <option value="/dashboard/pro/org/<%= org.id %>">Pro Analytics for <%= org.name %></option>
+    <% if @current_user_pro %>
+      <option value="<%= dashboard_pro_path %>">Pro Analytics</option>
+
+      <% if @organizations && (params[:which].blank? || params[:which] == "organization") %>
+        <% @organizations.each do |org| %>
+          <option value="<%= dashboard_pro_org_path(org.id) %>">Pro Analytics for <%= org.name %></option>
+        <% end %>
       <% end %>
     <% end %>
 
-    <% if current_user.created_at < 2.weeks.ago %>
-      <option value="/videos/new">Upload a video</option>
+    <% if policy(:video).new? %>
+      <option value="<%= new_video_path %>">Upload a video</option>
     <% end %>
   </select>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -392,8 +392,8 @@ Rails.application.routes.draw do
   get "/settings/:tab/:id" => "users#edit", :constraints => { tab: /response-templates/ }
   get "/signout_confirm" => "users#signout_confirm"
   get "/dashboard" => "dashboards#show"
-  get "/dashboard/pro" => "dashboards#pro"
-  get "dashboard/pro/org/:org_id" => "dashboards#pro"
+  get "/dashboard/pro", to: "dashboards#pro"
+  get "dashboard/pro/org/:org_id", to: "dashboards#pro", as: :dashboard_pro_org
   get "dashboard/following" => "dashboards#following_tags"
   get "dashboard/following_tags" => "dashboards#following_tags"
   get "dashboard/following_users" => "dashboards#following_users"


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The "pro analytics for org" link should only appear if the user has the pro role.

Closes https://github.com/thepracticaldev/dev.to/issues/9106

## QA Instructions, Screenshots, Recordings

1. create an org
1. add and remove the `:pro` role to see the link appearing or disappearing

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
