### PR TITLE
Add role and docs for user subscription liquid tag

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -63,6 +63,7 @@ class ArticlesController < ApplicationController
     @version = @article.has_frontmatter? ? "v1" : "v2"
     @user = @article.user
     @organizations = @user&.organizations
+    set_user_approved_liquid_tags
   end
 
   def manage
@@ -189,6 +190,10 @@ class ArticlesController < ApplicationController
     @organizations = @user&.organizations
     @tag = Tag.find_by(name: params[:template])
     @prefill = params[:prefill].to_s.gsub("\\n ", "\n").gsub("\\n", "\n")
+    set_user_approved_liquid_tags
+  end
+
+  def set_user_approved_liquid_tags
     @user_approved_liquid_tags = @user ? @user.roles.where(name: "restricted_liquid_tag").pluck(:resource_type) : []
   end
 

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -189,6 +189,7 @@ class ArticlesController < ApplicationController
     @organizations = @user&.organizations
     @tag = Tag.find_by(name: params[:template])
     @prefill = params[:prefill].to_s.gsub("\\n ", "\n").gsub("\\n", "\n")
+    @user_approved_liquid_tags = @user ? @user.roles.where(name: "restricted_liquid_tag").pluck(:resource_type) : []
   end
 
   def handle_user_or_organization_feed

--- a/app/liquid_tags/user_subscription_tag.rb
+++ b/app/liquid_tags/user_subscription_tag.rb
@@ -1,9 +1,10 @@
 class UserSubscriptionTag < LiquidTagBase
   PARTIAL = "liquids/user_subscription".freeze
   VALID_CONTEXTS = %w[Article].freeze
