### PR TITLE
Fix TypeError: userData is null in initializeOnboardingTaskCard.js

### DIFF
--- a/app/assets/javascripts/initializers/initializeOnboardingTaskCard.js
+++ b/app/assets/javascripts/initializers/initializeOnboardingTaskCard.js
@@ -10,13 +10,9 @@ function initializeOnboardingTaskCard() {
   }
 
   var taskCard = document.getElementsByClassName('onboarding-task-card')[0];
-  if (taskCard == null) {
-    return; // This guards against both a null and undefined taskCard.
-  }
-
   const user = userData();
-  if (!user) {
-    return;
+  if (taskCard == null || !user) {
+    return; // Guard against a null/undefined taskCard, and no user data.
   }
 
   var createdAt = new Date(user.created_at);

--- a/app/assets/javascripts/initializers/initializeOnboardingTaskCard.js
+++ b/app/assets/javascripts/initializers/initializeOnboardingTaskCard.js
@@ -11,10 +11,15 @@ function initializeOnboardingTaskCard() {
 
   var taskCard = document.getElementsByClassName('onboarding-task-card')[0];
   if (taskCard == null) {
-    return;
-  } // This guard against both null and undefined taskCard
+    return; // This guards against both a null and undefined taskCard.
+  }
 
-  var createdAt = new Date(userData().created_at);
+  const user = userData();
+  if (!user) {
+    return;
+  }
+
+  var createdAt = new Date(user.created_at);
   var now = new Date();
   var aWeekAgo = now.setDate(now.getDate() - 7);
 


### PR DESCRIPTION
What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
As [this Honeybadger error](https://app.honeybadger.io/fault/67192/65045742fda3390a067960f53a894e87) shows, we sometimes try to call `created_at` on `userData`, which can occasionally be `null`. My guess is that this error happens sometimes when we call `initializeOnboardingTaskCard` but for some reason (?) the `userData()` isn't there.

This particular error started occurring about 5 days ago, and seems to only be occurring on Firefox.

I suspect that there are times when the `document.body.dataset` doesn't have the `user` within it (for some reason?), and so we are unable to `JSON.parse(user)`, and then this function causes the subsequent `TypeError`. 

Probably, we should have some kind of better, global catchall system for handling the situations where `userData` doesn't exist on the page. But at a bare minimum, I don't think we want to continue execution of this function.

## Related Tickets & Documents
Should fix https://app.honeybadger.io/fault/67192/65045742fda3390a067960f53a894e87

## QA Instructions, Screenshots, Recordings

Not a great way to test this other than seeing if the Honeybadger error re-occurs after this guard clause (it _shouldn't_).🤞 

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## Are there any post deployment tasks we need to perform?
Once this PR is merged, I'll mark the Honeybadger error as resolved, and see if it happens again.

## What gif best describes this PR or how it makes you feel?

![oh dear dog](https://media1.giphy.com/media/l0MYH5mkQJAxVShqM/giphy.webp?cid=5a38a5a2308bb87b3c91128c2e0823d16cfa8a6539eae007&rid=giphy.webp)
