### PR TITLE
Revert "Rubocop: fix Performance/OpenStruct (#9241)"

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -12,6 +12,15 @@ require:
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
+# Offense count: 8
+Performance/OpenStruct:
+  Exclude:
+    - 'app/models/article.rb'
+    - 'app/models/organization.rb'
+    - 'app/services/notifications/reactions/send.rb'
+    - 'spec/models/github_repo_spec.rb'
+    - 'spec/requests/github_repos_spec.rb'
+
 # Offense count: 4
 # Configuration parameters: Include.
 # Include: app/models/**/*.rb

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -584,19 +584,23 @@ class Article < ApplicationRecord
   end
 
   def update_cached_user
-    self.cached_organization = set_cached_object(organization) if organization
-    self.cached_user = set_cached_object(user) if user
+    if organization
+      self.cached_organization = OpenStruct.new(set_cached_object(organization))
+    end
+
+    return unless user
+
+    self.cached_user = OpenStruct.new(set_cached_object(user))
   end
 
-  # TODO: [thepracticaldev/oss] this should eventually be moved to JSON, to avoid storing a native Ruby object in the DB
   def set_cached_object(object)
-    Struct.new(:name, :username, :slug, :profile_image_90, :profile_image_url).new.tap do |struct|
-      struct.name = object.name
-      struct.username = object.username
-      struct.slug = object.respond_to?(:slug) ? object.slug : object.username
-      struct.profile_image_90 = object.profile_image_90
-      struct.profile_image_url = object.profile_image_url
-    end
+    {
+      name: object.name,
+      username: object.username,
+      slug: object == organization ? object.slug : object.username,
+      profile_image_90: object.profile_image_90,
+      profile_image_url: object.profile_image_url
+    }
   end
 
   def set_all_dates

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -122,16 +122,14 @@ class Organization < ApplicationRecord
   def update_articles
     return unless saved_change_to_slug || saved_change_to_name || saved_change_to_profile_image
 
-    # TODO: [thepracticaldev/oss] this should eventually be moved to JSON,
-    # to avoid storing a native Ruby object in the DB
-    cached_org_object = Struct.new(:name, :username, :slug, :profile_image_90, :profile_image_url).new
-    cached_org_object.name = name
-    cached_org_object.username = username
-    cached_org_object.slug = slug
-    cached_org_object.profile_image_90 = profile_image_90
-    cached_org_object.profile_image_url = profile_image_url
-
-    articles.update(cached_organization: cached_org_object)
+    cached_org_object = {
+      name: name,
+      username: username,
+      slug: slug,
+      profile_image_90: profile_image_90,
+      profile_image_url: profile_image_url
+    }
+    articles.update(cached_organization: OpenStruct.new(cached_org_object))
   end
 
   def bust_cache

--- a/app/services/notifications/reactions/send.rb
+++ b/app/services/notifications/reactions/send.rb
@@ -1,8 +1,6 @@
 # send notifications about the new reaction
 module Notifications
   module Reactions
-    SendResult = Struct.new(:action, :notification_id)
-
     class Send
       # @param reaction_data [Hash]
       #   * :reactable_id [Integer] - article or comment id
@@ -20,7 +18,7 @@ module Notifications
         new(*args).call
       end
 
-      # @return [Struct, #action, #notification_id]
+      # @return [OpenStruct, #action, #notification_id]
       def call
         return unless receiver.is_a?(User) || receiver.is_a?(Organization)
 
@@ -47,8 +45,7 @@ module Notifications
 
         if aggregated_reaction_siblings.size.zero?
           Notification.where(notification_params).delete_all
-
-          SendResult.new(:deleted, nil)
+          OpenStruct.new(action: :deleted)
         else
           recent_reaction = reaction_siblings.first
 
@@ -66,7 +63,7 @@ module Notifications
 
           notification_id = save_notification(notification_params, notification)
 
-          SendResult.new(:saved, notification_id)
+          OpenStruct.new(action: :saved, notification_id: notification_id)
         end
       end
 

--- a/app/views/stories/feeds/show.json.jbuilder
+++ b/app/views/stories/feeds/show.json.jbuilder
@@ -11,10 +11,10 @@ article_methods_to_include = %i[
 
 json.array!(@stories) do |article|
   json.extract! article, *article_attributes_to_include
-  json.user article.cached_user.as_json
+  json.user article.cached_user.as_json["table"]
 
   if article.cached_organization?
-    json.organization article.cached_organization.as_json
+    json.organization article.cached_organization.as_json["table"]
   end
 
   if article.main_image?

--- a/spec/models/github_repo_spec.rb
+++ b/spec/models/github_repo_spec.rb
@@ -86,9 +86,7 @@ RSpec.describe GithubRepo, type: :model do
     end
 
     let(:stubbed_github_repo) do
-      # rubocop:disable Performance/OpenStruct
       OpenStruct.new(repo.attributes.merge(id: repo.github_id_code, html_url: repo.url))
-      # rubocop:enable Performance/OpenStruct
     end
     let(:github_client) { instance_double(fake_github_client, repository: stubbed_github_repo) }
 

--- a/spec/requests/github_repos_spec.rb
+++ b/spec/requests/github_repos_spec.rb
@@ -23,9 +23,7 @@ RSpec.describe "GithubRepos", type: :request do
       html_url: Faker::Internet.url,
     )
 
-    # rubocop:disable Performance/OpenStruct
     [OpenStruct.new(repo1_params), OpenStruct.new(repo2_params)]
-    # rubocop:enable Performance/OpenStruct
   end
   let(:github_client) do
     instance_double(


### PR DESCRIPTION
This reverts commit 101cca4a683dba740b094bc93a8281b0815fa174.

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Unfortunately I still don't know what's broken but I verified that by reverting this things profile images locally and hopefully in production will work again.

Closes https://github.com/thepracticaldev/dev.to/issues/9290

## QA Instructions, Screenshots, Recordings

Pull down the PR, fire it up, verify that as a logged in user, the profile images work

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
