### PR TITLE
Add metrics around welcome notifications + their click events

### DIFF
--- a/app/services/notifications/welcome_notification/send.rb
+++ b/app/services/notifications/welcome_notification/send.rb
@@ -30,11 +30,20 @@ module Notifications
           action: welcome_broadcast.type_of,
           json_data: json_data,
         )
+
+        log_to_datadog
       end
 
       private
 
       attr_reader :receiver_id, :welcome_broadcast
+
+      def log_to_datadog
+        DatadogStatsClient.increment(
+          "notifications.welcome",
+          tags: ["user:#{receiver_id}", "title:#{welcome_broadcast.title}"],
+        )
+      end
     end
   end
 end

--- a/app/services/notifications/welcome_notification/send.rb
+++ b/app/services/notifications/welcome_notification/send.rb
@@ -41,7 +41,7 @@ module Notifications
       def log_to_datadog
         DatadogStatsClient.increment(
           "notifications.welcome",
-          tags: ["user:#{receiver_id}", "title:#{welcome_broadcast.title}"],
+          tags: ["user_id:#{receiver_id}", "title:#{welcome_broadcast.title}"],
         )
       end
     end

--- a/app/workers/metrics/record_daily_notifications_worker.rb
+++ b/app/workers/metrics/record_daily_notifications_worker.rb
@@ -1,0 +1,34 @@
+module Metrics
+  class RecordDailyNotificationsWorker
+    include Sidekiq::Worker
+    sidekiq_options queue: :low_priority, retry: 10
+
+    EVENT_TITLES = %w[
+      welcome_notification_set_up_profile
+      welcome_notification_welcome_thread
+      welcome_notification_customize_feed
+      welcome_notification_twitter_connect
+      welcome_notification_github_connect
+      welcome_notification_customize_experience
+      welcome_notification_discuss_and_ask
+      welcome_notification_download_app
+      welcome_notification_ask_question
+      welcome_notification_start_discussion
+    ].freeze
+
+    def perform
+      # Welcome Notification click events created in the past day, logged by title.
+      EVENT_TITLES.each do |title|
+        event = Ahoy::Event.where(name: "Clicked Welcome Notification").
+          where("time > ?", 1.day.ago).
+          where("properties->>'title' = ?", title)
+
+        DatadogStatsClient.count(
+          "ahoy_events.#{title}",
+          event.size,
+          resource: "ahoy_events",
+        )
+      end
+    end
+  end
+end

--- a/app/workers/metrics/record_daily_notifications_worker.rb
+++ b/app/workers/metrics/record_daily_notifications_worker.rb
@@ -24,9 +24,9 @@ module Metrics
           where("properties->>'title' = ?", title)
 
         DatadogStatsClient.count(
-          "ahoy_events.#{title}",
+          "ahoy_events",
           event.size,
-          resource: "ahoy_events",
+          tags: ["title:#{title}"],
         )
       end
     end

--- a/app/workers/metrics/record_daily_usage_worker.rb
+++ b/app/workers/metrics/record_daily_usage_worker.rb
@@ -35,8 +35,8 @@ module Metrics
       )
 
       # Total negative reactions in the past 24 hours
-      nagative_reactions_past_24h = Reaction.where("points < 0").where("created_at > ?", 1.day.ago).size
-      DatadogStatsClient.count("reactions.negative_past_24h", nagative_reactions_past_24h, tags: ["resource:reactions"])
+      negative_reactions_past_24h = Reaction.where("points < 0").where("created_at > ?", 1.day.ago).size
+      DatadogStatsClient.count("reactions.negative_past_24h", negative_reactions_past_24h, tags: ["resource:reactions"])
 
       # Total abuse (etc.) reports in the past 24 hours
       categories = ["spam", "other", "rude or vulgar", "harassment"]

--- a/lib/tasks/metrics.rake
+++ b/lib/tasks/metrics.rake
@@ -8,4 +8,5 @@ end
 
 task log_daily_usage_measurables: :environment do
   Metrics::RecordDailyUsageWorker.perform_async
+  Metrics::RecordDailyNotificationsWorker.perform_async
 end

--- a/spec/factories/ahoy.rb
+++ b/spec/factories/ahoy.rb
@@ -1,0 +1,18 @@
+FactoryBot.define do
+  factory :ahoy_message, class: "Ahoy::Message" do
+    user
+  end
+
+  factory :ahoy_visit, class: "Ahoy::Visit" do
+    user
+    started_at { Timecop.freeze(Time.zone.now) }
+  end
+
+  factory :ahoy_event, class: "Ahoy::Event" do
+    user
+    visit { create(:ahoy_visit, user: user) } # Ahoy::Events require an Ahoy::Visit
+    time { Timecop.freeze(Time.zone.now) }
+    name { "Clicked Welcome Notification" }
+    properties { { title: "welcome_notification_welcome_thread" } }
+  end
+end

--- a/spec/factories/ahoy_message.rb
+++ b/spec/factories/ahoy_message.rb
@@ -1,5 +1,0 @@
-FactoryBot.define do
-  factory :ahoy_message, class: "Ahoy::Message" do
-    user
-  end
-end

--- a/spec/services/notifications/welcome_notification/send_spec.rb
+++ b/spec/services/notifications/welcome_notification/send_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Notifications::WelcomeNotification::Send, type: :service do
     it "logs to DataDog" do
       described_class.call(create(:user).id, welcome_broadcast)
       welcome_notification = Notification.find_by(notifiable_id: welcome_broadcast.id)
