### PR TITLE
GitPod: Use node version 12.16.3

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -7,7 +7,7 @@ RUN bash -lc "rvm install ruby-$RUBY_VERSION && rvm use ruby-$RUBY_VERSION --def
 
 # Install Node
 COPY ./.nvmrc "${APP_HOME}"/.nvmrc
-RUN bash -lc ". .nvm/nvm.sh && nvm install && nvm alias default $(cat .nvmrc) && nvm use default && nvm uninstall $NODE_VERSION && nvm use default"
+RUN bash -lc ". .nvm/nvm.sh && nvm install && nvm unalias default && nvm alias default $(cat /.nvmrc) && nvm use default && nvm uninstall $NODE_VERSION"
 
 # Install Redis.
 RUN sudo apt-get update \

--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -7,7 +7,7 @@ RUN bash -lc "rvm install ruby-$RUBY_VERSION && rvm use ruby-$RUBY_VERSION --def
 
 # Install Node
 ENV NODE_VERSION=12.16.3
-RUN bash -lc "nvm install $NODE_VERSION && nvm use $NODE_VERSION"
+RUN bash -lc ". .nvm/nvm.sh && nvm install $NODE_VERSION && nvm use $NODE_VERSION"
 
 # Install Redis.
 RUN sudo apt-get update \

--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -7,7 +7,7 @@ RUN bash -lc "rvm install ruby-$RUBY_VERSION && rvm use ruby-$RUBY_VERSION --def
 
 # Install Node
 ENV NODE_VERSION=12.16.3
-RUN bash -lc ". .nvm/nvm.sh && nvm install $NODE_VERSION"
+RUN bash -lc ". .nvm/nvm.sh && nvm install $NODE_VERSION && nvm use $NODE_VERSION"
 
 # Install Redis.
 RUN sudo apt-get update \

--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -7,7 +7,7 @@ RUN bash -lc "rvm install ruby-$RUBY_VERSION && rvm use ruby-$RUBY_VERSION --def
 
 # Install Node
 COPY ./.nvmrc "${APP_HOME}"/.nvmrc
-RUN bash -lc ". .nvm/nvm.sh && nvm install && nvm use && nvm uninstall $NODE_VERSION"
+RUN bash -lc ". .nvm/nvm.sh && nvm install && nvm alias default $(cat .nvmrc) && nvm use && nvm uninstall $NODE_VERSION"
 
 # Install Redis.
 RUN sudo apt-get update \

--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -5,9 +5,14 @@ ENV RUBY_VERSION=2.7.1
 RUN rm /home/gitpod/.rvmrc && touch /home/gitpod/.rvmrc && echo "rvm_gems_path=/home/gitpod/.rvm" > /home/gitpod/.rvmrc
 RUN bash -lc "rvm install ruby-$RUBY_VERSION && rvm use ruby-$RUBY_VERSION --default"
 
-# Install Node
+# Install Node and Yarn
 COPY ./.nvmrc "${APP_HOME}"/.nvmrc
-RUN bash -lc ". .nvm/nvm.sh && nvm install && nvm unalias default && nvm alias default $(cat /.nvmrc) && nvm use default && nvm uninstall $NODE_VERSION"
+RUN bash -lc ". .nvm/nvm.sh && nvm install \
+              && nvm unalias default \
+              && nvm alias default $(cat /.nvmrc) \
+              && nvm use default \
+              && nvm uninstall $NODE_VERSION \
+              && npm install -g yarn"
 
 # Install Redis.
 RUN sudo apt-get update \

--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -7,7 +7,7 @@ RUN bash -lc "rvm install ruby-$RUBY_VERSION && rvm use ruby-$RUBY_VERSION --def
 
 # Install Node
 ENV NODE_VERSION=12.16.3
-RUN bash -lc ". .nvm/nvm.sh && nvm install $NODE_VERSION && nvm use $NODE_VERSION"
+RUN bash -lc ". .nvm/nvm.sh && nvm install $NODE_VERSION && nvm alias default $NODE_VERSION"
 
 # Install Redis.
 RUN sudo apt-get update \

