### PR TITLE
Refactor: Report Pusher Errors to Honeybadger, Remove Comment Error Logging

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -9,6 +9,7 @@ class CommentsController < ApplicationController
 
   # GET /comments
   # GET /comments.json
+  # rubocop:disable Metrics/CyclomaticComplexity
   def index
     skip_authorization
     @on_comments_page = true
@@ -37,6 +38,7 @@ class CommentsController < ApplicationController
 
     render :deleted_commentable_comment unless @commentable
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   # GET /comments/1
   # GET /comments/1.json
@@ -114,7 +116,6 @@ class CommentsController < ApplicationController
   rescue StandardError => e
     skip_authorization
 
-    Rails.logger.error(e)
     message = "There was an error in your markdown: #{e}"
     render json: { error: message }, status: :unprocessable_entity
   end
@@ -146,7 +147,6 @@ class CommentsController < ApplicationController
   rescue StandardError => e
     skip_authorization
 
-    Rails.logger.error(e)
     message = "There was an error in your markdown: #{e}"
     render json: { error: "error", status: message }, status: :unprocessable_entity
   end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -35,7 +35,7 @@ class MessagesController < ApplicationController
       begin
         Pusher.trigger(@message.chat_channel.pusher_channels, "message-deleted", @message.to_json)
       rescue Pusher::Error => e
-        logger.info "PUSHER ERROR: #{e.message}"
+        Honeybadger.notify(e)
       end
     end
 
@@ -62,7 +62,7 @@ class MessagesController < ApplicationController
           message_json = create_pusher_payload(@message, "")
           Pusher.trigger(@message.chat_channel.pusher_channels, "message-edited", message_json)
         rescue Pusher::Error => e
-          logger.info "PUSHER ERROR: #{e.message}"
+          Honeybadger.notify(e)
         end
       end
       render json: { status: "success", message: "Message was edited" }

--- a/app/helpers/messages_helper.rb
+++ b/app/helpers/messages_helper.rb
@@ -35,7 +35,7 @@ module MessagesHelper
         Pusher.trigger(message.chat_channel.pusher_channels, "message-created", message_json)
       end
     rescue Pusher::Error => e
-      logger.info "PUSHER ERROR: #{e.message}"
+      Honeybadger.notify(e)
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
1) Send pusher errors to Honeybadger and don't just log them
2) Remove logging for comment markdown errors. These will be reported to the user, there is no need for us to also put them in our logs. 

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/9#card-41511704

## Added tests?
- [x] no, because they aren't needed

Once this cleanup is done hopefully everyone can view our logs! 
![alt_text](https://media.tenor.com/images/b5aaaca68ce689d160fc194ddee7cd02/tenor.gif)
