### PR TITLE
Update Docs, Travis,  and Containers to Use Postgres 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
 rvm:
   - 2.7.1
 addons:
-  postgresql: '9.6'
+  postgresql: '10' # Travis does not work out of the box with Postgres 11 yet
   chrome: 'stable'
   artifacts:
     paths:

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ A more complete overview of our stack is available in
   the badge.
 - [Yarn](https://yarnpkg.com/) 1.x: please refer to their
   [installation guide](https://classic.yarnpkg.com/en/docs/install).
-- [PostgreSQL](https://www.postgresql.org/) 9.5 or higher.
+- [PostgreSQL](https://www.postgresql.org/) 11 or higher.
 - [ImageMagick](https://imagemagick.org/): please refer to ImageMagick's
   [installation instructions](https://imagemagick.org/script/download.php).
 - [Redis](https://redis.io/) 4 or higher.

--- a/container-compose.yml
+++ b/container-compose.yml
@@ -112,7 +112,7 @@ services:
     command: ["bundle", "exec", "sidekiq","-c","2"]
 
   db:
-    image: postgres:9.6.15-alpine
+    image: postgres:11-alpine
     container_name: dev_postgresql
     environment:
       POSTGRES_USER: devto

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,7 +112,7 @@ services:
     command: ["bundle", "exec", "sidekiq","-c","2"]
 
   db:
-    image: postgres:9.6.15-alpine
+    image: postgres:11-alpine
     container_name: dev_postgresql
     environment:
       POSTGRES_USER: devto

--- a/docs/installation/linux.md
+++ b/docs/installation/linux.md
@@ -36,7 +36,7 @@ There are two ways to install Yarn.
 
 ### PostgreSQL
 
-DEV requires PostgreSQL version 9.5 or higher.
+DEV requires PostgreSQL version 11 or higher.
 
 1. Run
    `sudo apt update && sudo apt install postgresql postgresql-contrib libpq-dev`.

--- a/docs/installation/mac.md
+++ b/docs/installation/mac.md
@@ -20,7 +20,7 @@ Please refer to their [installation guide](https://yarnpkg.com/en/docs/install).
 
 ### PostgreSQL
 
-DEV requires PostgreSQL version 9.5 or higher.
+DEV requires PostgreSQL version 11 or higher.
 
 The easiest way to get started is to use
 [Postgres.app](https://postgresapp.com/). Alternatively, check out the official

--- a/docs/installation/windows.md
+++ b/docs/installation/windows.md
@@ -108,7 +108,7 @@ work fully. We install Node.js later on in the installation process.
 
 ### PostgreSQL
 
-DEV requires PostgreSQL version 9.5 or higher.
+DEV requires PostgreSQL version 11 or higher.
 
 If you don't have PostgreSQL installed on your Windows system, you can do so
 right now. WSL is able to connect to a PostgreSQL instance on your Windows


### PR DESCRIPTION
## Description
We recently discovered that our migrations are not compatible with Postgres versions <11. Rather than continuing to try and support these versions, we have decided to update our docs to require Postgres version 11 or higher to run DEV.

This PR...
1) Updates all container files to use Postgres 11 images
2) Updates the Docs to say we require Postgres 11
3) Runs migrations in a single Travis job (I confirmed if you drop the Travis version to 10 and the StrongMigrations supported version to 10 you will end up with the migration error that @jdoss saw)
4) Bumps Travis to 10....Wait, what?! Travis does not play nice with Postgres-11. If you install it through [their services](https://travis-ci.community/t/postgresql-11-2-cannot-connect/2680) it will fire up on port 5433 bc Postgres 9 which is fired up first takes port 5432. If you get that resolved with some fancy `sed` work, then you end up with user and permission errors for the database. TL;DR Unless you want to set up Postgres 11 manually you can't use it. I don't want to go through all of that setup bc it will add more time to our builds. Also, I struggled with it for a couple of hours with no luck and decided since I think we will be moving off Travis soon to cut our losses for now.

https://github.com/thepracticaldev/dev.to/projects/9#card-41592053
 

![alt_text](https://media.tenor.com/images/e68b970662553869d79093d481cb466c/tenor.gif)
