### PR TITLE
Hotfix: Disable Article Sinking

### DIFF
--- a/app/services/moderator/sink_articles.rb
+++ b/app/services/moderator/sink_articles.rb
@@ -1,7 +1,14 @@
 module Moderator
   class SinkArticles
     def self.call(user_id)
+      # rubocop:disable Lint/UnreachableCode
+      # HOTFIX
+      # @mstruve: This worker is broken and needs to be fixed. It can inadvertantly
+      # bump up scores for a user's articles if they have a lot of good reactions
+      # this leads to clumps of articles from the same user in feeds
+      return
       Moderator::SinkArticlesWorker.perform_async(user_id)
+      # rubocop:enable Lint/UnreachableCode
     end
   end
 end

--- a/spec/services/moderator/sink_articles_spec.rb
+++ b/spec/services/moderator/sink_articles_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Moderator::SinkArticles, type: :service do
   end
   let(:vomit_reaction) { create(:reaction, reactable: spam_user, user: moderator, category: "vomit") }
 
-  describe "#call" do
+  xdescribe "#call" do
     it "lowers all of a user's articles' scores by 25 each if not confirmed" do
       vomit_reaction
       expect do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Fixes an issue where a single user's articles are flooding the feed.

![alt_text](https://thumbs.gfycat.com/InferiorBetterCalf-size_restricted.gif)
