### PR TITLE
Fix TypeError: null is not an object in initializeArticleReactions.js

### DIFF
--- a/app/assets/javascripts/initializers/initializeArticleReactions.js
+++ b/app/assets/javascripts/initializers/initializeArticleReactions.js
@@ -41,13 +41,10 @@ function hasUserReacted(reactionName) {
 
 function getNumReactions(reactionName) {
   const reactionEl = document.getElementById('reaction-number-' + reactionName);
-
-  if (!reactionEl) {
-    return;
-  }
-  if (reactionEl.textContent === '') {
+  if (!reactionEl || reactionEl.textContent === '') {
     return 0;
   }
+
   return parseInt(reactionEl.textContent, 10);
 }
 

--- a/app/assets/javascripts/initializers/initializeArticleReactions.js
+++ b/app/assets/javascripts/initializers/initializeArticleReactions.js
@@ -40,12 +40,15 @@ function hasUserReacted(reactionName) {
 }
 
 function getNumReactions(reactionName) {
-  var num = document.getElementById('reaction-number-' + reactionName)
-    .textContent;
-  if (num === '') {
+  const reactionEl = document.getElementById('reaction-number-' + reactionName);
+
+  if (!reactionEl) {
+    return;
+  }
+  if (reactionEl.textContent === '') {
     return 0;
   }
-  return parseInt(num, 10);
+  return parseInt(reactionEl.textContent, 10);
 }
 
 function reactToArticle(articleId, reaction) {


### PR DESCRIPTION
What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
As [this Honeybadger error](https://app.honeybadger.io/fault/67192/6f9b4fdf475e2229c968fa26d785b90f) shows, we sometimes try to call `textContent` on an element that is `null`. My guess is that this error happens at some point when `initializeArticleReactions.js` is called, and when the DOM attempts to `getElementById("reaction-number-"+reactionName)`, but can't find that element on the page/`document` yet.

Since we can't continue with that function without the element existing, I'm adding as guard clause here, which should fix this particular error.

## Related Tickets & Documents
Should fix https://app.honeybadger.io/fault/67192/6f9b4fdf475e2229c968fa26d785b90f

## QA Instructions, Screenshots, Recordings

Not a great way to test this other than seeing if the Honeybadger error re-occurs after this guard clause (it _shouldn't_).🤞 

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## Are there any post deployment tasks we need to perform?
Once this PR is merged, I'll mark the Honeybadger error as resolved, and see if it happens again.

## What gif best describes this PR or how it makes you feel?

![new bugs](https://media3.giphy.com/media/11ZSwQNWba4YF2/200w.webp?cid=5a38a5a20800dda99d9e890c73456487b3c9bd3946745f68&rid=200w.webp)
