### PR TITLE
Update RssReader::Assembler#get_content hash syntax

### DIFF
--- a/app/services/rss_reader/assembler.rb
+++ b/app/services/rss_reader/assembler.rb
@@ -54,7 +54,7 @@ class RssReader
     end
 
     def get_content
-      @item.content || @item.summary || @item.description
+      @item[:content] || @item[:summary] || @item[:description]
     end
 
     def thorough_parsing(content, feed_url)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This change interaction with RSS's `@item` as hash instead of method call so it's nullable.

## Related Tickets & Documents
Resolves https://app.honeybadger.io/fault/66984/90d3be76e672b09bcf0fa82d0f7f1be7
## QA Instructions, Screenshots, Recordings
warning: this will create a lot of local articles.
1. spin up rails console.
2. Add the feed to your personal account. ie `me.update(feed_url: "http://www.blameless.com/blog/rss.xml")`
3. Run `RssReader.get_all_articles`
4. You should be able to fetch all feed successfully without error.

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
mark honeybadger item as resolved
