### PR TITLE
Remove unnecessary fragment cache

### DIFF
--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -206,9 +206,7 @@
       <% if has_long_markdown || @organization %>
         <section class="crayons-card crayons-card--secondary text-padding mb-4">
           <% if has_long_markdown %>
-            <% cache("article-about-author-#{@user.id}-#{@user.updated_at}", expires_in: 100.hours) do %>
-              <%= render "articles/about_author", published: @article.readable_publish_date %>
-            <% end %>
+            <%= render "articles/about_author", published: @article.readable_publish_date %>
           <% end %>
           <%= render "articles/org_branding", organization: @organization, author: has_long_markdown %>
         </section>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This fragment cache was causing a bug because the `published` is included and it's different on an article-by-article basis. But then I saw that this cache was not blocking any new queries or intense computation, so I figured it was best to do away with the cache for one less Redis query anyway.