--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -7,8 +7,8 @@ RUN bash -lc "rvm install ruby-$RUBY_VERSION && rvm use ruby-$RUBY_VERSION --def
 
 # Install Node and Yarn
 COPY ./.nvmrc /.nvmrc
-ARG nvmrc_node_version="$(cat /.nvmrc)"
-RUN bash -lc ". .nvm/nvm.sh && nvm install && nvm alias default ${nvmrc_node_version} && npm install -g yarn"
+RUN bash -lc ". .nvm/nvm.sh && nvm install && nvm alias default $(cat /.nvmrc) && npm install -g yarn"
+ARG nvmrc_node_version="$(echo nvm list default)"
 ENV PATH=/home/gitpod/.nvm/versions/node/v${nvmrc_node_version}/bin:$PATH
 
 # Install Redis.

--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -6,10 +6,12 @@ RUN rm /home/gitpod/.rvmrc && touch /home/gitpod/.rvmrc && echo "rvm_gems_path=/
 RUN bash -lc "rvm install ruby-$RUBY_VERSION && rvm use ruby-$RUBY_VERSION --default"
 
 # Install Node and Yarn
-COPY ./.nvmrc /.nvmrc
-RUN bash -lc ". .nvm/nvm.sh && nvm install && nvm alias default $(cat /.nvmrc) && npm install -g yarn"
-ARG nvmrc_node_version="$(echo nvm list default)"
-ENV PATH=/home/gitpod/.nvm/versions/node/v${nvmrc_node_version}/bin:$PATH
+ENV NODE_VERSION=12.16.3
+RUN bash -c ". .nvm/nvm.sh && \
+        nvm install ${NODE_VERSION} && \
+        nvm alias default ${NODE_VERSION} && \
+        npm install -g yarn"
+ENV PATH=/home/gitpod/.nvm/versions/node/v${NODE_VERSION}/bin:$PATH
 
 # Install Redis.
 RUN sudo apt-get update \

--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -7,7 +7,7 @@ RUN bash -lc "rvm install ruby-$RUBY_VERSION && rvm use ruby-$RUBY_VERSION --def
 
 # Install Node
 ENV NODE_VERSION=12.16.3
-RUN bash -lc ". .nvm/nvm.sh && nvm install $NODE_VERSION && nvm use $NODE_VERSION"
+RUN bash -lc "nvm install $NODE_VERSION && nvm use $NODE_VERSION"
 
 # Install Redis.
 RUN sudo apt-get update \

--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -7,7 +7,7 @@ RUN bash -lc "rvm install ruby-$RUBY_VERSION && rvm use ruby-$RUBY_VERSION --def
 
 # Install Node
 ENV NODE_VERSION=12.16.3
-RUN bash -lc ". .nvm/nvm.sh && nvm install $NODE_VERSION && nvm alias default $NODE_VERSION"
+RUN bash -lc ". .nvm/nvm.sh && nvm install $NODE_VERSION && nvm alias default $NODE_VERSION && nvm use default"
 
 # Install Redis.
 RUN sudo apt-get update \

--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -6,13 +6,10 @@ RUN rm /home/gitpod/.rvmrc && touch /home/gitpod/.rvmrc && echo "rvm_gems_path=/
 RUN bash -lc "rvm install ruby-$RUBY_VERSION && rvm use ruby-$RUBY_VERSION --default"
 
 # Install Node and Yarn
-COPY ./.nvmrc "${APP_HOME}"/.nvmrc
-RUN bash -lc ". .nvm/nvm.sh && nvm install \
-              && nvm unalias default \
-              && nvm alias default $(cat /.nvmrc) \
-              && nvm use default \
-              && nvm uninstall $NODE_VERSION \
-              && npm install -g yarn"
+COPY ./.nvmrc /.nvmrc
+ARG nvmrc_node_version="$(cat /.nvmrc)"
+RUN bash -lc ". .nvm/nvm.sh && nvm install && nvm alias default ${nvmrc_node_version} && npm install -g yarn"
+ENV PATH=/home/gitpod/.nvm/versions/node/v${nvmrc_node_version}/bin:$PATH
 
 # Install Redis.
 RUN sudo apt-get update \

