### PR TITLE
Refactor: Remove Omniauth Error Logs, Send to Honeybadger

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -72,18 +72,20 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
       user_errors = @user.errors.full_messages
 
-      Rails.logger.error("Log in error: sign in failed. username: #{@user.username} - email: #{@user.email}")
-      Rails.logger.error("Log in error: auth data hash - #{request.env['omniauth.auth']}")
-      Rails.logger.error("Log in error: auth data hash - #{request.env['omniauth.error']&.inspect}")
-      Rails.logger.error("Log in error: user_errors: #{user_errors}")
+      Honeybadger.context({
+                            username: @user.username,
+                            user_id: @user.id,
+                            auth_data: request.env["omniauth.auth"],
+                            auth_error: request.env["omniauth.error"]&.inspect,
+                            user_errors: user_errors
+                          })
+      Honeybadger.notify("Omniauth log in error")
 
       flash[:alert] = user_errors
       redirect_to new_user_registration_url
     end
   rescue StandardError => e
-    Rails.logger.error("Log in error: #{e}")
-    Rails.logger.error("Log in error: auth data hash - #{request.env['omniauth.auth']}")
-    Rails.logger.error("Log in error: auth data hash - #{request.env['omniauth.error']&.inspect}")
+    Honeybadger.notify(e)
 
     flash[:alert] = "Log in error: #{e}"
     redirect_to new_user_registration_url

--- a/spec/system/authentication/user_logs_in_with_github_spec.rb
+++ b/spec/system/authentication/user_logs_in_with_github_spec.rb
@@ -145,13 +145,13 @@ RSpec.describe "Authenticating with GitHub" do
         expect(page).to have_current_path("/users/sign_up")
       end
 
-      it "logs errors" do
-        allow(Rails.logger).to receive(:error)
+      it "reports errors" do
+        allow(Honeybadger).to receive(:notify)
 
         visit root_path
         click_link(sign_in_link, match: :first)
 
-        expect(Rails.logger).to have_received(:error).at_least(3).times
+        expect(Honeybadger).to have_received(:notify)
       end
     end
   end

--- a/spec/system/authentication/user_logs_in_with_twitter_spec.rb
+++ b/spec/system/authentication/user_logs_in_with_twitter_spec.rb
@@ -141,13 +141,13 @@ RSpec.describe "Authenticating with Twitter" do
         expect(page).to have_current_path("/users/sign_up")
       end
 
-      it "logs errors" do
-        allow(Rails.logger).to receive(:error)
+      it "reports errors" do
+        allow(Honeybadger).to receive(:notify)
 
         visit root_path
         click_link(sign_in_link, match: :first)
 
-        expect(Rails.logger).to have_received(:error).at_least(3).times
+        expect(Honeybadger).to have_received(:notify)
       end
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
In an effort to remove PII information from our logs so that we can allow the entire core team to access that data for debugging purposes I have moved these error logs to Honeybadger.

# Related Ticket
https://github.com/thepracticaldev/dev.to/projects/9#card-33250889

![alt_text](https://thumbs.gfycat.com/VapidFriendlyCommongonolek-size_restricted.gif)
