### PR TITLE
Rubocop: fix Metrics/CyclomaticComplexity and disable Metrics/AbcSize

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -161,6 +161,12 @@ Lint/StructNewOverride:
 
 #################### Metrics ###############################
 
+Metrics/AbcSize:
+  Description: >-
+                 A calculated magnitude based on number of assignments,
+                 branches, and conditions.
+  Enabled: false
+
 Metrics/BlockLength:
   Description: 'Avoid long blocks with many lines.'
   Enabled: true

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -23,11 +23,6 @@ Metrics/AbcSize:
 Metrics/BlockLength:
   Max: 61
 
-# Offense count: 3
-# Configuration parameters: IgnoredMethods.
-Metrics/CyclomaticComplexity:
-  Max: 15
-
 # Offense count: 8
 Performance/OpenStruct:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -12,11 +12,6 @@ require:
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 278
-# Configuration parameters: IgnoredMethods.
-Metrics/AbcSize:
-  Max: 62
-
 # Offense count: 14
 # Configuration parameters: CountComments, ExcludedMethods.
 # ExcludedMethods: refine

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -54,7 +54,7 @@ class ArticlesController < ApplicationController
   def new
     base_editor_assigments
 
-    @article, needs_authorization = Articles::Builder.new(@user, @tag, @prefill).build
+    @article, needs_authorization = Articles::Builder.call(@user, @tag, @prefill)
 
     needs_authorization ? authorize(Article) : skip_authorization
   end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,4 +1,5 @@
 class NotificationsController < ApplicationController
+  # rubocop:disable Metrics/CyclomaticComplexity
   # No authorization required because we provide authentication on notifications page
   def index
     return unless user_signed_in?
@@ -47,6 +48,7 @@ class NotificationsController < ApplicationController
     # will be the partial rendering of only the list of notifications that will be attached to the DOM by JS
     render partial: "notifications_list" if notified_at_offset
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   private
 

--- a/app/services/articles/builder.rb
+++ b/app/services/articles/builder.rb
@@ -8,27 +8,34 @@ module Articles
       @prefill = prefill
     end
 
-    def build
-      if @tag.present? && @user&.editor_version == "v2"
+    def self.call(*args)
+      new(*args).call
+    end
 
+    # rubocop:disable Metrics/CyclomaticComplexity
+    def call
+      if @tag.present? && @user&.editor_version == "v2"
         [tag_user_editor_v2, needs_authorization]
       elsif @tag&.submission_template.present? && @user
-
         [tag_user, needs_authorization]
       elsif @prefill.present? && @user&.editor_version == "v2"
-
         [prefill_user_editor_v2, needs_authorization]
       elsif @prefill.present? && @user
-
         [prefill_user, needs_authorization]
       elsif @tag.present?
-
         [tag, does_not_need_authorization]
+      elsif @user&.editor_version == "v2"
+        [user_editor_v2, does_not_need_authorization]
       else
-        return [user_editor_v2, does_not_need_authorization] if @user&.editor_version == "v2"
-
         [user_editor_v1, does_not_need_authorization]
       end
+    end
+    # rubocop:enable Metrics/CyclomaticComplexity
+
+    private
+
+    def editor_version_2?
+      @user&.editor_version == "v2"
     end
 
     def needs_authorization

--- a/app/services/articles/builder.rb
+++ b/app/services/articles/builder.rb
@@ -6,94 +6,79 @@ module Articles
       @user = user
       @tag = tag
       @prefill = prefill
+
+      @editor_version2 = @user&.editor_version == "v2"
     end
 
     def self.call(*args)
       new(*args).call
     end
 
-    # rubocop:disable Metrics/CyclomaticComplexity
+    # the Builder returns a pair of [article, needs_authorization?]
+    # => `needs_authorization? can be either true or false
     def call
-      if @tag.present? && @user&.editor_version == "v2"
-        [tag_user_editor_v2, needs_authorization]
-      elsif @tag&.submission_template.present? && @user
-        [tag_user, needs_authorization]
-      elsif @prefill.present? && @user&.editor_version == "v2"
-        [prefill_user_editor_v2, needs_authorization]
-      elsif @prefill.present? && @user
-        [prefill_user, needs_authorization]
-      elsif @tag.present?
-        [tag, does_not_need_authorization]
-      elsif @user&.editor_version == "v2"
-        [user_editor_v2, does_not_need_authorization]
-      else
-        [user_editor_v1, does_not_need_authorization]
-      end
+      return [tag_user_editor_v2, true] if tag && editor_version2
+      return [tag_user, true] if tag&.submission_template.present? && user
+      return [prefill_user_editor_v2, true] if prefill.present? && editor_version2
+      return [prefill_user, true] if prefill.present? && user
+      return [tag_article, false] if tag
+      return [user_editor_v2, false] if editor_version2
+
+      [user_editor_v1, false]
     end
