### PR TITLE
Fix Style/SingleLineBlockParams, RSpec/MultipleExpectations and remaining Layout/LineLength

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -446,3 +446,9 @@ RSpec/ExampleLength:
   Enabled: true
   Max: 15
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExampleLength
+
+RSpec/MultipleExpectations:
+  Description: Checks if examples contain too many `expect` calls.
+  Enabled: true
+  Max: 8
+  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MultipleExpectations

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -46,10 +46,6 @@ RSpec/ExampleLength:
     - 'spec/models/comment_spec.rb'
     - 'spec/requests/display_ad_events_spec.rb'
 
-# Offense count: 930
-RSpec/MultipleExpectations:
-  Max: 12
-
 # Offense count: 1
 RSpec/SubjectStub:
   Exclude:
@@ -93,10 +89,3 @@ Rails/UniqueValidationWithoutIndex:
 # SupportedStyles: nested, compact
 Style/ClassAndModuleChildren:
   Enabled: false
-
-# Offense count: 3
-# Configuration parameters: Methods.
-# Methods: {"reduce"=>["acc", "elem"]}, {"inject"=>["acc", "elem"]}
-# Style/SingleLineBlockParams:
-#   Exclude:
-#     - 'app/labor/markdown_fixer.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -97,6 +97,6 @@ Style/ClassAndModuleChildren:
 # Offense count: 3
 # Configuration parameters: Methods.
 # Methods: {"reduce"=>["acc", "elem"]}, {"inject"=>["acc", "elem"]}
-Style/SingleLineBlockParams:
-  Exclude:
-    - 'app/labor/markdown_fixer.rb'
+# Style/SingleLineBlockParams:
+#   Exclude:
+#     - 'app/labor/markdown_fixer.rb'

--- a/app/labor/markdown_fixer.rb
+++ b/app/labor/markdown_fixer.rb
@@ -7,17 +7,17 @@ class MarkdownFixer
         add_quotes_to_title add_quotes_to_description
         modify_hr_tags convert_new_lines split_tags underscores_in_usernames
       ]
-      methods.reduce(markdown) { |result, method| send(method, result) }
+      methods.reduce(markdown) { |acc, elem| send(elem, acc) }
     end
 
     def fix_for_preview(markdown)
       methods = %i[add_quotes_to_title add_quotes_to_description modify_hr_tags underscores_in_usernames]
-      methods.reduce(markdown) { |result, method| send(method, result) }
+      methods.reduce(markdown) { |acc, elem| send(elem, acc) }
     end
 
     def fix_for_comment(markdown)
       methods = %I[modify_hr_tags underscores_in_usernames]
-      methods.reduce(markdown) { |result, method| send(method, result) }
+      methods.reduce(markdown) { |acc, elem| send(elem, acc) }
     end
 
     def add_quotes_to_title(markdown)

--- a/spec/lib/data_update_scripts/re_index_feed_content_and_users_to_elasticsearch_spec.rb
+++ b/spec/lib/data_update_scripts/re_index_feed_content_and_users_to_elasticsearch_spec.rb
@@ -1,4 +1,3 @@
-# rubocop:disable RSpec/ExampleLength
 require "rails_helper"
 require Rails.root.join("lib/data_update_scripts/20200519142908_re_index_feed_content_and_users_to_elasticsearch.rb")
 
@@ -8,27 +7,49 @@ describe DataUpdateScripts::ReIndexFeedContentAndUsersToElasticsearch do
     Search::User.refresh_index
   end
 
-  it "indexes feed content(articles, comments, podcast episodes) and users to Elasticsearch" do
+  it "indexes feed(articles) to Elasticsearch" do
     article = create(:article)
-    podcast_episode = create(:podcast_episode)
-    comment = create(:comment)
-    user = create(:user)
 
     expect { article.elasticsearch_doc }.to raise_error(Search::Errors::Transport::NotFound)
