### PR TITLE
Bug Fix: Prevent Duplicate Follow Attempts by Preventing Multiple Workers

### DIFF
--- a/app/workers/users/follow_worker.rb
+++ b/app/workers/users/follow_worker.rb
@@ -1,7 +1,7 @@
 module Users
   class FollowWorker
     include Sidekiq::Worker
-    sidekiq_options queue: :high_priority, retry: 10
+    sidekiq_options queue: :high_priority, retry: 10, lock: :until_executed
 
     def perform(user_id, followable_id, followable_type)
       return unless %w[Tag Organization User].include?(followable_type)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix
- [x] Optimization

## Description
We are still getting duplicate follow attempts and it looks like its bc we are kicking off multiple workers at once. This will prevent that from happening so at least part of the problem will be fixed, I am not sure if it will fix all of it. 

Fixes Sidekiq Error:
```
ActiveRecord::RecordInvalid: Validation failed: Followable has already been taken
```

## QA Instructions, Screenshots, Recordings
Make sure you can still follow someone

## Added tests?
- [x] no, because they aren't needed

![alt_text](https://media1.tenor.com/images/c8bdc0cfec3972e7bfc1b95c47c3c702/tenor.gif?itemid=3320763)