-    # rubocop:enable Metrics/CyclomaticComplexity
 
     private
 
-    def editor_version_2?
-      @user&.editor_version == "v2"
-    end
-
-    def needs_authorization
-      true
-    end
-
-    def does_not_need_authorization
-      false
-    end
+    attr_reader :user, :tag, :prefill, :editor_version2
 
     def tag_user_editor_v2
-      submission_template = @tag.submission_template_customized(@user.name).to_s
+      submission_template = tag.submission_template_customized(user.name).to_s
 
       Article.new(
         body_markdown: submission_template.split("---").last.to_s.strip,
-        cached_tag_list: @tag.name,
+        cached_tag_list: tag.name,
         processed_html: "",
-        user_id: @user.id,
+        user_id: user.id,
         title: normalized_text(submission_template, "title:"),
       )
     end
 
     def tag_user
       Article.new(
-        body_markdown: @tag.submission_template_customized(@user.name),
+        body_markdown: tag.submission_template_customized(user.name),
         processed_html: "",
-        user_id: @user.id,
+        user_id: user.id,
       )
     end
 
     def prefill_user_editor_v2
       Article.new(
-        body_markdown: @prefill.split("---").last.to_s.strip,
-        cached_tag_list: normalized_text(@prefill, "tags:"),
+        body_markdown: prefill.split("---").last.to_s.strip,
+        cached_tag_list: normalized_text(prefill, "tags:"),
         processed_html: "",
-        user_id: @user.id,
-        title: normalized_text(@prefill, "title:"),
+        user_id: user.id,
+        title: normalized_text(prefill, "title:"),
       )
     end
 
     def prefill_user
       Article.new(
-        body_markdown: @prefill,
+        body_markdown: prefill,
         processed_html: "",
-        user_id: @user.id,
+        user_id: user.id,
       )
     end
 
-    def tag
+    def tag_article
       Article.new(
-        body_markdown: "---\ntitle: \npublished: false\ndescription: \ntags: #{@tag.name}\n---\n\n",
+        body_markdown: "---\ntitle: \npublished: false\ndescription: \ntags: #{tag.name}\n---\n\n",
         processed_html: "",
-        user_id: @user&.id,
+        user_id: user&.id,
       )
     end
 
     def user_editor_v2
-      Article.new(user_id: @user.id)
+      Article.new(user_id: user.id)
     end
 
     def user_editor_v1
@@ -103,13 +88,13 @@ module Articles
       Article.new(
         body_markdown: body,
         processed_html: "",
-        user_id: @user&.id,
+        user_id: user&.id,
       )
     end
 
     def normalized_text(source, split_pattern)
-      text = source.split(split_pattern)[1].to_s
-      text.split(LINE_BREAK)[0].to_s.strip
+      text = source.split(split_pattern).second.to_s
+      text.split(LINE_BREAK).first.to_s.strip
     end
   end
 end

--- a/spec/services/articles/builder_spec.rb
+++ b/spec/services/articles/builder_spec.rb
@@ -4,147 +4,144 @@ RSpec.describe Articles::Builder, type: :service do
   let(:user) { create(:user) }
   let(:tag) { nil }
   let(:prefill) { nil }
-  let(:article) { described_class.new(user, tag, prefill) }
 
