### PR TITLE
Add Polymorphism to Broadcasts (Part 1)

### DIFF
--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -1,0 +1,2 @@
+class Announcement < ApplicationRecord
+end

--- a/app/models/welcome_notification.rb
+++ b/app/models/welcome_notification.rb
@@ -1,0 +1,2 @@
+class WelcomeNotification < ApplicationRecord
+end

--- a/db/migrate/20200707170245_add_polymorphism_to_broadcasts.rb
+++ b/db/migrate/20200707170245_add_polymorphism_to_broadcasts.rb
@@ -1,0 +1,6 @@
+class AddPolymorphismToBroadcasts < ActiveRecord::Migration[6.0]
+  def change
+    add_column :broadcasts, :broadcastable_id, :integer
+    add_column :broadcasts, :broadcastable_type, :string
+  end
+end

--- a/db/migrate/20200707173316_create_announcements.rb
+++ b/db/migrate/20200707173316_create_announcements.rb
@@ -1,0 +1,8 @@
+class CreateAnnouncements < ActiveRecord::Migration[6.0]
+  def change
+    create_table :announcements do |t|
+      t.string :banner_style
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200707173524_create_welcome_notifications.rb
+++ b/db/migrate/20200707173524_create_welcome_notifications.rb
@@ -1,0 +1,7 @@
+class CreateWelcomeNotifications < ActiveRecord::Migration[6.0]
+  def change
+    create_table :welcome_notifications do |t|
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200710174257_add_index_to_broadcasts.rb
+++ b/db/migrate/20200710174257_add_index_to_broadcasts.rb
@@ -1,0 +1,7 @@
+class AddIndexToBroadcasts < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :broadcasts, %i[broadcastable_type broadcastable_id], unique: true, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_06_184804) do
+ActiveRecord::Schema.define(version: 2020_07_07_173524) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -293,6 +293,8 @@ ActiveRecord::Schema.define(version: 2020_07_06_184804) do
     t.datetime "active_status_updated_at"
     t.string "banner_style"
     t.text "body_markdown"
+    t.integer "broadcastable_id"
+    t.string "broadcastable_type"
     t.datetime "created_at"
     t.text "processed_html"
     t.string "title"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -58,6 +58,12 @@ ActiveRecord::Schema.define(version: 2020_07_07_173524) do
     t.index ["visit_token"], name: "index_ahoy_visits_on_visit_token", unique: true
   end
 
+  create_table "announcements", force: :cascade do |t|
+    t.string "banner_style"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "api_secrets", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "description", null: false
@@ -1326,6 +1332,11 @@ ActiveRecord::Schema.define(version: 2020_07_07_173524) do
     t.index ["oauth_application_id"], name: "index_webhook_endpoints_on_oauth_application_id"
     t.index ["target_url"], name: "index_webhook_endpoints_on_target_url", unique: true
     t.index ["user_id"], name: "index_webhook_endpoints_on_user_id"
+  end
+
+  create_table "welcome_notifications", force: :cascade do |t|
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   add_foreign_key "api_secrets", "users", on_delete: :cascade

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_07_173524) do
+ActiveRecord::Schema.define(version: 2020_07_10_174257) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -306,6 +306,7 @@ ActiveRecord::Schema.define(version: 2020_07_07_173524) do
     t.string "title"
     t.string "type_of"
     t.datetime "updated_at"
+    t.index ["broadcastable_type", "broadcastable_id"], name: "index_broadcasts_on_broadcastable_type_and_broadcastable_id", unique: true
     t.index ["title", "type_of"], name: "index_broadcasts_on_title_and_type_of", unique: true
   end
 

--- a/lib/data_update_scripts/20200708163323_backfill_broadcastable_type_for_broadcasts.rb
+++ b/lib/data_update_scripts/20200708163323_backfill_broadcastable_type_for_broadcasts.rb
@@ -2,7 +2,7 @@ module DataUpdateScripts
   class BackfillBroadcastableTypeForBroadcasts
     def run
       Broadcast.where(broadcastable_type: nil).each do |cast|
-        cast.update(broadcastable_type: broadcast.type_of)
+        cast.update!(broadcastable_type: broadcast.type_of)
       end
     end
   end

