### PR TITLE
Hotfix: Fix Typo in backfill_broadcastable_type_for_broadcasts

### DIFF
--- a/lib/data_update_scripts/20200708163323_backfill_broadcastable_for_broadcasts.rb
+++ b/lib/data_update_scripts/20200708163323_backfill_broadcastable_for_broadcasts.rb
@@ -1,5 +1,5 @@
 module DataUpdateScripts
-  class BackfillBroadcastableTypeForBroadcasts
+  class BackfillBroadcastableForBroadcasts
     def run
       Broadcast.where(broadcastable_type: nil).find_each do |cast|
         cast.update!(broadcastable_type: cast.type_of)

--- a/lib/data_update_scripts/20200708163323_backfill_broadcastable_type_for_broadcasts.rb
+++ b/lib/data_update_scripts/20200708163323_backfill_broadcastable_type_for_broadcasts.rb
@@ -1,8 +1,8 @@
 module DataUpdateScripts
   class BackfillBroadcastableTypeForBroadcasts
     def run
-      Broadcast.where(broadcastable_type: nil).each do |cast|
-        cast.update!(broadcastable_type: broadcast.type_of)
+      Broadcast.where(broadcastable_type: nil).find_each do |cast|
+        cast.update!(broadcastable_type: cast.type_of)
       end
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR fixes a typo in `backfill_broadcastable_type_for_broadcasts.rb` and uses `.find_each` in place of `.each` when looping through the Broadcasts in the `data_update` script per @rhymes' suggestion in this PR: https://github.com/thepracticaldev/dev.to/pull/9231

## Related Tickets & Documents
Fixes the typo in this PR: https://github.com/thepracticaldev/dev.to/pull/9231

## QA Instructions, Screenshots, Recordings
To QA these changes, you can manually run the `data_update` script (as shown below) and make sure that the build passes and that these changes do not break anything else.

To manually run the `data_update` script, do the following:
- Create a Broadcast without a `broadcastable_type`:
```
broadcast = Broadcast.create(title: "Hello, world!", processed_html: "Hello, world!", type_of: "Welcome", active: false, broadcastable_type: nil)
```
```
=> #<Broadcast:0x00007fe93beb74f0
 id: 19,
 active: false,
 active_status_updated_at: nil,
 banner_style: nil,
 body_markdown: nil,
 created_at: Mon, 13 Jul 2020 16:23:54 UTC +00:00,
 processed_html: "Hello, world!",
 title: "Hello, world!",
 type_of: "Welcome",
 updated_at: Mon, 13 Jul 2020 16:23:54 UTC +00:00,
 broadcastable_id: nil,
 broadcastable_type: nil>
```
- Run the code within the `data_update` script in your console:
```
  Broadcast.where(broadcastable_type: nil).find_each do |cast|
     cast.update(broadcastable_type: cast.type_of)
   end
```
- Check to see that the Broadcast's `broadcastable_type` column is no longer `nil` and contains the correct `broadcastable_type`:
```
=> #<Broadcast:0x00007fe93bd67000
  id: 19,
  active: false,
  active_status_updated_at: nil,
  banner_style: nil,
  body_markdown: nil,
  created_at: Mon, 13 Jul 2020 16:23:54 UTC +00:00,
  processed_html: "Hello, world!",
  title: "Hello, world!",
  type_of: "Welcome",
  updated_at: Mon, 13 Jul 2020 16:24:36 UTC +00:00,
  broadcastable_id: nil,
  broadcastable_type: "Welcome">
```

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?
The `data_update` script included in this PR should port over the data from the `type_of` column to the `broadcastable_type` column on Broadcasts.

💭 : **Is there anything special that needs to be done to rerun this script or will fixing the typo and then merge/deploying it be sufficient to resolve the honeybadger error?**

Answer to above thought: I just spoke with @mstruve and she answered this question for me: Yes! In order to trigger the script to run again, it is necessary that I change the name of the script, which I have since addressed. The more you know! 😄 

## [optional] What gif best describes this PR or how it makes you feel?

![Ron Swanson](https://media.giphy.com/media/ktcUyw6mBlMVa/giphy.gif)