-  describe "#build" do
-    context "when tag_user_editor_v2" do
-      let(:user) { create(:user, editor_version: "v2") }
-      let(:tag) { create(:tag) }
-      let(:submission_template) { tag.submission_template_customized(user.name).to_s }
-      let(:correct_attributes) do
-        {
-          body_markdown: submission_template.split("---").last.to_s.strip,
-          cached_tag_list: tag.name,
-          processed_html: "",
-          user_id: user.id,
-          title: submission_template.split("title:")[1].to_s.split("\n")[0].to_s.strip
-        }
-      end
-
-      it "initializes an article with the correct attributes and needs authorization" do
-        subject, needs_authorization = article.build
-
-        expect(subject).to be_an_instance_of(Article)
-        expect(subject).to have_attributes(correct_attributes)
-        expect(needs_authorization).to be true
-      end
+  context "when tag_user_editor_v2" do
+    let(:user) { create(:user, editor_version: "v2") }
+    let(:tag) { create(:tag) }
+    let(:submission_template) { tag.submission_template_customized(user.name).to_s }
+    let(:correct_attributes) do
+      {
+        body_markdown: submission_template.split("---").last.to_s.strip,
+        cached_tag_list: tag.name,
+        processed_html: "",
+        user_id: user.id,
+        title: submission_template.split("title:")[1].to_s.split("\n")[0].to_s.strip
+      }
     end
 
-    context "when tag_user" do
-      let(:tag) { create(:tag, submission_template: "submission_template") }
-      let(:correct_attributes) do
-        {
-          body_markdown: tag.submission_template_customized(user.name),
-          processed_html: "",
-          user_id: user.id
-        }
-      end
+    it "initializes an article with the correct attributes and needs authorization" do
+      subject, needs_authorization = described_class.call(user, tag, prefill)
 
-      it "initializes an article with the correct attributes and needs authorization" do
-        subject, needs_authorization = article.build
+      expect(subject).to be_an_instance_of(Article)
+      expect(subject).to have_attributes(correct_attributes)
+      expect(needs_authorization).to be true
+    end
+  end
 
-        expect(subject).to be_an_instance_of(Article)
-        expect(subject).to have_attributes(correct_attributes)
-        expect(needs_authorization).to be true
-      end
+  context "when tag_user" do
+    let(:tag) { create(:tag, submission_template: "submission_template") }
+    let(:correct_attributes) do
+      {
+        body_markdown: tag.submission_template_customized(user.name),
+        processed_html: "",
+        user_id: user.id
+      }
     end
 
-    context "when prefill_user_editor_v2" do
-      let(:user) { create(:user, editor_version: "v2") }
-      let(:prefill) { "dsdweewewew" }
-      let(:correct_attributes) do
-        {
-          body_markdown: prefill.split("---").last.to_s.strip,
-          cached_tag_list: prefill.split("tags:")[1].to_s.split("\n")[0].to_s.strip,
-          processed_html: "",
-          user_id: user.id,
-          title: prefill.split("title:")[1].to_s.split("\n")[0].to_s.strip
-        }
-      end
+    it "initializes an article with the correct attributes and needs authorization" do
+      subject, needs_authorization = described_class.call(user, tag, prefill)
 
-      it "initializes an article with the correct attributesand needs authorization" do
-        subject, needs_authorization = article.build
+      expect(subject).to be_an_instance_of(Article)
+      expect(subject).to have_attributes(correct_attributes)
+      expect(needs_authorization).to be true
+    end
+  end
 
-        expect(subject).to be_an_instance_of(Article)
-        expect(subject).to have_attributes(correct_attributes)
-        expect(needs_authorization).to be true
-      end
+  context "when prefill_user_editor_v2" do
+    let(:user) { create(:user, editor_version: "v2") }
+    let(:prefill) { "dsdweewewew" }
+    let(:correct_attributes) do
+      {
+        body_markdown: prefill.split("---").last.to_s.strip,
+        cached_tag_list: prefill.split("tags:")[1].to_s.split("\n")[0].to_s.strip,
+        processed_html: "",
+        user_id: user.id,
+        title: prefill.split("title:")[1].to_s.split("\n")[0].to_s.strip
+      }
     end
 
-    context "when prefill_user" do
-      let(:prefill) { "dsdweewewew" }
-      let(:correct_attributes) do
-        {
-          body_markdown: prefill,
-          processed_html: "",
-          user_id: user.id
-        }
-      end
+    it "initializes an article with the correct attributesand needs authorization" do
+      subject, needs_authorization = described_class.call(user, tag, prefill)
 
-      it "initializes an article with the correct attributes and needs authorization" do
-        subject, needs_authorization = article.build
+      expect(subject).to be_an_instance_of(Article)
+      expect(subject).to have_attributes(correct_attributes)
+      expect(needs_authorization).to be true
+    end
+  end
 
