### PR TITLE
Only run UserSubscription JS on appropriate Articles

### DIFF
--- a/app/liquid_tags/user_subscription_tag.rb
+++ b/app/liquid_tags/user_subscription_tag.rb
@@ -277,18 +277,22 @@ class UserSubscriptionTag < LiquidTagBase
       });
     }
 
-    // The markup defaults to signed out UX
-    if (isUserSignedIn()) {
-      showSignedIn();
-      addConfirmationModalClickHandlers();
+    // We load this JS on every Article. This is to only run it on Articles
+    // where the UserSubscription liquid tag is present
+    if (document.getElementById('user-subscription-tag')) {
+      // The markup defaults to signed out UX
+      if (isUserSignedIn()) {
+        showSignedIn();
+        addConfirmationModalClickHandlers();
 
-      // We need access to some DOM elements (i.e. csrf token, article id, userData, etc.)
-      document.addEventListener('DOMContentLoaded', function() {
-        checkIfSubscribed();
-      });
-    } else {
-      showSignedOut();
-      addSignInClickHandler();
+        // We need access to some DOM elements (i.e. csrf token, article id, userData, etc.)
+        document.addEventListener('DOMContentLoaded', function() {
+          checkIfSubscribed();
+        });
+      } else {
+        showSignedOut();
+        addSignInClickHandler();
+      }
     }
   JAVASCRIPT
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
@vaidehijoshi noticed an error in her browser console from some JS trying to hit the `/user_subscriptions/subscribed` endpoint while viewing a draft Article. I was unable to reproduce the error in a draft article or a published article, including or excluding the liquid tag.

Either way, it's probably better to not run the JS at all if the liquid tag is not on the page (this PR adds this check). I suspect it was a bad request because some DOM elements/data were missing given the article was a draft and/or didn't have the liquid tag.

## Related Tickets & Documents
n/a

## QA Instructions, Screenshots, Recordings
1. Write a draft article without the user subscription liquid tag - check the browser console for failed requests to `/user_subscriptions/subscribed`.
2. Publish the article, view the article - check the browser console for failed requests to `/user_subscriptions/subscribed`.
3. Write a draft article with the user subscription liquid tag (`{% user_subscription some CTA text %}`) - check the browser console for failed requests to `/user_subscriptions/subscribed`.
4. Publish the article, view the article - check the browser console for failed requests to `/user_subscriptions/subscribed`.

## Added tests?
- [x] no, because I need help
Given the setup, I don't see an easy way to verify the script is _not_ run 🤔 .

## Added to documentation?
- [x] no documentation needed

![over_it_gif](https://media.giphy.com/media/3o6ZtokgzQv6ThHzj2/giphy.gif)
