### PR TITLE
Feature: Label Honeybadger Env with Community Name

### DIFF
--- a/config/initializers/honeybadger.rb
+++ b/config/initializers/honeybadger.rb
@@ -13,6 +13,7 @@ COMPONENT_FINGERPRINTS = {
 }.freeze
 
 Honeybadger.configure do |config|
+  config.env = "#{ApplicationConfig['APP_DOMAIN']}-#{Rails.env}"
   config.api_key = ApplicationConfig["HONEYBADGER_API_KEY"]
   config.revision = ApplicationConfig["HEROKU_SLUG_COMMIT"]
   config.exceptions.ignore += [


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
When we start running and hosting multiple Forems ourselves we are going to want their errors in a single location for debugging. This will help us split up Forems we host by APP_DOMAIN in Honeybadger. I was originally going to go with community name but since that could contain special characters and spaces I thought APP_DOMAIN was safer and would make it easy to figure out where you need to go if you are looking at a Honeybadger

NOTE: With this change, all of our errors that we have seen in the past will get re-reported since Honeybadger will detect them for a new environment. This will mean a little cleanup on my end initially but after a couple of weeks everything should go back to normal error rates. Could also be a chance to clean up some things we have been ignoring. 

# Related Ticket
https://github.com/thepracticaldev/dev.to/projects/9#card-40830106

## QA Instructions, Screenshots, Recordings
Will check Honeybadger following deploying this to ensure data is coming in correctly. 

## Added tests?
- [x] no, because they aren't needed


![alt_text](https://media3.giphy.com/media/fsKSe2ykELgrsXdE2S/giphy.gif)