-        expect(subject).to be_an_instance_of(Article)
-        expect(subject).to have_attributes(correct_attributes)
-        expect(needs_authorization).to be true
-      end
+  context "when prefill_user" do
+    let(:prefill) { "dsdweewewew" }
+    let(:correct_attributes) do
+      {
+        body_markdown: prefill,
+        processed_html: "",
+        user_id: user.id
+      }
     end
 
-    context "when tag" do
-      let(:tag) { create(:tag) }
-      let(:correct_attributes) do
-        {
-          body_markdown: "---\ntitle: \npublished: false\ndescription: \ntags: #{tag.name}\n---\n\n",
-          processed_html: "",
-          user_id: user.id
-        }
-      end
+    it "initializes an article with the correct attributes and needs authorization" do
+      subject, needs_authorization = described_class.call(user, tag, prefill)
 
-      it "initializes an article with the correct attributes and does not need authorization" do
-        subject, needs_authorization = article.build
+      expect(subject).to be_an_instance_of(Article)
+      expect(subject).to have_attributes(correct_attributes)
+      expect(needs_authorization).to be true
+    end
+  end
 
-        expect(subject).to be_an_instance_of(Article)
-        expect(subject).to have_attributes(correct_attributes)
-        expect(needs_authorization).to be false
-      end
+  context "when tag" do
+    let(:tag) { create(:tag) }
+    let(:correct_attributes) do
+      {
+        body_markdown: "---\ntitle: \npublished: false\ndescription: \ntags: #{tag.name}\n---\n\n",
+        processed_html: "",
+        user_id: user.id
+      }
     end
 
-    context "when user_editor_v2" do
-      let(:user) { create(:user, editor_version: "v2") }
-      let(:correct_attributes) do
-        {
-          user_id: user.id
-        }
-      end
+    it "initializes an article with the correct attributes and does not need authorization" do
+      subject, needs_authorization = described_class.call(user, tag, prefill)
 
-      it "initializes an article with the correct attributes and does not need authorization" do
-        subject, needs_authorization = article.build
+      expect(subject).to be_an_instance_of(Article)
+      expect(subject).to have_attributes(correct_attributes)
+      expect(needs_authorization).to be false
+    end
+  end
 
-        expect(subject).to be_an_instance_of(Article)
-        expect(subject).to have_attributes(correct_attributes)
-        expect(needs_authorization).to be false
-      end
+  context "when user_editor_v2" do
+    let(:user) { create(:user, editor_version: "v2") }
+    let(:correct_attributes) do
+      {
+        user_id: user.id
+      }
     end
 
-    context "when user_editor_v1" do
-      let(:correct_attributes) do
-        body = "---\ntitle: \npublished: false\ndescription: \ntags: " \
-          "\n//cover_image: https://direct_url_to_image.jpg\n---\n\n"
+    it "initializes an article with the correct attributes and does not need authorization" do
+      subject, needs_authorization = described_class.call(user, tag, prefill)
 
-        {
-          body_markdown: body,
-          processed_html: "",
-          user_id: user.id
-        }
-      end
+      expect(subject).to be_an_instance_of(Article)
+      expect(subject).to have_attributes(correct_attributes)
+      expect(needs_authorization).to be false
+    end
+  end
 
-      it "initializes an article with the correct attributes and does not need authorization" do
-        subject, needs_authorization = article.build
+  context "when user_editor_v1" do
+    let(:correct_attributes) do
+      body = "---\ntitle: \npublished: false\ndescription: \ntags: " \
+        "\n//cover_image: https://direct_url_to_image.jpg\n---\n\n"
 
-        expect(subject).to be_an_instance_of(Article)
-        expect(subject).to have_attributes(correct_attributes)
-        expect(needs_authorization).to be false
-      end
+      {
+        body_markdown: body,
+        processed_html: "",
+        user_id: user.id
+      }
+    end
+
+    it "initializes an article with the correct attributes and does not need authorization" do
+      subject, needs_authorization = described_class.call(user, tag, prefill)
+
+      expect(subject).to be_an_instance_of(Article)
+      expect(subject).to have_attributes(correct_attributes)
+      expect(needs_authorization).to be false
     end
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

This PR:

- fixes `Metrics/CyclomaticComplexity`
- refactors a bit `Articles::Builder` to use `.call` and to fix `Metrics/CyclomaticComplexity`
- disables `Metrics/AbcSize` as we currently have 278 violations and I believe there's no point into keeping this particular violation activated or to find the threshold to hide some of them "under the rug"

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
