### PR TITLE
Optimization:Change Log Level in Prod to Info

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -56,7 +56,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
@maestromac was helping me scan logs for PII data and found that we expose emails when we log the entire email we send from the app. This occurs bc our logging level in Production is set to debug. Debug is a pretty aggressive logging level to have turned on in Production so I scaled it back to info which should be more than enough. 

If in the future we hit some really devious bugs, we can always flip it on but info should be plenty. 


![alt_text](https://media1.giphy.com/media/jw2I0g2XoRjrO/giphy.gif)