-  VALID_ROLES = %i[
-    admin
-    super_admin
+  VALID_ROLES = [
+    :admin,
+    [:restricted_liquid_tag, LiquidTags::UserSubscriptionTag],
+    :super_admin,
   ].freeze
 
   SCRIPT = <<~JAVASCRIPT.freeze

--- a/app/models/liquid_tags/user_subscription_tag.rb
+++ b/app/models/liquid_tags/user_subscription_tag.rb
@@ -1,0 +1,9 @@
+module LiquidTags
+  class UserSubscriptionTag < ApplicationRecord
+    resourcify
+    # This class exists to take advantage of Rolify for limiting authorization
+    # on internal reports.
+    # NOTE: It is not backed by a database table and should not be expected to
+    # function like a traditional Rails model
+  end
+end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -6,6 +6,7 @@ class Role < ApplicationRecord
     comment_banned
     podcast_admin
     pro
+    restricted_liquid_tag
     single_resource_admin
     super_admin
     tag_moderator

--- a/app/views/pages/_editor_liquid_help.html.erb
+++ b/app/views/pages/_editor_liquid_help.html.erb
@@ -1,290 +1,303 @@
 <div id="editor-liquid-help">
-  <div class="text-styles">
-    <p>We support native <a href="https://shopify.github.io/liquid" target="_blank" rel="noopener">Liquid tags</a> in our editor, but have created our own custom tags listed below:</p>
-    <h3><%= community_name %> Article/Post Embed</h3>
-    <p>All you need is the full link of the article:</p>
-    <code>{% link https://dev.to/kazz/boost-your-productivity-using-markdown-1be %}</code>
-    <p>You can also use the slug like this:</p>
-    <code>{% link kazz/boost-your-productivity-using-markdown-1be %}</code>
-    <p>You can also use the alias post instead of link like this:</p>
-    <code>{% post https://dev.to/kazz/boost-your-productivity-using-markdown-1be %}</code>
-    <p>or this:</p>
-    <code>{% post kazz/boost-your-productivity-using-markdown-1be %}</code>
-    <h3><%= community_name %> User Embed</h3>
-    <p>All you need is the <%= community_name %> username:</p>
-    <code>{% user jess %}</code>
-    <h3><%= community_name %> Tag Embed</h3>
-    <p>All you need is the tag name:</p>
-    <code>{% tag git %}</code>
-    <h3><%= community_name %> Comment Embed</h3>
-    <p>All you need is the
-      <code>ID</code> at the end of a comment URL. To get the comment link, click either the timestamp or the menu button in the top right corner on a comment and then click "Permalink". Here's an example:
-    </p>
-    <code>{% devcomment 2d1a %}</code>
-    <h3><%= community_name %> Podcast Episode Embed</h3>
-    <p>All you need is the full link of the podcast episode:</p>
-    <code>{% podcast https://dev.to/basecspodcast/s2e2--queues-irl %}</code>
-    <h3><%= community_name %> Listing Embed</h3>
-    <p>All you need is the full link of the listing:</p>
-    <code>{% listing https://dev.to/listings/collabs/dev-is-open-source-823 %}</code>
-    <p>You can also use the category and slug like this:</p>
-    <code>{% listing collabs/dev-is-open-source-823 %}</code>
-    <p>Note: Expired listings will raise an error. Make sure the listing is published or recently bumped.</p>
-    <h3>Twitter Embed</h3>
-    <p>Using the Twitter Liquid tag will allow the tweet to pre-render from the server, providing your reader with a better experience. All you need is the tweet
-      <code>id</code> from the url.</p>
-    <code>{% twitter 834439977220112384 %}</code>
-    <h3>Glitch embed</h3>
-    <p>All you need is the Glitch project slug</p>
-    <code>{% glitch earthy-course %}</code>
-    <p>There are several
-      <a href="https://glitch.com/help/how-can-i-customize-a-glitch-app-embed">optional attributes</a> you can use in your tag, just add them after the id, separated by spaces.
-    </p>
-    <ul>
-      <li><code>app</code> – Shows the app preview without the code.<br>
-        <code>{% glitch earthy-course app %}</code>
-      </li>
-      <li><code>code</code> – Shows the code without the app preview.<br>
-        <code>{% glitch earthy-course code %}</code></li>
-      <li><code>preview-first</code> – Swap panes: Show the app preview on the left and the code on the right.<br>
-        <code>{% glitch earthy-course preview-first %}</code></li>
-      <li><code>no-attribution</code> – Hides the avatar of the creator(s).<br>
-        <code>{% glitch earthy-course no-attribution %}</code></li>
-      <li><code>no-files</code> – Hides the file browser.<br>
-        <code>{% glitch earthy-course no-files %}</code></li>
-      <li><code>file</code> – Lets you choose which file to display in the code panel. Defaults to index.html.<br>
-        <code>{% glitch earthy-course file=script.js %}</code></li>
-    </ul>
-    <h3>GitHub Repo Embed</h3>
-    <p>All you need is the GitHub username and repo:</p>
-    <code>{% github thepracticaldev/dev.to %}</code>
-    <dl>
-      <dt><code>no-readme</code></dt>
-      <dd>
-        You can add a no-readme option to your GitHub tag to hide the readme file from the preview.<br>
-        <code>{% github thepracticaldev/dev.to no-readme %}</code>
-      </dd>
-    </dl>
-    <h3>GitHub Issue, Pull request or Comment Embed</h3>
-    <p>All you need is the GitHub issue, PR or comment URL:</p>
-    <code>{% github https://github.com/thepracticaldev/dev.to/issues/9 %}</code>
-    <h3>GitHub Gist Embed</h3>
-    <p>All you need is the gist link:</p>
-    <code>
-      {% gist https://gist.github.com/CristinaSolana/1885435 %}
-    </code>
-    <dl>
-      <dt><code>Single File Embed</code></dt>
-      <dd>
-        <p>You can choose to embed a single gist file. <br>
-        <code>{% gist https://gist.github.com/CristinaSolana/1885435 file=gistfile1.md %}</code></p>
-      </dd>
-      <dt><code>Specific Version Embed</code></dt>
-      <dd>
-        <p>You can choose to embed a specific version of a gist file. All you need
-        the link and the commit hash for that specific version. <br>
-        The format is <code>{% gist [gist-link]/[commit-hash] %}</code> <br>
-        e.g. <br>
-        <code>{% gist https://gist.github.com/suntong/3a31faf8129d3d7a380122d5a6d48ff6/f77d01e82defbf736ebf4879a812cf9c916a9252 %}</code></p>
-      </dd>
-      <dt><code>Specific Version File Embed</code></dt>
-      <dd>
-        <p>You can choose to embed a specific version of a gist file. All you need
-        the link, the filename and the commit hash for that specific version . <br>
-        The format is <code>{% gist [gist-link]/[commit-hash] file=[filename] %}</code> <br>
-        e.g. <br>
-        <code>
-          {% gist https://gist.github.com/suntong/3a31faf8129d3d7a380122d5a6d48ff6/f77d01e82defbf736ebf4879a812cf9c916a9252 file=Images.tmpl %}
-        </code></p>
-      </dd>
-    </dl>
-    <h3>GitPitch Embed</h3>
-    <p>All you need is the GitPitch link:</p>
-    <code>
-      {% gitpitch https://gitpitch.com/gitpitch/in-60-seconds %}
-    </code>
-    <h3>Video Embed</h3>
-    <p>All you need is the <code>id</code> from the URL.</p>
-    <ul>
-      <li><strong>YouTube:</strong> <code>{% youtube dQw4w9WgXcQ %}</code></li>
-      <li><strong>Vimeo:</strong> <code>{% vimeo 193110695 %}</code></li>
-    </ul>
-    <h3>Medium Embed</h3>
-    <p>Just enter the full URL of the Medium article you are trying to embed.</p>
-    <code>{% medium https://medium.com/s/story/boba-science-how-can-i-drink-a-bubble-tea-to-ensure-that-i-dont-finish-the-tea-before-the-bobas-7fc5fd0e442d %}</code>
-    <h3>SlideShare Embed</h3>
-    <p>All you need is the SlideShare <code>key</code>:</p>
-    <code>{% slideshare rdOzN9kr1yK5eE %}</code>
-    <h3>CodePen Embed</h3>
-    <p>All you need is the full CodePen <code>link</code>, ending in the pen ID code, as follows:</p>
-    <code>{% codepen https://codepen.io/twhite96/pen/XKqrJX %}</code>
-    <dl>
-      <dt><code>default-tab</code></dt>
-      <dd>
-        Add default-tab parameter to your CodePen embed tag. Default to <i>result</i><br>
-        <code>{% codepen https://codepen.io/twhite96/pen/XKqrJX default-tab=js,result %}</code>
-      </dd>
-    </dl>
-    <h3>Kotlin Playground</h3>
-    <p>To create a runnable kotlin snippet, create a Kotlin Snippet at <a href="https://play.kotlinlang.org">https://play.kotlinlang.org</a></p>
-    <p>Go to <code>Share</code> dialog and copy the full <code>link</code> from the <code>Medium</code> tab. Use it as follows:</p>
-    <code>{% kotlin https://pl.kotl.in/owreUFFUG?theme=darcula&from=3&to=6&readOnly=true %}</code>
-    <h3>RunKit Embed</h3>
-    <p>Put executable code within a runkit liquid block, as follows:</p>
-    <pre>{% runkit<br>// hidden setup JavaScript code goes in this preamble area<br>const hiddenVar = 42<br>%}<br>// visible, reader-editable JavaScript code goes here<br>console.log(hiddenVar)<br>{% endrunkit %}<br></pre>
-
-    <h3>KaTeX Embed</h3>
-    <p>Place your mathematical expression within a KaTeX liquid block, as follows:</p>
-    <pre>{% katex %}<br> c = \pm\sqrt{a^2 + b^2}<br>{% endkatex %}<br></pre>
-    <p>To render KaTeX inline add the "inline" option:</p>
-    <pre>{% katex inline %}<br> c = \pm\sqrt{a^2 + b^2}<br>{% endkatex %}<br></pre>
-
-    <h3>Stackblitz Embed</h3>
-    <p>All you need is the ID of the Stackblitz:</p>
-    <code>{% stackblitz ball-demo %}</code>
-    <dl>
-      <dt><code>Default view</code></dt>
-      <dd>
-        You can change the default view, the options are <i>both</i>, <i>preview</i>, <i>editor</i>. Defaults to
-        <i>both</i><br>
-        <code>{% stackblitz ball-demo view=preview %}</code>
-      </dd>
-      <dt><code>Default file</code></dt>
-      <dd>
-        You can change the default file you want your embed to point to<br>
-        <code>{% stackblitz ball-demo file=style.css %}</code>
-      </dd>
-    </dl>
-    <h3>CodeSandbox Embed</h3>
-    <p>All you need is the ID of the Sandbox:</p>
-    <code>{% codesandbox ppxnl191zx %}</code>
-    <p>Of CodeSandbox's many
-      <a href="https://codesandbox.io/docs/embedding#embed-options">optional attributes</a>, the following are supported by using them in your tag, just add them after the id, separated by spaces.
-    </p>
-    <dl>
-      <dt><code>initialpath</code></dt>
-      <dd>
-        Which url to initially load in address bar.<br>
-        <code>{% codesandbox ppxnl191zx initialpath=/initial/load/path %}</code>
-      </dd>
-      <dt><code>module</code></dt>
-      <dd>
-        Which module to open by default.<br>
-        <code>{% codesandbox ppxnl191zx module=/path/to/module %}</code>
-      </dd>
-      <dt><code>runonclick</code></dt>
-      <dd>
-        Delays when code is ran if <code>1</code> <br>
-        <code>{% codesandbox ppxnl191zx runonclick=1 %}</code>
-      </dd>
-    </dl>
-    <h3>JSFiddle Embed</h3>
-    <p>All you need is the full JSFiddle <code>link</code>, ending in the fiddle ID code, as follows:</p>
-    <code>{% jsfiddle https://jsfiddle.net/link2twenty/v2kx9jcd %}</code>
-    <dl>
-      <dt><code>Custom tabs</code></dt>
-      <dd>
-        You can add a custom tab order to you JSFiddle embed tag. Defaults to <i>js,html,css,result</i><br>
-        <code>{% jsfiddle https://jsfiddle.net/webdevem/Q8KVC result,html,css %}</code>
-      </dd>
-    </dl>
-
-    <h3>JSitor Liquid Tag</h3>
-    <p>
-      To use JSitor liquid tag you can use the JSitor full <code>link</code>, with or without the parameters
-    </p>
-    <code>{% jsitor https://jsitor.com/embed/B7FQ5tHbY %}</code>
-    <br />
-    <code>{% jsitor https://jsitor.com/embed/B7FQ5tHbY?html&js&css&result&light %}</code>
-    <p>
-      Other options to use JSitor liquid tag is just by its ID, you can add it with or without the parameters
-    </p>
-    <code>{% jsitor B7FQ5tHbY %}</code>
-    <br />
-    <code>{% jsitor B7FQ5tHbY?html&js&css&result&light %}</code>
-
-    <h3>repl.it Embed</h3>
-    <p>All you need is the URL after the domain name:</p>
-    <code>{% replit @WigWog/PositiveFineOpensource %}</code>
-    <h3>Stackery Embed</h3>
-    <p>Visualize your AWS Serverless Application Model templates with <a href="https://www.stackery.io/">Stackery's</a> visualizer embed</p>
-    <p>All you need is the repository owner, repository name, and branch that you would like visualized</p>
-    <code>{% stackery deeheber lambda-layer-example master %}</code>
-    <br />
-    <p>The repository must be a public GitHub repository and have a valid AWS SAM template in the project root titled template.yaml</p>
-    <h3>Next Tech Embed</h3>
-    <p>All you need is the share URL for your sandbox. You can get the share URL by clicking
-    the "Share" button in the top right when the sandbox is open.</p>
-    <p><img src="https://thepracticaldev.s3.amazonaws.com/i/r449xp8cay3383i139qv.png" alt="Share Replit sandbox" /></p>
-    <code>{% nexttech https://nt.dev/s/6ba1fffbd09e %}</code>
-    <h3>Instagram Embed</h3>
-    <p>All you need is the Instagram post <code>id</code> from the URL:</p>
-    <code>{% instagram BXgGcAUjM39 %}</code>
-    <h3>Speakerdeck Tag</h3>
-    <p>All you need is the data-id code from the embed link:</p>
-    <pre><span style="color: gray;"># Given this embed link:</span><br>&lt;script async class="speakerdeck-embed"<br>    data-id="<span style='color: orange;'>7e9f8c0fa0c949bd8025457181913fd0</span>"<br>    data-ratio="1.77777777777778" src="//speakerdeck.com/assets/embed.js"&gt;&lt;/script&gt;</pre>
-    <pre>{% speakerdeck <span style="color: orange;">7e9f8c0fa0c949bd8025457181913fd0</span> %}</pre>
-    <h3>Soundcloud Embed</h3>
-    <p>Just enter the full URL of the Soundcloud track you are trying to embed.</p>
-    <code>{% soundcloud https://soundcloud.com/user-261265215/dev-to-review-episode-1 %}</code>
-    <h3>Spotify Embed</h3>
-    <p>
-      Enter the Spotify URI of the Spotify track / playlist /
-      album / artist / podcast episode you are trying to embed.
-    </p>
-    <pre>{% spotify <span style="color: #1DB954;">spotify:episode:5V4XZWqZQJvbddd31n56mf</span> %}</pre>
-    <h3>Blogcast Tag</h3>
-    <p>All you need is the article id code from the embed code:</p>
-    <pre>{% blogcast <span style="color: orange;">1234</span> %}</pre>
-    <h3>Parler Tag</h3>
-    <p>Enter the full url of the Parler.io audio file you want to embed. </p>
-    <pre>{% parler https://www.parler.io/audio/73240183203/d53cff009eac2ab1bc9dd8821a638823c39cbcea.7dd28611-b7fc-4cf8-9977-b6e3aaf644a1.mp3 %}</pre>
-    <h3>Stack Exchange / Stack Overflow Tag</h3>
-    <p>
-      You'll need the question or answer's ID code, and the site. When using <code>{% stackoverflow %}</code> as the tag, the site will default to Stack Overflow.
-      For example:
-      <br>
-      <a href="https://stackoverflow.com/questions/24789130/colors-in-irb-rails-console">https://stackoverflow.com/questions/24789130/colors-in-irb-rails-console</a>
+  <div class="crayons-article">
+    <div class="crayons-article__body">
+      <p>We support native <a href="https://shopify.github.io/liquid" target="_blank" rel="noopener">Liquid tags</a> in our editor, but have created our own custom tags listed below:</p>
+      <h3><%= community_name %> Article/Post Embed</h3>
+      <p>All you need is the full link of the article:</p>
+      <code>{% link https://dev.to/kazz/boost-your-productivity-using-markdown-1be %}</code>
+      <p>You can also use the slug like this:</p>
+      <code>{% link kazz/boost-your-productivity-using-markdown-1be %}</code>
+      <p>You can also use the alias post instead of link like this:</p>
+      <code>{% post https://dev.to/kazz/boost-your-productivity-using-markdown-1be %}</code>
+      <p>or this:</p>
+      <code>{% post kazz/boost-your-productivity-using-markdown-1be %}</code>
+      <h3><%= community_name %> User Embed</h3>
+      <p>All you need is the <%= community_name %> username:</p>
+      <code>{% user jess %}</code>
+      <h3><%= community_name %> Tag Embed</h3>
+      <p>All you need is the tag name:</p>
+      <code>{% tag git %}</code>
+      <h3><%= community_name %> Comment Embed</h3>
+      <p>All you need is the
+        <code>ID</code> at the end of a comment URL. To get the comment link, click either the timestamp or the menu button in the top right corner on a comment and then click "Permalink". Here's an example:
+      </p>
+      <code>{% devcomment 2d1a %}</code>
+      <% if @user_approved_liquid_tags.include? "LiquidTags::UserSubscriptionTag" %>
+        <h3><%= community_name %> User Subscriptions</h3>
+        <p class="fs-s fw-bold">This tag can only be used in articles.</p>
+        <p>You can add call-to-action text that will show above the subscribe button:</p>
+        <code>{% user_subscription If you'd like to receive future updates, subscribe below! %}</code>
+        <p class="fs-s">
+          If a reader is signed out, the button will prompt them to sign in first
+          to subscribe. If the reader is signed in, the button will prompt them
+          to subscribe.
+        </p>
+      <% end %>
+      <h3><%= community_name %> Podcast Episode Embed</h3>
+      <p>All you need is the full link of the podcast episode:</p>
+      <code>{% podcast https://dev.to/basecspodcast/s2e2--queues-irl %}</code>
+      <h3><%= community_name %> Listing Embed</h3>
+      <p>All you need is the full link of the listing:</p>
+      <code>{% listing https://dev.to/listings/collabs/dev-is-open-source-823 %}</code>
+      <p>You can also use the category and slug like this:</p>
+      <code>{% listing collabs/dev-is-open-source-823 %}</code>
+      <p>Note: Expired listings will raise an error. Make sure the listing is published or recently bumped.</p>
+      <h3>Twitter Embed</h3>
+      <p>Using the Twitter Liquid tag will allow the tweet to pre-render from the server, providing your reader with a better experience. All you need is the tweet
+        <code>id</code> from the url.</p>
+      <code>{% twitter 834439977220112384 %}</code>
+      <h3>Glitch embed</h3>
+      <p>All you need is the Glitch project slug</p>
+      <code>{% glitch earthy-course %}</code>
+      <p>There are several
+        <a href="https://glitch.com/help/how-can-i-customize-a-glitch-app-embed">optional attributes</a> you can use in your tag, just add them after the id, separated by spaces.
+      </p>
       <ul>
-          <li>The question ID is: <code style="color: aquamarine; background-color: black;">24789130</code></li>
+        <li><code>app</code> – Shows the app preview without the code.<br>
+          <code>{% glitch earthy-course app %}</code>
+        </li>
+        <li><code>code</code> – Shows the code without the app preview.<br>
+          <code>{% glitch earthy-course code %}</code></li>
+        <li><code>preview-first</code> – Swap panes: Show the app preview on the left and the code on the right.<br>
+          <code>{% glitch earthy-course preview-first %}</code></li>
+        <li><code>no-attribution</code> – Hides the avatar of the creator(s).<br>
+          <code>{% glitch earthy-course no-attribution %}</code></li>
+        <li><code>no-files</code> – Hides the file browser.<br>
+          <code>{% glitch earthy-course no-files %}</code></li>
+        <li><code>file</code> – Lets you choose which file to display in the code panel. Defaults to index.html.<br>
+          <code>{% glitch earthy-course file=script.js %}</code></li>
       </ul>
-      <pre>{% stackoverflow <span style="color: aquamarine;">24789130</span> %}</pre>
-    </p>
-    <p>
-      For other Stack Exchange network sites, you'll need to provide the site's name and use <code>{% stackexchange %}</code> as the tag. For example:
-      <br>
-      <a href="https://diy.stackexchange.com/questions/169988/base-for-refrigerator-wine-shelf">https://diy.stackexchange.com/questions/169988/base-for-refrigerator-wine-shelf</a>
+      <h3>GitHub Repo Embed</h3>
+      <p>All you need is the GitHub username and repo:</p>
+      <code>{% github thepracticaldev/dev.to %}</code>
+      <dl>
+        <dt><code>no-readme</code></dt>
+        <dd>
+          You can add a no-readme option to your GitHub tag to hide the readme file from the preview.<br>
+          <code>{% github thepracticaldev/dev.to no-readme %}</code>
+        </dd>
+      </dl>
+      <h3>GitHub Issue, Pull request or Comment Embed</h3>
+      <p>All you need is the GitHub issue, PR or comment URL:</p>
+      <code>{% github https://github.com/thepracticaldev/dev.to/issues/9 %}</code>
+      <h3>GitHub Gist Embed</h3>
+      <p>All you need is the gist link:</p>
+      <code>
+        {% gist https://gist.github.com/CristinaSolana/1885435 %}
+      </code>
+      <dl>
+        <dt><code>Single File Embed</code></dt>
+        <dd>
+          <p>You can choose to embed a single gist file. <br>
+          <code>{% gist https://gist.github.com/CristinaSolana/1885435 file=gistfile1.md %}</code></p>
+        </dd>
+        <dt><code>Specific Version Embed</code></dt>
+        <dd>
+          <p>You can choose to embed a specific version of a gist file. All you need
+          the link and the commit hash for that specific version. <br>
+          The format is <code>{% gist [gist-link]/[commit-hash] %}</code> <br>
+          e.g. <br>
+          <code>{% gist https://gist.github.com/suntong/3a31faf8129d3d7a380122d5a6d48ff6/f77d01e82defbf736ebf4879a812cf9c916a9252 %}</code></p>
+        </dd>
+        <dt><code>Specific Version File Embed</code></dt>
+        <dd>
+          <p>You can choose to embed a specific version of a gist file. All you need
+          the link, the filename and the commit hash for that specific version . <br>
+          The format is <code>{% gist [gist-link]/[commit-hash] file=[filename] %}</code> <br>
+          e.g. <br>
+          <code>
+            {% gist https://gist.github.com/suntong/3a31faf8129d3d7a380122d5a6d48ff6/f77d01e82defbf736ebf4879a812cf9c916a9252 file=Images.tmpl %}
+          </code></p>
+        </dd>
+      </dl>
+      <h3>GitPitch Embed</h3>
+      <p>All you need is the GitPitch link:</p>
+      <code>
+        {% gitpitch https://gitpitch.com/gitpitch/in-60-seconds %}
+      </code>
+      <h3>Video Embed</h3>
+      <p>All you need is the <code>id</code> from the URL.</p>
       <ul>
-        <li>The question ID is: <code style="color: aquamarine; background-color: black;">169988</code></li>
-      <li>The site is <code style="color: orange; background-color: black;">diy</code></li>
+        <li><strong>YouTube:</strong> <code>{% youtube dQw4w9WgXcQ %}</code></li>
+        <li><strong>Vimeo:</strong> <code>{% vimeo 193110695 %}</code></li>
       </ul>
-      <pre>{% stackexchange <span style="color: aquamarine;">169988</span> <span style="color: orange;">diy</span> %}</pre>
-    </p>
-    <p>
-    For answers, you can get the answer's ID code by from the answer's "Share" link. For example:
-    <br>
-    <a href="https://diy.stackexchange.com/a/170185">https://diy.stackexchange.com/a/170185</a>
-    <ul>
-      <li>The answer ID is: <code style="color: aquamarine; background-color: black;">170185</code></li>
-      <li>The site is <code style="color: orange; background-color: black;">diy</code></li>
-    </ul>
-    <pre>{% stackexchange <span style="color: aquamarine;">170185</span> <span style="color: orange;">diy</span> %}</pre>
-    </p>
-    <h3>Wikipedia Embed</h3>
-    <p>Enter the full URL of the Wikipedia article you want to embed, with or without the anchor.</p>
-    <p>
-      <code>{% wikipedia https://en.wikipedia.org/wiki/Wikipedia %}</code>
+      <h3>Medium Embed</h3>
+      <p>Just enter the full URL of the Medium article you are trying to embed.</p>
+      <code>{% medium https://medium.com/s/story/boba-science-how-can-i-drink-a-bubble-tea-to-ensure-that-i-dont-finish-the-tea-before-the-bobas-7fc5fd0e442d %}</code>
+      <h3>SlideShare Embed</h3>
+      <p>All you need is the SlideShare <code>key</code>:</p>
+      <code>{% slideshare rdOzN9kr1yK5eE %}</code>
+      <h3>CodePen Embed</h3>
+      <p>All you need is the full CodePen <code>link</code>, ending in the pen ID code, as follows:</p>
+      <code>{% codepen https://codepen.io/twhite96/pen/XKqrJX %}</code>
+      <dl>
+        <dt><code>default-tab</code></dt>
+        <dd>
+          Add default-tab parameter to your CodePen embed tag. Default to <i>result</i><br>
+          <code>{% codepen https://codepen.io/twhite96/pen/XKqrJX default-tab=js,result %}</code>
+        </dd>
+      </dl>
+      <h3>Kotlin Playground</h3>
+      <p>To create a runnable kotlin snippet, create a Kotlin Snippet at <a href="https://play.kotlinlang.org">https://play.kotlinlang.org</a></p>
+      <p>Go to <code>Share</code> dialog and copy the full <code>link</code> from the <code>Medium</code> tab. Use it as follows:</p>
+      <code>{% kotlin https://pl.kotl.in/owreUFFUG?theme=darcula&from=3&to=6&readOnly=true %}</code>
+      <h3>RunKit Embed</h3>
+      <p>Put executable code within a runkit liquid block, as follows:</p>
+      <pre>{% runkit<br>// hidden setup JavaScript code goes in this preamble area<br>const hiddenVar = 42<br>%}<br>// visible, reader-editable JavaScript code goes here<br>console.log(hiddenVar)<br>{% endrunkit %}<br></pre>
+
+      <h3>KaTeX Embed</h3>
+      <p>Place your mathematical expression within a KaTeX liquid block, as follows:</p>
+      <pre>{% katex %}<br> c = \pm\sqrt{a^2 + b^2}<br>{% endkatex %}<br></pre>
+      <p>To render KaTeX inline add the "inline" option:</p>
+      <pre>{% katex inline %}<br> c = \pm\sqrt{a^2 + b^2}<br>{% endkatex %}<br></pre>
+
+      <h3>Stackblitz Embed</h3>
+      <p>All you need is the ID of the Stackblitz:</p>
+      <code>{% stackblitz ball-demo %}</code>
+      <dl>
+        <dt><code>Default view</code></dt>
+        <dd>
+          You can change the default view, the options are <i>both</i>, <i>preview</i>, <i>editor</i>. Defaults to
+          <i>both</i><br>
+          <code>{% stackblitz ball-demo view=preview %}</code>
+        </dd>
+        <dt><code>Default file</code></dt>
+        <dd>
+          You can change the default file you want your embed to point to<br>
+          <code>{% stackblitz ball-demo file=style.css %}</code>
+        </dd>
+      </dl>
+      <h3>CodeSandbox Embed</h3>
+      <p>All you need is the ID of the Sandbox:</p>
+      <code>{% codesandbox ppxnl191zx %}</code>
+      <p>Of CodeSandbox's many
+        <a href="https://codesandbox.io/docs/embedding#embed-options">optional attributes</a>, the following are supported by using them in your tag, just add them after the id, separated by spaces.
+      </p>
+      <dl>
+        <dt><code>initialpath</code></dt>
+        <dd>
+          Which url to initially load in address bar.<br>
+          <code>{% codesandbox ppxnl191zx initialpath=/initial/load/path %}</code>
+        </dd>
+        <dt><code>module</code></dt>
+        <dd>
+          Which module to open by default.<br>
+          <code>{% codesandbox ppxnl191zx module=/path/to/module %}</code>
+        </dd>
+        <dt><code>runonclick</code></dt>
+        <dd>
+          Delays when code is ran if <code>1</code> <br>
+          <code>{% codesandbox ppxnl191zx runonclick=1 %}</code>
+        </dd>
+      </dl>
+      <h3>JSFiddle Embed</h3>
+      <p>All you need is the full JSFiddle <code>link</code>, ending in the fiddle ID code, as follows:</p>
+      <code>{% jsfiddle https://jsfiddle.net/link2twenty/v2kx9jcd %}</code>
+      <dl>
+        <dt><code>Custom tabs</code></dt>
+        <dd>
+          You can add a custom tab order to you JSFiddle embed tag. Defaults to <i>js,html,css,result</i><br>
+          <code>{% jsfiddle https://jsfiddle.net/webdevem/Q8KVC result,html,css %}</code>
+        </dd>
+      </dl>
+
+      <h3>JSitor Liquid Tag</h3>
+      <p>
+        To use JSitor liquid tag you can use the JSitor full <code>link</code>, with or without the parameters
+      </p>
+      <code>{% jsitor https://jsitor.com/embed/B7FQ5tHbY %}</code>
       <br />
-      <code>{% wikipedia https://en.wikipedia.org/wiki/Wikipedia#Diversity %}</code>
-    </p>
-    <h3>Asciinema Embed</h3>
-    <p>All you need is the Asciinema id:</p>
-    <code>{% asciinema 239367 %}</code>
-    <h3>Parsing Liquid Tags as a Code Example</h3>
-    <p>To parse Liquid tags as code, simply wrap it with a single backtick or triple backticks.</p>
-    <p><code>`{% mytag %}{{ site.SOMETHING }}{% endmytag %}`</code></p>
-    <p>One specific edge case is with using the <code>raw</code> tag. To properly escape it, use this format:
-    </p>
-    <p><code>`{% raw %}{{site.SOMETHING }} {% ``endraw`` %}`</code></p>
+      <code>{% jsitor https://jsitor.com/embed/B7FQ5tHbY?html&js&css&result&light %}</code>
+      <p>
+        Other options to use JSitor liquid tag is just by its ID, you can add it with or without the parameters
+      </p>
+      <code>{% jsitor B7FQ5tHbY %}</code>
+      <br />
+      <code>{% jsitor B7FQ5tHbY?html&js&css&result&light %}</code>
+
+      <h3>repl.it Embed</h3>
+      <p>All you need is the URL after the domain name:</p>
+      <code>{% replit @WigWog/PositiveFineOpensource %}</code>
+      <h3>Stackery Embed</h3>
+      <p>Visualize your AWS Serverless Application Model templates with <a href="https://www.stackery.io/">Stackery's</a> visualizer embed</p>
+      <p>All you need is the repository owner, repository name, and branch that you would like visualized</p>
+      <code>{% stackery deeheber lambda-layer-example master %}</code>
+      <br />
+      <p>The repository must be a public GitHub repository and have a valid AWS SAM template in the project root titled template.yaml</p>
+      <h3>Next Tech Embed</h3>
+      <p>All you need is the share URL for your sandbox. You can get the share URL by clicking
+      the "Share" button in the top right when the sandbox is open.</p>
+      <p><img src="https://thepracticaldev.s3.amazonaws.com/i/r449xp8cay3383i139qv.png" alt="Share Replit sandbox" /></p>
+      <code>{% nexttech https://nt.dev/s/6ba1fffbd09e %}</code>
+      <h3>Instagram Embed</h3>
+      <p>All you need is the Instagram post <code>id</code> from the URL:</p>
+      <code>{% instagram BXgGcAUjM39 %}</code>
+      <h3>Speakerdeck Tag</h3>
+      <p>All you need is the data-id code from the embed link:</p>
+      <pre><span style="color: gray;"># Given this embed link:</span><br>&lt;script async class="speakerdeck-embed"<br>    data-id="<span style='color: orange;'>7e9f8c0fa0c949bd8025457181913fd0</span>"<br>    data-ratio="1.77777777777778" src="//speakerdeck.com/assets/embed.js"&gt;&lt;/script&gt;</pre>
+      <pre>{% speakerdeck <span style="color: orange;">7e9f8c0fa0c949bd8025457181913fd0</span> %}</pre>
+      <h3>Soundcloud Embed</h3>
+      <p>Just enter the full URL of the Soundcloud track you are trying to embed.</p>
+      <code>{% soundcloud https://soundcloud.com/user-261265215/dev-to-review-episode-1 %}</code>
+      <h3>Spotify Embed</h3>
+      <p>
+        Enter the Spotify URI of the Spotify track / playlist /
+        album / artist / podcast episode you are trying to embed.
+      </p>
+      <pre>{% spotify <span style="color: #1DB954;">spotify:episode:5V4XZWqZQJvbddd31n56mf</span> %}</pre>
+      <h3>Blogcast Tag</h3>
+      <p>All you need is the article id code from the embed code:</p>
+      <pre>{% blogcast <span style="color: orange;">1234</span> %}</pre>
+      <h3>Parler Tag</h3>
+      <p>Enter the full url of the Parler.io audio file you want to embed. </p>
+      <pre>{% parler https://www.parler.io/audio/73240183203/d53cff009eac2ab1bc9dd8821a638823c39cbcea.7dd28611-b7fc-4cf8-9977-b6e3aaf644a1.mp3 %}</pre>
+      <h3>Stack Exchange / Stack Overflow Tag</h3>
+      <p>
+        You'll need the question or answer's ID code, and the site. When using <code>{% stackoverflow %}</code> as the tag, the site will default to Stack Overflow.
+        For example:
+        <br>
+        <a href="https://stackoverflow.com/questions/24789130/colors-in-irb-rails-console">https://stackoverflow.com/questions/24789130/colors-in-irb-rails-console</a>
+        <ul>
+            <li>The question ID is: <code style="color: aquamarine; background-color: black;">24789130</code></li>
+        </ul>
+        <pre>{% stackoverflow <span style="color: aquamarine;">24789130</span> %}</pre>
+      </p>
+      <p>
+        For other Stack Exchange network sites, you'll need to provide the site's name and use <code>{% stackexchange %}</code> as the tag. For example:
+        <br>
+        <a href="https://diy.stackexchange.com/questions/169988/base-for-refrigerator-wine-shelf">https://diy.stackexchange.com/questions/169988/base-for-refrigerator-wine-shelf</a>
+        <ul>
+          <li>The question ID is: <code style="color: aquamarine; background-color: black;">169988</code></li>
+        <li>The site is <code style="color: orange; background-color: black;">diy</code></li>
+        </ul>
+        <pre>{% stackexchange <span style="color: aquamarine;">169988</span> <span style="color: orange;">diy</span> %}</pre>
+      </p>
+      <p>
+      For answers, you can get the answer's ID code by from the answer's "Share" link. For example:
+      <br>
+      <a href="https://diy.stackexchange.com/a/170185">https://diy.stackexchange.com/a/170185</a>
+      <ul>
+        <li>The answer ID is: <code style="color: aquamarine; background-color: black;">170185</code></li>
+        <li>The site is <code style="color: orange; background-color: black;">diy</code></li>
+      </ul>
+      <pre>{% stackexchange <span style="color: aquamarine;">170185</span> <span style="color: orange;">diy</span> %}</pre>
+      </p>
+      <h3>Wikipedia Embed</h3>
+      <p>Enter the full URL of the Wikipedia article you want to embed, with or without the anchor.</p>
+      <p>
+        <code>{% wikipedia https://en.wikipedia.org/wiki/Wikipedia %}</code>
+        <br />
+        <code>{% wikipedia https://en.wikipedia.org/wiki/Wikipedia#Diversity %}</code>
+      </p>
+      <h3>Asciinema Embed</h3>
+      <p>All you need is the Asciinema id:</p>
+      <code>{% asciinema 239367 %}</code>
+      <h3>Parsing Liquid Tags as a Code Example</h3>
+      <p>To parse Liquid tags as code, simply wrap it with a single backtick or triple backticks.</p>
+      <p><code>`{% mytag %}{{ site.SOMETHING }}{% endmytag %}`</code></p>
+      <p>One specific edge case is with using the <code>raw</code> tag. To properly escape it, use this format:
+      </p>
+      <p><code>`{% raw %}{{site.SOMETHING }} {% ``endraw`` %}`</code></p>
+    </div>
   </div>
 </div>

--- a/app/views/pages/_editor_liquid_help.html.erb
+++ b/app/views/pages/_editor_liquid_help.html.erb
@@ -21,7 +21,7 @@
       <code>ID</code> at the end of a comment URL. To get the comment link, click either the timestamp or the menu button in the top right corner on a comment and then click "Permalink". Here's an example:
     </p>
     <code>{% devcomment 2d1a %}</code>
-    <% if @user_approved_liquid_tags.include? "LiquidTags::UserSubscriptionTag" %>
+    <% if @user_approved_liquid_tags.include? UserSubscriptionTag %>
       <h3><%= community_name %> User Subscriptions</h3>
       <p class="fs-s fw-bold">This tag can only be used in articles.</p>
       <p>You can add call-to-action text that will show above the subscribe button:</p>

--- a/app/views/pages/_editor_liquid_help.html.erb
+++ b/app/views/pages/_editor_liquid_help.html.erb
@@ -22,17 +22,6 @@
         <code>ID</code> at the end of a comment URL. To get the comment link, click either the timestamp or the menu button in the top right corner on a comment and then click "Permalink". Here's an example:
       </p>
       <code>{% devcomment 2d1a %}</code>
-      <% if @user_approved_liquid_tags.include? "LiquidTags::UserSubscriptionTag" %>
-        <h3><%= community_name %> User Subscriptions</h3>
-        <p class="fs-s fw-bold">This tag can only be used in articles.</p>
-        <p>You can add call-to-action text that will show above the subscribe button:</p>
-        <code>{% user_subscription If you'd like to receive future updates, subscribe below! %}</code>
-        <p class="fs-s">
-          If a reader is signed out, the button will prompt them to sign in first
-          to subscribe. If the reader is signed in, the button will prompt them
-          to subscribe.
-        </p>
-      <% end %>
       <h3><%= community_name %> Podcast Episode Embed</h3>
       <p>All you need is the full link of the podcast episode:</p>
       <code>{% podcast https://dev.to/basecspodcast/s2e2--queues-irl %}</code>

--- a/app/views/pages/_editor_liquid_help.html.erb
+++ b/app/views/pages/_editor_liquid_help.html.erb
@@ -1,292 +1,301 @@
 <div id="editor-liquid-help">
-  <div class="crayons-article">
-    <div class="crayons-article__body">
-      <p>We support native <a href="https://shopify.github.io/liquid" target="_blank" rel="noopener">Liquid tags</a> in our editor, but have created our own custom tags listed below:</p>
-      <h3><%= community_name %> Article/Post Embed</h3>
-      <p>All you need is the full link of the article:</p>
-      <code>{% link https://dev.to/kazz/boost-your-productivity-using-markdown-1be %}</code>
-      <p>You can also use the slug like this:</p>
-      <code>{% link kazz/boost-your-productivity-using-markdown-1be %}</code>
-      <p>You can also use the alias post instead of link like this:</p>
-      <code>{% post https://dev.to/kazz/boost-your-productivity-using-markdown-1be %}</code>
-      <p>or this:</p>
-      <code>{% post kazz/boost-your-productivity-using-markdown-1be %}</code>
-      <h3><%= community_name %> User Embed</h3>
-      <p>All you need is the <%= community_name %> username:</p>
-      <code>{% user jess %}</code>
-      <h3><%= community_name %> Tag Embed</h3>
-      <p>All you need is the tag name:</p>
-      <code>{% tag git %}</code>
-      <h3><%= community_name %> Comment Embed</h3>
-      <p>All you need is the
-        <code>ID</code> at the end of a comment URL. To get the comment link, click either the timestamp or the menu button in the top right corner on a comment and then click "Permalink". Here's an example:
+  <div class="text-styles">
+    <p>We support native <a href="https://shopify.github.io/liquid" target="_blank" rel="noopener">Liquid tags</a> in our editor, but have created our own custom tags listed below:</p>
+    <h3><%= community_name %> Article/Post Embed</h3>
+    <p>All you need is the full link of the article:</p>
+    <code>{% link https://dev.to/kazz/boost-your-productivity-using-markdown-1be %}</code>
+    <p>You can also use the slug like this:</p>
+    <code>{% link kazz/boost-your-productivity-using-markdown-1be %}</code>
+    <p>You can also use the alias post instead of link like this:</p>
+    <code>{% post https://dev.to/kazz/boost-your-productivity-using-markdown-1be %}</code>
+    <p>or this:</p>
+    <code>{% post kazz/boost-your-productivity-using-markdown-1be %}</code>
+    <h3><%= community_name %> User Embed</h3>
+    <p>All you need is the <%= community_name %> username:</p>
+    <code>{% user jess %}</code>
+    <h3><%= community_name %> Tag Embed</h3>
+    <p>All you need is the tag name:</p>
+    <code>{% tag git %}</code>
+    <h3><%= community_name %> Comment Embed</h3>
+    <p>All you need is the
+      <code>ID</code> at the end of a comment URL. To get the comment link, click either the timestamp or the menu button in the top right corner on a comment and then click "Permalink". Here's an example:
+    </p>
+    <code>{% devcomment 2d1a %}</code>
+    <% if @user_approved_liquid_tags.include? "LiquidTags::UserSubscriptionTag" %>
+      <h3><%= community_name %> User Subscriptions</h3>
+      <p class="fs-s fw-bold">This tag can only be used in articles.</p>
+      <p>You can add call-to-action text that will show above the subscribe button:</p>
+      <code>{% user_subscription If you'd like to receive future updates, subscribe below! %}</code>
+      <p class="fs-s">
+        If a reader is signed out, the button will prompt them to sign in first
+        to subscribe. If the reader is signed in, the button will prompt them
+        to subscribe.
       </p>
-      <code>{% devcomment 2d1a %}</code>
-      <h3><%= community_name %> Podcast Episode Embed</h3>
-      <p>All you need is the full link of the podcast episode:</p>
-      <code>{% podcast https://dev.to/basecspodcast/s2e2--queues-irl %}</code>
-      <h3><%= community_name %> Listing Embed</h3>
-      <p>All you need is the full link of the listing:</p>
-      <code>{% listing https://dev.to/listings/collabs/dev-is-open-source-823 %}</code>
-      <p>You can also use the category and slug like this:</p>
-      <code>{% listing collabs/dev-is-open-source-823 %}</code>
-      <p>Note: Expired listings will raise an error. Make sure the listing is published or recently bumped.</p>
-      <h3>Twitter Embed</h3>
-      <p>Using the Twitter Liquid tag will allow the tweet to pre-render from the server, providing your reader with a better experience. All you need is the tweet
-        <code>id</code> from the url.</p>
-      <code>{% twitter 834439977220112384 %}</code>
-      <h3>Glitch embed</h3>
-      <p>All you need is the Glitch project slug</p>
-      <code>{% glitch earthy-course %}</code>
-      <p>There are several
-        <a href="https://glitch.com/help/how-can-i-customize-a-glitch-app-embed">optional attributes</a> you can use in your tag, just add them after the id, separated by spaces.
-      </p>
-      <ul>
-        <li><code>app</code> – Shows the app preview without the code.<br>
-          <code>{% glitch earthy-course app %}</code>
-        </li>
-        <li><code>code</code> – Shows the code without the app preview.<br>
-          <code>{% glitch earthy-course code %}</code></li>
-        <li><code>preview-first</code> – Swap panes: Show the app preview on the left and the code on the right.<br>
-          <code>{% glitch earthy-course preview-first %}</code></li>
-        <li><code>no-attribution</code> – Hides the avatar of the creator(s).<br>
-          <code>{% glitch earthy-course no-attribution %}</code></li>
-        <li><code>no-files</code> – Hides the file browser.<br>
-          <code>{% glitch earthy-course no-files %}</code></li>
-        <li><code>file</code> – Lets you choose which file to display in the code panel. Defaults to index.html.<br>
-          <code>{% glitch earthy-course file=script.js %}</code></li>
-      </ul>
-      <h3>GitHub Repo Embed</h3>
-      <p>All you need is the GitHub username and repo:</p>
-      <code>{% github thepracticaldev/dev.to %}</code>
-      <dl>
-        <dt><code>no-readme</code></dt>
-        <dd>
-          You can add a no-readme option to your GitHub tag to hide the readme file from the preview.<br>
-          <code>{% github thepracticaldev/dev.to no-readme %}</code>
-        </dd>
-      </dl>
-      <h3>GitHub Issue, Pull request or Comment Embed</h3>
-      <p>All you need is the GitHub issue, PR or comment URL:</p>
-      <code>{% github https://github.com/thepracticaldev/dev.to/issues/9 %}</code>
-      <h3>GitHub Gist Embed</h3>
-      <p>All you need is the gist link:</p>
-      <code>
-        {% gist https://gist.github.com/CristinaSolana/1885435 %}
-      </code>
-      <dl>
-        <dt><code>Single File Embed</code></dt>
-        <dd>
-          <p>You can choose to embed a single gist file. <br>
-          <code>{% gist https://gist.github.com/CristinaSolana/1885435 file=gistfile1.md %}</code></p>
-        </dd>
-        <dt><code>Specific Version Embed</code></dt>
-        <dd>
-          <p>You can choose to embed a specific version of a gist file. All you need
-          the link and the commit hash for that specific version. <br>
-          The format is <code>{% gist [gist-link]/[commit-hash] %}</code> <br>
-          e.g. <br>
-          <code>{% gist https://gist.github.com/suntong/3a31faf8129d3d7a380122d5a6d48ff6/f77d01e82defbf736ebf4879a812cf9c916a9252 %}</code></p>
-        </dd>
-        <dt><code>Specific Version File Embed</code></dt>
-        <dd>
-          <p>You can choose to embed a specific version of a gist file. All you need
-          the link, the filename and the commit hash for that specific version . <br>
-          The format is <code>{% gist [gist-link]/[commit-hash] file=[filename] %}</code> <br>
-          e.g. <br>
-          <code>
-            {% gist https://gist.github.com/suntong/3a31faf8129d3d7a380122d5a6d48ff6/f77d01e82defbf736ebf4879a812cf9c916a9252 file=Images.tmpl %}
-          </code></p>
-        </dd>
-      </dl>
-      <h3>GitPitch Embed</h3>
-      <p>All you need is the GitPitch link:</p>
-      <code>
-        {% gitpitch https://gitpitch.com/gitpitch/in-60-seconds %}
-      </code>
-      <h3>Video Embed</h3>
-      <p>All you need is the <code>id</code> from the URL.</p>
-      <ul>
-        <li><strong>YouTube:</strong> <code>{% youtube dQw4w9WgXcQ %}</code></li>
-        <li><strong>Vimeo:</strong> <code>{% vimeo 193110695 %}</code></li>
-      </ul>
-      <h3>Medium Embed</h3>
-      <p>Just enter the full URL of the Medium article you are trying to embed.</p>
-      <code>{% medium https://medium.com/s/story/boba-science-how-can-i-drink-a-bubble-tea-to-ensure-that-i-dont-finish-the-tea-before-the-bobas-7fc5fd0e442d %}</code>
-      <h3>SlideShare Embed</h3>
-      <p>All you need is the SlideShare <code>key</code>:</p>
-      <code>{% slideshare rdOzN9kr1yK5eE %}</code>
-      <h3>CodePen Embed</h3>
-      <p>All you need is the full CodePen <code>link</code>, ending in the pen ID code, as follows:</p>
-      <code>{% codepen https://codepen.io/twhite96/pen/XKqrJX %}</code>
-      <dl>
-        <dt><code>default-tab</code></dt>
-        <dd>
-          Add default-tab parameter to your CodePen embed tag. Default to <i>result</i><br>
-          <code>{% codepen https://codepen.io/twhite96/pen/XKqrJX default-tab=js,result %}</code>
-        </dd>
-      </dl>
-      <h3>Kotlin Playground</h3>
-      <p>To create a runnable kotlin snippet, create a Kotlin Snippet at <a href="https://play.kotlinlang.org">https://play.kotlinlang.org</a></p>
-      <p>Go to <code>Share</code> dialog and copy the full <code>link</code> from the <code>Medium</code> tab. Use it as follows:</p>
-      <code>{% kotlin https://pl.kotl.in/owreUFFUG?theme=darcula&from=3&to=6&readOnly=true %}</code>
-      <h3>RunKit Embed</h3>
-      <p>Put executable code within a runkit liquid block, as follows:</p>
-      <pre>{% runkit<br>// hidden setup JavaScript code goes in this preamble area<br>const hiddenVar = 42<br>%}<br>// visible, reader-editable JavaScript code goes here<br>console.log(hiddenVar)<br>{% endrunkit %}<br></pre>
+    <% end %>
+    <h3><%= community_name %> Podcast Episode Embed</h3>
+    <p>All you need is the full link of the podcast episode:</p>
+    <code>{% podcast https://dev.to/basecspodcast/s2e2--queues-irl %}</code>
+    <h3><%= community_name %> Listing Embed</h3>
+    <p>All you need is the full link of the listing:</p>
+    <code>{% listing https://dev.to/listings/collabs/dev-is-open-source-823 %}</code>
+    <p>You can also use the category and slug like this:</p>
+    <code>{% listing collabs/dev-is-open-source-823 %}</code>
+    <p>Note: Expired listings will raise an error. Make sure the listing is published or recently bumped.</p>
+    <h3>Twitter Embed</h3>
+    <p>Using the Twitter Liquid tag will allow the tweet to pre-render from the server, providing your reader with a better experience. All you need is the tweet
+      <code>id</code> from the url.</p>
+    <code>{% twitter 834439977220112384 %}</code>
+    <h3>Glitch embed</h3>
+    <p>All you need is the Glitch project slug</p>
+    <code>{% glitch earthy-course %}</code>
+    <p>There are several
+      <a href="https://glitch.com/help/how-can-i-customize-a-glitch-app-embed">optional attributes</a> you can use in your tag, just add them after the id, separated by spaces.
+    </p>
+    <ul>
+      <li><code>app</code> – Shows the app preview without the code.<br>
+        <code>{% glitch earthy-course app %}</code>
+      </li>
+      <li><code>code</code> – Shows the code without the app preview.<br>
+        <code>{% glitch earthy-course code %}</code></li>
+      <li><code>preview-first</code> – Swap panes: Show the app preview on the left and the code on the right.<br>
+        <code>{% glitch earthy-course preview-first %}</code></li>
+      <li><code>no-attribution</code> – Hides the avatar of the creator(s).<br>
+        <code>{% glitch earthy-course no-attribution %}</code></li>
+      <li><code>no-files</code> – Hides the file browser.<br>
+        <code>{% glitch earthy-course no-files %}</code></li>
+      <li><code>file</code> – Lets you choose which file to display in the code panel. Defaults to index.html.<br>
+        <code>{% glitch earthy-course file=script.js %}</code></li>
+    </ul>
+    <h3>GitHub Repo Embed</h3>
+    <p>All you need is the GitHub username and repo:</p>
+    <code>{% github thepracticaldev/dev.to %}</code>
+    <dl>
+      <dt><code>no-readme</code></dt>
+      <dd>
+        You can add a no-readme option to your GitHub tag to hide the readme file from the preview.<br>
+        <code>{% github thepracticaldev/dev.to no-readme %}</code>
+      </dd>
+    </dl>
+    <h3>GitHub Issue, Pull request or Comment Embed</h3>
+    <p>All you need is the GitHub issue, PR or comment URL:</p>
+    <code>{% github https://github.com/thepracticaldev/dev.to/issues/9 %}</code>
+    <h3>GitHub Gist Embed</h3>
+    <p>All you need is the gist link:</p>
+    <code>
+      {% gist https://gist.github.com/CristinaSolana/1885435 %}
+    </code>
+    <dl>
+      <dt><code>Single File Embed</code></dt>
+      <dd>
+        <p>You can choose to embed a single gist file. <br>
+        <code>{% gist https://gist.github.com/CristinaSolana/1885435 file=gistfile1.md %}</code></p>
+      </dd>
+      <dt><code>Specific Version Embed</code></dt>
+      <dd>
+        <p>You can choose to embed a specific version of a gist file. All you need
+        the link and the commit hash for that specific version. <br>
+        The format is <code>{% gist [gist-link]/[commit-hash] %}</code> <br>
+        e.g. <br>
+        <code>{% gist https://gist.github.com/suntong/3a31faf8129d3d7a380122d5a6d48ff6/f77d01e82defbf736ebf4879a812cf9c916a9252 %}</code></p>
+      </dd>
+      <dt><code>Specific Version File Embed</code></dt>
+      <dd>
+        <p>You can choose to embed a specific version of a gist file. All you need
+        the link, the filename and the commit hash for that specific version . <br>
+        The format is <code>{% gist [gist-link]/[commit-hash] file=[filename] %}</code> <br>
+        e.g. <br>
+        <code>
+          {% gist https://gist.github.com/suntong/3a31faf8129d3d7a380122d5a6d48ff6/f77d01e82defbf736ebf4879a812cf9c916a9252 file=Images.tmpl %}
+        </code></p>
+      </dd>
+    </dl>
+    <h3>GitPitch Embed</h3>
+    <p>All you need is the GitPitch link:</p>
+    <code>
+      {% gitpitch https://gitpitch.com/gitpitch/in-60-seconds %}
+    </code>
+    <h3>Video Embed</h3>
+    <p>All you need is the <code>id</code> from the URL.</p>
+    <ul>
+      <li><strong>YouTube:</strong> <code>{% youtube dQw4w9WgXcQ %}</code></li>
+      <li><strong>Vimeo:</strong> <code>{% vimeo 193110695 %}</code></li>
+    </ul>
+    <h3>Medium Embed</h3>
+    <p>Just enter the full URL of the Medium article you are trying to embed.</p>
+    <code>{% medium https://medium.com/s/story/boba-science-how-can-i-drink-a-bubble-tea-to-ensure-that-i-dont-finish-the-tea-before-the-bobas-7fc5fd0e442d %}</code>
+    <h3>SlideShare Embed</h3>
+    <p>All you need is the SlideShare <code>key</code>:</p>
+    <code>{% slideshare rdOzN9kr1yK5eE %}</code>
+    <h3>CodePen Embed</h3>
+    <p>All you need is the full CodePen <code>link</code>, ending in the pen ID code, as follows:</p>
+    <code>{% codepen https://codepen.io/twhite96/pen/XKqrJX %}</code>
+    <dl>
+      <dt><code>default-tab</code></dt>
+      <dd>
+        Add default-tab parameter to your CodePen embed tag. Default to <i>result</i><br>
+        <code>{% codepen https://codepen.io/twhite96/pen/XKqrJX default-tab=js,result %}</code>
+      </dd>
+    </dl>
+    <h3>Kotlin Playground</h3>
+    <p>To create a runnable kotlin snippet, create a Kotlin Snippet at <a href="https://play.kotlinlang.org">https://play.kotlinlang.org</a></p>
+    <p>Go to <code>Share</code> dialog and copy the full <code>link</code> from the <code>Medium</code> tab. Use it as follows:</p>
+    <code>{% kotlin https://pl.kotl.in/owreUFFUG?theme=darcula&from=3&to=6&readOnly=true %}</code>
+    <h3>RunKit Embed</h3>
+    <p>Put executable code within a runkit liquid block, as follows:</p>
+    <pre>{% runkit<br>// hidden setup JavaScript code goes in this preamble area<br>const hiddenVar = 42<br>%}<br>// visible, reader-editable JavaScript code goes here<br>console.log(hiddenVar)<br>{% endrunkit %}<br></pre>
 
-      <h3>KaTeX Embed</h3>
-      <p>Place your mathematical expression within a KaTeX liquid block, as follows:</p>
-      <pre>{% katex %}<br> c = \pm\sqrt{a^2 + b^2}<br>{% endkatex %}<br></pre>
-      <p>To render KaTeX inline add the "inline" option:</p>
-      <pre>{% katex inline %}<br> c = \pm\sqrt{a^2 + b^2}<br>{% endkatex %}<br></pre>
+    <h3>KaTeX Embed</h3>
+    <p>Place your mathematical expression within a KaTeX liquid block, as follows:</p>
+    <pre>{% katex %}<br> c = \pm\sqrt{a^2 + b^2}<br>{% endkatex %}<br></pre>
+    <p>To render KaTeX inline add the "inline" option:</p>
+    <pre>{% katex inline %}<br> c = \pm\sqrt{a^2 + b^2}<br>{% endkatex %}<br></pre>
 
-      <h3>Stackblitz Embed</h3>
-      <p>All you need is the ID of the Stackblitz:</p>
-      <code>{% stackblitz ball-demo %}</code>
-      <dl>
-        <dt><code>Default view</code></dt>
-        <dd>
-          You can change the default view, the options are <i>both</i>, <i>preview</i>, <i>editor</i>. Defaults to
-          <i>both</i><br>
-          <code>{% stackblitz ball-demo view=preview %}</code>
-        </dd>
-        <dt><code>Default file</code></dt>
-        <dd>
-          You can change the default file you want your embed to point to<br>
-          <code>{% stackblitz ball-demo file=style.css %}</code>
-        </dd>
-      </dl>
-      <h3>CodeSandbox Embed</h3>
-      <p>All you need is the ID of the Sandbox:</p>
-      <code>{% codesandbox ppxnl191zx %}</code>
-      <p>Of CodeSandbox's many
-        <a href="https://codesandbox.io/docs/embedding#embed-options">optional attributes</a>, the following are supported by using them in your tag, just add them after the id, separated by spaces.
-      </p>
-      <dl>
-        <dt><code>initialpath</code></dt>
-        <dd>
-          Which url to initially load in address bar.<br>
-          <code>{% codesandbox ppxnl191zx initialpath=/initial/load/path %}</code>
-        </dd>
-        <dt><code>module</code></dt>
-        <dd>
-          Which module to open by default.<br>
-          <code>{% codesandbox ppxnl191zx module=/path/to/module %}</code>
-        </dd>
-        <dt><code>runonclick</code></dt>
-        <dd>
-          Delays when code is ran if <code>1</code> <br>
-          <code>{% codesandbox ppxnl191zx runonclick=1 %}</code>
-        </dd>
-      </dl>
-      <h3>JSFiddle Embed</h3>
-      <p>All you need is the full JSFiddle <code>link</code>, ending in the fiddle ID code, as follows:</p>
-      <code>{% jsfiddle https://jsfiddle.net/link2twenty/v2kx9jcd %}</code>
-      <dl>
-        <dt><code>Custom tabs</code></dt>
-        <dd>
-          You can add a custom tab order to you JSFiddle embed tag. Defaults to <i>js,html,css,result</i><br>
-          <code>{% jsfiddle https://jsfiddle.net/webdevem/Q8KVC result,html,css %}</code>
-        </dd>
-      </dl>
+    <h3>Stackblitz Embed</h3>
+    <p>All you need is the ID of the Stackblitz:</p>
+    <code>{% stackblitz ball-demo %}</code>
+    <dl>
+      <dt><code>Default view</code></dt>
+      <dd>
+        You can change the default view, the options are <i>both</i>, <i>preview</i>, <i>editor</i>. Defaults to
+        <i>both</i><br>
+        <code>{% stackblitz ball-demo view=preview %}</code>
+      </dd>
+      <dt><code>Default file</code></dt>
+      <dd>
+        You can change the default file you want your embed to point to<br>
+        <code>{% stackblitz ball-demo file=style.css %}</code>
+      </dd>
+    </dl>
+    <h3>CodeSandbox Embed</h3>
+    <p>All you need is the ID of the Sandbox:</p>
+    <code>{% codesandbox ppxnl191zx %}</code>
+    <p>Of CodeSandbox's many
+      <a href="https://codesandbox.io/docs/embedding#embed-options">optional attributes</a>, the following are supported by using them in your tag, just add them after the id, separated by spaces.
+    </p>
+    <dl>
+      <dt><code>initialpath</code></dt>
+      <dd>
+        Which url to initially load in address bar.<br>
+        <code>{% codesandbox ppxnl191zx initialpath=/initial/load/path %}</code>
+      </dd>
+      <dt><code>module</code></dt>
+      <dd>
+        Which module to open by default.<br>
+        <code>{% codesandbox ppxnl191zx module=/path/to/module %}</code>
+      </dd>
+      <dt><code>runonclick</code></dt>
+      <dd>
+        Delays when code is ran if <code>1</code> <br>
+        <code>{% codesandbox ppxnl191zx runonclick=1 %}</code>
+      </dd>
+    </dl>
+    <h3>JSFiddle Embed</h3>
+    <p>All you need is the full JSFiddle <code>link</code>, ending in the fiddle ID code, as follows:</p>
+    <code>{% jsfiddle https://jsfiddle.net/link2twenty/v2kx9jcd %}</code>
+    <dl>
+      <dt><code>Custom tabs</code></dt>
+      <dd>
+        You can add a custom tab order to you JSFiddle embed tag. Defaults to <i>js,html,css,result</i><br>
+        <code>{% jsfiddle https://jsfiddle.net/webdevem/Q8KVC result,html,css %}</code>
+      </dd>
+    </dl>
 
-      <h3>JSitor Liquid Tag</h3>
-      <p>
-        To use JSitor liquid tag you can use the JSitor full <code>link</code>, with or without the parameters
-      </p>
-      <code>{% jsitor https://jsitor.com/embed/B7FQ5tHbY %}</code>
-      <br />
-      <code>{% jsitor https://jsitor.com/embed/B7FQ5tHbY?html&js&css&result&light %}</code>
-      <p>
-        Other options to use JSitor liquid tag is just by its ID, you can add it with or without the parameters
-      </p>
-      <code>{% jsitor B7FQ5tHbY %}</code>
-      <br />
-      <code>{% jsitor B7FQ5tHbY?html&js&css&result&light %}</code>
+    <h3>JSitor Liquid Tag</h3>
+    <p>
+      To use JSitor liquid tag you can use the JSitor full <code>link</code>, with or without the parameters
+    </p>
+    <code>{% jsitor https://jsitor.com/embed/B7FQ5tHbY %}</code>
+    <br />
+    <code>{% jsitor https://jsitor.com/embed/B7FQ5tHbY?html&js&css&result&light %}</code>
+    <p>
+      Other options to use JSitor liquid tag is just by its ID, you can add it with or without the parameters
+    </p>
+    <code>{% jsitor B7FQ5tHbY %}</code>
+    <br />
+    <code>{% jsitor B7FQ5tHbY?html&js&css&result&light %}</code>
 
-      <h3>repl.it Embed</h3>
-      <p>All you need is the URL after the domain name:</p>
-      <code>{% replit @WigWog/PositiveFineOpensource %}</code>
-      <h3>Stackery Embed</h3>
-      <p>Visualize your AWS Serverless Application Model templates with <a href="https://www.stackery.io/">Stackery's</a> visualizer embed</p>
-      <p>All you need is the repository owner, repository name, and branch that you would like visualized</p>
-      <code>{% stackery deeheber lambda-layer-example master %}</code>
-      <br />
-      <p>The repository must be a public GitHub repository and have a valid AWS SAM template in the project root titled template.yaml</p>
-      <h3>Next Tech Embed</h3>
-      <p>All you need is the share URL for your sandbox. You can get the share URL by clicking
-      the "Share" button in the top right when the sandbox is open.</p>
-      <p><img src="https://thepracticaldev.s3.amazonaws.com/i/r449xp8cay3383i139qv.png" alt="Share Replit sandbox" /></p>
-      <code>{% nexttech https://nt.dev/s/6ba1fffbd09e %}</code>
-      <h3>Instagram Embed</h3>
-      <p>All you need is the Instagram post <code>id</code> from the URL:</p>
-      <code>{% instagram BXgGcAUjM39 %}</code>
-      <h3>Speakerdeck Tag</h3>
-      <p>All you need is the data-id code from the embed link:</p>
-      <pre><span style="color: gray;"># Given this embed link:</span><br>&lt;script async class="speakerdeck-embed"<br>    data-id="<span style='color: orange;'>7e9f8c0fa0c949bd8025457181913fd0</span>"<br>    data-ratio="1.77777777777778" src="//speakerdeck.com/assets/embed.js"&gt;&lt;/script&gt;</pre>
-      <pre>{% speakerdeck <span style="color: orange;">7e9f8c0fa0c949bd8025457181913fd0</span> %}</pre>
-      <h3>Soundcloud Embed</h3>
-      <p>Just enter the full URL of the Soundcloud track you are trying to embed.</p>
-      <code>{% soundcloud https://soundcloud.com/user-261265215/dev-to-review-episode-1 %}</code>
-      <h3>Spotify Embed</h3>
-      <p>
-        Enter the Spotify URI of the Spotify track / playlist /
-        album / artist / podcast episode you are trying to embed.
-      </p>
-      <pre>{% spotify <span style="color: #1DB954;">spotify:episode:5V4XZWqZQJvbddd31n56mf</span> %}</pre>
-      <h3>Blogcast Tag</h3>
-      <p>All you need is the article id code from the embed code:</p>
-      <pre>{% blogcast <span style="color: orange;">1234</span> %}</pre>
-      <h3>Parler Tag</h3>
-      <p>Enter the full url of the Parler.io audio file you want to embed. </p>
-      <pre>{% parler https://www.parler.io/audio/73240183203/d53cff009eac2ab1bc9dd8821a638823c39cbcea.7dd28611-b7fc-4cf8-9977-b6e3aaf644a1.mp3 %}</pre>
-      <h3>Stack Exchange / Stack Overflow Tag</h3>
-      <p>
-        You'll need the question or answer's ID code, and the site. When using <code>{% stackoverflow %}</code> as the tag, the site will default to Stack Overflow.
-        For example:
-        <br>
-        <a href="https://stackoverflow.com/questions/24789130/colors-in-irb-rails-console">https://stackoverflow.com/questions/24789130/colors-in-irb-rails-console</a>
-        <ul>
-            <li>The question ID is: <code style="color: aquamarine; background-color: black;">24789130</code></li>
-        </ul>
-        <pre>{% stackoverflow <span style="color: aquamarine;">24789130</span> %}</pre>
-      </p>
-      <p>
-        For other Stack Exchange network sites, you'll need to provide the site's name and use <code>{% stackexchange %}</code> as the tag. For example:
-        <br>
-        <a href="https://diy.stackexchange.com/questions/169988/base-for-refrigerator-wine-shelf">https://diy.stackexchange.com/questions/169988/base-for-refrigerator-wine-shelf</a>
-        <ul>
-          <li>The question ID is: <code style="color: aquamarine; background-color: black;">169988</code></li>
-        <li>The site is <code style="color: orange; background-color: black;">diy</code></li>
-        </ul>
-        <pre>{% stackexchange <span style="color: aquamarine;">169988</span> <span style="color: orange;">diy</span> %}</pre>
-      </p>
-      <p>
-      For answers, you can get the answer's ID code by from the answer's "Share" link. For example:
+    <h3>repl.it Embed</h3>
+    <p>All you need is the URL after the domain name:</p>
+    <code>{% replit @WigWog/PositiveFineOpensource %}</code>
+    <h3>Stackery Embed</h3>
+    <p>Visualize your AWS Serverless Application Model templates with <a href="https://www.stackery.io/">Stackery's</a> visualizer embed</p>
+    <p>All you need is the repository owner, repository name, and branch that you would like visualized</p>
+    <code>{% stackery deeheber lambda-layer-example master %}</code>
+    <br />
+    <p>The repository must be a public GitHub repository and have a valid AWS SAM template in the project root titled template.yaml</p>
+    <h3>Next Tech Embed</h3>
+    <p>All you need is the share URL for your sandbox. You can get the share URL by clicking
+    the "Share" button in the top right when the sandbox is open.</p>
+    <p><img src="https://thepracticaldev.s3.amazonaws.com/i/r449xp8cay3383i139qv.png" alt="Share Replit sandbox" /></p>
+    <code>{% nexttech https://nt.dev/s/6ba1fffbd09e %}</code>
+    <h3>Instagram Embed</h3>
+    <p>All you need is the Instagram post <code>id</code> from the URL:</p>
+    <code>{% instagram BXgGcAUjM39 %}</code>
+    <h3>Speakerdeck Tag</h3>
+    <p>All you need is the data-id code from the embed link:</p>
+    <pre><span style="color: gray;"># Given this embed link:</span><br>&lt;script async class="speakerdeck-embed"<br>    data-id="<span style='color: orange;'>7e9f8c0fa0c949bd8025457181913fd0</span>"<br>    data-ratio="1.77777777777778" src="//speakerdeck.com/assets/embed.js"&gt;&lt;/script&gt;</pre>
+    <pre>{% speakerdeck <span style="color: orange;">7e9f8c0fa0c949bd8025457181913fd0</span> %}</pre>
+    <h3>Soundcloud Embed</h3>
+    <p>Just enter the full URL of the Soundcloud track you are trying to embed.</p>
+    <code>{% soundcloud https://soundcloud.com/user-261265215/dev-to-review-episode-1 %}</code>
+    <h3>Spotify Embed</h3>
+    <p>
+      Enter the Spotify URI of the Spotify track / playlist /
+      album / artist / podcast episode you are trying to embed.
+    </p>
+    <pre>{% spotify <span style="color: #1DB954;">spotify:episode:5V4XZWqZQJvbddd31n56mf</span> %}</pre>
+    <h3>Blogcast Tag</h3>
+    <p>All you need is the article id code from the embed code:</p>
+    <pre>{% blogcast <span style="color: orange;">1234</span> %}</pre>
+    <h3>Parler Tag</h3>
+    <p>Enter the full url of the Parler.io audio file you want to embed. </p>
+    <pre>{% parler https://www.parler.io/audio/73240183203/d53cff009eac2ab1bc9dd8821a638823c39cbcea.7dd28611-b7fc-4cf8-9977-b6e3aaf644a1.mp3 %}</pre>
+    <h3>Stack Exchange / Stack Overflow Tag</h3>
+    <p>
+      You'll need the question or answer's ID code, and the site. When using <code>{% stackoverflow %}</code> as the tag, the site will default to Stack Overflow.
+      For example:
       <br>
-      <a href="https://diy.stackexchange.com/a/170185">https://diy.stackexchange.com/a/170185</a>
+      <a href="https://stackoverflow.com/questions/24789130/colors-in-irb-rails-console">https://stackoverflow.com/questions/24789130/colors-in-irb-rails-console</a>
       <ul>
-        <li>The answer ID is: <code style="color: aquamarine; background-color: black;">170185</code></li>
-        <li>The site is <code style="color: orange; background-color: black;">diy</code></li>
+          <li>The question ID is: <code style="color: aquamarine; background-color: black;">24789130</code></li>
       </ul>
-      <pre>{% stackexchange <span style="color: aquamarine;">170185</span> <span style="color: orange;">diy</span> %}</pre>
-      </p>
-      <h3>Wikipedia Embed</h3>
-      <p>Enter the full URL of the Wikipedia article you want to embed, with or without the anchor.</p>
-      <p>
-        <code>{% wikipedia https://en.wikipedia.org/wiki/Wikipedia %}</code>
-        <br />
-        <code>{% wikipedia https://en.wikipedia.org/wiki/Wikipedia#Diversity %}</code>
-      </p>
-      <h3>Asciinema Embed</h3>
-      <p>All you need is the Asciinema id:</p>
-      <code>{% asciinema 239367 %}</code>
-      <h3>Parsing Liquid Tags as a Code Example</h3>
-      <p>To parse Liquid tags as code, simply wrap it with a single backtick or triple backticks.</p>
-      <p><code>`{% mytag %}{{ site.SOMETHING }}{% endmytag %}`</code></p>
-      <p>One specific edge case is with using the <code>raw</code> tag. To properly escape it, use this format:
-      </p>
-      <p><code>`{% raw %}{{site.SOMETHING }} {% ``endraw`` %}`</code></p>
-    </div>
+      <pre>{% stackoverflow <span style="color: aquamarine;">24789130</span> %}</pre>
+    </p>
+    <p>
+      For other Stack Exchange network sites, you'll need to provide the site's name and use <code>{% stackexchange %}</code> as the tag. For example:
+      <br>
+      <a href="https://diy.stackexchange.com/questions/169988/base-for-refrigerator-wine-shelf">https://diy.stackexchange.com/questions/169988/base-for-refrigerator-wine-shelf</a>
+      <ul>
+        <li>The question ID is: <code style="color: aquamarine; background-color: black;">169988</code></li>
+      <li>The site is <code style="color: orange; background-color: black;">diy</code></li>
+      </ul>
+      <pre>{% stackexchange <span style="color: aquamarine;">169988</span> <span style="color: orange;">diy</span> %}</pre>
+    </p>
+    <p>
+    For answers, you can get the answer's ID code by from the answer's "Share" link. For example:
+    <br>
+    <a href="https://diy.stackexchange.com/a/170185">https://diy.stackexchange.com/a/170185</a>
+    <ul>
+      <li>The answer ID is: <code style="color: aquamarine; background-color: black;">170185</code></li>
+      <li>The site is <code style="color: orange; background-color: black;">diy</code></li>
+    </ul>
+    <pre>{% stackexchange <span style="color: aquamarine;">170185</span> <span style="color: orange;">diy</span> %}</pre>
+    </p>
+    <h3>Wikipedia Embed</h3>
+    <p>Enter the full URL of the Wikipedia article you want to embed, with or without the anchor.</p>
+    <p>
+      <code>{% wikipedia https://en.wikipedia.org/wiki/Wikipedia %}</code>
+      <br />
+      <code>{% wikipedia https://en.wikipedia.org/wiki/Wikipedia#Diversity %}</code>
+    </p>
+    <h3>Asciinema Embed</h3>
+    <p>All you need is the Asciinema id:</p>
+    <code>{% asciinema 239367 %}</code>
+    <h3>Parsing Liquid Tags as a Code Example</h3>
+    <p>To parse Liquid tags as code, simply wrap it with a single backtick or triple backticks.</p>
+    <p><code>`{% mytag %}{{ site.SOMETHING }}{% endmytag %}`</code></p>
+    <p>One specific edge case is with using the <code>raw</code> tag. To properly escape it, use this format:
+    </p>
+    <p><code>`{% raw %}{{site.SOMETHING }} {% ``endraw`` %}`</code></p>
   </div>
 </div>

--- a/docs/frontend/liquid-tags.md
+++ b/docs/frontend/liquid-tags.md
@@ -129,8 +129,8 @@ Here we are saying that the `UserSubscriptionTag` is only usable by users with
 the `admin` role or with a role of `:restricted_liquid_tag` and a specified
 resource of `LiquidTags::UserSubscriptionTag`.
 
-`LiquidTags::UserSubscriptionTag` is simply a resource model to play nicely with
-the [Rolify][rolify] gem. See [/internal](/internal) for more information.
+`LiquidTags::UserSubscriptionTag` is a resource model to play nicely with the
+[Rolify][rolify] gem. See [/internal](/internal) for more information.
 
 **REMINDER: if you do not define a `VALID_ROLES` constant, the liquid tag will
 be usable by all users by default.**

--- a/docs/frontend/liquid-tags.md
+++ b/docs/frontend/liquid-tags.md
@@ -113,21 +113,24 @@ https://github.com/thepracticaldev/dev.to/pull/3801
 
 To only allow users with specific roles to use a liquid tag, you need to define
 a `VALID_ROLES` constant on the liquid tag itself. It needs to be an `Array` of
-valid roles. For [single admin resource roles](/internal), it needs to be an
-`Array` with the role and the resource. Here's an example:
+valid roles. For [single resource roles](/internal), it needs to be an `Array`
+with the role and the resource. Here's an example:
 
 ```ruby
 class NewLiquidTag < LiquidTagBase
   VALID_ROLES = [
     :admin,
-    [:single_resource_admin, NewLiquidTag]
+    [:restricted_liquid_tag, LiquidTags::UserSubscriptionTag]
   ].freeze
 end
 ```
 
-Here we are saying that the `NewLiquidTag` is only usable by users with the
-`admin` role or with a role of `:single_resource_admin` and a specified resource
-of `NewLiquidTag`.
+Here we are saying that the `UserSubscriptionTag` is only usable by users with
+the `admin` role or with a role of `:restricted_liquid_tag` and a specified
+resource of `LiquidTags::UserSubscriptionTag`.
+
+`LiquidTags::UserSubscriptionTag` is simply a resource model to play nicely with
+the [Rolify][rolify] gem. See [/internal](/internal) for more information.
 
 **REMINDER: if you do not define a `VALID_ROLES` constant, the liquid tag will
 be usable by all users by default.**
@@ -151,3 +154,5 @@ end
 
 **REMINDER: if you do not define a `VALID_CONTEXTS` constant the liquid tag will
 be usable in all contexts by default.**
+
+[rolify]: https://github.com/RolifyCommunity/rolify

--- a/docs/frontend/liquid-tags.md
+++ b/docs/frontend/liquid-tags.md
@@ -129,8 +129,8 @@ Here we are saying that the `UserSubscriptionTag` is only usable by users with
 the `admin` role or with a role of `:restricted_liquid_tag` and a specified
 resource of `LiquidTags::UserSubscriptionTag`.
 
-`LiquidTags::UserSubscriptionTag` is a resource model to play nicely with the
-[Rolify][rolify] gem. See [/internal](/internal) for more information.
+`LiquidTags::UserSubscriptionTag` is a resource model so we that can play nicely
+with the [Rolify][rolify] gem. See [/internal](/internal) for more information.
 
 **REMINDER: if you do not define a `VALID_ROLES` constant, the liquid tag will
 be usable by all users by default.**

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -56,8 +56,7 @@ FactoryBot.define do
     end
   end
 
-  # TODO: (Alex Smith) - update roles before release
   trait :with_user_subscription_tag_role_user do
-    after(:build) { |article| article.user.add_role(:super_admin) }
+    after(:build) { |article| article.user.add_role(:restricted_liquid_tag, LiquidTags::UserSubscriptionTag) }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -55,6 +55,14 @@ FactoryBot.define do
       after(:build) { |user, options| user.add_role(:single_resource_admin, options.resource) }
     end
 
+    trait :restricted_liquid_tag do
+      transient do
+        resource { nil }
+      end
+
+      after(:build) { |user, options| user.add_role(:restricted_liquid_tag, options.resource) }
+    end
+
     trait :super_plus_single_resource_admin do
       transient do
         resource { nil }

--- a/spec/liquid_tags/user_subscription_tag_spec.rb
+++ b/spec/liquid_tags/user_subscription_tag_spec.rb
@@ -4,8 +4,14 @@ RSpec.describe UserSubscriptionTag, type: :liquid_tag do
   setup { Liquid::Template.register_tag("user_subscription", described_class) }
 
   let(:subscriber) { create(:user) }
-  let(:author) { create(:user, :restricted_liquid_tag, resource: LiquidTags::UserSubscriptionTag) }
+  let(:author) { create(:user) }
   let(:article_with_user_subscription_tag) { create(:article, :with_user_subscription_tag_role_user, with_user_subscription_tag: true) }
+
+  # Stub roles because adding them normally can cause flaky specs
+  before do
+    allow(author).to receive(:has_role?).and_call_original
+    allow(author).to receive(:has_role?).with(:restricted_liquid_tag, LiquidTags::UserSubscriptionTag).and_return(true)
+  end
 
   context "when rendering" do
     it "renders default data correctly" do

--- a/spec/liquid_tags/user_subscription_tag_spec.rb
+++ b/spec/liquid_tags/user_subscription_tag_spec.rb
@@ -4,10 +4,8 @@ RSpec.describe UserSubscriptionTag, type: :liquid_tag do
   setup { Liquid::Template.register_tag("user_subscription", described_class) }
 
   let(:subscriber) { create(:user) }
-  let(:author) { create(:user, :super_admin) } # TODO: (Alex Smith) - update roles before release
-  let(:article_with_user_subscription_tag) do
-    create(:article, :with_user_subscription_tag_role_user, with_user_subscription_tag: true)
-  end
+  let(:author) { create(:user, :restricted_liquid_tag, resource: LiquidTags::UserSubscriptionTag) }
+  let(:article_with_user_subscription_tag) { create(:article, :with_user_subscription_tag_role_user, with_user_subscription_tag: true) }
 
   context "when rendering" do
     it "renders default data correctly" do

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -8,10 +8,9 @@ RSpec.describe Role, type: :model do
   describe "::ROLES" do
     it "contains the correct values" do
       expected_roles = %w[
-        admin banned chatroom_beta_tester comment_banned
-        podcast_admin pro single_resource_admin super_admin
-        tag_moderator mod_relations_admin tech_admin
-        trusted warned workshop_pass
+        admin banned chatroom_beta_tester comment_banned podcast_admin pro restricted_liquid_tag
+        single_resource_admin super_admin tag_moderator mod_relations_admin tech_admin trusted
+        warned workshop_pass
       ]
       expect(described_class::ROLES).to eq(expected_roles)
     end

--- a/spec/policies/liquid_tag_policy_spec.rb
+++ b/spec/policies/liquid_tag_policy_spec.rb
@@ -41,8 +41,10 @@ RSpec.describe LiquidTagPolicy, type: :policy do
 
     it "handles single resource roles" do
       user = create(:user)
+      # Stub roles because adding them normally can cause flaky specs
       single_resource_role = [:restricted_liquid_tag, LiquidTags::UserSubscriptionTag]
-      user.add_role(*single_resource_role)
+      allow(user).to receive(:has_role?).and_call_original
+      allow(user).to receive(:has_role?).with(*single_resource_role).and_return(true)
       parse_context = { source: article, user: user }
 
       allow(liquid_tag).to receive(:parse_context).and_return(parse_context)

--- a/spec/policies/liquid_tag_policy_spec.rb
+++ b/spec/policies/liquid_tag_policy_spec.rb
@@ -40,12 +40,13 @@ RSpec.describe LiquidTagPolicy, type: :policy do
     end
 
     it "handles single resource roles" do
-      # TODO: (Alex Smith) - update roles to new liquid tag role for more relevant example/use
-      user = create(:user, :single_resource_admin, resource: Article)
+      user = create(:user)
+      single_resource_role = [:restricted_liquid_tag, LiquidTags::UserSubscriptionTag]
+      user.add_role(*single_resource_role)
       parse_context = { source: article, user: user }
 
       allow(liquid_tag).to receive(:parse_context).and_return(parse_context)
-      stub_const("#{liquid_tag.class}::VALID_ROLES", [[:single_resource_admin, Article]])
+      stub_const("#{liquid_tag.class}::VALID_ROLES", [single_resource_role])
       expect do
         Pundit.authorize(user, liquid_tag, action, policy_class: described_class)
       end.not_to raise_error


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)
- [x] Feature

## Description
This PR adds the new role that's going to be used for the liquid tag and adds some documentation to liquid tags for using it.

A few things to note:
- The way we currently handle documenting liquid tags needs a re-factor, but that's outside the scope of this PR. Currently, we render directions for liquid tags in 3 different pages ([`/app/views/_editor_liquid_help.html.erb`](https://github.com/thepracticaldev/dev.to/blob/master/app/views/pages/_editor_liquid_help.html.erb), [`/app/views/pages/markdown_basics.html.erb`](https://github.com/thepracticaldev/dev.to/blob/master/app/views/pages/markdown_basics.html.erb), [`/app/views/pages/_editor_guide_text.html.erb`](https://github.com/thepracticaldev/dev.to/blob/master/app/views/pages/markdown_basics.html.erb)). Ideally, it would be one location that the different areas render as needed.
- Furthermore, we could probably come up with a better way to handle the conditional rendering of liquid tag documentation. For example, show only liquid tags that can be used in articles in the editor.
- The design of liquid tag documentation will likely be updated in the near future as well. You'll notice we aren't consistent with how we do it right now.
- For now, since the `user_subscription` liquid tag is the first and only liquid tag that's context and role-specific, I just took the shortcut. I render the documentation for it if the user has any of the tag's permitted roles and it's hard-coded to say it's only for use in articles.

**I'll copy and paste this description on each PR.**
We are building a liquid tag where permitted authors can embed a button that users/readers can click to share the email address associated with their DEV account with the author.

_We are restricting this liquid tag only for use in `Articles` (not `Comments` or `Pages`) and for use only by approved organizations for CodeLand (using a new role)._
- [x] [Create a new database table to hold subscriptions](https://github.com/thepracticaldev/dev.to/issues/8170)
- [x] [Capture the subscriber's email address](https://github.com/thepracticaldev/dev.to/issues/8722)
- [x] [Create a new endpoint to handle email signups from the new liquid tag](https://github.com/thepracticaldev/dev.to/issues/8171)
- [x] [Create a user subscription button liquid tag](https://github.com/thepracticaldev/dev.to/issues/8168)
- [x] [Add subscriptions to the dashbaord](https://github.com/thepracticaldev/dev.to/issues/8169)
- [x] [Create a new role for users approved to use the new user subscription liquid tag and add docs](https://github.com/thepracticaldev/dev.to/issues/8165)

## Related Tickets & Documents
Closes #9086 

## QA Instructions, Screenshots, Recordings
_Setup_
Grab a user record that you can sign in with. For me, that's usually `User.last`.
```ruby
user = User.last
# or
user = User.find_by(email: 'emailaddressofyourlocaluser@hey.com')
```
and add the new role to this user:
```ruby
user.add_role(:restricted_liquid_tag, LiquidTags::UserSubscriptionTag)
```
1. Go to the editor - **Write a post** / https://localhost:3000/new.
2. Click into the body of the article editor to trigger the helper to pop up on the right.
3. Click the **Liquid Tags** link in the helper.
4. Make sure you see the documentation for the user subscription tag 🎉 .

![Screen Shot 2020-07-06 at 2 01 48 PM](https://user-images.githubusercontent.com/15987080/86624674-ba00d000-bf91-11ea-9d96-1424aa327f36.png)

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

![exhausted_gif](https://media.giphy.com/media/FqdruC6cJYXxC/giphy.gif)
