### PR TITLE
Remove arrow-left-... from github issue embed

### DIFF
--- a/app/assets/stylesheets/ltags/GithubTag.scss
+++ b/app/assets/stylesheets/ltags/GithubTag.scss
@@ -51,40 +51,6 @@
   margin: 0;
   width: 98%;
   overflow: hidden;
-  .arrow-left-outer {
-    display: none;
-    @media screen and (min-width: 500px) {
-      display: block;
-      width: 0;
-      height: 0;
-      border-width: 8px;
-      border-color: transparent;
-      border-style: solid solid outset;
-      border-right-color: #d1d5da;
-      content: ' ';
-      float: left;
-      margin-left: -31px;
-      margin-top: 13px;
-    }
-  }
-
-  .arrow-left-inner {
-    display: none;
-    @media screen and (min-width: 500px) {
-      display: block;
-      width: 0;
-      height: 0;
-      border-width: 8px;
-      border-color: transparent;
-      border-style: solid solid outset;
-      border-right-color: #f6f8fa;
-      content: ' ';
-      float: left;
-      margin-left: -30px;
-      margin-top: 13px;
-    }
-  }
-
   .timeline-comment-header {
     display: flex;
     background: #f6f8fa;

--- a/app/views/liquids/_github_issue.html.erb
+++ b/app/views/liquids/_github_issue.html.erb
@@ -13,8 +13,6 @@
       <a href="<%= user_html_url %>">
         <img class="github-liquid-tag-img" src="<%= user_avatar_url %>" alt="<%= username %> avatar">
       </a>
-      <span class="arrow-left-outer"></span>
-      <span class="arrow-left-inner"></span>
       <div class="timeline-comment-header-text">
         <strong>
           <a href="<%= user_html_url %>"><%= username %></a>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

I believe we made a style adjustment to how github issues are displayed but this element was still lingering. It only causes problems within comments so I think we just missed it... But it's easy to 🔪

Note the white arrow in the way of the profile image here...

<img width="251" alt="Screen Shot 2020-07-09 at 5 41 27 PM" src="https://user-images.githubusercontent.com/3102842/87093589-6d282e00-c20b-11ea-82fb-7f863b835613.png">
