### PR TITLE
Fix sign in flow for user subscription liquid tag

### DIFF
--- a/app/liquid_tags/user_subscription_tag.rb
+++ b/app/liquid_tags/user_subscription_tag.rb
@@ -147,9 +147,11 @@ class UserSubscriptionTag < LiquidTagBase
     // ***************************************
     function addSignInClickHandler() {
       const signInBtn = document.getElementById('sign-in-btn');
-      if (signInBtn && typeof showModal !== 'undefined') {
+      if (signInBtn) {
         signInBtn.addEventListener('click', function(e) {
-          showModal('email_signup');
+          if (typeof showModal !== 'undefined') {
+            showModal('user_subscription');
+          }
         });
       }
     }

--- a/spec/liquid_tags/user_subscription_tag_spec.rb
+++ b/spec/liquid_tags/user_subscription_tag_spec.rb
@@ -108,6 +108,12 @@ RSpec.describe UserSubscriptionTag, type: :liquid_tag do
       expect(page).to have_css("#subscriber-apple-auth", visible: :hidden)
       expect(page).to have_css("#subscription-signed-out", visible: :visible)
     end
+
+    it "allows a user to sign in", type: :system, js: true do
+      expect(page).to have_css("#global-signup-modal", visible: :hidden)
+      click_button("Sign In", id: "sign-in-btn")
+      expect(page).to have_css("#global-signup-modal", visible: :visible)
+    end
   end
 
   # TODO: [@thepracticaldev/delightful]: re-enable this once email confirmation


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
When I re-did the JS in #9082 I accidentally messed up the sign in flow. This PR fixes that bug and adds a spec to check for this case.

## QA Instructions, Screenshots, Recordings
1. Make sure you're signed in locally as an admin user.
2. Write a post and include the liquid tag `{% user_subscription Some sweet CTA text %}`.
3. Publish your Article.
4. Sign out.
5. View your Article.
6. Click sign in on the liquid tag - you should be directed to sign in 🎉 .

## Related Tickets & Documents
#9082 

## Added tests?
- [x] yes

## Added to documentation?
- [x] no documentation needed

![blinds_a_mess_gif](https://media.giphy.com/media/YFkpsHWCsNUUo/giphy.gif)
