### PR TITLE
Refactor: Remove Unnecessary logging from Video States, Stripe, and GA Events

### DIFF
--- a/app/controllers/ga_events_controller.rb
+++ b/app/controllers/ga_events_controller.rb
@@ -24,7 +24,6 @@ class GaEventsController < ApplicationController
       cache_buster: rand(100_000_000_000).to_s,
       data_source: "web",
     )
-    logger.info("Server-Side Google Analytics Tracking - #{client_id}")
     render body: nil
   end
 

--- a/app/controllers/stripe_active_cards_controller.rb
+++ b/app/controllers/stripe_active_cards_controller.rb
@@ -7,12 +7,10 @@ class StripeActiveCardsController < ApplicationController
     customer = find_or_create_customer
 
     if Payments::Customer.create_source(customer.id, stripe_params[:stripe_token])
-      Rails.logger.info("Stripe Add New Card Success - #{current_user.username}")
       flash[:settings_notice] = "Your billing information has been updated"
     else
       DatadogStatsClient.increment("stripe.errors", tags: ["action:create_card", "user_id:#{current_user.id}"])
 
-      Rails.logger.error("Stripe Add New Card Failure - #{current_user.username}")
       flash[:error] = "There was a problem updating your billing info."
     end
     redirect_to user_settings_path(:billing)
@@ -30,12 +28,9 @@ class StripeActiveCardsController < ApplicationController
     customer.default_source = card.id
 
     if Payments::Customer.save(customer)
-      Rails.logger.info("Stripe Card Update Success - #{current_user.username}")
       flash[:settings_notice] = "Your billing information has been updated"
     else
       DatadogStatsClient.increment("stripe.errors", tags: ["action:update_card", "user_id:#{current_user.id}"])
-
-      Rails.logger.error("Stripe Card Update Failure - #{current_user.username}")
       flash[:error] = "There was a problem updating your billing info."
     end
 

--- a/app/controllers/video_states_controller.rb
+++ b/app/controllers/video_states_controller.rb
@@ -9,13 +9,10 @@ class VideoStatesController < ApplicationController
       return
     end
     begin
-      logger.info "VIDEO STATES: #{params}"
       request_json = JSON.parse(request.raw_post, symbolize_names: true)
-      logger.info "VIDEO STATES: #{request_json}"
     rescue StandardError => e
-      Rails.logger.warn(e)
+      Honeybadger.notify(e)
     end
-    request_json = JSON.parse(request.raw_post, symbolize_names: true)
     message_json = JSON.parse(request_json[:Message], symbolize_names: true)
     @article = Article.find_by(video_code: message_json[:input][:key])
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Optimization

## Description
1) Remove logs from Video States Controller and de-dup the JSON parsing. If we receive an error send it to Honeybadger
2) Remove logging from Stripe Creation controller. We are already sending error info to Datadog so there is no need for it in our logs. As for successes, we will have a new card in the database so there is not really a reason to log that either. 
3) Remove unnecessary logging from GA events controller. 

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/9#card-41511704

## Added tests?
- [x] no, because they aren't needed


![alt_text](https://i.pinimg.com/originals/76/a7/7c/76a77c2faa144915d3d525d20624356e.gif)
