### PR TITLE
Rubocop: Address Rails/OutputSafety violations

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -12,17 +12,6 @@ require:
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 16
-Rails/OutputSafety:
-  Exclude:
-    - 'app/helpers/application_helper.rb'
-    - 'app/helpers/comments_helper.rb'
-    - 'app/liquid_tags/github_tag/github_issue_tag.rb'
-    - 'app/liquid_tags/liquid_tag_base.rb'
-    - 'app/models/comment.rb'
-    - 'app/models/display_ad.rb'
-    - 'app/models/message.rb'
-
 # Offense count: 4
 # Configuration parameters: Include.
 # Include: app/models/**/*.rb

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -155,7 +155,7 @@ module ApplicationHelper
 
   def logo_svg
     if SiteConfig.logo_svg.present?
-      SiteConfig.logo_svg.html_safe
+      SiteConfig.logo_svg.html_safe # rubocop:disable Rails/OutputSafety
     else
       inline_svg_tag("devplain.svg", class: "logo", size: "20% * 20%", aria: true, title: "App logo")
     end

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -35,10 +35,12 @@ module CommentsHelper
   private
 
   def nested_comments(tree:, commentable:, is_view_root: false)
-    tree.map do |comment, sub_comments|
+    comments = tree.map do |comment, sub_comments|
       render("comments/comment", comment: comment, commentable: commentable,
                                  is_view_root: is_view_root, is_childless: sub_comments.empty?,
                                  subtree_html: nested_comments(tree: sub_comments, commentable: commentable))
-    end.join.html_safe
+    end
+
+    safe_join(comments)
   end
 end

--- a/app/liquid_tags/github_tag/github_issue_tag.rb
+++ b/app/liquid_tags/github_tag/github_issue_tag.rb
@@ -17,7 +17,7 @@ class GithubTag
       @content_json = @content.issue_serialized
       @is_issue = @content_json[:title].present?
       @created_at = @content_json[:created_at]
-      @body = @content.processed_html.html_safe
+      @body = @content.processed_html.html_safe # rubocop:disable Rails/OutputSafety
     end
 
     def render
@@ -76,12 +76,6 @@ class GithubTag
       path = uri.path.delete_prefix("/")
 
       URI.parse(API_BASE_ENDPOINT).merge(path).to_s
-    end
-
-    def finalize_html(input)
-      input.gsub(/(?!<code[^>]*?>)(@[a-zA-Z]{3,})(?![^<]*?<\/code>)/) do |target|
-        "<a class=\"github-user-link\" href=\"https://github.com/#{target.delete('@')}\">#{target}</a>"
-      end.html_safe
     end
 
     def valid_link?(link)

--- a/app/liquid_tags/liquid_tag_base.rb
+++ b/app/liquid_tags/liquid_tag_base.rb
@@ -15,14 +15,6 @@ class LiquidTagBase < Liquid::Tag
     )
   end
 
-  def finalize_html(input)
-    input.gsub(/ {2,}/, "").
-      gsub(/\n/m, " ").
-      gsub(/>\n{1,}</m, "><").
-      strip.
-      html_safe
-  end
-
   private
 
   def validate_contexts

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -123,7 +123,7 @@ class Comment < ApplicationRecord
   end
 
   def safe_processed_html
-    processed_html.html_safe
+    processed_html.html_safe # rubocop:disable Rails/OutputSafety
   end
 
   def root_exists?
@@ -177,7 +177,7 @@ class Comment < ApplicationRecord
         anchor.content = strip_url(anchor.content) unless anchor.to_s.include?("<img")
       end
     end
-    self.processed_html = doc.to_html.html_safe
+    self.processed_html = doc.to_html.html_safe # rubocop:disable Rails/OutputSafety
   end
 
   def calculate_score

--- a/app/models/display_ad.rb
+++ b/app/models/display_ad.rb
@@ -32,7 +32,7 @@ class DisplayAd < ApplicationRecord
     # stripped_html = ActionController::Base.helpers.sanitize initial_html,
     #                                                         tags: %w[a em i b u br img h1 h2 h3 h4 div style],
     #                                                         attributes: %w[href target src height width style]
-    stripped_html = initial_html.html_safe
+    stripped_html = initial_html.html_safe # rubocop:disable Rails/OutputSafety
     html = stripped_html.delete("\n")
     self.processed_html = MarkdownParser.new(html).prefix_all_images(html, 350)
   end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -100,6 +100,7 @@ class Message < ApplicationRecord
 
   # rubocop:disable Layout/LineLength
   # rubocop:disable Metrics/BlockLength
+  # rubocop:disable Rails/OutputSafety
   def append_rich_links(html)
     doc = Nokogiri::HTML(html)
     doc.css("a").each do |anchor|
@@ -145,9 +146,11 @@ class Message < ApplicationRecord
     end
     html
   end
-  # rubocop:enable Metrics/BlockLength
   # rubocop:enable Layout/LineLength
+  # rubocop:enable Metrics/BlockLength
+  # rubocop:enable Rails/OutputSafety
 
+  # rubocop:disable Rails/OutputSafety
   def handle_slash_command(html)
     response = if html.to_s.strip == "<p>/call</p>"
                  "<a href='/video_chats/#{chat_channel_id}'
@@ -169,6 +172,7 @@ class Message < ApplicationRecord
     html = response if response
     html
   end
+  # rubocop:enable Rails/OutputSafety
 
   def cl_path(img_src)
     ActionController::Base.helpers.


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

- addressed `Rails/OutputSafety` by mostly disabling them locally
- used [safe_join](https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsoutputsafety) in one case
- removed a legacy method that wasn't called anywhere


## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
