### PR TITLE
Use custom UglifierCompressor to enable source-maps

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -31,7 +31,7 @@ Rails.application.configure do
   }
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = Uglifier.new(harmony: true)
+  config.assets.js_compressor = :uglify_with_source_maps
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.

--- a/config/initializers/sprockets_uglifier_with_source_maps_compressor.rb
+++ b/config/initializers/sprockets_uglifier_with_source_maps_compressor.rb
@@ -1,0 +1,49 @@
+require "sprockets/digest_utils"
+require "sprockets/uglifier_compressor"
+
+module Sprockets
+  class UglifierWithSourceMapsCompressor < Sprockets::UglifierCompressor
+    def call(input)
+      data = input.fetch(:data) # Non-Uglified contents of the JS file
+      name = input.fetch(:name) # name of the to-be-compressed JS file.
+
+      @uglifier ||= Autoload::Uglifier.new(@options.merge({ harmony: true }))
+      compressed_data, sourcemap_json = @uglifier.compile_with_map(input[:data])
+
+      # Update source map according to the version 3 spec: https://sourcemaps.info/spec.html
+      sourcemap                   = JSON.parse(sourcemap_json)
+      sourcemap["sources"]        = [name + ".js"]
+      sourcemap["sourceRoot"]     = ::Rails.application.config.assets.prefix
+      sourcemap["sourcesContent"] = [data]
+      sourcemap_json              = sourcemap.to_json
+
+      sourcemap_filename = File.join(
+        ::Rails.application.config.assets.prefix,
+        "#{name}-#{digest(sourcemap_json)}.js.map",
+      )
+      sourcemap_path = File.join(::Rails.public_path, sourcemap_filename)
+      sourcemap_url  = filename_to_url(sourcemap_filename)
+
+      FileUtils.mkdir_p File.dirname(sourcemap_path)
+      File.open(sourcemap_path, "w") { |f| f.write sourcemap_json }
+
+      # Add the source map URL to the compressed JS file.
+      compressed_data.concat "\n//# sourceMappingURL=#{sourcemap_url}\n"
+    end
+
+    def filename_to_url(filename)
+      url_root = ::Rails.application.config.assets.source_maps_domain
+      File.join url_root.to_s, filename
+    end
+
+    def digest(io)
+      Sprockets::DigestUtils.pack_hexdigest Sprockets::DigestUtils.digest(io)
+    end
+  end
+end
+
+Sprockets.register_compressor(
+  "application/javascript",
+  :uglify_with_source_maps,
+  Sprockets::UglifierWithSourceMapsCompressor,
+)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature/DX

## Description
This PR enables source map for our `app/asset/javascripts` on production. While Sprocket indicate that it is possible to enable source map but there's no documentation anywhere on it. I decided to go with modified UglifierCompressor because it doesn't require `assets.debug = true` and still allow us to use Uglifier as our compressor.
## Related Tickets & Documents
https://blog.experteer.engineering/generating-sourcemaps-with-sprockets-3-and-uglify.html
## QA Instructions, Screenshots, Recordings
1. Place `config.assets.js_compressor = :uglify_with_source_maps` in `development.rb`
2. run `bin/rails assets:clobber`
3. run `bin/rails assets:precompile`
4. Start up the server and navigate to homepage.
5. Open up browser console and you should see source map being detected
![Screen Shot 2020-07-07 at 1 04 36 PM](https://user-images.githubusercontent.com/15793250/86817540-27c10080-c053-11ea-9d60-26d8b5117fed.png)


## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
none
## [optional] What gif best describes this PR or how it makes you feel?
![](https://media.giphy.com/media/5e7IgAQL94d6ooCi43/giphy.gif)

![alt_text](gif_link)
