### PR TITLE
Bug Fix: Remove Rails Validation for Follow Uniqueness, Guard against dup Follow Jobs

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -243,7 +243,7 @@ class UsersController < ApplicationController
     return unless user.looking_for_work?
 
     hiring_tag = Tag.find_by(name: "hiring")
-    return if user.following?(hiring_tag)
+    return if !hiring_tag || user.following?(hiring_tag)
 
     Users::FollowWorker.perform_async(user.id, hiring_tag.id, "Tag")
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -243,6 +243,8 @@ class UsersController < ApplicationController
     return unless user.looking_for_work?
 
     hiring_tag = Tag.find_by(name: "hiring")
+    return if user.following?(hiring_tag)
+
     Users::FollowWorker.perform_async(user.id, hiring_tag.id, "Tag")
   end
 

--- a/app/models/follow.rb
+++ b/app/models/follow.rb
@@ -34,7 +34,6 @@ class Follow < ApplicationRecord
   after_create_commit :create_chat_channel
   before_destroy :modify_chat_channel_status
 
-  validates :followable_id, uniqueness: { scope: %i[followable_type follower_id follower_type] }
   validates :subscription_status, inclusion: { in: %w[all_articles none] }
 
   def self.need_new_follower_notification_for?(followable_type)

--- a/spec/models/follow_spec.rb
+++ b/spec/models/follow_spec.rb
@@ -8,12 +8,6 @@ RSpec.describe Follow, type: :model do
     subject { user.follow(user_2) }
 
     it { is_expected.to validate_inclusion_of(:subscription_status).in_array(%w[all_articles none]) }
-
-    # rubocop:disable RSpec/NamedSubject
-    it {
-      expect(subject).to validate_uniqueness_of(:followable_id).scoped_to(%i[followable_type follower_id follower_type])
-    }
-    # rubocop:enable RSpec/NamedSubject
   end
 
   it "follows user" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
We have been seeing a lot of ActiveRecord validation errors when a record tries to follow a record they are already following. We attempted to prevent this using `create_or_find_by!`, however we were still seeing the error. The reason, and you all can thank @rhymes for figuring this out is
> create_or_find_by! rescues ActiveRecord::RecordNotUnique which is the exception the database sends up through its constraints, but we have “mounted” on top of it a second layer which is Rails’s, through ActiveRecord::RecordInvalid which is not the exception create_or_find_by! handles. 
```ruby
    def create_or_find_by!(attributes, &block)
      transaction(requires_new: true) { create!(attributes, &block) }
    rescue ActiveRecord::RecordNotUnique
      find_by!(attributes)
    end
```


## Added tests?
- [x] no, because they aren't needed


![alt_text](https://media1.tenor.com/images/526cd63dc3b260ed057b736a70526f0d/tenor.gif?itemid=13481429)