+
+    sidekiq_perform_enqueued_jobs { described_class.new.run }
+
+    expect(article.elasticsearch_doc).not_to be_nil
+    expect(article.elasticsearch_doc["_source"].keys).to include("public_reactions_count")
+  end
+
+  it "indexes feed(podcast episodes) to Elasticsearch" do
+    podcast_episode = create(:podcast_episode)
+
     expect { podcast_episode.elasticsearch_doc }.to raise_error(Search::Errors::Transport::NotFound)
+
+    sidekiq_perform_enqueued_jobs { described_class.new.run }
+
+    expect(podcast_episode.elasticsearch_doc).not_to be_nil
+    expect(podcast_episode.elasticsearch_doc["_source"].keys).to include("public_reactions_count")
+  end
+
+  it "indexes feed(comments) to Elasticsearch" do
+    comment = create(:comment)
+
     expect { comment.elasticsearch_doc }.to raise_error(Search::Errors::Transport::NotFound)
+
+    sidekiq_perform_enqueued_jobs { described_class.new.run }
+
+    expect(comment.elasticsearch_doc).not_to be_nil
+
+    expect(comment.elasticsearch_doc["_source"].keys).to include("public_reactions_count")
+  end
+
+  it "indexes users to Elasticsearch" do
+    user = create(:user)
+
     expect { user.elasticsearch_doc }.to raise_error(Search::Errors::Transport::NotFound)
 
     sidekiq_perform_enqueued_jobs { described_class.new.run }
-    expect(article.elasticsearch_doc).not_to be_nil
-    expect(podcast_episode.elasticsearch_doc).not_to be_nil
-    expect(comment.elasticsearch_doc).not_to be_nil
+
     expect(user.elasticsearch_doc).not_to be_nil
 
-    expect(article.elasticsearch_doc["_source"].keys).to include "public_reactions_count"
-    expect(podcast_episode.elasticsearch_doc["_source"].keys).to include "public_reactions_count"
-    expect(comment.elasticsearch_doc["_source"].keys).to include "public_reactions_count"
-    expect(user.elasticsearch_doc["_source"].keys).to include "public_reactions_count"
+    expect(user.elasticsearch_doc["_source"].keys).to include("public_reactions_count")
   end
 end
-# rubocop:enable RSpec/ExampleLength

--- a/spec/lib/data_update_scripts/re_index_feed_content_and_users_to_elasticsearch_spec.rb
+++ b/spec/lib/data_update_scripts/re_index_feed_content_and_users_to_elasticsearch_spec.rb
@@ -7,49 +7,29 @@ describe DataUpdateScripts::ReIndexFeedContentAndUsersToElasticsearch do
     Search::User.refresh_index
   end
 
-  it "indexes feed(articles) to Elasticsearch" do
+  # rubocop:disable RSpec/ExampleLength
+  it "indexes feed content(articles, comments, podcast episodes) and users to Elasticsearch", :aggregate_failures do
     article = create(:article)
-
-    expect { article.elasticsearch_doc }.to raise_error(Search::Errors::Transport::NotFound)
-
-    sidekiq_perform_enqueued_jobs { described_class.new.run }
-
-    expect(article.elasticsearch_doc).not_to be_nil
-    expect(article.elasticsearch_doc["_source"].keys).to include("public_reactions_count")
-  end
-
-  it "indexes feed(podcast episodes) to Elasticsearch" do
     podcast_episode = create(:podcast_episode)
-
-    expect { podcast_episode.elasticsearch_doc }.to raise_error(Search::Errors::Transport::NotFound)
-
-    sidekiq_perform_enqueued_jobs { described_class.new.run }
-
-    expect(podcast_episode.elasticsearch_doc).not_to be_nil
-    expect(podcast_episode.elasticsearch_doc["_source"].keys).to include("public_reactions_count")
-  end
-
-  it "indexes feed(comments) to Elasticsearch" do
     comment = create(:comment)