--- a/lib/data_update_scripts/20200708163323_backfill_broadcastable_type_for_broadcasts.rb
+++ b/lib/data_update_scripts/20200708163323_backfill_broadcastable_type_for_broadcasts.rb
@@ -1,0 +1,9 @@
+module DataUpdateScripts
+  class BackfillBroadcastableTypeForBroadcasts
+    def run
+      Broadcast.where(broadcastable_type: nil).each do |cast|
+        cast.update(broadcastable_type: broadcast.type_of)
+      end
+    end
+  end
+end

--- a/lib/data_update_scripts/20200708163323_backfill_columns_for_broadcasts.rb
+++ b/lib/data_update_scripts/20200708163323_backfill_columns_for_broadcasts.rb
@@ -1,9 +1,0 @@
-module DataUpdateScripts
-  class BackfillColumnsForBroadcasts
-    def run
-      # Place your data update logic here
-      # Make sure your code is idempotent and can be run safely
-      # multiple times at any time
-    end
-  end
-end

--- a/lib/data_update_scripts/20200708163323_backfill_columns_for_broadcasts.rb
+++ b/lib/data_update_scripts/20200708163323_backfill_columns_for_broadcasts.rb
@@ -1,0 +1,9 @@
+module DataUpdateScripts
+  class BackfillColumnsForBroadcasts
+    def run
+      # Place your data update logic here
+      # Make sure your code is idempotent and can be run safely
+      # multiple times at any time
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR is part one of a two-part refactor that creates a polymorphic association between Broadcasts, Announcements, and Welcome Notifications. This PR adds polymorphism to the Broadcasts table and a `data_update` script to properly backfill the newly added `broadcastable_type` column, as shown below. Additionally, this PR adds an Announcement and Welcome Notification table to the database with `created_at` and `updated_at` timestamps on both tables and an additional `banner_style` column on the Announcements table. It also stubs out the Announcement and Welcome Notification models in preparation for the next PR, Part 2 of the move to polymorphic Broadcasts.

## Related Tickets & Documents
Related to #7169 and #8861 

## QA Instructions, Screenshots, Recordings
To QA these changes, you can manually run the `data_update` script (as shown below) and make sure that the build passes and that these changes do not break anything else.

To manually run the `data_update` script, do the following:
- Create a Broadcast without a `broadcastable_type`:
```
broadcast = Broadcast.create(title: "Hello, world!", processed_html: "Hello, world!", type_of: "Welcome", active: false, broadcastable_type: nil)
```
```
=> #<Broadcast:0x00007fa982de3c98
 id: 17,
 active: false,
 active_status_updated_at: nil,
 banner_style: nil,
 body_markdown: nil,
 created_at: Thu, 09 Jul 2020 20:22:31 UTC +00:00,
 processed_html: "Hello, world!",
 title: "Hello, world!",
 type_of: "Welcome",
 updated_at: Thu, 09 Jul 2020 20:22:31 UTC +00:00,
 broadcastable_id: nil,
 broadcastable_type: nil>
```
- Run the code within the `data_update` script in your console:
```
  Broadcast.where(broadcastable_type: nil).each do |cast|
     cast.update(broadcastable_type: broadcast.type_of)
   end
```
- Check to see that the Broadcast's `broadcastable_type` column is no longer `nil` and contains the correct `broadcastable_type`:
```
=> [#<Broadcast:0x00007fa982d09340
  id: 17,
  active: false,
  active_status_updated_at: nil,
  banner_style: nil,
  body_markdown: nil,
  created_at: Thu, 09 Jul 2020 20:22:31 UTC +00:00,
  processed_html: "Hello, world!",
  title: "Hello, world!",
  type_of: "Welcome",
  updated_at: Thu, 09 Jul 2020 20:23:45 UTC +00:00,
  broadcastable_id: nil,
  broadcastable_type: "Welcome">]
```

## Added tests?

- [ ] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
- [x] no, because the necessary tests will be included in the following PR, Polymorphism Part 2.

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?
There is a `data_update` script included in this PR to port over the data from the `type_of` column to the `broadcastable_type` column on Broadcasts.

## [optional] What gif best describes this PR or how it makes you feel?

![Homer Simpson](https://media.giphy.com/media/citBl9yPwnUOs/giphy.gif)
