### PR TITLE
Remove unnecessary ?url= param from report-abuse

### DIFF
--- a/app/views/articles/_conduct_and_abuse_actions.html.erb
+++ b/app/views/articles/_conduct_and_abuse_actions.html.erb
@@ -1,3 +1,3 @@
 <a href="/code-of-conduct">code of conduct</a>
 -
-<a href="/report-abuse?url=<%= request.url %>">report abuse</a>
+<a href="/report-abuse">report abuse</a>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

This PR removes the `?url=` from the `report-abuse` button. This is fine because the report abuse page actually prefills the field based on the referring URL anyway.

Several reasons for this change:

- We already have this functionality in the "three dots" menu on article pages, so this brings parity.
- Currently the `request.url` includes `?i=i` if the page is loaded by service workers (under the hood) so this is a small issue)
- This removes a huge longtail of pages we link to which don't provide SEO value. One less type of page the bots feel they need to crawl every time.