### PR TITLE
Refactor:Use if/else When Selecting Production Log Strategy

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -94,25 +94,23 @@ Rails.application.configure do
   ]
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
-  # config.log_formatter = ::Logger::Formatter.new
   config.log_formatter = ::Logger::Formatter.new
 
-  # Use a different logger for distributed setups.
-  # require 'syslog/logger'
-  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
-
   if ENV["RAILS_LOG_TO_STDOUT"].present?
+    # Use a different logger for distributed setups.
+    # require 'syslog/logger'
+    # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
+
     logger           = ActiveSupport::Logger.new(STDOUT)
     logger.formatter = config.log_formatter
     config.logger    = ActiveSupport::TaggedLogging.new(logger)
+  elsif (ENV["SEND_LOGS_TO_TIMBER"] || "true") == "true"
+    # Timber.io logger
+    log_device = Timber::LogDevices::HTTP.new(ENV["TIMBER"])
+    logger = Timber::Logger.new(log_device)
+    logger.level = config.log_level
+    config.logger = ActiveSupport::TaggedLogging.new(logger)
   end
-
-  # Timber.io logger
-  send_logs_to_timber = ENV["SEND_LOGS_TO_TIMBER"] || "true" # <---- production should send timber logs by default
-  log_device = send_logs_to_timber == "true" ? Timber::LogDevices::HTTP.new(ENV["TIMBER"]) : STDOUT
-  logger = Timber::Logger.new(log_device)
-  logger.level = config.log_level
-  config.logger = ActiveSupport::TaggedLogging.new(logger)
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
**I am close to attempting to switch us over to Datadog for logging.** In order to ensure that we can do it smoothly I rewrote the production logging set up so we only configure it once for `RAILS_LOG_TO_STDOUT` and once if we are using Timber, `SEND_LOGS_TO_TIMBER`.

Next Steps
1) Set `RAILS_LOG_TO_STDOUT` to true 
2) [Add a log drain to Heroku to send logs to Datadog](https://docs.datadoghq.com/logs/guide/collect-heroku-logs/). NOTE: This feature is still in beta so if we do run into problems then I will go the fallback route.
- Fallback Plan: [Follow these directions to use the buildpack to send logs to Datadog](https://www.ironin.it/blog/sending-logs-from-your-heroku-app-to-datadog.html)

## Related Tickets & Documents
https://github.com/thepracticaldev/dev.to/projects/9#card-33250889


![alt_text](https://media0.giphy.com/media/SGV9O1fuh2nf5T8FNW/200.gif)
