### PR TITLE
Bug Fix: Setup STDOUT Logger bc we need it

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -105,7 +105,9 @@ Rails.application.configure do
     logger           = ActiveSupport::Logger.new(STDOUT)
     logger.formatter = config.log_formatter
     config.logger    = ActiveSupport::TaggedLogging.new(logger)
-  elsif (ENV["SEND_LOGS_TO_TIMBER"] || "true") == "true"
+  end
+
+  if (ENV["SEND_LOGS_TO_TIMBER"] || "true") == "true"
     # Timber.io logger
     log_device = Timber::LogDevices::HTTP.new(ENV["TIMBER"])
     logger = Timber::Logger.new(log_device)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Apparently we need the STDOUT logging part bc, [surprise `RAILS_LOG_TO_STDOUT` is present on Heroku.](https://blog.heroku.com/container_ready_rails_5)
> This value can be set by the container or the platform on which your Rails app runs. In our case, the Ruby buildpack detects your Rails version, and if it's Rails 5 or greater will set the RAILS_LOG_TO_STDOUT environment variable.
```
irb(main):002:0> ENV["RAILS_LOG_TO_STDOUT"].present?
=> true
```


![alt_text](https://media1.tenor.com/images/736ff579acc959173ea403c367d91a17/tenor.gif?itemid=8225002)