-
-    expect { comment.elasticsearch_doc }.to raise_error(Search::Errors::Transport::NotFound)
-
-    sidekiq_perform_enqueued_jobs { described_class.new.run }
-
-    expect(comment.elasticsearch_doc).not_to be_nil
-
-    expect(comment.elasticsearch_doc["_source"].keys).to include("public_reactions_count")
-  end
-
-  it "indexes users to Elasticsearch" do
     user = create(:user)
 
+    expect { article.elasticsearch_doc }.to raise_error(Search::Errors::Transport::NotFound)
+    expect { podcast_episode.elasticsearch_doc }.to raise_error(Search::Errors::Transport::NotFound)
+    expect { comment.elasticsearch_doc }.to raise_error(Search::Errors::Transport::NotFound)
     expect { user.elasticsearch_doc }.to raise_error(Search::Errors::Transport::NotFound)
 
     sidekiq_perform_enqueued_jobs { described_class.new.run }
 
+    expect(article.elasticsearch_doc).not_to be_nil
+    expect(podcast_episode.elasticsearch_doc).not_to be_nil
+    expect(comment.elasticsearch_doc).not_to be_nil
     expect(user.elasticsearch_doc).not_to be_nil
 
-    expect(user.elasticsearch_doc["_source"].keys).to include("public_reactions_count")
+    expect(article.elasticsearch_doc["_source"].keys).to include "public_reactions_count"
+    expect(podcast_episode.elasticsearch_doc["_source"].keys).to include "public_reactions_count"
+    expect(comment.elasticsearch_doc["_source"].keys).to include "public_reactions_count"
+    expect(user.elasticsearch_doc["_source"].keys).to include "public_reactions_count"
   end
+  # rubocop:enable RSpec/ExampleLength
 end

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -381,6 +381,10 @@ RSpec.describe "Dashboards", type: :request do
                   102, # Current pagination limit is 100
                   author: author,
                   user_subscription_sourceable: article_with_user_subscription_tag)
+      params = {
+        source_type: article_with_user_subscription_tag.class.name,
+        source_id: article_with_user_subscription_tag.id
+      }
       get "/dashboard/subscriptions", params: params
       expect(response.body).to include "pagination"
     end

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -381,10 +381,6 @@ RSpec.describe "Dashboards", type: :request do
                   102, # Current pagination limit is 100
                   author: author,
                   user_subscription_sourceable: article_with_user_subscription_tag)
-      params = {
-        source_type: article_with_user_subscription_tag.class.name,
-        source_id: article_with_user_subscription_tag.id
-      }
       get "/dashboard/subscriptions", params: params
       expect(response.body).to include "pagination"
     end

--- a/spec/services/broadcasts/welcome_notification/generator_spec.rb
+++ b/spec/services/broadcasts/welcome_notification/generator_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe Broadcasts::WelcomeNotification::Generator, type: :service do
     end
 
     # rubocop:disable RSpec/ExampleLength
+    # rubocop:disable RSpec/MultipleExpectations
     it "sends only 1 notification at a time, in the correct order" do
       user.update!(created_at: 1.day.ago)
 
@@ -93,6 +94,7 @@ RSpec.describe Broadcasts::WelcomeNotification::Generator, type: :service do
       expect(user.notifications.last.notifiable).to eq(download_app_broadcast)
       Timecop.return
     end
+    # rubocop:enable RSpec/MultipleExpectations
     # rubocop:enable RSpec/ExampleLength
   end
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Instead of ignoring `RSpec/MultipleExpectations` which by default is set to 1 `expect()` per test case (with 930 violations) I set it to a more than reasonable 8 (mostly by process of elimination :D) and refactored a couple of tests that had 12 `expect()`.

In general I think we should work towards getting rid of the `.rubocop_todo.yml` over inline `rubocop:disable` statements as they are visible during the process of creating code. The todo file is likely to be overlooked most of the times.

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
