### PR TITLE
Service Worker default value to cached shell version

### DIFF
--- a/app/views/service_worker/index.js.erb
+++ b/app/views/service_worker/index.js.erb
@@ -159,7 +159,9 @@
         }
 
         fetch('/async_info/shell_version').then(response => response.json()).then(json => {
-          caches.match('/async_info/shell_version').then(cachedResponse => cachedResponse.json()).then(cacheJson => {
+          caches.match('/async_info/shell_version')
+          .then(cachedResponse => (cachedResponse === undefined) ? {} : cachedResponse.json())
+          .then(cacheJson => {
             if (cacheJson['version'] != json['version']) {
               caches.open(staticCacheName)
               .then(cache => cache.addAll([


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Safari has had issues with the service worker implementation and after some debugging found that when the cache is manually cleared a promise chain is broken because the `cachedResponsed` ([here](https://github.com/fdoxyz/dev.to/blob/master/app/views/service_worker/index.js.erb#L162)) returns `undefined`.

To solve this a default empty object `{}` is passed down when this happens, [as suggested here](https://github.com/thepracticaldev/dev.to/issues/5434#issuecomment-655181637). The intention was to edit as little as possible of the service worker code.

## Related Tickets & Documents

#5434 

## QA Instructions, Screenshots, Recordings

This is not easy to debug, the steps I take are the following (Safari):

1. Open page (Safari requires HTTPS in order to enable service workers so I used [ngrok](https://ngrok.com/) for this)
1. Clear all local data for the site
1. Reload (this will refresh the service worker code)
1. Open the service worker console
1. Manually empty the cache
1. Reload and check service worker console (separate from the dev tools console)

When testing this in [production](https://dev.to/) the last step will hang and an error should be visible in the service worker console, but this PR fixes this. Here's a video of the process (slow connection with the roundtrip requests to ngrok servers):

https://share.getcloudapp.com/v1ueqlRE

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [x] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

Maybe bump the shell version number? Unsure about this 👀🚨 

## [optional] What gif best describes this PR or how it makes you feel?

![confused pug](https://media.giphy.com/media/vX6lOurcRw7q8/giphy.gif)
