### PR TITLE
Fix TypeError: userData is null in blockButton.js

### DIFF
--- a/app/javascript/profileDropdown/blockButton.js
+++ b/app/javascript/profileDropdown/blockButton.js
@@ -24,8 +24,8 @@ export default function initBlock() {
         },
       }),
     })
-      .then(response => response.json())
-      .then(response => {
+      .then((response) => response.json())
+      .then((response) => {
         if (response.result === 'unblocked') {
           blockButton.innerText = 'Block';
           /* eslint-disable-next-line no-use-before-define */
@@ -36,7 +36,7 @@ export default function initBlock() {
           );
         }
       })
-      .catch(e => {
+      .catch((e) => {
         window.alert(
           `Something went wrong: ${e}. -- Please refresh the page to try again.`,
         );
@@ -64,8 +64,8 @@ export default function initBlock() {
           },
         }),
       })
-        .then(response => response.json())
-        .then(response => {
+        .then((response) => response.json())
+        .then((response) => {
           if (response.result === 'blocked') {
             blockButton.innerText = 'Unblock';
             blockButton.addEventListener('click', unblock, { once: true });
@@ -75,7 +75,7 @@ export default function initBlock() {
             );
           }
         })
-        .catch(e => {
+        .catch((e) => {
           window.alert(
             `Something went wrong: ${e}. -- Please refresh the page to try again.`,
           );
@@ -87,14 +87,17 @@ export default function initBlock() {
 
   // userData() is a global function
   /* eslint-disable-next-line no-undef */
-  const currentUserId = userData().id;
+  const user = userData();
+  if (!user) {
+    return;
+  }
 
-  if (currentUserId === parseInt(profileUserId, 10)) {
+  if (user.id === parseInt(profileUserId, 10)) {
     blockButton.style.display = 'none';
   } else {
     fetch(`/user_blocks/${profileUserId}`)
-      .then(response => response.json())
-      .then(response => {
+      .then((response) => response.json())
+      .then((response) => {
         if (response.result === 'blocking') {
           blockButton.innerText = 'Unblock';
           blockButton.addEventListener('click', unblock, { once: true });


### PR DESCRIPTION
What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
As [this Honeybadger error](https://app.honeybadger.io/fault/67192/ed6f6b392b5bd791d6dc04732f125123) shows, we sometimes try to call `id` on `userData`, which can occasionally be `null`.

This particular error seems to really only happen to one user, who is on Firefox. I'm not sure why `userData` doesn't seem to exist for this user on this browser specifically (and that too from `initBlock.js`?), but it seems like we shouldn't be throwing a TypeError here if the `userData` object doesn't even exist. 🤷 

As I mentioned in https://github.com/thepracticaldev/dev.to/pull/9298, we probably need to investigate the non-existant user data set on the page, but for now, this should bring down some of the high error counts for _this_ error that we've been seeing on the JS Honeybadger dashboard.

## Related Tickets & Documents
Should fix https://app.honeybadger.io/fault/67192/ed6f6b392b5bd791d6dc04732f125123

## QA Instructions, Screenshots, Recordings

Not a great way to test this other than seeing if the Honeybadger error re-occurs after this guard clause (it _shouldn't_).🤞 

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## Are there any post deployment tasks we need to perform?
Once this PR is merged, I'll mark the Honeybadger error as resolved, and see if it happens again.

## What gif best describes this PR or how it makes you feel?

![oh no panda](https://media3.giphy.com/media/14aUO0Mf7dWDXW/giphy.webp?cid=5a38a5a28b7baba4af7ac1054ab0aaa8b0407c2a841b5863&rid=giphy.webp)