--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -7,7 +7,7 @@ RUN bash -lc "rvm install ruby-$RUBY_VERSION && rvm use ruby-$RUBY_VERSION --def
 
 # Install Node
 COPY ./.nvmrc "${APP_HOME}"/.nvmrc
-RUN bash -lc ". .nvm/nvm.sh && nvm install && nvm alias default $(cat .nvmrc) && nvm use && nvm uninstall $NODE_VERSION"
+RUN bash -lc ". .nvm/nvm.sh && nvm install && nvm alias default $(cat .nvmrc) && nvm use default && nvm uninstall $NODE_VERSION && nvm use default"
 
 # Install Redis.
 RUN sudo apt-get update \

--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -5,9 +5,8 @@ ENV RUBY_VERSION=2.7.1
 RUN rm /home/gitpod/.rvmrc && touch /home/gitpod/.rvmrc && echo "rvm_gems_path=/home/gitpod/.rvm" > /home/gitpod/.rvmrc
 RUN bash -lc "rvm install ruby-$RUBY_VERSION && rvm use ruby-$RUBY_VERSION --default"
 
-# Install Node
-ENV NODE_VERSION=12.16.3
-RUN bash -lc ". .nvm/nvm.sh && nvm install $NODE_VERSION && nvm alias default $NODE_VERSION && nvm use default"
+# Install Node from .nvmrc version
+RUN bash -lc ". .nvm/nvm.sh && nvm install"
 
 # Install Redis.
 RUN sudo apt-get update \

--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -7,7 +7,7 @@ RUN bash -lc "rvm install ruby-$RUBY_VERSION && rvm use ruby-$RUBY_VERSION --def
 
 # Install Node
 COPY ./.nvmrc "${APP_HOME}"/.nvmrc
-RUN bash -lc ". .nvm/nvm.sh && nvm install && nvm use"
+RUN bash -lc ". .nvm/nvm.sh && nvm install && nvm use && nvm uninstall $NODE_VERSION"
 
 # Install Redis.
 RUN sudo apt-get update \

--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -7,7 +7,7 @@ RUN bash -lc "rvm install ruby-$RUBY_VERSION && rvm use ruby-$RUBY_VERSION --def
 
 # Install Node
 COPY ./.nvmrc "${APP_HOME}"/.nvmrc
-RUN bash -lc ". .nvm/nvm.sh && nvm install"
+RUN bash -lc ". .nvm/nvm.sh && nvm install && nvm use"
 
 # Install Redis.
 RUN sudo apt-get update \

--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -5,7 +5,8 @@ ENV RUBY_VERSION=2.7.1
 RUN rm /home/gitpod/.rvmrc && touch /home/gitpod/.rvmrc && echo "rvm_gems_path=/home/gitpod/.rvm" > /home/gitpod/.rvmrc
 RUN bash -lc "rvm install ruby-$RUBY_VERSION && rvm use ruby-$RUBY_VERSION --default"
 
-# Install Node from .nvmrc version
+# Install Node
+COPY ./.nvmrc "${APP_HOME}"/.nvmrc
 RUN bash -lc ". .nvm/nvm.sh && nvm install"
 
 # Install Redis.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

After installing a new node version with nvm it has to be explicitly chosen to use. This adds the nvm use command to fix the `bin/setup` script

## Related Tickets & Documents

#8849 

## QA Instructions, Screenshots, Recordings

View the [GitPod workflow for this PR](https://gitpod.io/#https://github.com/thepracticaldev/dev.to/pull/9271) and verify an error is no longer thrown on [yarn install](https://user-images.githubusercontent.com/22113778/85383294-6b990d80-b55d-11ea-92ff-a74d807c917b.png)

## Added tests?

- [x] no, because they aren't needed

## Added to documentation?

- [x] no documentation needed