### PR TITLE
Feature: Filter Sensitive Data From Production Logs

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -84,6 +84,15 @@ Rails.application.configure do
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
 
+  # Filter sensitive information from production logs
+  config.filter_parameters += %i[
+    auth_data_dump email encrypted
+    encrypted_password message_html message_markdown
+    password previous_refresh_token refresh_token secret
+    token current_sign_in_ip last_sign_in_ip
+    reset_password_token remember_token unconfirmed_email
+  ]
+
   # Use default logging formatter so that PID and timestamp are not suppressed.
   # config.log_formatter = ::Logger::Formatter.new
   config.log_formatter = ::Logger::Formatter.new


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
[Rails 6 offers the option of filtering data from logs](https://blog.saeloun.com/2019/12/03/rails-6-adds-activesupport-parameter-filter.html). I think using this we could quickly get logs into Datadog to allow for a more full-featured debugging experience. This can tie us over until we have a full logging solution using Fluentd and Elasticsearch. 

To get logs into Datadog all we have to do is [update our Heroku setup to drain logs to Datadog](https://docs.datadoghq.com/logs/guide/collect-heroku-logs/) and then we should be able to remove Timber. The advantage here is that we can remove the Timber specific code yet all Datadog is doing is tailing the application logs so we dont have to add additional special code to the app to get the logs we want. 

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/9#card-33250889

## QA Instructions, Screenshots, Recordings
I will QA this by exploring Timber logs after this is out to ensure that all the relevant data is being filtered. I will also checkout Honeycomb to see if that is affect in any way by this change. 

## Added tests?
- [x] no, because they aren't needed


![alt_text](https://media3.giphy.com/media/Pmk5IQyi88qmP7SrVs/source.gif)
