### PR TITLE
API: add docs for get published article by path

### DIFF
--- a/docs/api_v0.yml
+++ b/docs/api_v0.yml
@@ -1808,7 +1808,7 @@ paths:
         example: 150589
     get:
       operationId: getArticleById
-      summary: A published article
+      summary: A published article by ID
       description: |
         This endpoint allows the client to retrieve a single
         published article given its `id`.
@@ -1948,6 +1948,55 @@ paths:
               -H "api-key: API_KEY" \
               -d '{"article":{"title":"Title"}}' \
               https://dev.to/api/articles/{id}
+
+  /articles/{username}/{slug}:
+    parameters:
+      - name: username
+        in: path
+        required: true
+        description: User or organization username.
+        schema:
+          type: string
+        example: devteam
+      - name: slug
+        in: path
+        required: true
+        description: Slug of the article.
+        schema:
+          type: string
+        example: for-empowering-community-2k6h
+    get:
+      operationId: getArticleByPath
+      summary: A published article by path
+      description: |
+        This endpoint allows the client to retrieve a single
+        published article given its `path`.
+      tags:
+        - articles
+      responses:
+        "200":
+          description: An article
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ArticleShow"
+              examples:
+                article-success:
+                  $ref: "#/components/examples/ArticleShow"
+        "404":
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/APIError"
+              examples:
+                article-not-found:
+                  $ref: "#/components/examples/ErrorNotFound"
+      x-code-samples:
+        - lang: Shell
+          label: curl
+          source: |
+            curl https://dev.to/bytesized/byte-sized-episode-2-the-creation-of-graph-theory-34g1
 
   /articles/me:
     get:


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

In https://github.com/thepracticaldev/dev.to/pull/8929 the endpoint https://dev.to/api/articles/devteam/for-empowering-community-2k6h was added, this adds the documentation for it.

I think we should do a changelog post as well.

## QA Instructions, Screenshots, Recordings

`yarn api-docs:serve` and browse the local API

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [x] docs.dev.to
- [ ] readme
- [ ] no documentation needed