-      tags = ["user:#{welcome_notification.user_id}", "title:#{welcome_notification.notifiable.title}"]
+      tags = ["user_id:#{welcome_notification.user_id}", "title:#{welcome_notification.notifiable.title}"]
 
       expect(DatadogStatsClient).to have_received(:increment).with("notifications.welcome", tags: tags)
     end

--- a/spec/services/notifications/welcome_notification/send_spec.rb
+++ b/spec/services/notifications/welcome_notification/send_spec.rb
@@ -2,18 +2,31 @@ require "rails_helper"
 
 RSpec.describe Notifications::WelcomeNotification::Send, type: :service do
   describe "::call" do
+    let!(:welcome_broadcast) { create(:set_up_profile_broadcast) }
+
     before do
       allow(User).to receive(:mascot_account).and_return(create(:user))
+      allow(DatadogStatsClient).to receive(:increment)
     end
 
     it "creates a new welcome notification", :aggregate_failures do
-      welcome_broadcast = create(:set_up_profile_broadcast)
-      welcome_notification = described_class.call(create(:user).id, welcome_broadcast)
+      expect(Notification.find_by(notifiable_id: welcome_broadcast.id)).to be(nil)
 
+      described_class.call(create(:user).id, welcome_broadcast)
+
+      welcome_notification = Notification.find_by(notifiable_id: welcome_broadcast.id)
       expect(welcome_notification).to be_kind_of(Notification)
       expect(welcome_notification.notifiable_type).to eq "Broadcast"
       expect(welcome_notification.action).to eq "Welcome"
       expect(welcome_notification.json_data["broadcast"]["processed_html"]).to eq welcome_broadcast.processed_html
+    end
+
+    it "logs to DataDog" do
+      described_class.call(create(:user).id, welcome_broadcast)
+      welcome_notification = Notification.find_by(notifiable_id: welcome_broadcast.id)
+      tags = ["user:#{welcome_notification.user_id}", "title:#{welcome_notification.notifiable.title}"]
+
+      expect(DatadogStatsClient).to have_received(:increment).with("notifications.welcome", tags: tags)
     end
   end
 end

--- a/spec/workers/metrics/record_daily_notifications_worker_spec.rb
+++ b/spec/workers/metrics/record_daily_notifications_worker_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe Metrics::RecordDailyNotificationsWorker, type: :worker do
+  include_examples "#enqueues_on_correct_queue", "low_priority", 1
+
+  describe "#perform" do
+    let(:user) { create(:user) }
+    let!(:ahoy_event) { create(:ahoy_event) }
+    let(:event_title_count) { Metrics::RecordDailyNotificationsWorker::EVENT_TITLES.count }
+
+    before do
+      allow(DatadogStatsClient).to receive(:count)
+      ahoy_event
+      described_class.new.perform
+    end
+
+    it "logs welcome notification click events created in the past day" do
+      expect(DatadogStatsClient).to have_received(:count).exactly(event_title_count).times
+      expect(
+        DatadogStatsClient,
+      ).to have_received(:count).
+        with("ahoy_events.welcome_notification_welcome_thread", 1, resource: "ahoy_events").
+        at_least(1)
+    end
+  end
+end

--- a/spec/workers/metrics/record_daily_notifications_worker_spec.rb
+++ b/spec/workers/metrics/record_daily_notifications_worker_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Metrics::RecordDailyNotificationsWorker, type: :worker do
       expect(
         DatadogStatsClient,
       ).to have_received(:count).
-        with("ahoy_events.welcome_notification_welcome_thread", 1, resource: "ahoy_events").
+        with("ahoy_events", 1, { tags: ["title:welcome_notification_welcome_thread"] }).
         at_least(1)
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
While we currently have tracking around welcome notifications, our way of looking up data isn't the greatest (it's just a basic [blazer query](https://dev.to/internal/blazer/queries/99-daily-welcome-notification-events-graph)). It would be great to have these metrics reported to DataDog since we have them now (!!), so this PR does just that.

Specifically, it:
- [x] Logs to DataDog whenever a welcome notification is created, within the `Notifications:: WelcomeNotification::Send` service.
- [x] Add a `Metrics::RecordDailyNotificationsWorker`, which logs daily welcome notification click event counts to DataDog.
- [x] Calls on the `Metrics::RecordDailyNotificationsWorker` from within the `log_daily_usage_measurables` rake task.

## Related Tickets & Documents

This was one of my cool-down [pebble jar tasks](https://github.com/thepracticaldev/dev.to/projects/7#card-40958551)! 🌱 

## QA Instructions, Screenshots, Recordings

I'd say that the tests are the best way to measure this (I've added tests for both forms of logging), but if you want to try to stub out `DataDog` locally and see if this works, you could!

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## Are there any post deployment tasks we need to perform?
None that I can think of, aside from checking in on DataDog to make sure this is actually getting reported the way we expect :)

## [optional] What gif best describes this PR or how it makes you feel?

![happy dog and wiggly ears](https://media3.giphy.com/media/4Zo41lhzKt6iZ8xff9/giphy.webp?cid=5a38a5a2e06c41750fcbc00f93a420b9ad56c0e8e0674be6&rid=giphy.webp)
